### PR TITLE
feat(dev): support for externally provided SFU urls

### DIFF
--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -15,10 +15,17 @@ import { ICETrickle, TrackType } from './gen/video/sfu/models/models';
 
 const hostnameFromUrl = (url: string) => {
   try {
-    return new URL(url).hostname;
+    const u = new URL(url);
+    return {
+      hostname: u.hostname,
+      port: u.port,
+    };
   } catch (e) {
     console.warn(`Invalid URL. Can't extract hostname from it.`, e);
-    return url;
+    return {
+      hostname: url,
+      port: 3031,
+    };
   }
 };
 
@@ -54,9 +61,9 @@ export class StreamSfuClient {
     });
 
     // FIXME: OL: this should come from the coordinator API
-    const sfuHost = hostnameFromUrl(url);
-    let wsEndpoint = `ws://${sfuHost}:3031/ws`;
-    if (!['localhost', '127.0.0.1'].includes(sfuHost)) {
+    const { hostname, port } = hostnameFromUrl(url);
+    let wsEndpoint = `ws://${hostname}:${port}/ws`;
+    if (!['localhost', '127.0.0.1'].includes(hostname)) {
       const sfuUrl = toURL(url);
       if (sfuUrl) {
         sfuUrl.protocol = 'wss:';

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -323,7 +323,13 @@ export class StreamVideoClient {
         );
 
         const { server, ice_servers, token } = edge.credentials;
-        const sfuClient = new StreamSfuClient(server.url, token);
+        let sfuUrl = server.url;
+        if (typeof window !== 'undefined') {
+          const params = new URLSearchParams(window.location.search);
+          const sfuUrlParam = params.get('sfuUrl');
+          sfuUrl = sfuUrlParam || server.url;
+        }
+        const sfuClient = new StreamSfuClient(sfuUrl, token);
         const metadata = new CallMetadata(callMeta, members);
         const callOptions = {
           connectionConfig: this.toRtcConfiguration(ice_servers),


### PR DESCRIPTION
### Overview
This is a cherry-pick from #227 on top of latest `main`. Enables SFU URL overriding via a query parameter.