### PR TITLE
fix: catch stat reporting errors

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -116,8 +116,14 @@ export class StreamVideoClient {
 
     reportStats(
       this.readOnlyStateStore,
-      (e) => this.reportCallStats(e),
-      (e) => this.reportCallStatEvent(e),
+      (e) =>
+        this.reportCallStats(e).catch((err) => {
+          console.error('Failed to report stats', err);
+        }),
+      (e) =>
+        this.reportCallStatEvent(e).catch((err) => {
+          console.error('Failed to report stats', err);
+        }),
     );
   }
 


### PR DESCRIPTION
### Overview
There are some rate limiters in place on the coordinator side which are sometimes activated for our stat reporting mechanism. Hitting a rate limit results in a rejected RPC call which isn't handled by the client.
This PR adds a bare-minimum error handling for this scenario.