### PR TITLE
chore: ignore unknown json fields

### DIFF
--- a/packages/client/src/rpc/createClient.ts
+++ b/packages/client/src/rpc/createClient.ts
@@ -15,6 +15,9 @@ import { SignalServerClient } from '../gen/video/sfu/signal_rpc/signal.client';
 const defaultOptions: TwirpOptions = {
   baseUrl: '',
   sendJson: true,
+  jsonOptions: {
+    ignoreUnknownFields: true,
+  },
 };
 
 export const withHeaders = (


### PR DESCRIPTION
Otherwise not possible to iterate in the server without breaking clients.