### PR TITLE
fix(client): remove keepAlive optimization

### DIFF
--- a/packages/client/src/ws/StreamWebSocketClient.ts
+++ b/packages/client/src/ws/StreamWebSocketClient.ts
@@ -36,7 +36,7 @@ export class StreamWebSocketClient implements StreamWSClient {
 
     this.keepAlive = keepAlive(
       this,
-      20 * 1000, // in seconds
+      30 * 1000, // in seconds
     );
   }
 
@@ -58,6 +58,8 @@ export class StreamWebSocketClient implements StreamWSClient {
         }),
       );
       this.off('healthcheck', catchOneHealthcheckMessage);
+      // schedule pinging once the payload is set
+      this.keepAlive.schedulePing();
     };
     this.on('healthcheck', catchOneHealthcheckMessage);
 
@@ -69,7 +71,6 @@ export class StreamWebSocketClient implements StreamWSClient {
 
     this.ws = await createCoordinatorWebSocket(this.endpoint, authRequest, {
       onMessage: (message: WebsocketEvent) => {
-        this.keepAlive.schedulePing();
         this.dispatchMessage(message);
       },
 

--- a/packages/client/src/ws/keepAlive.ts
+++ b/packages/client/src/ws/keepAlive.ts
@@ -1,15 +1,6 @@
 import type { StreamWSClient } from './types';
 
-export interface KeepAlive {
-  cancelPendingPing: () => void;
-  schedulePing: () => void;
-  setPayload: (payload: Uint8Array) => void;
-}
-
-export const keepAlive = (
-  client: StreamWSClient,
-  timeThreshold: number,
-): KeepAlive => {
+export const keepAlive = (client: StreamWSClient, timeThreshold: number) => {
   let timeoutId: NodeJS.Timeout;
   let data: Uint8Array;
   return {
@@ -29,3 +20,5 @@ export const keepAlive = (
     },
   };
 };
+
+export type KeepAlive = ReturnType<typeof keepAlive>;


### PR DESCRIPTION
Coordinator WS expects a healthcheck ping every 40 seconds otherwise it closes the connection. Previous optimization would postpone healthcheck ping each time the message was either sent or received. The interval was increased to 30 seconds.