### PR TITLE
fix: add create param to join calls

### DIFF
--- a/packages/client/src/rtc/Call.ts
+++ b/packages/client/src/rtc/Call.ts
@@ -302,12 +302,6 @@ export class Call {
       throw new Error(`Illegal State: Already joined.`);
     }
 
-    // FIXME OL: temporary fix which restores the previous behavior.
-    // This data should come from the SDK, or integration
-    data = data || {
-      create: true,
-    };
-
     const call = await join(this.streamClient, this.type, this.id, data);
     this.state.setCurrentValue(this.state.metadataSubject, call.metadata);
     this.state.setCurrentValue(this.state.membersSubject, call.members);

--- a/packages/react-dogfood/components/MeetingUI.tsx
+++ b/packages/react-dogfood/components/MeetingUI.tsx
@@ -81,7 +81,7 @@ export const MeetingUI = ({
     if (!client) return;
     setShow('loading');
     try {
-      await client.call(callType, callId).join();
+      await client.call(callType, callId).join({ create: true });
       setShow('active-call');
     } catch (e) {
       console.error(e);

--- a/packages/react-native-sdk/src/components/LobbyView.tsx
+++ b/packages/react-native-sdk/src/components/LobbyView.tsx
@@ -75,7 +75,7 @@ export const LobbyView = (props: LobbyViewProps) => {
   const joinCallHandler = () => {
     videoClient
       ?.call('default', callID)
-      .join()
+      .join({ create: true })
       .then(() => {
         if (onActiveCall) {
           onActiveCall();

--- a/packages/react-native-sdk/src/contexts/CallCycleContext.tsx
+++ b/packages/react-native-sdk/src/contexts/CallCycleContext.tsx
@@ -82,9 +82,13 @@ export const CallCycleProvider = (
       }
       try {
         if (outgoingCall && client.callConfig.joinCallInstantly) {
-          client.call(outgoingCall.type, outgoingCall.id).join();
+          client
+            .call(outgoingCall.type, outgoingCall.id)
+            .join({ create: true });
         } else if (acceptedCall && !client.callConfig.joinCallInstantly) {
-          client.call(outgoingCall.type, outgoingCall.id).join();
+          client
+            .call(outgoingCall.type, outgoingCall.id)
+            .join({ create: true });
         }
         InCallManager.start({ media: 'video' });
         InCallManager.setForceSpeakerphoneOn(true);

--- a/packages/react-sample-app/src/App.tsx
+++ b/packages/react-sample-app/src/App.tsx
@@ -6,7 +6,7 @@ import {
   ThemeProvider,
 } from '@mui/material';
 import {
-  GetOrCreateCallRequest,
+  JoinCallRequest,
   StreamMeeting,
   StreamVideo,
   useCreateStreamVideoClient,
@@ -44,9 +44,9 @@ const App = () => {
   });
   const [callId, setCallId] = useState<string | undefined>(undefined);
   const [callType, setCallType] = useState<string>('default');
-  const [callInput, setCallInput] = useState<
-    GetOrCreateCallRequest | undefined
-  >(undefined);
+  const [callInput, setCallInput] = useState<JoinCallRequest | undefined>(
+    undefined,
+  );
   const [errorMessage] = useState('');
 
   useEffect(() => {
@@ -83,6 +83,7 @@ const App = () => {
           user_id: userId,
         })),
       },
+      create: true,
     });
   };
 

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/05-participant-list.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/05-participant-list.mdx
@@ -126,7 +126,11 @@ export const App = () => {
 
   return (
     <StreamVideo client={client}>
-      <StreamMeeting callId={callId} callType="default">
+      <StreamMeeting
+        callId={callId}
+        callType="default"
+        input={{ create: true }}
+      >
         <SpeakerView />
       </StreamMeeting>
     </StreamVideo>

--- a/packages/react-sdk/src/components/StreamCall/StreamCall.tsx
+++ b/packages/react-sdk/src/components/StreamCall/StreamCall.tsx
@@ -21,14 +21,14 @@ export const StreamCall = ({ children }: { children: ReactNode }) => {
     if (outgoingCall && videoClient.callConfig.joinCallInstantly) {
       videoClient
         .call(outgoingCall.type, outgoingCall.id)
-        .join()
+        .join({ create: true })
         .catch((e) => {
           console.error('Error joining call', e);
         });
     } else if (acceptedCall && !videoClient.callConfig.joinCallInstantly) {
       videoClient
         .call(outgoingCall.type, outgoingCall.id)
-        .join()
+        .join({ create: true })
         .catch((e) => {
           console.error('Error joining call', e);
         });

--- a/packages/react-sdk/src/components/StreamMeeting/StreamMeeting.tsx
+++ b/packages/react-sdk/src/components/StreamMeeting/StreamMeeting.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren, useEffect } from 'react';
-import { GetOrCreateCallRequest } from '@stream-io/video-client';
+import { JoinCallRequest } from '@stream-io/video-client';
 import {
   StreamCallProvider,
   useActiveCall,
@@ -10,7 +10,7 @@ import { MediaDevicesProvider } from '../../contexts';
 export type StreamMeetingProps = {
   callId: string;
   callType: string;
-  input?: Omit<GetOrCreateCallRequest, 'members'>;
+  input?: JoinCallRequest;
 };
 
 export const StreamMeeting = ({

--- a/sample-apps/react/cookbook-participant-list/src/App.tsx
+++ b/sample-apps/react/cookbook-participant-list/src/App.tsx
@@ -44,7 +44,11 @@ const App = () => {
         {!callId && <CallSetup onJoin={setCallId} />}
         {callId && (
           <StreamVideo client={client}>
-            <StreamMeeting callId={callId} callType="default">
+            <StreamMeeting
+              callId={callId}
+              callType="default"
+              input={{ create: true }}
+            >
               <SpeakerView />
             </StreamMeeting>
           </StreamVideo>

--- a/sample-apps/react/stream-video-react-tutorial/src/components/ui/Lobby.tsx
+++ b/sample-apps/react/stream-video-react-tutorial/src/components/ui/Lobby.tsx
@@ -49,7 +49,7 @@ const StartNewCallButton = () => {
     try {
       await videoClient
         .call(String(Math.round(Math.random() * 100000000)), 'default')
-        .join();
+        .join({ create: true });
     } catch (e) {
       console.error(e);
     } finally {
@@ -74,7 +74,7 @@ const JoinExistingCallForm = () => {
       event.preventDefault();
       setLoading(true);
       try {
-        await videoClient.call('default', joinCallId).join();
+        await videoClient.call('default', joinCallId).join({ create: true });
       } catch (e) {
         console.error(e);
       } finally {

--- a/sample-apps/react/zoom-clone/src/components/Call.tsx
+++ b/sample-apps/react/zoom-clone/src/components/Call.tsx
@@ -17,7 +17,7 @@ export const Call = () => {
 
   useEffect(() => {
     const call = client?.call('default', callId as string);
-    const joining = call?.join();
+    const joining = call?.join({ create: true });
 
     return () => {
       joining?.then(() => call?.leave());


### PR DESCRIPTION
`join_call` endpoints now needs `{create: true}` to be used for call creation