### PR TITLE
feat: provide cascading params to get_edge_server

### DIFF
--- a/packages/client/src/rtc/flows/join.ts
+++ b/packages/client/src/rtc/flows/join.ts
@@ -44,7 +44,10 @@ export const watch = async (
       },
     );
   }
-  return httpClient.post<JoinCallResponse>(`/call/${type}/${id}/join`, data);
+  return httpClient.post<JoinCallResponse, JoinCallRequest>(
+    `/call/${type}/${id}/join`,
+    data,
+  );
 };
 
 export const join = async (
@@ -81,11 +84,25 @@ const getCallEdgeServer = async (
     }),
   );
 
-  return httpClient.post<GetCallEdgeServerResponse>(
+  const data = {
+    latency_measurements: latencyByEdge,
+  };
+  // FIXME OL: remove this once cascading is enabled by default
+  const cascadingModeParams = getCascadingModeParams();
+  if (cascadingModeParams) {
+    return httpClient.doAxiosRequest<
+      GetCallEdgeServerResponse,
+      GetCallEdgeServerRequest
+    >('post', `/call/${type}/${id}/get_edge_server`, data, {
+      params: {
+        ...cascadingModeParams,
+      },
+    });
+  }
+
+  return httpClient.post<GetCallEdgeServerResponse, GetCallEdgeServerRequest>(
     `/call/${type}/${id}/get_edge_server`,
-    {
-      latency_measurements: latencyByEdge,
-    },
+    data,
   );
 };
 

--- a/packages/react-dogfood/pages/api/call/create.ts
+++ b/packages/react-dogfood/pages/api/call/create.ts
@@ -30,12 +30,15 @@ const createCallSlackHookAPI = async (
   console.log(`Received input`, req.body);
   const initiator = req.body.user_name || 'Stream Pronto Bot';
   const { _, $0, ...args } = await yargs().parse(req.body.text || '');
-  const queryParams = new URLSearchParams(
-    args as Record<string, string>,
-  ).toString();
+  const queryParams = new URLSearchParams(args as Record<string, string>);
 
   try {
-    const call = client.call('default', meetingId());
+    let [type, id] = queryParams.get('cid')?.split(':') || [];
+    if (!id && type) {
+      id = type;
+      type = 'default';
+    }
+    const call = client.call(type || 'default', id || meetingId());
     await call.getOrCreate({
       ring: false,
     });
@@ -49,7 +52,7 @@ const createCallSlackHookAPI = async (
         req.headers.host,
         '/join/',
         call.id,
-        queryParams && `?${queryParams}`,
+        queryParams.toString() && `?${queryParams.toString()}`,
       ]
         .filter(Boolean)
         .join('');


### PR DESCRIPTION
Also, support `/pronto --cid=123 -> pronto.app/join/123`