### PR TITLE
Ws events upgrade

### DIFF
--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -2,7 +2,6 @@ import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { StableWSConnection } from './connection';
 import {
   ConnectedEvent,
-  HealthCheckEvent,
   VideoEvent,
 } from '../../gen/coordinator';
 
@@ -67,10 +66,7 @@ export type StreamVideoEvent = (
 ) & { received_at?: string | Date };
 
 // TODO: we should use WSCallEvent here but that needs fixing
-export type StreamCallEvent = Extract<
-  StreamVideoEvent,
-  {call_cid: string}
->;
+export type StreamCallEvent = Extract<StreamVideoEvent, { call_cid: string }>;
 
 export type EventHandler = (event: StreamVideoEvent) => void;
 
@@ -78,7 +74,7 @@ export type CallEventHandler = (event: StreamCallEvent) => void;
 
 export type EventTypes = 'all' | StreamVideoEvent['type'];
 
-export type CallEventTypes = StreamCallEvent['type']
+export type CallEventTypes = StreamCallEvent['type'];
 
 export type Logger = (
   logLevel: LogLevel,

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -45,20 +45,6 @@ export class ErrorFromResponse<T> extends Error {
   status?: number;
 }
 
-type ClientEventTypes = 'health.check' | 'connection.ok';
-
-type LocalEventTypes =
-  | 'connection.changed'
-  | 'transport.changed'
-  | 'connection.recovered';
-
-export type EventTypes = 'all' | VideoEvent['type'] | LocalEventTypes;
-
-export type CallEventTypes = Exclude<
-  EventTypes,
-  'all' | ClientEventTypes | LocalEventTypes
->;
-
 export type ConnectionChangedEvent = {
   type: 'connection.changed';
   online: boolean;
@@ -80,17 +66,19 @@ export type StreamVideoEvent = (
   | ConnectionRecoveredEvent
 ) & { received_at?: string | Date };
 
-export type StreamCallEvent = Exclude<
+// TODO: we should use WSCallEvent here but that needs fixing
+export type StreamCallEvent = Extract<
   StreamVideoEvent,
-  | HealthCheckEvent
-  | ConnectionChangedEvent
-  | TransportChangedEvent
-  | ConnectionRecoveredEvent
+  {call_cid: string}
 >;
 
 export type EventHandler = (event: StreamVideoEvent) => void;
 
 export type CallEventHandler = (event: StreamCallEvent) => void;
+
+export type EventTypes = 'all' | StreamVideoEvent['type'];
+
+export type CallEventTypes = StreamCallEvent['type']
 
 export type Logger = (
   logLevel: LogLevel,

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -1,9 +1,6 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { StableWSConnection } from './connection';
-import {
-  ConnectedEvent,
-  VideoEvent,
-} from '../../gen/coordinator';
+import { ConnectedEvent, VideoEvent } from '../../gen/coordinator';
 
 export type UR = Record<string, unknown>;
 

--- a/packages/client/src/rtc/Call.ts
+++ b/packages/client/src/rtc/Call.ts
@@ -247,11 +247,11 @@ export class Call {
     if (isSfuEvent(eventName)) {
       return this.dispatcher.on(eventName, fn as SfuEventListener);
     } else {
-      const eventHandler: CallEventHandler = ((event: StreamCallEvent) => {
+      const eventHandler: CallEventHandler = (event: StreamCallEvent) => {
         if (event.call_cid && event.call_cid === this.cid) {
           (fn as EventHandler)(event);
         }
-      });
+      };
       this.streamClientEventHandlers.set(fn, eventHandler);
 
       return this.streamClient.on(eventName, eventHandler as EventHandler);
@@ -264,21 +264,24 @@ export class Call {
    * @param fn
    * @returns
    */
-   off(eventName: SfuEventKinds, fn: SfuEventListener): void;
-   off(eventName: CallEventTypes, fn: CallEventHandler): void;
-   off(
-     eventName: SfuEventKinds | CallEventTypes,
-     fn: SfuEventListener | CallEventHandler,
-   ) {
-     if (isSfuEvent(eventName)) {
+  off(eventName: SfuEventKinds, fn: SfuEventListener): void;
+  off(eventName: CallEventTypes, fn: CallEventHandler): void;
+  off(
+    eventName: SfuEventKinds | CallEventTypes,
+    fn: SfuEventListener | CallEventHandler,
+  ) {
+    if (isSfuEvent(eventName)) {
       return this.dispatcher.off(eventName, fn as SfuEventListener);
-     } else {
+    } else {
       const registeredEventHandler = this.streamClientEventHandlers.get(fn);
       if (registeredEventHandler) {
-        return this.streamClient.off(eventName, registeredEventHandler as EventHandler);
+        return this.streamClient.off(
+          eventName,
+          registeredEventHandler as EventHandler,
+        );
       }
-     }
-  };
+    }
+  }
 
   /**
    * Leave the call and stop the media streams that were published by the call.
@@ -1322,7 +1325,9 @@ export class Call {
     );
   };
 
-  sendEvent = async (event: SendEventRequest) => {
+  sendEvent = async (
+    event: SendEventRequest & { type: StreamCallEvent['type'] },
+  ) => {
     return this.streamClient.post(`${this.streamClientBasePath}/event`, event);
   };
 }


### PR DESCRIPTION
- Implement `call.off` for coordinator WS events
- Simplify WS event type definitions
- `call.sendEvent` now only accepts valid call event type names