### PR TITLE
fix: don't attempt joining the call twice

### DIFF
--- a/packages/egress-composite/src/main.ts
+++ b/packages/egress-composite/src/main.ts
@@ -59,7 +59,7 @@ import './style.css';
     throw new Error(`Failed to join a call with id: ${callId}`);
   }
 
-  await call.join();
+  // await call.join();
   console.log('Connection is established.');
 
   store$.dominantSpeaker$.subscribe((dominantSpeaker) => {


### PR DESCRIPTION
Due to the double invocation of `call.join()` an error was thrown which interrupts the normal execution of the Egress Composite app.