### PR TITLE
chore: instructions for setting up Sentry in the RN Dogfooding app

### DIFF
--- a/packages/react-native-dogfood/README.md
+++ b/packages/react-native-dogfood/README.md
@@ -8,7 +8,7 @@
 4. Move to `cd packages/react-native-dogfood/`
 5. Run `npx pod-install` to install pods (ios only)
 6. Follow [this guide](https://www.notion.so/stream-wiki/Video-dogfood-app-8fd4b72b2ac9495eb55872f5a70b5f6d) and setup Sentry error tracking (or: `SENTRY_RN_AUTH_TOKEN=<your-token> ./scripts/create-sentry-properties.sh`)
-8. Run `yarn ios` and/or `yarn android` to run the app
+7. Run `yarn ios` and/or `yarn android` to run the app
 
 ## Invite links to install app on devices
 


### PR DESCRIPTION
The step for configuring Sentry was missing in the ReadMe file. This PR adds the necessary instructions.