### PR TITLE
fix(react-native): pronto deeplinking was broken

### DIFF
--- a/packages/react-native-dogfood/src/components/Meeting/Meeting.tsx
+++ b/packages/react-native-dogfood/src/components/Meeting/Meeting.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   StyleSheet,
   TextInput,
@@ -6,7 +6,6 @@ import {
   Text,
   Switch,
   Button,
-  ActivityIndicator,
 } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { RootStackParamList } from '../../../types';
@@ -21,9 +20,11 @@ import { meetingId } from '../../modules/helpers/meetingId';
 import { prontoCallId$ } from '../../hooks/useProntoLinkEffect';
 import { useStreamVideoClient } from '@stream-io/video-react-native-sdk';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'HomeScreen'>;
+type Props = NativeStackScreenProps<RootStackParamList, 'HomeScreen'> & {
+  setLoadingCall: (loading: boolean) => void;
+};
 
-const Meeting = ({ navigation }: Props) => {
+const Meeting = ({ navigation, setLoadingCall }: Props) => {
   const meetingCallID = useAppGlobalStoreValue((store) => store.meetingCallID);
   const videoClient = useStreamVideoClient();
   const loopbackMyVideo = useAppGlobalStoreValue(
@@ -32,13 +33,12 @@ const Meeting = ({ navigation }: Props) => {
   const localMediaStream = useAppGlobalStoreValue(
     (store) => store.localMediaStream,
   );
-  const [loading, setLoading] = useState(false);
   const setState = useAppGlobalStoreSetState();
 
   const joinCallHandler = useCallback(
     async (callId: string) => {
       if (videoClient && localMediaStream) {
-        setLoading(true);
+        setLoadingCall(true);
         try {
           const response = await joinCall(videoClient, localMediaStream, {
             autoJoin: true,
@@ -52,10 +52,10 @@ const Meeting = ({ navigation }: Props) => {
         } catch (err) {
           console.log(err);
         }
-        setLoading(false);
+        setLoadingCall(false);
       }
     },
-    [localMediaStream, navigation, videoClient],
+    [localMediaStream, navigation, setLoadingCall, videoClient],
   );
 
   useEffect(() => {
@@ -123,7 +123,6 @@ const Meeting = ({ navigation }: Props) => {
         color="blue"
         onPress={handleCopyInviteLink}
       />
-      {loading && <ActivityIndicator />}
     </View>
   );
 };

--- a/packages/react-native-dogfood/src/components/Ringing/Ringing.tsx
+++ b/packages/react-native-dogfood/src/components/Ringing/Ringing.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import {
-  ActivityIndicator,
   Button,
   Pressable,
   SafeAreaView,
@@ -82,10 +81,11 @@ const styles = StyleSheet.create({
   },
 });
 
-type Props = NativeStackScreenProps<RootStackParamList, 'HomeScreen'>;
+type Props = NativeStackScreenProps<RootStackParamList, 'HomeScreen'> & {
+  setLoadingCall: (loading: boolean) => void;
+};
 
-const Ringing = ({ navigation }: Props) => {
-  const [loading, setLoading] = useState(false);
+const Ringing = ({ navigation, setLoadingCall }: Props) => {
   const [ringingUserIdsText, setRingingUserIdsText] = useState<string>('');
   const videoClient = useStreamVideoClient();
   const localMediaStream = useAppGlobalStoreValue(
@@ -112,7 +112,7 @@ const Ringing = ({ navigation }: Props) => {
   const setState = useAppGlobalStoreSetState();
 
   const startCallHandler = async () => {
-    setLoading(true);
+    setLoadingCall(true);
     if (videoClient && localMediaStream) {
       try {
         const callID = uuidv4().toLowerCase();
@@ -136,7 +136,7 @@ const Ringing = ({ navigation }: Props) => {
           callId: callID,
           callType: 'default',
         }).then(() => {
-          setLoading(false);
+          setLoadingCall(false);
         });
       } catch (err) {
         console.log(err);
@@ -199,7 +199,6 @@ const Ringing = ({ navigation }: Props) => {
         title="Start a Call"
         onPress={startCallHandler}
       />
-      {loading && <ActivityIndicator />}
     </SafeAreaView>
   );
 };

--- a/packages/react-native-dogfood/src/screens/HomeScreen.tsx
+++ b/packages/react-native-dogfood/src/screens/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 import { TabBar } from '../components/TabBar';
 import Meeting from '../components/Meeting/Meeting';
 import Ringing from '../components/Ringing/Ringing';
@@ -17,6 +17,17 @@ import {
 const styles = StyleSheet.create({
   container: {
     marginTop: 20,
+    flex: 1,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: {
+    marginTop: 16,
+    fontSize: 20,
+    fontWeight: 'bold',
   },
 });
 
@@ -24,6 +35,7 @@ type Props = NativeStackScreenProps<RootStackParamList, 'HomeScreen'>;
 
 export const HomeScreen = ({ navigation, route }: Props) => {
   const [selectedTab, setSelectedTab] = useState('Meeting');
+  const [loadingCall, setLoadingCall] = useState(false);
 
   const activeRingCallMeta = useActiveRingCall();
   const incomingRingCalls = useIncomingRingCalls();
@@ -69,11 +81,28 @@ export const HomeScreen = ({ navigation, route }: Props) => {
 
   return (
     <View style={styles.container}>
-      <TabBar selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
-      {selectedTab === 'Meeting' ? (
-        <Meeting navigation={navigation} route={route} />
+      {loadingCall ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size={'large'} />
+          <Text style={styles.loadingText}>Calling...</Text>
+        </View>
       ) : (
-        <Ringing navigation={navigation} route={route} />
+        <>
+          <TabBar selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
+          {selectedTab === 'Meeting' ? (
+            <Meeting
+              navigation={navigation}
+              route={route}
+              setLoadingCall={setLoadingCall}
+            />
+          ) : (
+            <Ringing
+              navigation={navigation}
+              route={route}
+              setLoadingCall={setLoadingCall}
+            />
+          )}
+        </>
       )}
     </View>
   );


### PR DESCRIPTION
* useCall hook was removed in https://github.com/GetStream/stream-video-js/pull/74 this broke the pronto deeplink support. This is fixed in this PR
* additionally added a common loader for meeting and ringing