### PR TITLE
fix: permission-based rendering of call control buttons

### DIFF
--- a/packages/react-sdk/src/components/CallControls/ReactionsButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ReactionsButton.tsx
@@ -1,7 +1,8 @@
 import { CompositeButton, IconButton } from '../Button';
 import { useActiveCall } from '@stream-io/video-react-bindings';
-import { StreamReaction } from '@stream-io/video-client';
+import { OwnCapability, StreamReaction } from '@stream-io/video-client';
 import { defaultEmojiReactions } from '../Reaction';
+import { Restricted } from '../Moderation';
 
 export const defaultReactions: StreamReaction[] = [
   {
@@ -30,20 +31,22 @@ export const ReactionsButton = ({
   reactions = defaultReactions,
 }: ReactionsButtonProps) => {
   return (
-    <CompositeButton
-      active={false}
-      caption="Reactions"
-      menuPlacement="top-start"
-      Menu={<DefaultReactionsMenu reactions={reactions} />}
-    >
-      <IconButton
-        icon="reactions"
-        title="Reactions"
-        onClick={() => {
-          console.log('Reactions');
-        }}
-      />
-    </CompositeButton>
+    <Restricted requiredGrants={[OwnCapability.CREATE_REACTION]}>
+      <CompositeButton
+        active={false}
+        caption="Reactions"
+        menuPlacement="top-start"
+        Menu={<DefaultReactionsMenu reactions={reactions} />}
+      >
+        <IconButton
+          icon="reactions"
+          title="Reactions"
+          onClick={() => {
+            console.log('Reactions');
+          }}
+        />
+      </CompositeButton>
+    </Restricted>
   );
 };
 

--- a/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Call } from '@stream-io/video-client';
+import { Call, OwnCapability } from '@stream-io/video-client';
 import { useIsCallRecordingInProgress } from '@stream-io/video-react-bindings';
 import { CompositeButton, IconButton } from '../Button/';
 import { LoadingIndicator } from '../LoadingIndicator';
+import { Restricted } from '../Moderation';
 
 export type RecordCallButtonProps = {
   call: Call;
@@ -39,22 +40,29 @@ export const RecordCallButton = ({
   }, [call, isCallRecordingInProgress]);
 
   return (
-    <CompositeButton active={isCallRecordingInProgress} caption={caption}>
-      {isAwaitingResponse ? (
-        <LoadingIndicator
-          tooltip={
-            isCallRecordingInProgress
-              ? 'Waiting for recording to stop... '
-              : 'Waiting for recording to start...'
-          }
-        />
-      ) : (
-        <IconButton
-          icon={isCallRecordingInProgress ? 'recording-on' : 'recording-off'}
-          title="Record call"
-          onClick={toggleRecording}
-        />
-      )}
-    </CompositeButton>
+    <Restricted
+      requiredGrants={[
+        OwnCapability.START_RECORD_CALL,
+        OwnCapability.STOP_RECORD_CALL,
+      ]}
+    >
+      <CompositeButton active={isCallRecordingInProgress} caption={caption}>
+        {isAwaitingResponse ? (
+          <LoadingIndicator
+            tooltip={
+              isCallRecordingInProgress
+                ? 'Waiting for recording to stop... '
+                : 'Waiting for recording to start...'
+            }
+          />
+        ) : (
+          <IconButton
+            icon={isCallRecordingInProgress ? 'recording-on' : 'recording-off'}
+            title="Record call"
+            onClick={toggleRecording}
+          />
+        )}
+      </CompositeButton>
+    </Restricted>
   );
 };

--- a/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
@@ -9,6 +9,7 @@ import { useMediaDevices } from '../../contexts';
 import { DeviceSelectorAudioInput } from '../DeviceSettings';
 import { CompositeButton, IconButton } from '../Button';
 import { PermissionNotification } from '../Notification';
+import { Restricted } from '../Moderation';
 
 export type ToggleAudioPreviewButtonProps = { caption?: string };
 
@@ -83,23 +84,25 @@ export const ToggleAudioPublishingButton = ({
   ]);
 
   return (
-    <PermissionNotification
-      permission={OwnCapability.SEND_AUDIO}
-      isAwaitingApproval={isAwaitingApproval}
-      messageApproved="You can now speak."
-      messageAwaitingApproval="Awaiting for an approval to speak."
-      messageRevoked="You can no longer speak."
-    >
-      <CompositeButton
-        Menu={DeviceSelectorAudioInput}
-        active={isAudioMute}
-        caption={caption}
+    <Restricted requiredGrants={[OwnCapability.SEND_AUDIO]}>
+      <PermissionNotification
+        permission={OwnCapability.SEND_AUDIO}
+        isAwaitingApproval={isAwaitingApproval}
+        messageApproved="You can now speak."
+        messageAwaitingApproval="Awaiting for an approval to speak."
+        messageRevoked="You can no longer speak."
       >
-        <IconButton
-          icon={isAudioMute ? 'mic-off' : 'mic'}
-          onClick={handleClick}
-        />
-      </CompositeButton>
-    </PermissionNotification>
+        <CompositeButton
+          Menu={DeviceSelectorAudioInput}
+          active={isAudioMute}
+          caption={caption}
+        >
+          <IconButton
+            icon={isAudioMute ? 'mic-off' : 'mic'}
+            onClick={handleClick}
+          />
+        </CompositeButton>
+      </PermissionNotification>
+    </Restricted>
   );
 };

--- a/packages/react-sdk/src/components/CallControls/ToggleCameraButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleCameraButton.tsx
@@ -9,6 +9,7 @@ import { CompositeButton, IconButton } from '../Button/';
 import { useMediaDevices } from '../../contexts';
 import { DeviceSelectorVideo } from '../DeviceSettings';
 import { PermissionNotification } from '../Notification';
+import { Restricted } from '../Moderation';
 
 export type ToggleCameraPreviewButtonProps = { caption?: string };
 
@@ -83,23 +84,25 @@ export const ToggleCameraPublishingButton = ({
   ]);
 
   return (
-    <PermissionNotification
-      permission={OwnCapability.SEND_VIDEO}
-      isAwaitingApproval={isAwaitingApproval}
-      messageApproved="You can now share your video."
-      messageAwaitingApproval="Awaiting for an approval to share your video."
-      messageRevoked="You can no longer share your video."
-    >
-      <CompositeButton
-        Menu={DeviceSelectorVideo}
-        active={isVideoMute}
-        caption={caption}
+    <Restricted requiredGrants={[OwnCapability.SEND_VIDEO]}>
+      <PermissionNotification
+        permission={OwnCapability.SEND_VIDEO}
+        isAwaitingApproval={isAwaitingApproval}
+        messageApproved="You can now share your video."
+        messageAwaitingApproval="Awaiting for an approval to share your video."
+        messageRevoked="You can no longer share your video."
       >
-        <IconButton
-          icon={isVideoMute ? 'camera-off' : 'camera'}
-          onClick={handleClick}
-        />
-      </CompositeButton>
-    </PermissionNotification>
+        <CompositeButton
+          Menu={DeviceSelectorVideo}
+          active={isVideoMute}
+          caption={caption}
+        >
+          <IconButton
+            icon={isVideoMute ? 'camera-off' : 'camera'}
+            onClick={handleClick}
+          />
+        </CompositeButton>
+      </PermissionNotification>
+    </Restricted>
   );
 };

--- a/packages/react-sdk/src/components/CallParticipantsList/BlockedUserListing.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/BlockedUserListing.tsx
@@ -1,8 +1,5 @@
-import {
-  useCall,
-  useCallMetadata,
-  useOwnCapabilities,
-} from '@stream-io/video-react-bindings';
+import { OwnCapability } from '@stream-io/video-client';
+import { useCall, useCallMetadata } from '@stream-io/video-react-bindings';
 
 import { Restricted } from '../Moderation';
 import { TextButton } from '../Button';
@@ -27,7 +24,6 @@ export const BlockedUserListing = () => {
 };
 
 const BlockedUserListingItem = ({ userId }: { userId: string }) => {
-  const ownCapabilities = useOwnCapabilities();
   const activeCall = useCall();
 
   const unblockUserClickHandler = () => {
@@ -39,10 +35,7 @@ const BlockedUserListingItem = ({ userId }: { userId: string }) => {
       <div className="str-video__participant-listing-item__display-name">
         {userId}
       </div>
-      <Restricted
-        availableGrants={ownCapabilities}
-        requiredGrants={['block-users']}
-      >
+      <Restricted requiredGrants={[OwnCapability.BLOCK_USERS]}>
         <TextButton onClick={unblockUserClickHandler}>Unblock</TextButton>
       </Restricted>
     </div>

--- a/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListing.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListing.tsx
@@ -1,6 +1,6 @@
 import { ComponentType } from 'react';
 import { OwnCapability, StreamVideoParticipant } from '@stream-io/video-client';
-import { useCall, useOwnCapabilities } from '@stream-io/video-react-bindings';
+import { useCall } from '@stream-io/video-react-bindings';
 import { TextButton } from '../Button';
 import { Restricted } from '../Moderation';
 import { CallParticipantListingItem } from './CallParticipantListingItem';
@@ -8,7 +8,6 @@ import { CallParticipantListingItem } from './CallParticipantListingItem';
 // FIXME: will probably cease to exist with new design
 const CallParticipantListingHeader = () => {
   const activeCall = useCall();
-  const ownCapabilities = useOwnCapabilities();
 
   const muteAllClickHandler = () => {
     activeCall?.muteAllUsers('audio');
@@ -23,10 +22,7 @@ const CallParticipantListingHeader = () => {
       }}
     >
       <div>Active users</div>
-      <Restricted
-        availableGrants={ownCapabilities}
-        requiredGrants={[OwnCapability.MUTE_USERS]}
-      >
+      <Restricted requiredGrants={[OwnCapability.MUTE_USERS]}>
         <TextButton onClick={muteAllClickHandler}>Mute all</TextButton>
       </Restricted>
     </div>

--- a/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListingItem.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListingItem.tsx
@@ -1,10 +1,6 @@
 import clsx from 'clsx';
 import { ComponentProps, ComponentType, forwardRef } from 'react';
-import {
-  useCall,
-  useConnectedUser,
-  useOwnCapabilities,
-} from '@stream-io/video-react-bindings';
+import { useCall, useConnectedUser } from '@stream-io/video-react-bindings';
 import {
   OwnCapability,
   SfuModels,
@@ -123,7 +119,6 @@ export const ParticipantActionsContextMenu = ({
   participant: StreamVideoParticipant;
 }) => {
   const activeCall = useCall();
-  const ownCapabilities = useOwnCapabilities();
 
   const blockUser = () => {
     activeCall?.blockUser(participant.userId);
@@ -171,19 +166,13 @@ export const ParticipantActionsContextMenu = ({
       <GenericMenuButtonItem onClick={toggleParticipantPinnedAt}>
         {participant.pinnedAt ? 'Unpin' : 'Pin'}
       </GenericMenuButtonItem>
-      <Restricted
-        availableGrants={ownCapabilities}
-        requiredGrants={[OwnCapability.BLOCK_USERS]}
-      >
+      <Restricted requiredGrants={[OwnCapability.BLOCK_USERS]}>
         <GenericMenuButtonItem onClick={blockUser}>Block</GenericMenuButtonItem>
       </Restricted>
       {/* <GenericMenuButtonItem disabled onClick={kickUserClickHandler}>
         Kick
       </GenericMenuButtonItem> */}
-      <Restricted
-        availableGrants={ownCapabilities}
-        requiredGrants={[OwnCapability.MUTE_USERS]}
-      >
+      <Restricted requiredGrants={[OwnCapability.MUTE_USERS]}>
         <GenericMenuButtonItem
           disabled={
             !participant.publishedTracks.includes(SfuModels.TrackType.VIDEO)
@@ -201,10 +190,7 @@ export const ParticipantActionsContextMenu = ({
           Mute audio
         </GenericMenuButtonItem>
       </Restricted>
-      <Restricted
-        availableGrants={ownCapabilities}
-        requiredGrants={[OwnCapability.UPDATE_CALL_PERMISSIONS]}
-      >
+      <Restricted requiredGrants={[OwnCapability.UPDATE_CALL_PERMISSIONS]}>
         <GenericMenuButtonItem
           onClick={grantPermission(OwnCapability.SEND_AUDIO)}
         >


### PR DESCRIPTION
### Overview

Checks whether the current user has the appropriate permissions before rendering the default call control buttons.