### PR TITLE
fix: switch to WebRTC based latency measurement

### DIFF
--- a/packages/angular-sdk/projects/video-angular-sdk/src/lib/call-statistics/call-statistics.component.ts
+++ b/packages/angular-sdk/projects/video-angular-sdk/src/lib/call-statistics/call-statistics.component.ts
@@ -46,7 +46,10 @@ export class CallStatisticsComponent implements OnInit, OnDestroy {
         .pipe(pairwise())
         .subscribe(([prevReport, report]) => {
           this.datacenter = report?.datacenter;
-          this.latencyInMs = this.toStringWithUnit(report?.latencyInMs, 'ms');
+          this.latencyInMs = this.toStringWithUnit(
+            report?.publisherStats.averageRoundTripTimeInMs,
+            'ms',
+          );
           this.jitter = this.toStringWithUnit(
             report?.subscriberStats?.averageJitterInMs,
             'ms',
@@ -80,7 +83,9 @@ export class CallStatisticsComponent implements OnInit, OnDestroy {
               new Date(report.timestamp).toLocaleTimeString(),
             );
             this.lineChartData.datasets[0].data.shift();
-            this.lineChartData.datasets[0].data.push(report.latencyInMs);
+            this.lineChartData.datasets[0].data.push(
+              report.publisherStats.averageRoundTripTimeInMs,
+            );
             this.chart?.update();
           }
         }),

--- a/packages/client/src/stats/types.ts
+++ b/packages/client/src/stats/types.ts
@@ -2,6 +2,7 @@ export type BaseStats = {
   bytesSent?: number;
   bytesReceived?: number;
   codec?: string;
+  currentRoundTripTime?: number;
   frameWidth?: number;
   frameHeight?: number;
   framesPerSecond?: number;
@@ -22,6 +23,7 @@ export type AggregatedStatsReport = {
   totalBytesSent: number;
   totalBytesReceived: number;
   averageJitterInMs: number;
+  averageRoundTripTimeInMs: number;
   qualityLimitationReasons: string;
   highestFrameWidth: number;
   highestFrameHeight: number;
@@ -35,7 +37,6 @@ export type ParticipantsStatsReport = {
 
 export type CallStatsReport = {
   datacenter: string;
-  latencyInMs: number;
   publisherStats: AggregatedStatsReport;
   publisherRawStats?: RTCStatsReport;
   subscriberStats: AggregatedStatsReport;

--- a/packages/react-sdk/src/components/StreamCall/CallControls.tsx
+++ b/packages/react-sdk/src/components/StreamCall/CallControls.tsx
@@ -149,7 +149,7 @@ export const CallControls = (props: {
               await call.publishScreenShareStream(stream);
             }
           } else {
-            call.stopPublish(SfuModels.TrackType.SCREEN_SHARE);
+            await call.stopPublish(SfuModels.TrackType.SCREEN_SHARE);
           }
         }}
       />
@@ -159,7 +159,7 @@ export const CallControls = (props: {
           if (isAudioMute) {
             void publishAudioStream();
           } else {
-            call.stopPublish(SfuModels.TrackType.AUDIO);
+            void call.stopPublish(SfuModels.TrackType.AUDIO);
           }
         }}
       />
@@ -169,7 +169,7 @@ export const CallControls = (props: {
           if (isVideoMute) {
             void publishVideoStream();
           } else {
-            call.stopPublish(SfuModels.TrackType.VIDEO);
+            void call.stopPublish(SfuModels.TrackType.VIDEO);
           }
         }}
       />

--- a/packages/react-sdk/src/components/StreamCall/CallStats.tsx
+++ b/packages/react-sdk/src/components/StreamCall/CallStats.tsx
@@ -59,7 +59,7 @@ export const CallStats = (props: {
       const newLatencyBuffer = latencyBuffer.slice(-19);
       newLatencyBuffer.push({
         x: callStatsReport.timestamp,
-        y: callStatsReport.latencyInMs,
+        y: callStatsReport.publisherStats.averageRoundTripTimeInMs,
       });
       return newLatencyBuffer;
     });
@@ -90,7 +90,7 @@ export const CallStats = (props: {
             <StatCard label="Region" value={callStatsReport.datacenter} />
             <StatCard
               label="Latency"
-              value={`${callStatsReport.latencyInMs} ms.`}
+              value={`${callStatsReport.publisherStats.averageRoundTripTimeInMs} ms.`}
             />
             <StatCard
               label="Jitter"


### PR DESCRIPTION
### Overview
Call latency is now determined by the values reported by WebRTC stats. 

The previous way of measuring the latency was imprecise as it measured how long it takes a single 1KB image to be downloaded from the data center that hosts the SFU we are connected to.