### PR TITLE
chore: remove redundant parameters

### DIFF
--- a/packages/client/src/rtc/Call.ts
+++ b/packages/client/src/rtc/Call.ts
@@ -76,25 +76,21 @@ export class Call {
     this.currentUserId = stateStore.getCurrentValue(
       stateStore.connectedUserSubject,
     )!.name;
-    const { dispatcher, iceTrickleBuffer } = this.client;
+
     this.subscriber = createSubscriber({
       rpcClient: this.client,
-
-      // FIXME: don't do this
-      dispatcher: dispatcher,
       connectionConfig: this.options.connectionConfig,
       onTrack: this.handleOnTrack,
-      candidates: iceTrickleBuffer.subscriberCandidates,
     });
 
     this.publisher = createPublisher({
       rpcClient: this.client,
       connectionConfig: this.options.connectionConfig,
-      candidates: iceTrickleBuffer.publisherCandidates,
     });
 
     this.statEventListeners = [];
 
+    const { dispatcher } = this.client;
     registerEventHandlers(this, this.stateStore, dispatcher);
 
     this.trackSubscriptionsSubject

--- a/packages/client/src/rtc/subscriber.ts
+++ b/packages/client/src/rtc/subscriber.ts
@@ -1,23 +1,17 @@
 import { StreamSfuClient } from '../StreamSfuClient';
-import { Dispatcher } from './Dispatcher';
 import { getIceCandidate } from './helpers/iceCandidate';
-import { ICETrickle, PeerType } from '../gen/video/sfu/models/models';
-import { ReplaySubject } from 'rxjs';
+import { PeerType } from '../gen/video/sfu/models/models';
 
 export type SubscriberOpts = {
   rpcClient: StreamSfuClient;
-  dispatcher: Dispatcher;
   connectionConfig?: RTCConfiguration;
   onTrack?: (e: RTCTrackEvent) => void;
-  candidates: ReplaySubject<ICETrickle>;
 };
 
 export const createSubscriber = ({
   rpcClient,
-  dispatcher,
   connectionConfig,
   onTrack,
-  candidates,
 }: SubscriberOpts) => {
   const subscriber = new RTCPeerConnection(connectionConfig);
   subscriber.addEventListener('icecandidate', async (e) => {
@@ -58,6 +52,7 @@ export const createSubscriber = ({
     subscriber.addEventListener('track', onTrack);
   }
 
+  const { dispatcher, iceTrickleBuffer } = rpcClient;
   dispatcher.on('subscriberOffer', async (message) => {
     if (message.eventPayload.oneofKind !== 'subscriberOffer') return;
     const { subscriberOffer } = message.eventPayload;
@@ -68,7 +63,7 @@ export const createSubscriber = ({
       sdp: subscriberOffer.sdp,
     });
 
-    candidates.subscribe((candidate) => {
+    iceTrickleBuffer.subscriberCandidates.subscribe((candidate) => {
       try {
         const iceCandidate = JSON.parse(candidate.iceCandidate);
         subscriber.addIceCandidate(iceCandidate);


### PR DESCRIPTION
Fixed one long-standing FIXME in the Call.ts. Thanks, @MartinCupela for spotting and reminding for it :) 