### PR TITLE
fix: skip subscribing to audio tracks, consider track's state before stopping it

### DIFF
--- a/packages/client/src/rtc/publisher.ts
+++ b/packages/client/src/rtc/publisher.ts
@@ -148,14 +148,18 @@ export class Publisher {
   /**
    * Stops publishing the given track type to the SFU, if it is currently being published.
    * Underlying track will be stopped and removed from the publisher.
-   * @param trackType
+   * @param trackType the track type to unpublish.
    * @returns `true` if track with the given track type was found, otherwise `false`
    */
   unpublishStream = (trackType: TrackType) => {
     const transceiver = this.publisher
       .getTransceivers()
       .find((t) => t === this.transceiverRegistry[trackType] && t.sender.track);
-    if (transceiver && transceiver.sender.track) {
+    if (
+      transceiver &&
+      transceiver.sender.track &&
+      transceiver.sender.track.readyState === 'live'
+    ) {
       transceiver.sender.track.stop();
       return true;
     } else {


### PR DESCRIPTION
### Overview

We have detected a loop in the scenario when a certain publish permission is revoked for a participant.
The culprit was found in the `Publisher.unpublishStream` method which wasn't checking the track's `readyState` before stopping it and reporting the `wasPublishing` value back to the original caller.

In addition, we aren't explicitly subscribing to audio tracks as the SFU would make sure that every participant is automatically subscribed to other participants' audio tracks.