### PR TITLE
fix: egress-composite app improvements

### DIFF
--- a/packages/client/src/rtc/types.ts
+++ b/packages/client/src/rtc/types.ts
@@ -20,7 +20,11 @@ export type StreamVideoParticipant = {
 } & Participant;
 
 export type SubscriptionChange = {
-  videoDimension: VideoDimension;
+  /**
+   * The video dimension to request.
+   * Set it to `undefined` in case you want to unsubscribe.
+   */
+  videoDimension: VideoDimension | undefined;
 };
 
 export type SubscriptionChanges = {

--- a/packages/egress-composite/index.html
+++ b/packages/egress-composite/index.html
@@ -8,7 +8,15 @@
   <body>
     <div id="app">
       <video
-        id="current-speaker-video"
+        id="speaker-a"
+        class="speaker primary"
+        width="100%"
+        height="100%"
+        autoplay="autoplay"
+      ></video>
+      <video
+        id="speaker-b"
+        class="speaker secondary hidden"
         width="100%"
         height="100%"
         autoplay="autoplay"

--- a/packages/egress-composite/src/main.ts
+++ b/packages/egress-composite/src/main.ts
@@ -128,14 +128,30 @@ import './style.css';
 })();
 
 function createSpeakerUpdater(call: Call) {
-  const $videoEl = document.getElementById(
-    'current-speaker-video',
-  ) as HTMLVideoElement;
+  const $videoA = document.getElementById('speaker-a') as HTMLVideoElement;
+  const $videoB = document.getElementById('speaker-b') as HTMLVideoElement;
 
-  $videoEl.addEventListener('canplay', () => {
-    $videoEl.play();
+  $videoA.addEventListener('canplay', () => {
+    void $videoA.play();
+  });
+  $videoB.addEventListener('canplay', () => {
+    void $videoB.play();
   });
 
+  const other = ($current: HTMLVideoElement) =>
+    $current === $videoA ? $videoB : $videoA;
+
+  $videoA.addEventListener('playing', () => {
+    $videoB.classList.toggle('hidden');
+    $videoA.classList.remove('hidden');
+  });
+
+  $videoB.addEventListener('playing', () => {
+    $videoA.classList.toggle('hidden');
+    $videoB.classList.remove('hidden');
+  });
+
+  let $currentVideoEl = $videoA;
   let lastSpeaker: StreamVideoParticipant | undefined;
   return function highlightSpeaker(speaker?: StreamVideoParticipant) {
     if (speaker && speaker.sessionId !== lastSpeaker?.sessionId) {
@@ -147,15 +163,21 @@ function createSpeakerUpdater(call: Call) {
               height: 1080,
             },
           },
+          ...(lastSpeaker && {
+            [lastSpeaker.sessionId]: {
+              videoDimension: undefined,
+            },
+          }),
         });
         return;
       }
 
       console.log(`Swapping highlighted speaker`, speaker.user!.id);
 
+      $currentVideoEl = other($currentVideoEl);
       // FIXME: use avatar as the speaker might not be always publishing a video track
-      $videoEl.srcObject = speaker.videoTrack!;
-      $videoEl.title = speaker.user!.id;
+      $currentVideoEl.srcObject = speaker.videoTrack!;
+      $currentVideoEl.title = speaker.user!.id;
 
       updateCurrentSpeakerName(speaker);
 

--- a/packages/egress-composite/src/style.css
+++ b/packages/egress-composite/src/style.css
@@ -4,8 +4,8 @@
   line-height: 24px;
   font-weight: 400;
 
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -20,7 +20,7 @@ a {
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #747bff;
 }
 
 body {
@@ -40,6 +40,14 @@ body {
   position: relative;
 }
 
+#app span {
+  color: #ffffff;
+}
+
+video.speaker.hidden {
+  display: none;
+}
+
 span#current-user-name {
   position: absolute;
   left: 10px;
@@ -53,7 +61,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #f9f9f9;
   cursor: pointer;
   transition: border-color 0.25s;
 }


### PR DESCRIPTION
- mount the "current-user-name" once the video starts playing (this signals the recorder process to start recording)
- wait until the next highlighted speaker's video starts playing before making the swap
- `updateSubscriptions` now supports unsubscribing from someone's video track.