### PR TITLE
fix: Update subscriptions not always called

### DIFF
--- a/packages/client/src/rtc/Call.ts
+++ b/packages/client/src/rtc/Call.ts
@@ -18,6 +18,7 @@ import { SfuRequest } from '../gen/video/sfu/event/events';
 import { SfuEventListener } from './Dispatcher';
 import { StreamVideoWriteableStateStore } from '../stateStore';
 import { SubscriptionChanges } from './types';
+import { debounceTime, Subject } from 'rxjs';
 
 export type CallOptions = {
   connectionConfig: RTCConfiguration | undefined;
@@ -30,6 +31,9 @@ export class Call {
   private videoLayers?: OptimalVideoLayer[];
   readonly subscriber: RTCPeerConnection;
   readonly publisher: RTCPeerConnection;
+  private readonly trackSubscriptionsSubject = new Subject<{
+    [key: string]: VideoDimension;
+  }>();
 
   constructor(
     private readonly client: StreamSfuClient,
@@ -57,6 +61,12 @@ export class Call {
     });
 
     registerEventHandlers(this, this.stateStore, dispatcher);
+
+    this.trackSubscriptionsSubject
+      .pipe(debounceTime(1200))
+      .subscribe((subscriptions) =>
+        this.client.updateSubscriptions(subscriptions),
+      );
   }
 
   // FIXME: change the call-sites in the SDK
@@ -234,7 +244,7 @@ export class Call {
       ]);
     });
 
-    return this.updateSubscriptions(includeCurrentUser);
+    this.updateSubscriptions(includeCurrentUser);
   };
 
   changeInputDevice = async (
@@ -374,7 +384,7 @@ export class Call {
         subscriptions[p.user!.id] = p.videoDimension || { height: 0, width: 0 };
       }
     });
-    return this.client.updateSubscriptions(subscriptions);
+    this.trackSubscriptionsSubject.next(subscriptions);
   };
 
   private get participants() {

--- a/packages/react-sdk/src/components/StreamCall/Stage.tsx
+++ b/packages/react-sdk/src/components/StreamCall/Stage.tsx
@@ -1,6 +1,6 @@
 import { Participant } from '@stream-io/video-client/dist/src/gen/video/sfu/models/models';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Call, SubscriptionChanges } from '@stream-io/video-client';
+import { useCallback, useEffect } from 'react';
+import { Call } from '@stream-io/video-client';
 import { useParticipants } from '../../hooks/useParticipants';
 import { useMediaDevices } from '../../contexts/MediaDevicesContext';
 import { ParticipantBox } from './ParticipantBox';
@@ -27,54 +27,6 @@ export const Stage = (props: {
     [call],
   );
 
-  const videoElementsByParticipant = useRef<{
-    [sesionId: string]: HTMLVideoElement | null;
-  }>({});
-
-  const updateVideoSubscriptionForAllParticipantsDebounced = useMemo(() => {
-    return debounce(() => {
-      const changes: SubscriptionChanges = {};
-      Object.keys(videoElementsByParticipant.current).forEach((sessionId) => {
-        const videoElement = videoElementsByParticipant.current[sessionId];
-        if (videoElement) {
-          const width = videoElement.clientWidth;
-          const height = videoElement.clientHeight;
-          changes[sessionId] = {
-            videoDimension: { width, height },
-          };
-        }
-      });
-
-      call.updateSubscriptionsPartial(changes, includeSelf);
-    }, 1200);
-  }, [call, includeSelf]);
-
-  const updateVideoElementForParticipant = useCallback(
-    (sessionId: string, el: HTMLVideoElement | null) => {
-      const isNewParticipant = !videoElementsByParticipant.current[sessionId];
-      videoElementsByParticipant.current[sessionId] = el;
-      if (isNewParticipant) {
-        updateVideoSubscriptionForAllParticipantsDebounced();
-      }
-    },
-    [updateVideoSubscriptionForAllParticipantsDebounced],
-  );
-
-  const gridRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!gridRef.current || !updateVideoSubscriptionForAllParticipantsDebounced)
-      return;
-
-    const resizeObserver = new ResizeObserver(
-      updateVideoSubscriptionForAllParticipantsDebounced,
-    );
-    resizeObserver.observe(gridRef.current);
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, [updateVideoSubscriptionForAllParticipantsDebounced]);
-
   const { audioStream: localAudioStream, videoStream: localVideoStream } =
     useMediaDevices();
 
@@ -86,7 +38,7 @@ export const Stage = (props: {
 
   const grid = `str-video__grid-${participants.length || 1}`;
   return (
-    <div className={`str-video__stage ${grid}`} ref={gridRef}>
+    <div className={`str-video__stage ${grid}`}>
       {participants.map((participant) => {
         const userId = participant.user!.id;
         const isLocalParticipant = participant.isLoggedInUser;
@@ -100,7 +52,6 @@ export const Stage = (props: {
             updateVideoSubscriptionForParticipant={
               updateVideoSubscriptionForParticipant
             }
-            updateVideoElementForParticipant={updateVideoElementForParticipant}
           />
         );
       })}


### PR DESCRIPTION
- ResizeObserver attached to video elements instead of the grid (logic not yet moved to the client, will do after we have a solution for separating web-specific code in client)
- Update subscription throttling moved to video client
- UI for no video is started but will only be finished once mute state changed event is supported by the client
