### PR TITLE
fix(react-sdk): lift enumeration trigger to props

### DIFF
--- a/packages/react-sdk/src/components/StreamCall/StreamCall.tsx
+++ b/packages/react-sdk/src/components/StreamCall/StreamCall.tsx
@@ -39,5 +39,9 @@ export const StreamCall = ({ children }: { children: ReactNode }) => {
 
   if (!videoClient) return null;
 
-  return <MediaDevicesProvider>{children}</MediaDevicesProvider>;
+  return (
+    <MediaDevicesProvider enumerate={!!activeCall}>
+      {children}
+    </MediaDevicesProvider>
+  );
 };

--- a/packages/react-sdk/src/components/StreamMeeting/StreamMeeting.tsx
+++ b/packages/react-sdk/src/components/StreamMeeting/StreamMeeting.tsx
@@ -1,6 +1,9 @@
 import { PropsWithChildren, useEffect } from 'react';
 import { CreateCallInput } from '@stream-io/video-client';
-import { useStreamVideoClient } from '@stream-io/video-react-bindings';
+import {
+  useActiveCall,
+  useStreamVideoClient,
+} from '@stream-io/video-react-bindings';
 import { MediaDevicesProvider } from '../../contexts';
 
 export type StreamMeetingProps = {
@@ -18,6 +21,7 @@ export const StreamMeeting = ({
   input,
 }: PropsWithChildren<StreamMeetingProps>) => {
   const client = useStreamVideoClient();
+  const activeCall = useActiveCall();
 
   useEffect(() => {
     if (!client) return;
@@ -44,5 +48,9 @@ export const StreamMeeting = ({
     });
   }, [callId, client, callType, currentUser, input]);
 
-  return <MediaDevicesProvider>{children}</MediaDevicesProvider>;
+  return (
+    <MediaDevicesProvider enumerate={!!activeCall}>
+      {children}
+    </MediaDevicesProvider>
+  );
 };

--- a/packages/react-sdk/src/contexts/MediaDevicesContext.tsx
+++ b/packages/react-sdk/src/contexts/MediaDevicesContext.tsx
@@ -14,7 +14,6 @@ import {
   getAudioOutputDevices,
   checkIfAudioOutputChangeSupported,
 } from '@stream-io/video-client';
-import { useActiveCall } from '@stream-io/video-react-bindings';
 
 export type MediaDevicesContextAPI = {
   audioDevices: MediaDeviceInfo[];
@@ -30,7 +29,14 @@ export type MediaDevicesContextAPI = {
 
 const MediaDevicesContext = createContext<MediaDevicesContextAPI | null>(null);
 
-export const MediaDevicesProvider = (props: PropsWithChildren<{}>) => {
+export type MediaDevicesProviderProps = PropsWithChildren<{
+  enumerate?: boolean;
+}>;
+
+export const MediaDevicesProvider = ({
+  children,
+  enumerate = true,
+}: MediaDevicesProviderProps) => {
   const [audioDevices, setAudioDevices] = useState<MediaDeviceInfo[]>([]);
   const [videoDevices, setVideoDevices] = useState<MediaDeviceInfo[]>([]);
   const [selectedAudioDeviceId, selectAudioDeviceId] =
@@ -43,8 +49,6 @@ export const MediaDevicesProvider = (props: PropsWithChildren<{}>) => {
   const [isAudioOutputChangeSupported] = useState<boolean>(() =>
     checkIfAudioOutputChangeSupported(),
   );
-
-  const activeCall = useActiveCall();
 
   const switchDevice = useCallback(
     async (kind: 'videoinput' | 'audioinput', deviceId?: string) => {
@@ -59,25 +63,27 @@ export const MediaDevicesProvider = (props: PropsWithChildren<{}>) => {
   );
 
   useEffect(() => {
-    if (!activeCall) return;
+    if (!enumerate) return;
 
     const subscription = getAudioDevices().subscribe(setAudioDevices);
     return () => subscription.unsubscribe();
-  }, [activeCall]);
+  }, [enumerate]);
 
   useEffect(() => {
-    if (!activeCall) return;
+    if (!enumerate) return;
+
     const subscription = getVideoDevices().subscribe(setVideoDevices);
     return () => subscription.unsubscribe();
-  }, [activeCall]);
+  }, [enumerate]);
 
   useEffect(() => {
-    if (!activeCall) return;
+    if (!enumerate) return;
+
     const subscription = getAudioOutputDevices().subscribe(
       setAudioOutputDevices,
     );
     return () => subscription.unsubscribe();
-  }, [activeCall]);
+  }, [enumerate]);
 
   const contextValue = {
     audioDevices,
@@ -93,7 +99,7 @@ export const MediaDevicesProvider = (props: PropsWithChildren<{}>) => {
 
   return (
     <MediaDevicesContext.Provider value={contextValue}>
-      {props.children}
+      {children}
     </MediaDevicesContext.Provider>
   );
 };


### PR DESCRIPTION
Lift enumeration trigger to props so users can decide when to trigger device enumeration - useful for preview-like components.