### PR TITLE
fix: enable source-maps in dev mode

### DIFF
--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -18,7 +18,9 @@
     "skipLibCheck": true,
     "strict": true,
     "strictNullChecks": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "inlineSources": true,
+    "inlineSourceMap": true
   },
   "include": [
     "./src",

--- a/packages/react-dogfood/next.config.mjs
+++ b/packages/react-dogfood/next.config.mjs
@@ -31,6 +31,21 @@ const nextConfig = {
     ];
   },
 
+  webpack: (config, { dev }) => {
+    if (dev) {
+      config.module.rules.push({
+        test: /\.js$/,
+        enforce: 'pre',
+        use: ['source-map-loader'],
+      });
+      config.ignoreWarnings = [
+        ...(config.ignoreWarnings || []),
+        /Failed to parse source map/,
+      ];
+    }
+    return config;
+  },
+
   sentry: {
     // Use `hidden-source-map` rather than `source-map` as the Webpack `devtool`
     // for client-side builds. (This will be the default starting in

--- a/packages/react-dogfood/package.json
+++ b/packages/react-dogfood/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/yargs": "^17.0.22",
-    "sass": "^1.58.3"
+    "sass": "^1.58.3",
+    "source-map-loader": "^4.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8502,6 +8502,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     sass: ^1.58.3
+    source-map-loader: ^4.0.1
     stream-chat: ^8.4.1
     stream-chat-react: ^10.7.2
     yargs: ^17.7.1
@@ -32933,6 +32934,19 @@ __metadata:
   peerDependencies:
     webpack: ^5.0.0
   checksum: d5a4e2ab190c93ae5cba68c247fbaa9fd560333c91060602b634c399a8a4b3205b8c07714c3bcdb0a11c6cc5476c06256bd8e824e71fbbb7981e8fad5cba4a00
+  languageName: node
+  linkType: hard
+
+"source-map-loader@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "source-map-loader@npm:4.0.1"
+  dependencies:
+    abab: ^2.0.6
+    iconv-lite: ^0.6.3
+    source-map-js: ^1.0.2
+  peerDependencies:
+    webpack: ^5.72.1
+  checksum: 4ddca8b03dc61f406effd4bffe70de4b87fef48bae6f737017b2dabcbc7d609133325be1e73838e9265331de28039111d729fcbb8bce88a6018a816bef510eb1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Overview

Enables source maps in Pronto in dev mode.
Until now, we were looking at the transpiled JS whenever we had to debug our code. Hopefully, this change would drastically improve our DX.