### PR TITLE
fix(react-native): remove isSpeaking blue border from ParticipantView while screen sharing

### DIFF
--- a/packages/react-native-sdk/src/components/ParticipantView.tsx
+++ b/packages/react-native-sdk/src/components/ParticipantView.tsx
@@ -155,8 +155,6 @@ const styles = StyleSheet.create({
   videoRenderer: {
     flex: 1,
     justifyContent: 'center',
-    overflow: 'hidden',
-    borderRadius: 16,
   },
   screenVideoRenderer: {
     flex: 1,


### PR DESCRIPTION
Fixes - https://www.notion.so/stream-wiki/8e8d9743b99f4379b24bd2415e5bfdbd?v=714cda30bb2d433fa7151a33556811c5&p=b3364f0be3834bdfa230d14c3f795d76&pm=c