### PR TITLE
fix(react-dogfood): adjust UnreadCountBadge styling

### DIFF
--- a/packages/react-dogfood/style/chat.scss
+++ b/packages/react-dogfood/style/chat.scss
@@ -72,15 +72,15 @@
 .str-chat__chat-button__unread-count-bubble {
   font-size: 10px;
   background-color: var(--str-video__danger-color2);
-  width: 20px;
-  height: 20px;
+  width: 17px;
+  height: 17px;
   position: absolute;
-  border-radius: 9999px;
+  border-radius: 5px;
   display: flex;
   align-items: center;
   justify-content: center;
-  top: -10px;
-  right: -10px;
+  top: -7px;
+  left: -7px;
   font-weight: bold;
 }
 


### PR DESCRIPTION
Move `UnreadCountBadge` to the left corner of the chat button, size it slightly down, prevents scrollbar from showing up when the badge is rendered.

![image](https://user-images.githubusercontent.com/43254280/233316214-26723134-d1ec-4ae9-9707-2fe5c1abbc99.png)
