### PR TITLE
fix(react-sdk): forward menu placement

### DIFF
--- a/packages/react-sdk/src/components/Button/CompositeButton.tsx
+++ b/packages/react-sdk/src/components/Button/CompositeButton.tsx
@@ -2,11 +2,13 @@ import clsx from 'clsx';
 import { MenuToggle, ToggleMenuButtonProps } from '../Menu';
 import { ComponentType, forwardRef, PropsWithChildren } from 'react';
 import { IconButton } from './IconButton';
+import { Placement } from '@floating-ui/react';
 
 export type IconButtonWithMenuProps = PropsWithChildren<{
   active?: boolean;
   Menu?: ComponentType;
   caption?: string;
+  menuPlacement?: Placement;
 }>;
 
 export const CompositeButton = ({
@@ -14,6 +16,7 @@ export const CompositeButton = ({
   children,
   active,
   Menu,
+  menuPlacement,
 }: IconButtonWithMenuProps) => {
   return (
     <div className="str-video__composite-button">
@@ -24,7 +27,7 @@ export const CompositeButton = ({
       >
         {children}
         {Menu && (
-          <MenuToggle ToggleButton={ToggleMenuButton}>
+          <MenuToggle placement={menuPlacement} ToggleButton={ToggleMenuButton}>
             <Menu />
           </MenuToggle>
         )}

--- a/packages/react-sdk/src/components/CallControls/ReactionsButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ReactionsButton.tsx
@@ -11,6 +11,7 @@ export const ReactionsButton = () => {
     <CompositeButton
       active={false}
       caption="Reactions"
+      menuPlacement="top-start"
       Menu={DefaultReactionsMenu}
     >
       <IconButton

--- a/packages/react-sdk/src/components/DeviceSettings/DeviceSettings.tsx
+++ b/packages/react-sdk/src/components/DeviceSettings/DeviceSettings.tsx
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 
 export const DeviceSettings = () => {
   return (
-    <MenuToggle ToggleButton={ToggleMenuButton}>
+    <MenuToggle placement="bottom-end" ToggleButton={ToggleMenuButton}>
       <Menu />
     </MenuToggle>
   );

--- a/packages/react-sdk/src/components/Menu/MenuToggle.tsx
+++ b/packages/react-sdk/src/components/Menu/MenuToggle.tsx
@@ -5,8 +5,13 @@ import {
   useState,
   ForwardedRef,
 } from 'react';
-import { Placement } from '@popperjs/core';
-import { offset, autoUpdate, size, useFloating } from '@floating-ui/react';
+import {
+  offset,
+  autoUpdate,
+  size,
+  useFloating,
+  Placement,
+} from '@floating-ui/react';
 
 export type ToggleMenuButtonProps = {
   menuShown: boolean;
@@ -33,7 +38,7 @@ export const MenuToggle = ({
     update,
     elements: { domReference, floating },
   } = useFloating({
-    placement: 'bottom-end',
+    placement,
     middleware: [
       offset(10),
       size({


### PR DESCRIPTION
Ref: #321

Missed that `ReactionsButton` was utilizing the same menu component so I added `placement` drilling so it works normally as well. 