### PR TITLE
feat: switch to the SDK provided Grid implementation

### DIFF
--- a/packages/react-sdk/src/components/CallLayout/PaginatedGridLayout.tsx
+++ b/packages/react-sdk/src/components/CallLayout/PaginatedGridLayout.tsx
@@ -160,27 +160,3 @@ const chunk = <T extends unknown[]>(array: T, size = GROUP_SIZE) => {
     (_, index) => array.slice(size * index, size * index + size) as T,
   );
 };
-
-// TODO: maybe use this?
-// problem is, participants change due to anything (someone muted video for example)
-// which would yield new merged stream anytime someone interacted with something
-// completely unrelated to published audio tracks
-// const useMergeAudioStreams = (participants: StreamVideoParticipant[]) => {
-//   return useMemo(() => {
-//     const audioStreams = participants
-//       .map((p) => p.audioStream)
-//       .filter(Boolean) as MediaStream[];
-//
-//     const audioContext = new AudioContext();
-//
-//     const sourceNodes = audioStreams.map((stream) =>
-//       audioContext.createMediaStreamSource(stream),
-//     );
-//
-//     const dest = audioContext.createMediaStreamDestination();
-//
-//     sourceNodes.forEach((sourceNode) => sourceNode.connect(dest));
-//
-//     return dest.stream;
-//   }, [participants]);
-// };

--- a/packages/react-sdk/src/components/CallLayout/PaginatedGridLayout.tsx
+++ b/packages/react-sdk/src/components/CallLayout/PaginatedGridLayout.tsx
@@ -1,27 +1,38 @@
 import { useEffect, useMemo, useState } from 'react';
-
 import {
   useActiveCall,
   useLocalParticipant,
   useParticipants,
   useRemoteParticipants,
 } from '@stream-io/video-react-bindings';
-import { StreamVideoLocalParticipant } from '@stream-io/video-client';
-import { StreamVideoParticipant } from '@stream-io/video-client';
+import {
+  StreamVideoLocalParticipant,
+  StreamVideoParticipant,
+} from '@stream-io/video-client';
 import clsx from 'clsx';
 
 import { IconButton, ParticipantBox } from '..';
-import { Audio } from '../StreamCall/Audio';
+import { Audio } from '../StreamCall';
 
 const GROUP_SIZE = 16;
 
+type PaginatedGridLayoutGroupProps = {
+  /**
+   * The group of participants to render.
+   */
+  group: Array<StreamVideoParticipant | StreamVideoLocalParticipant>;
+
+  /**
+   * Turns on/off the status indicator icons (mute, connection quality, etc...)
+   * on the participant boxes.
+   */
+  indicatorsVisible?: boolean;
+};
 const PaginatedGridLayoutGroup = ({
   group,
-}: {
-  group: Array<StreamVideoParticipant | StreamVideoLocalParticipant>;
-}) => {
+  indicatorsVisible = true,
+}: PaginatedGridLayoutGroupProps) => {
   const call = useActiveCall();
-
   return (
     <div
       className={clsx('str-video__paginated-grid-layout--group', {
@@ -37,17 +48,43 @@ const PaginatedGridLayoutGroup = ({
           key={participant.sessionId}
           participant={participant}
           call={call!}
+          indicatorsVisible={indicatorsVisible}
+          muteAudio
         />
       ))}
     </div>
   );
 };
 
+export type PaginatedGridLayoutProps = {
+  /**
+   * The number of participants to display per page.
+   */
+  groupSize?: number;
+
+  /**
+   * Whether to exclude the local participant from the grid.
+   */
+  excludeLocalParticipant?: boolean;
+
+  /**
+   * Turns on/off the status indicator icons (mute, connection quality, etc...)
+   * on the participant boxes.
+   */
+  indicatorsVisible?: boolean;
+
+  /**
+   * Turns on/off the pagination arrows.
+   */
+  pageArrowsVisible?: boolean;
+};
+
 export const PaginatedGridLayout = ({
   groupSize = GROUP_SIZE,
-}: {
-  groupSize?: number;
-}) => {
+  excludeLocalParticipant = false,
+  indicatorsVisible = true,
+  pageArrowsVisible = true,
+}: PaginatedGridLayoutProps) => {
   const [page, setPage] = useState(0);
 
   const localParticipant = useLocalParticipant();
@@ -57,8 +94,12 @@ export const PaginatedGridLayout = ({
 
   // only used to render video elements
   const participantGroups = useMemo(
-    () => chunk(participants, groupSize),
-    [participants, groupSize],
+    () =>
+      chunk(
+        excludeLocalParticipant ? remoteParticipants : participants,
+        groupSize,
+      ),
+    [excludeLocalParticipant, remoteParticipants, participants, groupSize],
   );
 
   const pageCount = participantGroups.length;
@@ -82,7 +123,7 @@ export const PaginatedGridLayout = ({
       ))}
       <div className="str-video__paginated-grid-layout--wrapper">
         <div className="str-video__paginated-grid-layout">
-          {pageCount > 1 && (
+          {pageArrowsVisible && pageCount > 1 && (
             <IconButton
               icon="caret-left"
               disabled={page === 0}
@@ -90,9 +131,12 @@ export const PaginatedGridLayout = ({
             />
           )}
           {selectedGroup && (
-            <PaginatedGridLayoutGroup group={participantGroups[page]} />
+            <PaginatedGridLayoutGroup
+              group={participantGroups[page]}
+              indicatorsVisible={indicatorsVisible}
+            />
           )}
-          {pageCount > 1 && (
+          {pageArrowsVisible && pageCount > 1 && (
             <IconButton
               disabled={page === pageCount - 1}
               icon="caret-right"
@@ -121,22 +165,22 @@ const chunk = <T extends unknown[]>(array: T, size = GROUP_SIZE) => {
 // problem is, participants change due to anything (someone muted video for example)
 // which would yield new merged stream anytime someone interacted with something
 // completely unrelated to published audio tracks
-const useMergeAudioStreams = (participants: StreamVideoParticipant[]) => {
-  return useMemo(() => {
-    const audioStreams = participants
-      .map((p) => p.audioStream)
-      .filter(Boolean) as MediaStream[];
-
-    const audioContext = new AudioContext();
-
-    const sourceNodes = audioStreams.map((stream) =>
-      audioContext.createMediaStreamSource(stream),
-    );
-
-    const dest = audioContext.createMediaStreamDestination();
-
-    sourceNodes.forEach((sourceNode) => sourceNode.connect(dest));
-
-    return dest.stream;
-  }, [participants]);
-};
+// const useMergeAudioStreams = (participants: StreamVideoParticipant[]) => {
+//   return useMemo(() => {
+//     const audioStreams = participants
+//       .map((p) => p.audioStream)
+//       .filter(Boolean) as MediaStream[];
+//
+//     const audioContext = new AudioContext();
+//
+//     const sourceNodes = audioStreams.map((stream) =>
+//       audioContext.createMediaStreamSource(stream),
+//     );
+//
+//     const dest = audioContext.createMediaStreamDestination();
+//
+//     sourceNodes.forEach((sourceNode) => sourceNode.connect(dest));
+//
+//     return dest.stream;
+//   }, [participants]);
+// };

--- a/packages/react-sdk/src/components/StreamCall/ParticipantBox.tsx
+++ b/packages/react-sdk/src/components/StreamCall/ParticipantBox.tsx
@@ -42,6 +42,11 @@ export interface ParticipantBoxProps {
   indicatorsVisible?: boolean;
 
   /**
+   * Turns on/off the audio for the participant.
+   */
+  muteAudio?: boolean;
+
+  /**
    * A function meant for exposing the "native" element ref to the integrators.
    * The element can either be:
    * - `<video />` for participants with enabled video.
@@ -65,6 +70,7 @@ export const ParticipantBox = (props: ParticipantBoxProps) => {
     videoKind = 'video',
     call,
     sinkId,
+    muteAudio,
     setVideoElementRef,
     className,
   } = props;
@@ -131,7 +137,7 @@ export const ParticipantBox = (props: ParticipantBoxProps) => {
       <div className="str-video__video-container">
         <Audio
           // mute the local participant, as we don't want to hear ourselves
-          muted={participant.isLoggedInUser}
+          muted={participant.isLoggedInUser || muteAudio}
           sinkId={sinkId}
           audioStream={audioStream}
         />

--- a/sample-apps/react/egress-composite/src/hooks/useAppConfig.ts
+++ b/sample-apps/react/egress-composite/src/hooks/useAppConfig.ts
@@ -11,6 +11,7 @@ export type AppConfig = {
   callType: string;
   spotlightMode: SpotlightMode;
   layout: LayoutId;
+  gridSize: number;
 };
 
 export const useAppConfig = () => {
@@ -24,6 +25,7 @@ export const useAppConfig = () => {
     const spotlightMode =
       (urlParams.get('spotlight_mode') as SpotlightMode) || DEFAULT_LAYOUT_ID;
     const layout = (urlParams.get('layout') as LayoutId) || DEFAULT_LAYOUT_ID;
+    const gridSize = Number(urlParams.get('grid.size')) || 25;
 
     return {
       apiKey: apiKey,
@@ -34,6 +36,7 @@ export const useAppConfig = () => {
       baseURL: urlParams.get('base_url')!,
       spotlightMode: spotlightMode,
       layout: layout,
+      gridSize: gridSize,
     };
   }, [query]);
 };

--- a/sample-apps/react/egress-composite/src/layouts/dominant-speaker/DominantSpeaker.tsx
+++ b/sample-apps/react/egress-composite/src/layouts/dominant-speaker/DominantSpeaker.tsx
@@ -28,6 +28,7 @@ export const DominantSpeaker = () => {
             call={activeCall}
             indicatorsVisible={false}
             setVideoElementRef={setParticipantVideoRef}
+            muteAudio
           />
         )}
       </div>

--- a/sample-apps/react/egress-composite/src/layouts/grid/GridView.scss
+++ b/sample-apps/react/egress-composite/src/layouts/grid/GridView.scss
@@ -12,20 +12,4 @@
   .str-video__participant {
     transition: width 0.2s ease-in-out;
   }
-
-  .width--full {
-    width: 100%;
-  }
-
-  .width--half {
-    width: calc(50% - var(--gap-size));
-  }
-
-  .width--one-third {
-    width: calc(33% - var(--gap-size));
-  }
-
-  .width--one-fourth {
-    width: calc(25% - var(--gap-size));
-  }
 }

--- a/sample-apps/react/egress-composite/src/layouts/grid/GridView.tsx
+++ b/sample-apps/react/egress-composite/src/layouts/grid/GridView.tsx
@@ -1,40 +1,18 @@
-import {
-  ParticipantBox,
-  useActiveCall,
-  useRemoteParticipants,
-} from '@stream-io/video-react-sdk';
-import clsx from 'clsx';
-import { useEgressReadyWhenAnyParticipantMounts } from '../egressReady';
+import { PaginatedGridLayout } from '@stream-io/video-react-sdk';
+import { useAppConfig } from '../../hooks/useAppConfig';
+
 import './GridView.scss';
 
 export const GridView = () => {
-  const activeCall = useActiveCall();
-  const participants = useRemoteParticipants();
-  const setParticipantVideoRef = useEgressReadyWhenAnyParticipantMounts();
-
-  const totalParticipants = participants.length;
-  const widthClassName = clsx(
-    totalParticipants <= 1 && 'width--full',
-    totalParticipants === 2 && 'width--half',
-    totalParticipants === 3 && 'width--one-third',
-    totalParticipants >= 4 && totalParticipants < 6 && 'width--half',
-    totalParticipants >= 6 && totalParticipants <= 8 && 'width--one-third',
-    totalParticipants === 9 && 'width--one-third',
-    totalParticipants > 9 && 'width--one-fourth',
-  );
-
+  // const setParticipantVideoRef = useEgressReadyWhenAnyParticipantMounts();
+  const { gridSize } = useAppConfig();
   return (
     <div className="grid-view">
-      {participants.map((participant, index) => (
-        <ParticipantBox
-          key={participant.sessionId}
-          className={widthClassName}
-          participant={participant}
-          call={activeCall!}
-          indicatorsVisible={false}
-          setVideoElementRef={index === 0 ? setParticipantVideoRef : undefined}
-        />
-      ))}
+      <PaginatedGridLayout
+        excludeLocalParticipant
+        indicatorsVisible={false}
+        groupSize={gridSize || 25}
+      />
     </div>
   );
 };


### PR DESCRIPTION
### Overview

Drops the custom grid implementation in Composite in favor of the paginated grid implementation coming from the SDK.

In the SDK, the PaginatedGrid has been extended with some extra props for showing/hiding certain UI elements in Composite mode.
Also, this PR fixes an issue in PaginatedGrid where a single audio track might be played twice.