### PR TITLE
build: don't hoist React Native dependencies

### DIFF
--- a/packages/react-native-dogfood/package.json
+++ b/packages/react-native-dogfood/package.json
@@ -63,5 +63,8 @@
   },
   "jest": {
     "preset": "react-native"
+  },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
   }
 }


### PR DESCRIPTION
There are two problems with hoisting for React Native:

1. RN's bundler Metro [does not follow symlinks](https://github.com/facebook/metro/issues/1)
2. React Native has a tendency of reaching into `node_modules/` (see for example `react-native-dogfood/ios/Podfile`)

This PR configures specifically the `react-native-dogfood` workspace to not hoist dependencies at all. The `hoist` configuration in `package.json` is deprecated with yarn berry, and it's suggested to use this configuration instead.