### PR TITLE
chore: remove latency-measurement leftovers

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -229,7 +229,6 @@ export class StreamVideoClient {
       }
       if (edge.credentials && edge.credentials.server) {
         const edgeName = edge.credentials.server.edgeName;
-        const selectedEdge = response.edges.find((e) => e.name === edgeName);
         const { server, iceServers, token } = edge.credentials;
         const sfuClient = new StreamSfuClient(server.url, token, sessionId);
         this.writeableStateStore.setCurrentValue(
@@ -246,7 +245,6 @@ export class StreamVideoClient {
           sfuClient,
           {
             connectionConfig: this.toRtcConfiguration(iceServers),
-            latencyCheckUrl: selectedEdge?.latencyUrl,
             edgeName,
           },
           this.writeableStateStore,

--- a/packages/client/src/rtc/Call.ts
+++ b/packages/client/src/rtc/Call.ts
@@ -69,7 +69,6 @@ export class Call {
       subscriber: this.subscriber,
       publisher: this.publisher,
       store: stateStore,
-      latencyCheckUrl: this.options.latencyCheckUrl,
       edgeName: this.options.edgeName,
     });
 

--- a/packages/client/src/rtc/types.ts
+++ b/packages/client/src/rtc/types.ts
@@ -94,7 +94,6 @@ export type SubscriptionChanges = {
 
 export type CallOptions = {
   connectionConfig?: RTCConfiguration;
-  latencyCheckUrl?: string;
   edgeName?: string;
 };
 

--- a/packages/client/src/stats/state-store-stats-reporter.ts
+++ b/packages/client/src/stats/state-store-stats-reporter.ts
@@ -12,7 +12,6 @@ export type StatsReporterOpts = {
   publisher: RTCPeerConnection;
   store: StreamVideoWriteableStateStore;
   pollingIntervalInMs?: number;
-  latencyCheckUrl?: string;
   edgeName?: string;
 };
 
@@ -67,7 +66,6 @@ export const createStatsReporter = ({
   subscriber,
   publisher,
   store,
-  latencyCheckUrl,
   edgeName,
   pollingIntervalInMs = 2000,
 }: StatsReporterOpts): StatsReporter => {


### PR DESCRIPTION
Recently the ping-based latency measurement was replaced with a WebRTC-based solution. However, the code hasn't been adequately cleaned up. This PR removes the unused config and props.