### PR TITLE
fix: unsubscribe in useObservable value

### DIFF
--- a/packages/react-native-dogfood/src/hooks/useObservable.ts
+++ b/packages/react-native-dogfood/src/hooks/useObservable.ts
@@ -5,7 +5,7 @@ export const useObservableValue = <T>(observable$: Observable<T>) => {
   const [value, setValue] = useState<T>(() => getCurrentValue(observable$));
   useEffect(() => {
     const subscription = observable$.subscribe(setValue);
-    return subscription.unsubscribe;
+    return () => subscription.unsubscribe();
   }, [observable$]);
 
   return value;

--- a/packages/react-sdk/src/hooks/useStore.ts
+++ b/packages/react-sdk/src/hooks/useStore.ts
@@ -17,7 +17,7 @@ export const useObservableValue = <T>(observable$: Observable<T>) => {
   const [value, setValue] = useState<T>(() => getCurrentValue(observable$));
   useEffect(() => {
     const subscription = observable$.subscribe(setValue);
-    return subscription.unsubscribe;
+    return () => subscription.unsubscribe();
   }, [observable$]);
 
   return value;


### PR DESCRIPTION
The `unsubscribe` is a method on the subscription class that needs to be bound to a valid `this`. This means that we cannot use it like a function and return it to useEffect. 

ref: https://stackoverflow.com/questions/71149561/react-unsubscribe-from-rxjs-subscription-in-useeffect/71151640#71151640