### PR TITLE
ci: add job timeouts

### DIFF
--- a/.github/workflows/deploy-sample-apps.yml
+++ b/.github/workflows/deploy-sample-apps.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   build-and-deploy-sample-apps:
     name: Deploy ${{ matrix.application.name }}
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docusaurus-deploy.yml
+++ b/.github/workflows/docusaurus-deploy.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   push_docusaurus:
     name: Build and deploy the documentation
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/react-native-workflow.yml
+++ b/.github/workflows/react-native-workflow.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   deploy_ios:
     name: Build iOS and Deploy-${{ github.ref == 'refs/heads/main' }}
+    timeout-minutes: 60
     runs-on: macos-latest
     strategy:
       matrix:
@@ -78,6 +79,7 @@ jobs:
           bundle exec fastlane build_ios deploy:${{ github.ref == 'refs/heads/main' }};
   deploy_android:
     name: Deploy Android and Deploy-${{ github.ref == 'refs/heads/main' }}
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   test-and-build:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Add timeouts to jobs so they don't run for [6 hours](https://github.com/GetStream/stream-video-js/actions/runs/4345086042) without any results. I used average values (+some extra) from past successful jobs.