### PR TITLE
refactor(client): move stateStore.ts to its parent folder

### DIFF
--- a/packages/client/src/events/call.ts
+++ b/packages/client/src/events/call.ts
@@ -4,7 +4,7 @@ import {
   CallCreated,
   CallRejected,
 } from '../gen/video/coordinator/event_v1/event';
-import { StreamVideoWriteableStateStore } from '../stateStore';
+import { StreamVideoWriteableStateStore } from '../store';
 import { StreamEventListener } from '../ws';
 
 /**

--- a/packages/client/src/events/internal.ts
+++ b/packages/client/src/events/internal.ts
@@ -1,6 +1,6 @@
 import { Dispatcher } from '../rtc/Dispatcher';
 import { Call } from '../rtc/Call';
-import { StreamVideoWriteableStateStore } from '../stateStore';
+import { StreamVideoWriteableStateStore } from '../store';
 import { StreamVideoParticipantPatches } from '../rtc/types';
 
 /**

--- a/packages/client/src/events/speaker.ts
+++ b/packages/client/src/events/speaker.ts
@@ -1,5 +1,5 @@
 import { Dispatcher } from '../rtc/Dispatcher';
-import { StreamVideoWriteableStateStore } from '../stateStore';
+import { StreamVideoWriteableStateStore } from '../store';
 import { StreamVideoParticipantPatches } from '../rtc/types';
 
 /**

--- a/packages/client/src/rtc/Call.ts
+++ b/packages/client/src/rtc/Call.ts
@@ -5,7 +5,7 @@ import { getGenericSdp } from './codecs';
 import { CallState, TrackType } from '../gen/video/sfu/models/models';
 import { registerEventHandlers } from './callEventHandlers';
 import { SfuEventListener } from './Dispatcher';
-import { StreamVideoWriteableStateStore } from '../stateStore';
+import { StreamVideoWriteableStateStore } from '../store';
 import { trackTypeToParticipantStreamKey } from './helpers/tracks';
 import type {
   CallOptions,

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,2 +1,2 @@
 export * as RxUtils from './rxUtils';
-export * from '../stateStore';
+export * from './stateStore';

--- a/packages/client/src/store/stateStore.ts
+++ b/packages/client/src/store/stateStore.ts
@@ -1,18 +1,18 @@
 import { BehaviorSubject, Observable, ReplaySubject } from 'rxjs';
 import { combineLatestWith, distinctUntilChanged, map } from 'rxjs/operators';
-import { RxUtils } from './store';
-import { UserInput } from './gen/video/coordinator/user_v1/user';
-import { Call, CallDetails } from './gen/video/coordinator/call_v1/call';
-import { CallAccepted } from './gen/video/coordinator/event_v1/event';
+import * as RxUtils from './rxUtils';
+import { UserInput } from '../gen/video/coordinator/user_v1/user';
+import { Call, CallDetails } from '../gen/video/coordinator/call_v1/call';
+import { CallAccepted } from '../gen/video/coordinator/event_v1/event';
 import {
   StreamVideoLocalParticipant,
   StreamVideoParticipant,
   StreamVideoParticipantPatch,
   StreamVideoParticipantPatches,
-} from './rtc/types';
-import { CallStatsReport } from './stats/types';
-import { Call as CallController } from './rtc/Call';
-import { TrackType } from './gen/video/sfu/models/models';
+} from '../rtc/types';
+import { CallStatsReport } from '../stats/types';
+import { Call as CallController } from '../rtc/Call';
+import { TrackType } from '../gen/video/sfu/models/models';
 
 export type PendingCall = {
   call?: Call;


### PR DESCRIPTION
## Goal

Tidy up the folder structure && prevent circular imports.