### PR TITLE
fix: using changed event names

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -445,31 +445,6 @@ export class StreamVideoClient {
     return this.coordinatorClient.updateUserPermissions(callId, callType, data);
   };
 
-  /**
-   * Reports call WebRTC metrics to coordinator API
-   * @param stats
-   * @returns
-   */
-  private reportCallStats = async (stats: Object) => {
-    const callMetadata = this.writeableStateStore.getCurrentValue(
-      this.writeableStateStore.activeCallSubject,
-    )?.data;
-
-    if (!callMetadata) {
-      console.log("There isn't an active call");
-      return;
-    }
-    const request = {
-      callCid: callMetadata.call.cid,
-      statsJson: new TextEncoder().encode(JSON.stringify(stats)),
-    };
-    await this.coordinatorClient.reportCallStats(
-      callMetadata.call.id,
-      callMetadata.call.type,
-      request,
-    );
-  };
-
   private getCallEdgeServer = async (
     id: string,
     type: string,
@@ -499,34 +474,6 @@ export class StreamVideoClient {
       })),
     };
     return rtcConfig;
-  };
-
-  /**
-   * Reports call events (for example local participant muted themselves) to the coordinator API
-   * @param statEvent
-   * @returns
-   */
-  private reportCallStatEvent = async (
-    statEvent: ReportCallStatEventRequest['event'],
-  ) => {
-    const callMetadata = this.writeableStateStore.getCurrentValue(
-      this.writeableStateStore.activeCallSubject,
-    )?.data;
-    if (!callMetadata) {
-      console.log("There isn't an active call");
-      return;
-    }
-
-    const request = {
-      callCid: callMetadata.call.cid,
-      timestamp: Timestamp.fromDate(new Date()),
-      event: statEvent,
-    };
-    await this.coordinatorClient.reportCallStatEvent(
-      callMetadata.call.id,
-      callMetadata.call.type,
-      request,
-    );
   };
 
   /**

--- a/packages/client/src/events/call-permissions.ts
+++ b/packages/client/src/events/call-permissions.ts
@@ -1,6 +1,6 @@
 import {
-  CallPermissionRequest,
-  CallPermissionsUpdated,
+  PermissionRequestEvent,
+  UpdatedCallPermissionsEvent,
 } from '../gen/coordinator';
 import { StreamVideoWriteableStateStore } from '../store';
 
@@ -11,7 +11,7 @@ import { StreamVideoWriteableStateStore } from '../store';
 export const watchCallPermissionRequest = (
   store: StreamVideoWriteableStateStore,
 ) => {
-  return function onCallPermissionRequest(event: CallPermissionRequest) {
+  return function onCallPermissionRequest(event: PermissionRequestEvent) {
     const activeCall = store.getCurrentValue(store.activeCallSubject);
 
     if (!activeCall) {
@@ -53,7 +53,7 @@ export const watchCallPermissionRequest = (
 export const watchCallPermissionsUpdated = (
   store: StreamVideoWriteableStateStore,
 ) => {
-  return function onCallPermissionsUpdated(event: CallPermissionsUpdated) {
+  return function onCallPermissionsUpdated(event: UpdatedCallPermissionsEvent) {
     console.warn(event);
     const activeCall = store.getCurrentValue(store.activeCallSubject);
 

--- a/packages/client/src/events/call.ts
+++ b/packages/client/src/events/call.ts
@@ -1,9 +1,9 @@
 import { StreamVideoWriteableStateStore } from '../store';
 import {
-  CallAccepted,
-  CallCancelled,
-  CallCreated,
-  CallRejected,
+  CallAcceptedEvent,
+  CallCancelledEvent,
+  CallCreatedEvent,
+  CallRejectedEvent,
 } from '../gen/coordinator';
 import { CallMetadata } from '../rtc/CallMetadata';
 
@@ -13,16 +13,16 @@ import { CallMetadata } from '../rtc/CallMetadata';
  * a new pending call has been initiated.
  */
 export const watchCallCreated = (store: StreamVideoWriteableStateStore) => {
-  return function onCallCreated(event: CallCreated) {
+  return function onCallCreated(event: CallCreatedEvent) {
     const { call, members } = event;
     if (!call) {
-      console.warn("Can't find call in CallCreated event");
+      console.warn("Can't find call in CallCreatedEvent");
       return;
     }
 
     const currentUser = store.getCurrentValue(store.connectedUserSubject);
     if (currentUser?.id === call.created_by.id) {
-      console.warn('Received CallCreated event sent by the current user');
+      console.warn('Received CallCreatedEvent sent by the current user');
       return;
     }
 
@@ -34,15 +34,15 @@ export const watchCallCreated = (store: StreamVideoWriteableStateStore) => {
 };
 
 /**
- * Event handler that watched the delivery of CallAccepted Websocket event
+ * Event handler that watched the delivery of CallAcceptedEvent
  * Updates the state store and notifies its subscribers that
  * the given user will be joining the call.
  */
 export const watchCallAccepted = (store: StreamVideoWriteableStateStore) => {
-  return function onCallAccepted(event: CallAccepted) {
+  return function onCallAccepted(event: CallAcceptedEvent) {
     const { call_cid } = event;
     if (!call_cid) {
-      console.warn("Can't find call_cid in CallAccepted event");
+      console.warn("Can't find call_cid in CallAcceptedEvent");
       return;
     }
 
@@ -51,7 +51,7 @@ export const watchCallAccepted = (store: StreamVideoWriteableStateStore) => {
       .find((incomingCall) => incomingCall.call.cid === call_cid);
 
     if (acceptedIncomingCall) {
-      console.warn('Received CallAccepted event for an incoming call');
+      console.warn('Received CallAcceptedEvent for an incoming call');
       return;
     }
 
@@ -69,7 +69,7 @@ export const watchCallAccepted = (store: StreamVideoWriteableStateStore) => {
 
     if (!acceptedOutgoingCall && !acceptedActiveCall) {
       console.warn(
-        `CallAccepted event received for a non-existent outgoing call (CID: ${call_cid}`,
+        `CallAcceptedEvent received for a non-existent outgoing call (CID: ${call_cid}`,
       );
       return;
     }
@@ -89,10 +89,10 @@ export const watchCallAccepted = (store: StreamVideoWriteableStateStore) => {
  * the given user will not be joining the call.
  */
 export const watchCallRejected = (store: StreamVideoWriteableStateStore) => {
-  return function onCallRejected(event: CallRejected) {
+  return function onCallRejected(event: CallRejectedEvent) {
     const { call_cid } = event;
     if (!call_cid) {
-      console.warn("Can't find call_cid in CallRejected event");
+      console.warn("Can't find call_cid in CallRejectedEvent");
       return;
     }
 
@@ -101,7 +101,7 @@ export const watchCallRejected = (store: StreamVideoWriteableStateStore) => {
       .find((incomingCall) => incomingCall.call.cid === call_cid);
 
     if (rejectedIncomingCall) {
-      console.warn('Received CallRejected event for an incoming call');
+      console.warn('Received CallRejectedEvent for an incoming call');
       return;
     }
 
@@ -117,7 +117,7 @@ export const watchCallRejected = (store: StreamVideoWriteableStateStore) => {
 
     if (!rejectedOutgoingCall && !rejectedActiveCall) {
       console.warn(
-        `CallRejected event received for a non-existent outgoing call (CID: ${call_cid}`,
+        `CallRejectedEvent received for a non-existent outgoing call (CID: ${call_cid}`,
       );
       return;
     }
@@ -129,15 +129,15 @@ export const watchCallRejected = (store: StreamVideoWriteableStateStore) => {
 };
 
 /**
- * Event handler that watches the delivery of CallCancelled Websocket event
+ * Event handler that watches the delivery of CallCancelledEvent
  * Updates the state store and notifies its subscribers that
  * the call is now considered terminated.
  */
 export const watchCallCancelled = (store: StreamVideoWriteableStateStore) => {
-  return function onCallCancelled(event: CallCancelled) {
+  return function onCallCancelled(event: CallCancelledEvent) {
     const { call_cid } = event;
     if (!call_cid) {
-      console.log("Can't find call in CallCancelled event");
+      console.log("Can't find call in CallCancelledEvent");
       return;
     }
 
@@ -154,7 +154,7 @@ export const watchCallCancelled = (store: StreamVideoWriteableStateStore) => {
 
     if (!cancelledIncomingCall && !cancelledActiveCall) {
       console.warn(
-        `CallCancelled event received for a non-existent incoming call (CID: ${call_cid}`,
+        `CallCancelledEvent received for a non-existent incoming call (CID: ${call_cid}`,
       );
       return;
     }

--- a/packages/client/src/events/recording.ts
+++ b/packages/client/src/events/recording.ts
@@ -1,5 +1,8 @@
 import { StreamVideoWriteableStateStore } from '../store';
-import { CallRecordingStarted, CallRecordingStopped } from '../gen/coordinator';
+import {
+  CallRecordingStartedEvent,
+  CallRecordingStoppedEvent,
+} from '../gen/coordinator';
 
 /**
  * Watches for `call.recording_started` events.
@@ -7,11 +10,11 @@ import { CallRecordingStarted, CallRecordingStopped } from '../gen/coordinator';
 export const watchCallRecordingStarted = (
   store: StreamVideoWriteableStateStore,
 ) => {
-  return function onCallRecordingStarted(event: CallRecordingStarted) {
+  return function onCallRecordingStarted(event: CallRecordingStartedEvent) {
     const { call_cid } = event;
     const activeCall = store.getCurrentValue(store.activeCallSubject);
     if (!activeCall || activeCall.data.call.cid !== call_cid) {
-      console.warn('Received CallRecordingStarted event for a non-active call');
+      console.warn('Received CallRecordingStartedEvent for a non-active call');
       return;
     }
     store.setCurrentValue(store.callRecordingInProgressSubject, true);
@@ -24,11 +27,11 @@ export const watchCallRecordingStarted = (
 export const watchCallRecordingStopped = (
   store: StreamVideoWriteableStateStore,
 ) => {
-  return function onCallRecordingStopped(event: CallRecordingStopped) {
+  return function onCallRecordingStopped(event: CallRecordingStoppedEvent) {
     const { call_cid } = event;
     const activeCall = store.getCurrentValue(store.activeCallSubject);
     if (!activeCall || activeCall.data.call.cid !== call_cid) {
-      console.warn('Received CallRecordingStopped event for a non-active call');
+      console.warn('Received CallRecordingStoppedEvent for a non-active call');
       return;
     }
     store.setCurrentValue(store.callRecordingInProgressSubject, false);

--- a/packages/client/src/store/stateStore.ts
+++ b/packages/client/src/store/stateStore.ts
@@ -13,7 +13,10 @@ import type {
 import { isStreamVideoLocalParticipant } from '../rtc/types';
 import type { CallStatsReport } from '../stats/types';
 import type { User } from '../coordinator/connection/types';
-import type { CallAccepted, CallPermissionRequest } from '../gen/coordinator';
+import type {
+  CallAcceptedEvent,
+  PermissionRequestEvent,
+} from '../gen/coordinator';
 
 export class StreamVideoWriteableStateStore {
   /**
@@ -37,7 +40,7 @@ export class StreamVideoWriteableStateStore {
    */
   // todo: Currently not updating this Subject
   // FIXME OL: what is the difference (from customer perspective) between "activeCall" and "acceptedCall"?
-  acceptedCallSubject = new BehaviorSubject<CallAccepted | undefined>(
+  acceptedCallSubject = new BehaviorSubject<CallAcceptedEvent | undefined>(
     undefined,
   );
   /**
@@ -77,7 +80,7 @@ export class StreamVideoWriteableStateStore {
   callRecordingInProgressSubject = new ReplaySubject<boolean>(1);
   hasOngoingScreenShare$: Observable<boolean>;
   callPermissionRequestSubject = new BehaviorSubject<
-    CallPermissionRequest | undefined
+    PermissionRequestEvent | undefined
   >(undefined);
 
   constructor() {
@@ -260,7 +263,7 @@ export class StreamVideoReadOnlyStateStore {
    * The call data describing an incoming call accepted by a participant.
    * Serves as a flag decide, whether an incoming call should be joined.
    */
-  acceptedCall$: Observable<CallAccepted | undefined>;
+  acceptedCall$: Observable<CallAcceptedEvent | undefined>;
   /**
    * The call controller instance representing the call the user attends.
    * The controller instance exposes call metadata as well.
@@ -316,7 +319,7 @@ export class StreamVideoReadOnlyStateStore {
   /**
    * Emits the latest call permission request sent by any participant of the active call. Or `undefined` if there is no active call or if the current user doesn't have the necessary permission to handle these events.
    */
-  callPermissionRequest$: Observable<CallPermissionRequest | undefined>;
+  callPermissionRequest$: Observable<PermissionRequestEvent | undefined>;
   /**
    * This method allows you the get the current value of a state variable.
    *


### PR DESCRIPTION
This PR aims to fix:
- Broken TS references throughout the client package as a result of this [PR](https://github.com/GetStream/stream-video-js/pull/271)
- Broken client docs generation. See [CI](https://github.com/GetStream/stream-video-js/actions/runs/4297376411/jobs/7490274278#step:6:8)
- Remove `reportCallStats` implem. usage
