### PR TITLE
Remove cancel calls

### DIFF
--- a/packages/client/src/rtc/Call.ts
+++ b/packages/client/src/rtc/Call.ts
@@ -1107,9 +1107,7 @@ export class Call {
         state.remoteParticipants$,
       );
       if (!remoteParticipants.length && !leavingActiveCall) {
-        await this.streamClient.post(`${this.streamClientBasePath}/event`, {
-          type: 'call.cancelled',
-        });
+        await this.endCall();
       }
     }
   };


### PR DESCRIPTION
Quick fix to avoid runtime errors due to `call.cancelled` event being dropped