### PR TITLE
fix(recording): toggle loading state indicator on WS events

### DIFF
--- a/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Call } from '@stream-io/video-client';
 import {
   useIsCallRecordingInProgress,
@@ -14,23 +14,41 @@ export type RecordCallButtonProps = {
 export const RecordCallButton = ({ call }: RecordCallButtonProps) => {
   const client = useStreamVideoClient();
   const isCallRecordingInProgress = useIsCallRecordingInProgress();
-  const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+  const [isAwaitingResponse, setIsAwaitingResponse] = useState(false);
+  useEffect(() => {
+    // we wait until call.recording_started/stopped event to flips the
+    // `isCallRecordingInProgress` state variable.
+    // Once the flip happens, we remove the loading indicator
+    setIsAwaitingResponse((isAwaiting) => {
+      if (isAwaiting) return false;
+      return isAwaiting;
+    });
+  }, [isCallRecordingInProgress]);
+
   const toggleRecording = useCallback(async () => {
     const { id, type } = call.data.call;
-    if (isCallRecordingInProgress) {
-      client?.stopRecording(id, type);
-    } else {
-      try {
-        setIsWaitingForResponse(true);
+    try {
+      setIsAwaitingResponse(true);
+      if (isCallRecordingInProgress) {
+        await client?.stopRecording(id, type);
+      } else {
         await client?.startRecording(id, type);
-      } finally {
-        setIsWaitingForResponse(false);
       }
+    } catch (e) {
+      console.error(`Failed start recording`, e);
     }
   }, [call.data.call, client, isCallRecordingInProgress]);
 
-  if (isWaitingForResponse) {
-    return <LoadingIndicator tooltip="Waiting for recording to start..." />;
+  if (isAwaitingResponse) {
+    return (
+      <LoadingIndicator
+        tooltip={
+          isCallRecordingInProgress
+            ? 'Waiting for recording to stop... '
+            : 'Waiting for recording to start...'
+        }
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
### Overview

In order to prevent "high-latency" responses, the backend will now immediately respond with OK/NOK when triggering call recording.
However, the backend will delay the delivery of `call.recording_started` or `call.recording_stopped` until the system is ready.
With this PR, the loading indicator of `RecordCallButton` is liked to the delivery of the above-mentioned events.