### PR TITLE
chore: remove unnecessary dependencies

### DIFF
--- a/packages/react-dogfood/components/CallHeaderTitle.tsx
+++ b/packages/react-dogfood/components/CallHeaderTitle.tsx
@@ -2,13 +2,14 @@ import {
   useActiveCall,
   useConnectedUser,
   useRemoteParticipants,
-} from '@stream-io/video-react-bindings';
+} from '@stream-io/video-react-sdk';
 import { useMemo } from 'react';
 import { HomeButton } from './LobbyHeader';
 
 type CallTitleProps = {
   title?: string;
 };
+
 export const CallHeaderTitle = ({ title }: CallTitleProps) => {
   const activeCall = useActiveCall();
   const connectedUser = useConnectedUser();

--- a/packages/react-dogfood/components/MeetingUI.tsx
+++ b/packages/react-dogfood/components/MeetingUI.tsx
@@ -2,10 +2,6 @@ import { useRouter } from 'next/router';
 import { useCallback, useEffect, useState } from 'react';
 import Gleap from 'gleap';
 import {
-  useActiveCall,
-  useStreamVideoClient,
-} from '@stream-io/video-react-bindings';
-import {
   CallParticipantsList,
   CallStatsButton,
   CancelCallButton,
@@ -22,6 +18,8 @@ import {
   ToggleAudioPublishingButton,
   ToggleCameraPublishingButton,
   ToggleParticipantListButton,
+  useActiveCall,
+  useStreamVideoClient,
 } from '@stream-io/video-react-sdk';
 import { IconInviteLinkButton, InviteLinkButton } from './InviteLinkButton';
 import { CallHeaderTitle } from './CallHeaderTitle';

--- a/packages/react-dogfood/package.json
+++ b/packages/react-dogfood/package.json
@@ -13,8 +13,6 @@
     "@mui/icons-material": "^5.10.16",
     "@mui/material": "^5.10.16",
     "@sentry/nextjs": "^7.22.0",
-    "@stream-io/video-client": "workspace:^",
-    "@stream-io/video-react-bindings": "workspace:^",
     "@stream-io/video-react-sdk": "workspace:^",
     "@stream-io/video-styling": "workspace:^",
     "clsx": "^1.2.1",

--- a/packages/react-dogfood/pages/api/call/create.ts
+++ b/packages/react-dogfood/pages/api/call/create.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { StreamVideoClient } from '@stream-io/video-client';
+import { StreamVideoClient } from '@stream-io/video-react-sdk';
 import yargs from 'yargs';
 import { meetingId } from '../../../lib/meetingId';
 import { createToken } from '../../../helpers/jwt';

--- a/packages/react-dogfood/pages/join/[callId].tsx
+++ b/packages/react-dogfood/pages/join/[callId].tsx
@@ -6,12 +6,13 @@ import { unstable_getServerSession } from 'next-auth';
 import { GetServerSidePropsContext } from 'next';
 import { createToken } from '../../helpers/jwt';
 import {
+  Call,
   MediaDevicesProvider,
   StreamVideo,
   useCreateStreamVideoClient,
+  User,
 } from '@stream-io/video-react-sdk';
 import Head from 'next/head';
-import { Call, User } from '@stream-io/video-client';
 
 import { useCreateStreamChatClient } from '../../hooks';
 import { LoadingScreen, MeetingUI } from '../../components';

--- a/packages/react-sample-app/package.json
+++ b/packages/react-sample-app/package.json
@@ -7,8 +7,6 @@
     "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.10.16",
     "@mui/material": "^5.10.16",
-    "@stream-io/video-client": "workspace:^",
-    "@stream-io/video-react-bindings": "workspace:^",
     "@stream-io/video-react-sdk": "workspace:^",
     "@stream-io/video-styling": "workspace:^",
     "react": "^18.2.0",

--- a/packages/react-sample-app/src/App.tsx
+++ b/packages/react-sample-app/src/App.tsx
@@ -5,11 +5,12 @@ import {
   CssBaseline,
   ThemeProvider,
 } from '@mui/material';
-import { GetOrCreateCallRequest, User } from '@stream-io/video-client';
 import {
+  GetOrCreateCallRequest,
   StreamMeeting,
   StreamVideo,
   useCreateStreamVideoClient,
+  User,
 } from '@stream-io/video-react-sdk';
 import { useEffect, useMemo, useState } from 'react';
 import { MeetingUI } from './components/MeetingUI';

--- a/packages/react-sample-app/src/components/MeetingUI.tsx
+++ b/packages/react-sample-app/src/components/MeetingUI.tsx
@@ -1,8 +1,8 @@
-import { useActiveCall } from '@stream-io/video-react-bindings';
 import {
   CallControls,
   DeviceSettings,
   Stage,
+  useActiveCall,
 } from '@stream-io/video-react-sdk';
 
 export const MeetingUI = () => {

--- a/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListing.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListing.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { ComponentProps, useState } from 'react';
+import { ComponentProps, ComponentType, useState } from 'react';
 import { SfuModels, StreamVideoParticipant } from '@stream-io/video-client';
 import { useConnectedUser } from '@stream-io/video-react-bindings';
 import { useEnterLeaveHandlers } from '../Tooltip/hooks';
@@ -75,7 +75,7 @@ type CallParticipantListingItemProps = {
   /** Participant object be rendered */
   participant: StreamVideoParticipant;
   /** Custom component used to display participant's name */
-  DisplayName?: React.ComponentType<{ participant: StreamVideoParticipant }>;
+  DisplayName?: ComponentType<{ participant: StreamVideoParticipant }>;
 };
 export const CallParticipantListingItem = ({
   participant,

--- a/packages/react-sdk/src/components/CallParticipantsList/CallParticipantsList.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/CallParticipantsList.tsx
@@ -25,11 +25,11 @@ type CallParticipantListProps = {
   /** Click event listener function to be invoked in order to dismiss / hide the CallParticipantsList from the UI */
   onClose: () => void;
   /** Custom component to render the list of participants. Used render participant search results as well. */
-  CallParticipantListing?: React.ComponentType<CallParticipantListingProps>;
+  CallParticipantListing?: ComponentType<CallParticipantListingProps>;
   /** Custom component to be rendered when search result is empty */
-  EmptyParticipantSearchResultComponent?: React.ComponentType;
+  EmptyParticipantSearchResultComponent?: ComponentType;
   /** Custom CallParticipantsList Header component */
-  Header?: React.ComponentType<CallParticipantListHeaderProps>;
+  Header?: ComponentType<CallParticipantListHeaderProps>;
   /** Custom component to replace a button for generating invitation link to the call */
   InviteLinkButton?: ComponentType<
     ComponentPropsWithRef<'button'> & { ref: ForwardedRef<HTMLButtonElement> }

--- a/packages/styling/src/CallParticipantList/CallParticiantListingItem-layout.scss
+++ b/packages/styling/src/CallParticipantList/CallParticiantListingItem-layout.scss
@@ -6,6 +6,7 @@
   gap: 0.75rem;
   padding-block: 0.5rem;
   width: 100%;
+  cursor: pointer;
 
   .str-video__participant-listing-item__display-name {
     @include utils.ellipsis-text();

--- a/sample-apps/react/messenger-clone/package.json
+++ b/sample-apps/react/messenger-clone/package.json
@@ -12,8 +12,6 @@
   },
   "dependencies": {
     "@mui/icons-material": "^5.10.16",
-    "@stream-io/video-client": "workspace:^",
-    "@stream-io/video-react-bindings": "workspace:^",
     "@stream-io/video-react-sdk": "workspace:^",
     "@stream-io/video-styling": "workspace:^",
     "clsx": "^1.2.1",

--- a/sample-apps/react/messenger-clone/src/components/ChannelHeader/ChannelHeader.tsx
+++ b/sample-apps/react/messenger-clone/src/components/ChannelHeader/ChannelHeader.tsx
@@ -6,15 +6,15 @@ import {
   useChatContext,
   useTranslationContext,
 } from 'stream-chat-react';
-import { MemberRequest } from '@stream-io/video-client';
 import { LocalPhone, PhoneDisabled } from '@mui/icons-material';
 
 import { MenuIcon } from './icons';
 import type { StreamChatType } from '../../types/chat';
 import {
+  MemberRequest,
   useActiveCall,
   useStreamVideoClient,
-} from '@stream-io/video-react-bindings';
+} from '@stream-io/video-react-sdk';
 import { meetingId } from '../../utils/meetingId';
 
 export type ChannelHeaderProps = {

--- a/sample-apps/react/messenger-clone/src/components/Video/CallPanel/ActiveCallPanel.tsx
+++ b/sample-apps/react/messenger-clone/src/components/Video/CallPanel/ActiveCallPanel.tsx
@@ -1,12 +1,13 @@
-import { ParticipantBox, useMediaDevices } from '@stream-io/video-react-sdk';
 import {
   Call,
+  ParticipantBox,
   StreamVideoLocalParticipant,
   StreamVideoParticipant,
-} from '@stream-io/video-client';
+  useConnectedUser,
+  useMediaDevices,
+} from '@stream-io/video-react-sdk';
 import { ParticipantPlaceholder } from './ParticipantPlaceholder';
 import { ActiveCallControls } from './CallControls';
-import { useConnectedUser } from '@stream-io/video-react-bindings';
 
 type ActiveCallPanelProps = {
   activeCall: Call;

--- a/sample-apps/react/messenger-clone/src/components/Video/CallPanel/CallControls.tsx
+++ b/sample-apps/react/messenger-clone/src/components/Video/CallPanel/CallControls.tsx
@@ -2,8 +2,8 @@ import {
   Call,
   SfuModels,
   StreamVideoLocalParticipant,
-} from '@stream-io/video-client';
-import { useStreamVideoClient } from '@stream-io/video-react-bindings';
+  useStreamVideoClient,
+} from '@stream-io/video-react-sdk';
 import {
   LocalPhone,
   Mic,

--- a/sample-apps/react/messenger-clone/src/components/Video/CallPanel/CallPanel.tsx
+++ b/sample-apps/react/messenger-clone/src/components/Video/CallPanel/CallPanel.tsx
@@ -1,12 +1,12 @@
-import { User } from '@stream-io/video-client';
 import {
   useActiveCall,
   useConnectedUser,
   useIncomingCalls,
   useLocalParticipant,
   useOutgoingCalls,
+  User,
   useRemoteParticipants,
-} from '@stream-io/video-react-bindings';
+} from '@stream-io/video-react-sdk';
 import { ActiveCallPanel } from './ActiveCallPanel';
 import { PendingCallPanel } from './PendingCallPanel';
 

--- a/sample-apps/react/messenger-clone/src/components/Video/CallPanel/PendingCallPanel.tsx
+++ b/sample-apps/react/messenger-clone/src/components/Video/CallPanel/PendingCallPanel.tsx
@@ -1,6 +1,6 @@
 import { ParticipantPlaceholder } from './ParticipantPlaceholder';
 import { IncomingCallControls, OutgoingCallControls } from './CallControls';
-import { CallMetadata, User } from '@stream-io/video-client';
+import { CallMetadata, User } from '@stream-io/video-react-sdk';
 
 type OutgoingCallPanelProps = {
   incomingCall?: CallMetadata;

--- a/sample-apps/react/messenger-clone/src/components/Video/Video.tsx
+++ b/sample-apps/react/messenger-clone/src/components/Video/Video.tsx
@@ -1,11 +1,11 @@
 import { PropsWithChildren, ReactNode, useMemo } from 'react';
 import { useChatContext } from 'stream-chat-react';
 import {
+  CALL_CONFIG,
   StreamCall,
   StreamVideo,
   useCreateStreamVideoClient,
 } from '@stream-io/video-react-sdk';
-import { CALL_CONFIG } from '@stream-io/video-client';
 
 import { CallPanel } from './CallPanel/CallPanel';
 

--- a/sample-apps/react/messenger-clone/src/types/chat.ts
+++ b/sample-apps/react/messenger-clone/src/types/chat.ts
@@ -1,5 +1,5 @@
-import type { UR, LiteralStringForUnion } from 'stream-chat';
-import { User } from '@stream-io/video-client';
+import type { LiteralStringForUnion, UR } from 'stream-chat';
+import { User } from '@stream-io/video-react-sdk';
 
 export type AttachmentType = UR;
 export type ChannelType = UR & { subtitle?: string };

--- a/sample-apps/react/stream-video-react-tutorial/data/users.ts
+++ b/sample-apps/react/stream-video-react-tutorial/data/users.ts
@@ -1,4 +1,4 @@
-import { User } from '@stream-io/video-client';
+import { User } from '@stream-io/video-react-sdk';
 
 export default {
   alice: {

--- a/sample-apps/react/stream-video-react-tutorial/package.json
+++ b/sample-apps/react/stream-video-react-tutorial/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@stream-io/video-client": "workspace:^",
     "@stream-io/video-react-sdk": "workspace:^",
     "@stream-io/video-styling": "workspace:^",
     "nanoid": "^4.0.1",

--- a/sample-apps/react/stream-video-react-tutorial/src/components/VideoRoot.tsx
+++ b/sample-apps/react/stream-video-react-tutorial/src/components/VideoRoot.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {
+  CALL_CONFIG,
   MediaDevicesProvider,
   StreamVideo,
   useCreateStreamVideoClient,
 } from '@stream-io/video-react-sdk';
-import { CALL_CONFIG } from '@stream-io/video-client';
 
 import { UI } from './ui/UI';
 import { useUserData } from '../context/UserContext';

--- a/sample-apps/react/stream-video-react-tutorial/src/context/UserContext.tsx
+++ b/sample-apps/react/stream-video-react-tutorial/src/context/UserContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, ReactNode, useContext, useState } from 'react';
-import { User } from '@stream-io/video-client';
+import { User } from '@stream-io/video-react-sdk';
 import users from '../../data/users';
 
 type UserDataContextValue = {

--- a/sample-apps/react/zoom-clone/package.json
+++ b/sample-apps/react/zoom-clone/package.json
@@ -10,8 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@stream-io/video-client": "workspace:^",
-    "@stream-io/video-react-bindings": "workspace:^",
     "@stream-io/video-react-sdk": "workspace:^",
     "@stream-io/video-styling": "workspace:^",
     "clsx": "^1.2.1",

--- a/sample-apps/react/zoom-clone/src/components/Call.tsx
+++ b/sample-apps/react/zoom-clone/src/components/Call.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useStreamVideoClient } from '@stream-io/video-react-bindings';
+import { useStreamVideoClient } from '@stream-io/video-react-sdk';
 import { useParams } from 'react-router-dom';
 
 import { MeetingUI } from './MeetingUI';

--- a/sample-apps/react/zoom-clone/src/components/MeetingUI.tsx
+++ b/sample-apps/react/zoom-clone/src/components/MeetingUI.tsx
@@ -1,10 +1,9 @@
 import {
   CallControls,
-  Stage,
   DeviceSettings,
+  Stage,
+  useActiveCall,
 } from '@stream-io/video-react-sdk';
-
-import { useActiveCall } from '@stream-io/video-react-bindings';
 import { useNavigate } from 'react-router-dom';
 import { PropsWithChildren } from 'react';
 

--- a/sample-apps/react/zoom-clone/src/components/Preview.tsx
+++ b/sample-apps/react/zoom-clone/src/components/Preview.tsx
@@ -1,27 +1,25 @@
 import {
-  useState,
-  useRef,
-  useLayoutEffect,
-  PropsWithChildren,
-  createContext,
-  useContext,
   ComponentProps,
+  createContext,
   Dispatch,
+  PropsWithChildren,
   SetStateAction,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState,
 } from 'react';
 import { clsx } from 'clsx';
 import {
-  IconButton,
-  useMediaDevices,
-  MediaDevicesProvider,
-  useActiveCall,
+  createSoundDetector,
   DeviceSettings,
-} from '@stream-io/video-react-sdk';
-import {
   getAudioStream,
   getVideoStream,
-  createSoundDetector,
-} from '@stream-io/video-client';
+  IconButton,
+  MediaDevicesProvider,
+  useActiveCall,
+  useMediaDevices,
+} from '@stream-io/video-react-sdk';
 
 const disposeOfMediaStream = (ms: MediaStream) => {
   return ms.getTracks().forEach((track) => track.stop());

--- a/yarn.lock
+++ b/yarn.lock
@@ -6369,8 +6369,6 @@ __metadata:
   resolution: "@stream-io/messenger-clone-react@workspace:sample-apps/react/messenger-clone"
   dependencies:
     "@mui/icons-material": ^5.10.16
-    "@stream-io/video-client": "workspace:^"
-    "@stream-io/video-react-bindings": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@stream-io/video-styling": "workspace:^"
     "@types/react": ^18.0.26
@@ -6594,8 +6592,6 @@ __metadata:
     "@mui/icons-material": ^5.10.16
     "@mui/material": ^5.10.16
     "@sentry/nextjs": ^7.22.0
-    "@stream-io/video-client": "workspace:^"
-    "@stream-io/video-react-bindings": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@stream-io/video-styling": "workspace:^"
     "@types/yargs": ^17.0.17
@@ -6707,8 +6703,6 @@ __metadata:
     "@emotion/styled": ^11.10.5
     "@mui/icons-material": ^5.10.16
     "@mui/material": ^5.10.16
-    "@stream-io/video-client": "workspace:^"
-    "@stream-io/video-react-bindings": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@stream-io/video-styling": "workspace:^"
     "@types/node": ^18.11.17
@@ -6767,8 +6761,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stream-io/zoom-clone-react@workspace:sample-apps/react/zoom-clone"
   dependencies:
-    "@stream-io/video-client": "workspace:^"
-    "@stream-io/video-react-bindings": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@stream-io/video-styling": "workspace:^"
     "@types/react": ^18.0.26
@@ -27609,7 +27601,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "stream-video-react-tutorial@workspace:sample-apps/react/stream-video-react-tutorial"
   dependencies:
-    "@stream-io/video-client": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@stream-io/video-styling": "workspace:^"
     "@types/react": ^18.0.26


### PR DESCRIPTION
### Overview
`@stream-io/video-client` and `@stream-io/video-react-bindings` are now re-exported through `@stream-io/video-react-sdk`.
This PR removes the unnecessary dependencies from our apps and updates the `import` statements accordingly.