### PR TITLE
fix: datacenterId is optional on the backend

### DIFF
--- a/packages/angular-sdk/projects/sample-app/src/app/app.component.ts
+++ b/packages/angular-sdk/projects/sample-app/src/app/app.component.ts
@@ -69,7 +69,7 @@ export class AppComponent implements OnInit, OnDestroy {
     await this.videoService.videoClient?.joinCall({
       id,
       type,
-      datacenterId: 'amsterdam',
+      datacenterId: '',
     });
   }
 }

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -145,11 +145,7 @@ export class StreamVideoClient {
   };
 
   joinCall = async (data: JoinCallRequest, sessionId?: string) => {
-    const { response } = await this.client.joinCall({
-      ...data,
-      // FIXME: OL this needs to come from somewhere
-      datacenterId: 'amsterdam',
-    });
+    const { response } = await this.client.joinCall(data);
     if (response.call && response.call.call && response.edges) {
       const edge = await this.getCallEdgeServer(
         response.call.call,

--- a/packages/egress-composite/src/main.ts
+++ b/packages/egress-composite/src/main.ts
@@ -50,7 +50,7 @@ import './style.css';
   const call = await client.joinCall({
     id: callId,
     type: 'default',
-    datacenterId: 'aws-egress',
+    datacenterId: '',
   });
 
   if (!call) {

--- a/packages/react-native-dogfood/src/hooks/useCall.ts
+++ b/packages/react-native-dogfood/src/hooks/useCall.ts
@@ -33,8 +33,8 @@ export const useCall = ({
       const result = await videoClient.joinCallRaw({
         id,
         type,
-        // FIXME: OL this needs to come from somewhere // TODO: SANTHOSH, this is optional, check its purpose
-        datacenterId: 'amsterdam',
+        // TODO: SANTHOSH, this is optional, check its purpose
+        datacenterId: '',
       });
       if (result) {
         const { response, edge } = result;

--- a/packages/react-sdk/src/hooks/useCall.ts
+++ b/packages/react-sdk/src/hooks/useCall.ts
@@ -25,8 +25,8 @@ export const useCall = ({
       const call = await client.joinCall({
         id,
         type,
-        // FIXME: OL this needs to come from somewhere
-        datacenterId: 'amsterdam',
+        // FIXME: OL optional, but it is marked as required in proto
+        datacenterId: '',
       });
       setActiveCall(call);
     },


### PR DESCRIPTION
It is better to not provide any value at all (and default to '') than providing an incorrect value.