### PR TITLE
feat: add ring call hooks to react bindings

### DIFF
--- a/packages/react-bindings/src/hooks/call.ts
+++ b/packages/react-bindings/src/hooks/call.ts
@@ -10,3 +10,28 @@ export const useDominantSpeaker = () => {
   const { dominantSpeaker$ } = useStore();
   return useObservableValue(dominantSpeaker$);
 };
+
+export const useActiveCall = () => {
+  const { activeCall$ } = useStore();
+  return useObservableValue(activeCall$);
+};
+
+export const useActiveRingCall = () => {
+  const { activeRingCallMeta$ } = useStore();
+  return useObservableValue(activeRingCallMeta$);
+};
+
+export const useTerminatedRingCall = () => {
+  const { terminatedRingCallMeta$ } = useStore();
+  return useObservableValue(terminatedRingCallMeta$);
+};
+
+export const useActiveRingCallDetails = () => {
+  const { activeRingCallDetails$ } = useStore();
+  return useObservableValue(activeRingCallDetails$);
+};
+
+export const useIncomingRingCalls = () => {
+  const { incomingRingCalls$ } = useStore();
+  return useObservableValue(incomingRingCalls$);
+};


### PR DESCRIPTION
This PR adds the necessary Ring call hooks to the React bindings so that it can be used around SDKs with ease.

The following hooks are introduced:
- useActiveCall
- useActiveRingCall
- useTerminatedRingCall
- useActiveRingCallDetails
- useIncomingRingCalls
