### PR TITLE
fix: handle gracefully abrupt track ending

### DIFF
--- a/packages/client/src/rtc/Call.ts
+++ b/packages/client/src/rtc/Call.ts
@@ -790,7 +790,7 @@ export class Call {
    */
   stopPublish = async (trackType: TrackType) => {
     console.log(`stopPublish`, TrackType[trackType]);
-    return this.publisher?.unpublishStream(trackType);
+    await this.publisher?.unpublishStream(trackType);
   };
 
   /**

--- a/packages/client/src/rtc/Call.ts
+++ b/packages/client/src/rtc/Call.ts
@@ -15,10 +15,7 @@ import {
   CallState,
   StreamVideoWriteableStateStore,
 } from '../store';
-import {
-  muteTypeToTrackType,
-  trackTypeToParticipantStreamKey,
-} from './helpers/tracks';
+import { muteTypeToTrackType } from './helpers/tracks';
 import {
   BlockUserRequest,
   BlockUserResponse,
@@ -589,7 +586,7 @@ export class Call {
     }
 
     this.subscriber = createSubscriber({
-      rpcClient: sfuClient,
+      sfuClient,
       dispatcher: this.dispatcher,
       connectionConfig: call.connectionConfig,
       onTrack: this.handleOnTrack,
@@ -611,7 +608,8 @@ export class Call {
     }
     console.log('DTX enabled', isDtxEnabled);
     this.publisher = new Publisher({
-      rpcClient: sfuClient,
+      sfuClient,
+      state: this.state,
       connectionConfig: call.connectionConfig,
       isDtxEnabled,
     });
@@ -708,27 +706,12 @@ export class Call {
       return console.error(`There is no video track in the stream.`);
     }
 
-    const trackType = TrackType.VIDEO;
-
-    try {
-      await this.publisher.publishStream(
-        videoStream,
-        videoTrack,
-        trackType,
-        opts,
-      );
-      await this.sfuClient?.updateMuteState(trackType, false);
-    } catch (e) {
-      throw e;
-    }
-
-    this.state.updateParticipant(this.sfuClient!.sessionId, (p) => ({
+    await this.publisher.publishStream(
       videoStream,
-      videoDeviceId: videoTrack.getSettings().deviceId,
-      publishedTracks: p.publishedTracks.includes(trackType)
-        ? p.publishedTracks
-        : [...p.publishedTracks, trackType],
-    }));
+      videoTrack,
+      TrackType.VIDEO,
+      opts,
+    );
   };
 
   /**
@@ -755,24 +738,14 @@ export class Call {
       return console.error(`There is no audio track in the stream`);
     }
 
-    const trackType = TrackType.AUDIO;
-
-    try {
-      await this.publisher.publishStream(audioStream, audioTrack, trackType, {
-        preferredCodec: this.preferredAudioCodec,
-      });
-      await this.sfuClient!.updateMuteState(trackType, false);
-    } catch (e) {
-      throw e;
-    }
-
-    this.state.updateParticipant(this.sfuClient!.sessionId, (p) => ({
+    await this.publisher.publishStream(
       audioStream,
-      audioDeviceId: audioTrack.getSettings().deviceId,
-      publishedTracks: p.publishedTracks.includes(trackType)
-        ? p.publishedTracks
-        : [...p.publishedTracks, trackType],
-    }));
+      audioTrack,
+      TrackType.AUDIO,
+      {
+        preferredCodec: this.preferredAudioCodec,
+      },
+    );
   };
 
   /**
@@ -798,28 +771,11 @@ export class Call {
       return console.error(`There is no video track in the stream`);
     }
 
-    // fires when browser's native 'Stop Sharing button' is clicked
-    const onTrackEnded = () => this.stopPublish(trackType);
-    screenShareTrack.addEventListener('ended', onTrackEnded);
-
-    const trackType = TrackType.SCREEN_SHARE;
-    try {
-      await this.publisher.publishStream(
-        screenShareStream,
-        screenShareTrack,
-        trackType,
-      );
-      await this.sfuClient!.updateMuteState(trackType, false);
-    } catch (e) {
-      throw e;
-    }
-
-    this.state.updateParticipant(this.sfuClient!.sessionId, (p) => ({
+    await this.publisher.publishStream(
       screenShareStream,
-      publishedTracks: p.publishedTracks.includes(trackType)
-        ? p.publishedTracks
-        : [...p.publishedTracks, trackType],
-    }));
+      screenShareTrack,
+      TrackType.SCREEN_SHARE,
+    );
   };
 
   /**
@@ -834,19 +790,7 @@ export class Call {
    */
   stopPublish = async (trackType: TrackType) => {
     console.log(`stopPublish`, TrackType[trackType]);
-    const wasPublishing = this.publisher?.unpublishStream(trackType);
-    if (wasPublishing && this.sfuClient) {
-      await this.sfuClient.updateMuteState(trackType, true);
-
-      const audioOrVideoOrScreenShareStream =
-        trackTypeToParticipantStreamKey(trackType);
-      if (audioOrVideoOrScreenShareStream) {
-        this.state.updateParticipant(this.sfuClient.sessionId, (p) => ({
-          publishedTracks: p.publishedTracks.filter((t) => t !== trackType),
-          [audioOrVideoOrScreenShareStream]: undefined,
-        }));
-      }
-    }
+    return this.publisher?.unpublishStream(trackType);
   };
 
   /**

--- a/packages/client/src/rtc/helpers/tracks.ts
+++ b/packages/client/src/rtc/helpers/tracks.ts
@@ -3,7 +3,7 @@ import type { StreamVideoParticipant } from '../types';
 
 export const trackTypeToParticipantStreamKey = (
   trackType: TrackType,
-): keyof StreamVideoParticipant | undefined => {
+): keyof StreamVideoParticipant => {
   switch (trackType) {
     case TrackType.SCREEN_SHARE:
       return 'screenShareStream';
@@ -12,14 +12,13 @@ export const trackTypeToParticipantStreamKey = (
     case TrackType.AUDIO:
       return 'audioStream';
     default:
-      console.error(`Unknown track type: ${trackType}`);
-      return undefined;
+      throw new Error(`Unknown track type: ${trackType}`);
   }
 };
 
 export const muteTypeToTrackType = (
   muteType: 'audio' | 'video' | 'screenshare',
-): TrackType | undefined => {
+): TrackType => {
   switch (muteType) {
     case 'audio':
       return TrackType.AUDIO;
@@ -28,7 +27,6 @@ export const muteTypeToTrackType = (
     case 'screenshare':
       return TrackType.SCREEN_SHARE;
     default:
-      console.error(`Unknown mute type: ${muteType}`);
-      return undefined;
+      throw new Error(`Unknown mute type: ${muteType}`);
   }
 };

--- a/packages/client/src/rtc/publisher.ts
+++ b/packages/client/src/rtc/publisher.ts
@@ -12,10 +12,13 @@ import {
   findOptimalVideoLayers,
 } from './videoLayers';
 import { getPreferredCodecs } from './codecs';
+import { trackTypeToParticipantStreamKey } from './helpers/tracks';
+import { CallState } from '../store';
 import { PublishOptions } from './types';
 
 export type PublisherOpts = {
-  rpcClient: StreamSfuClient;
+  sfuClient: StreamSfuClient;
+  state: CallState;
   connectionConfig?: RTCConfiguration;
   isDtxEnabled: boolean;
 };
@@ -26,7 +29,8 @@ export type PublisherOpts = {
  */
 export class Publisher {
   private readonly publisher: RTCPeerConnection;
-  private readonly rpcClient: StreamSfuClient;
+  private readonly sfuClient: StreamSfuClient;
+  private readonly state: CallState;
   private readonly transceiverRegistry: {
     [key in TrackType]: RTCRtpTransceiver | undefined;
   } = {
@@ -47,7 +51,12 @@ export class Publisher {
   };
   private isDtxEnabled: boolean;
 
-  constructor({ connectionConfig, rpcClient, isDtxEnabled }: PublisherOpts) {
+  constructor({
+    connectionConfig,
+    sfuClient,
+    state,
+    isDtxEnabled,
+  }: PublisherOpts) {
     const pc = new RTCPeerConnection(connectionConfig);
     pc.addEventListener('icecandidate', this.onIceCandidate);
     pc.addEventListener('negotiationneeded', this.onNegotiationNeeded);
@@ -63,7 +72,8 @@ export class Publisher {
     );
 
     this.publisher = pc;
-    this.rpcClient = rpcClient;
+    this.sfuClient = sfuClient;
+    this.state = state;
     this.isDtxEnabled = isDtxEnabled;
   }
 
@@ -92,64 +102,69 @@ export class Publisher {
           t.sender.track?.kind === this.trackKindRegistry[trackType],
       );
 
+    /**
+     * An event handler which listens for the 'ended' event on the track.
+     * Once the track has ended, it will notify the SFU and update the state.
+     */
+    const handleTrackEnded = async () => {
+      console.log(`Track ${TrackType[trackType]} has ended, notifying the SFU`);
+      await this.notifyTrackMuteStateChanged(mediaStream, trackType, true);
+      // clean-up, this event listener needs to run only once.
+      track.removeEventListener('ended', handleTrackEnded);
+    };
+
     if (!transceiver) {
-      let videoEncodings: RTCRtpEncodingParameters[] | undefined;
-      if (trackType === TrackType.VIDEO) {
-        videoEncodings = findOptimalVideoLayers(track);
-      }
+      const videoEncodings =
+        trackType === TrackType.VIDEO
+          ? findOptimalVideoLayers(track)
+          : undefined;
+
+      const codecPreferences = this.getCodecPreferences(
+        trackType,
+        opts.preferredCodec,
+      );
+
+      // listen for 'ended' event on the track as it might be ended abruptly
+      // by an external factor as permission revokes, device disconnected, etc.
+      // keep in mind that `track.stop()` doesn't trigger this event.
+      track.addEventListener('ended', handleTrackEnded);
+
       transceiver = this.publisher.addTransceiver(track, {
         direction: 'sendonly',
         streams:
           trackType === TrackType.VIDEO || trackType === TrackType.SCREEN_SHARE
             ? [mediaStream]
             : undefined,
-        sendEncodings:
-          trackType === TrackType.VIDEO ? videoEncodings : undefined,
+        sendEncodings: videoEncodings,
       });
 
       this.transceiverRegistry[trackType] = transceiver;
 
-      if (trackType === TrackType.VIDEO) {
-        const codecPreferences = getPreferredCodecs(
-          'video',
-          opts.preferredCodec || 'vp8',
+      if ('setCodecPreferences' in transceiver && codecPreferences) {
+        console.log(
+          `Setting ${TrackType[trackType]} codec preferences`,
+          codecPreferences,
         );
-
-        if ('setCodecPreferences' in transceiver && codecPreferences) {
-          console.log(`set video codec preferences`, codecPreferences);
-          // @ts-ignore
-          transceiver.setCodecPreferences(codecPreferences);
-        }
-      }
-
-      if (trackType === TrackType.AUDIO) {
-        let returnOnlyMatched = opts.preferredCodec === 'opus';
-        const codecPreferences = getPreferredCodecs(
-          'audio',
-          opts.preferredCodec!,
-          returnOnlyMatched,
-        );
-        console.log('Preferred codec', opts.preferredCodec);
-        if ('setCodecPreferences' in transceiver && codecPreferences) {
-          console.log(`set audio codec preferences`, codecPreferences);
-          // @ts-ignore
-          transceiver.setCodecPreferences(codecPreferences);
-        }
+        transceiver.setCodecPreferences(codecPreferences);
       }
     } else {
+      const previousTrack = transceiver.sender.track;
       // don't stop the track if we are re-publishing the same track
-      if (transceiver.sender.track !== track) {
-        transceiver.sender.track?.stop();
+      if (previousTrack && previousTrack !== track) {
+        previousTrack.stop();
+        previousTrack.removeEventListener('ended', handleTrackEnded);
+        track.addEventListener('ended', handleTrackEnded);
       }
       await transceiver.sender.replaceTrack(track);
     }
+
+    await this.notifyTrackMuteStateChanged(mediaStream, trackType, false);
   };
 
   /**
    * Stops publishing the given track type to the SFU, if it is currently being published.
    * Underlying track will be stopped and removed from the publisher.
    * @param trackType the track type to unpublish.
-   * @returns `true` if track with the given track type was found, otherwise `false`
    */
   unpublishStream = (trackType: TrackType) => {
     const transceiver = this.publisher
@@ -161,9 +176,31 @@ export class Publisher {
       transceiver.sender.track.readyState === 'live'
     ) {
       transceiver.sender.track.stop();
-      return true;
+      return this.notifyTrackMuteStateChanged(undefined, trackType, true);
+    }
+  };
+
+  private notifyTrackMuteStateChanged = async (
+    mediaStream: MediaStream | undefined,
+    trackType: TrackType,
+    isMuted: boolean,
+  ) => {
+    await this.sfuClient.updateMuteState(trackType, isMuted);
+
+    const audioOrVideoOrScreenShareStream =
+      trackTypeToParticipantStreamKey(trackType);
+    if (isMuted) {
+      this.state.updateParticipant(this.sfuClient.sessionId, (p) => ({
+        publishedTracks: p.publishedTracks.filter((t) => t !== trackType),
+        [audioOrVideoOrScreenShareStream]: undefined,
+      }));
     } else {
-      return false;
+      this.state.updateParticipant(this.sfuClient.sessionId, (p) => ({
+        publishedTracks: p.publishedTracks.includes(trackType)
+          ? p.publishedTracks
+          : [...p.publishedTracks, trackType],
+        [audioOrVideoOrScreenShareStream]: mediaStream,
+      }));
     }
   };
 
@@ -229,13 +266,26 @@ export class Publisher {
     return this.publisher.getStats(selector);
   }
 
+  private getCodecPreferences = (
+    trackType: TrackType,
+    preferredCodec?: string | null,
+  ) => {
+    if (trackType === TrackType.VIDEO) {
+      return getPreferredCodecs('video', preferredCodec || 'vp8');
+    }
+    if (trackType === TrackType.AUDIO) {
+      const matchedOnly = preferredCodec === 'opus';
+      return getPreferredCodecs('audio', preferredCodec || 'opus', matchedOnly);
+    }
+  };
+
   private onIceCandidate = async (e: RTCPeerConnectionIceEvent) => {
     const { candidate } = e;
     if (!candidate) {
       console.log('null ice candidate');
       return;
     }
-    await this.rpcClient.iceTrickle({
+    await this.sfuClient.iceTrickle({
       iceCandidate: getIceCandidate(candidate),
       peerType: PeerType.PUBLISHER_UNSPECIFIED,
     });
@@ -295,7 +345,7 @@ export class Publisher {
       });
 
     // TODO debounce for 250ms
-    const { response } = await this.rpcClient.setPublisher({
+    const { response } = await this.sfuClient.setPublisher({
       sdp: offer.sdp || '',
       tracks: trackInfos,
     });
@@ -309,7 +359,7 @@ export class Publisher {
       console.error(`Publisher: setRemoteDescription error`, response.sdp, e);
     }
 
-    this.rpcClient.iceTrickleBuffer.publisherCandidates.subscribe(
+    this.sfuClient.iceTrickleBuffer.publisherCandidates.subscribe(
       async (candidate) => {
         try {
           const iceCandidate = JSON.parse(candidate.iceCandidate);

--- a/packages/client/src/rtc/subscriber.ts
+++ b/packages/client/src/rtc/subscriber.ts
@@ -4,14 +4,14 @@ import { PeerType } from '../gen/video/sfu/models/models';
 import { Dispatcher } from './Dispatcher';
 
 export type SubscriberOpts = {
-  rpcClient: StreamSfuClient;
+  sfuClient: StreamSfuClient;
   dispatcher: Dispatcher;
   connectionConfig?: RTCConfiguration;
   onTrack?: (e: RTCTrackEvent) => void;
 };
 
 export const createSubscriber = ({
-  rpcClient,
+  sfuClient,
   dispatcher,
   connectionConfig,
   onTrack,
@@ -26,7 +26,7 @@ export const createSubscriber = ({
       return;
     }
 
-    await rpcClient.iceTrickle({
+    await sfuClient.iceTrickle({
       iceCandidate: getIceCandidate(candidate),
       peerType: PeerType.SUBSCRIBER,
     });
@@ -36,7 +36,7 @@ export const createSubscriber = ({
     subscriber.addEventListener('track', onTrack);
   }
 
-  const { iceTrickleBuffer } = rpcClient;
+  const { iceTrickleBuffer } = sfuClient;
   const unsubscribe = dispatcher.on('subscriberOffer', async (message) => {
     if (message.eventPayload.oneofKind !== 'subscriberOffer') return;
     const { subscriberOffer } = message.eventPayload;
@@ -60,7 +60,7 @@ export const createSubscriber = ({
     const answer = await subscriber.createAnswer();
     await subscriber.setLocalDescription(answer);
 
-    await rpcClient.sendAnswer({
+    await sfuClient.sendAnswer({
       peerType: PeerType.SUBSCRIBER,
       sdp: answer.sdp || '',
     });


### PR DESCRIPTION
### Overview

Any `MediaStreamTrack` we publish can be ended abruptly by an external factor such as permission revoking, detaching a device, etc.
In such cases, our engine should be able to detect this and update our internal state and notify the SFU accordingly, as otherwise, remote call participants might observe a frozen stream.
With this change, these abruptions will be handled as "graceful muting" and remote participants would react to this appropriately (muting audio, rendering avatar instead of video, hiding screen share, etc...).