### PR TITLE
refactor(react-sdk): replace PopperJS with Floating UI

### DIFF
--- a/packages/react-dogfood/components/ActiveCallHeader.tsx
+++ b/packages/react-dogfood/components/ActiveCallHeader.tsx
@@ -82,7 +82,7 @@ export const ActiveCallHeader = ({
             return (
               <Notification
                 isVisible
-                placement="auto"
+                placement="bottom"
                 message={
                   isOffline
                     ? 'You are offline. Check your internet connection and try again later.'
@@ -98,7 +98,7 @@ export const ActiveCallHeader = ({
             <Notification
               isVisible={isRecoveringConnection}
               iconClassName={null}
-              placement="auto"
+              placement="bottom"
               message={<LoadingIndicator text="Reconnecting..." />}
             >
               <span />

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -15,25 +15,19 @@
     "@floating-ui/react": "^0.22.0",
     "@nivo/core": "^0.80.0",
     "@nivo/line": "^0.80.0",
-    "@popperjs/core": "^2.11.6",
     "@stream-io/i18n": "workspace:^",
     "@stream-io/video-client": "workspace:^",
     "@stream-io/video-react-bindings": "workspace:^",
     "@stream-io/video-styling": "workspace:^",
     "clsx": "^1.2.1",
-    "lodash.throttle": "^4.1.1",
-    "react-popper": "^2.3.0",
-    "rxjs": "~7.5.7",
-    "uuid": "^9.0.0"
+    "rxjs": "~7.5.7"
   },
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@types/lodash.throttle": "^4",
     "@types/rimraf": "^3.0.2",
-    "@types/uuid": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "replace-in-file": "^6.3.5",

--- a/packages/react-sdk/src/components/Button/CompositeButton.tsx
+++ b/packages/react-sdk/src/components/Button/CompositeButton.tsx
@@ -22,15 +22,12 @@ const isComponentType = (
   return !isValidElement(elementOrComponent);
 };
 
-export const CompositeButton = ({
-  caption,
-  children,
-  active,
-  Menu,
-  menuPlacement,
-}: IconButtonWithMenuProps) => {
+export const CompositeButton = forwardRef<
+  HTMLDivElement,
+  IconButtonWithMenuProps
+>(({ caption, children, active, Menu, menuPlacement }, ref) => {
   return (
-    <div className="str-video__composite-button">
+    <div className="str-video__composite-button" ref={ref}>
       <div
         className={clsx('str-video__composite-button__button-group', {
           'str-video__composite-button__button-group--active': active,
@@ -48,7 +45,7 @@ export const CompositeButton = ({
       )}
     </div>
   );
-};
+});
 
 const ToggleMenuButton = forwardRef<HTMLButtonElement, ToggleMenuButtonProps>(
   ({ menuShown }, ref) => (

--- a/packages/react-sdk/src/components/Button/CopyToClipboardButton.tsx
+++ b/packages/react-sdk/src/components/Button/CopyToClipboardButton.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from 'react';
 import clsx from 'clsx';
-import { Placement } from '@popperjs/core';
+import { Placement } from '@floating-ui/react';
 
 import { Tooltip } from '../Tooltip';
 

--- a/packages/react-sdk/src/components/CallControls/CallStatsButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/CallStatsButton.tsx
@@ -1,6 +1,8 @@
-import { useRef, useState } from 'react';
+import { forwardRef } from 'react';
+
 import { CallStats } from '../StreamCall/CallStats';
 import { CompositeButton, IconButton } from '../Button/';
+import { MenuToggle, ToggleMenuButtonProps } from '../Menu';
 
 type CallStatsButtonProps = {
   caption?: string;
@@ -9,28 +11,18 @@ type CallStatsButtonProps = {
 export const CallStatsButton = ({
   caption = 'Stats',
 }: CallStatsButtonProps) => {
-  const [isStatsOpen, setIsStatsOpen] = useState(false);
-  const statsAnchorRef = useRef<HTMLButtonElement>(null);
   return (
-    <>
-      {isStatsOpen && (
-        <CallStats
-          anchor={statsAnchorRef.current!}
-          onClose={() => {
-            setIsStatsOpen(false);
-          }}
-        />
-      )}
-      <CompositeButton active={isStatsOpen} caption={caption}>
-        <IconButton
-          icon="stats"
-          title="Statistics"
-          ref={statsAnchorRef}
-          onClick={() => {
-            setIsStatsOpen((v) => !v);
-          }}
-        />
-      </CompositeButton>
-    </>
+    <MenuToggle placement="top-end" ToggleButton={ToggleMenuButton}>
+      <CallStats />
+    </MenuToggle>
   );
 };
+
+const ToggleMenuButton = forwardRef<
+  HTMLDivElement,
+  ToggleMenuButtonProps<HTMLDivElement>
+>(({ menuShown }, ref) => (
+  <CompositeButton ref={ref} active={menuShown} caption={'Stats'}>
+    <IconButton icon="stats" title="Statistics" />
+  </CompositeButton>
+));

--- a/packages/react-sdk/src/components/Debug/DebugStatsView.tsx
+++ b/packages/react-sdk/src/components/Debug/DebugStatsView.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { usePopper } from 'react-popper';
 import { Call } from '@stream-io/video-client';
 import { useRtcStats } from '../../hooks/useRtcStats';
+import { useFloatingUIPreset } from '../../hooks';
 
 export const DebugStatsView = (props: {
   call: Call;
@@ -11,9 +11,11 @@ export const DebugStatsView = (props: {
   const { call, kind, mediaStream } = props;
   const stats = useRtcStats(call, kind, mediaStream);
 
-  const [anchor, setAnchor] = useState<HTMLSpanElement | null>(null);
-  const [popover, setPopover] = useState<HTMLDivElement | null>(null);
-  const { styles, attributes } = usePopper(anchor, popover);
+  const { refs, strategy, y, x } = useFloatingUIPreset({
+    placement: 'top',
+    strategy: 'absolute',
+  });
+
   const [isPopperOpen, setIsPopperOpen] = useState(false);
 
   const [videoTrack] = mediaStream?.getVideoTracks() ?? [];
@@ -23,7 +25,7 @@ export const DebugStatsView = (props: {
       <span
         className="str-video__debug__track-stats-icon"
         tabIndex={0}
-        ref={setAnchor}
+        ref={refs.setReference}
         title={
           settings &&
           `${settings.width}x${settings.height}@${Math.round(
@@ -37,9 +39,13 @@ export const DebugStatsView = (props: {
       {isPopperOpen && (
         <div
           className="str-video__debug__track-stats"
-          ref={setPopover}
-          style={styles.popper}
-          {...attributes.popper}
+          ref={refs.setFloating}
+          style={{
+            position: strategy,
+            top: y ?? 0,
+            left: x ?? 0,
+            overflowY: 'auto',
+          }}
         >
           <pre>{JSON.stringify(stats, null, 2)}</pre>
         </div>

--- a/packages/react-sdk/src/components/Menu/MenuToggle.tsx
+++ b/packages/react-sdk/src/components/Menu/MenuToggle.tsx
@@ -5,64 +5,33 @@ import {
   useState,
   ForwardedRef,
 } from 'react';
-import {
-  offset,
-  autoUpdate,
-  size,
-  useFloating,
-  Placement,
-  Strategy,
-} from '@floating-ui/react';
+import { Placement, Strategy } from '@floating-ui/react';
 
-export type ToggleMenuButtonProps = {
+import { useFloatingUIPreset } from '../../hooks';
+
+export type ToggleMenuButtonProps<E extends HTMLElement = HTMLButtonElement> = {
   menuShown: boolean;
-  ref: ForwardedRef<HTMLButtonElement>;
+  ref: ForwardedRef<E>;
 };
 
-export type MenuToggleProps = PropsWithChildren<{
-  ToggleButton: ComponentType<ToggleMenuButtonProps>;
+export type MenuToggleProps<E extends HTMLElement> = PropsWithChildren<{
+  ToggleButton: ComponentType<ToggleMenuButtonProps<E>>;
   placement?: Placement;
   strategy?: Strategy;
 }>;
 
-export const MenuToggle = ({
+export const MenuToggle = <E extends HTMLElement>({
   ToggleButton,
   placement = 'top-start',
   strategy = 'absolute',
   children,
-}: MenuToggleProps) => {
+}: MenuToggleProps<E>) => {
   const [menuShown, setMenuShown] = useState(false);
 
-  const {
-    refs,
-    x,
-    y,
-    update,
-    elements: { domReference, floating },
-  } = useFloating({
+  const { floating, domReference, refs, x, y } = useFloatingUIPreset({
     placement,
     strategy,
-    middleware: [
-      offset(10),
-      size({
-        padding: 10,
-        apply({ availableHeight, elements }) {
-          Object.assign(elements.floating.style, {
-            maxHeight: `${availableHeight}px`,
-          });
-        },
-      }),
-    ],
   });
-
-  // handle window resizing
-  useEffect(() => {
-    if (!domReference || !floating) return;
-
-    const cleanup = autoUpdate(domReference, floating, update);
-
-    return () => cleanup();
-  }, [domReference, floating, update]);
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {

--- a/packages/react-sdk/src/components/Notification/Notification.tsx
+++ b/packages/react-sdk/src/components/Notification/Notification.tsx
@@ -1,6 +1,7 @@
-import { Placement } from '@popperjs/core';
-import { PropsWithChildren, ReactNode, useEffect, useState } from 'react';
-import { usePopper } from 'react-popper';
+import { PropsWithChildren, ReactNode, useEffect } from 'react';
+import { Placement } from '@floating-ui/react';
+
+import { useFloatingUIPreset } from '../../hooks';
 
 export type NotificationProps = {
   message?: ReactNode;
@@ -21,18 +22,10 @@ export const Notification = (props: PropsWithChildren<NotificationProps>) => {
     placement = 'top',
     iconClassName = 'str-video__notification__icon',
   } = props;
-  const [anchor, setAnchor] = useState<HTMLSpanElement | null>(null);
-  const [popover, setPopover] = useState<HTMLDivElement | null>(null);
-  const { styles, attributes } = usePopper(anchor, popover, {
+
+  const { refs, x, y, strategy } = useFloatingUIPreset({
     placement,
-    modifiers: [
-      {
-        name: 'offset',
-        options: {
-          offset: [0, 15],
-        },
-      },
-    ],
+    strategy: 'absolute',
   });
 
   useEffect(() => {
@@ -46,13 +39,17 @@ export const Notification = (props: PropsWithChildren<NotificationProps>) => {
   }, [isVisible, resetIsVisible, visibilityTimeout]);
 
   return (
-    <div ref={setAnchor} data-popper-anchor="">
+    <div ref={refs.setReference}>
       {isVisible && (
         <div
           className="str-video__notification"
-          ref={setPopover}
-          style={styles.popper}
-          {...attributes.popper}
+          ref={refs.setFloating}
+          style={{
+            position: strategy,
+            top: y ?? 0,
+            left: x ?? 0,
+            overflowY: 'auto',
+          }}
         >
           {iconClassName && <i className={iconClassName} />}
           <span className="str-video__notification__message">{message}</span>

--- a/packages/react-sdk/src/components/Permissions/PermissionRequests.tsx
+++ b/packages/react-sdk/src/components/Permissions/PermissionRequests.tsx
@@ -12,9 +12,10 @@ import {
   PermissionRequestEvent,
   UserResponse,
 } from '@stream-io/video-client';
-import { usePopper } from 'react-popper';
 import { useCall, useHasPermissions } from '@stream-io/video-react-bindings';
 import clsx from 'clsx';
+
+import { useFloatingUIPreset } from '../../hooks';
 
 const byNameOrId = (a: UserResponse, b: UserResponse) => {
   if (a.name && b.name && a.name < b.name) return -1;
@@ -68,25 +69,16 @@ export const PermissionRequests = () => {
     };
   };
 
-  const [anchor, setAnchor] = useState<HTMLDivElement | null>(null);
-  const [popover, setPopover] = useState<HTMLDivElement | null>(null);
-  const { styles, attributes } = usePopper(anchor, popover, {
+  const { refs, x, y, strategy } = useFloatingUIPreset({
     placement: 'bottom',
-    modifiers: [
-      {
-        name: 'offset',
-        options: {
-          offset: [0, 0],
-        },
-      },
-    ],
+    strategy: 'absolute',
   });
 
   // don't render anything if there are no permission requests
   if (permissionRequests.length === 0) return null;
 
   return (
-    <div className="str-video__permission-requests" ref={setAnchor}>
+    <div className="str-video__permission-requests" ref={refs.setReference}>
       <div className="str-video__permission-requests__notification">
         <span className="str-video__permission-requests__notification__message">
           {permissionRequests.length} pending permission requests
@@ -102,9 +94,13 @@ export const PermissionRequests = () => {
       </div>
       {expanded && (
         <PermissionRequestList
-          ref={setPopover}
-          style={styles.popper}
-          {...attributes.popper}
+          ref={refs.setFloating}
+          style={{
+            position: strategy,
+            top: y ?? 0,
+            left: x ?? 0,
+            overflowY: 'auto',
+          }}
           permissionRequests={permissionRequests}
           handleUpdatePermission={handleUpdatePermission}
         />

--- a/packages/react-sdk/src/components/StreamCall/CallStats.tsx
+++ b/packages/react-sdk/src/components/StreamCall/CallStats.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { usePopper } from 'react-popper';
 import {
   AggregatedStatsReport,
   CallStatsReport,
@@ -7,32 +6,14 @@ import {
 import { useCurrentCallStatsReport } from '@stream-io/video-react-bindings';
 import { CallStatsLatencyChart } from './CallStatsLatencyChart';
 
-export const CallStats = (props: {
-  anchor?: HTMLElement;
-  onClose?: () => void;
-}) => {
-  const { anchor, onClose } = props;
-  const [popover, setPopover] = useState<HTMLDivElement | null>(null);
-  const { styles, attributes } = usePopper(anchor, popover, {
-    placement: 'auto',
-    modifiers: [
-      {
-        name: 'offset',
-        options: {
-          offset: [0, 10],
-        },
-      },
-    ],
-  });
-
+export const CallStats = () => {
   const [latencyBuffer, setLatencyBuffer] = useState<
     Array<{ x: number; y: number }>
   >(() => {
     const now = Date.now();
-    return Array(20)
-      .fill(null)
-      .map((_, i) => ({ x: now + i, y: 0 }));
+    return Array.from({ length: 20 }, (_, i) => ({ x: now + i, y: 0 }));
   });
+
   const [publishBitrate, setPublishBitrate] = useState('-');
   const [subscribeBitrate, setSubscribeBitrate] = useState('-');
   const previousStats = useRef<CallStatsReport>();
@@ -68,18 +49,7 @@ export const CallStats = (props: {
   }, [callStatsReport]);
 
   return (
-    <div
-      className="str-video__call-stats"
-      ref={setPopover}
-      style={styles.popper}
-      {...attributes.popper}
-    >
-      <h2 className="str-video__call-stats__title">
-        Statistics{' '}
-        <span className="str-video__call-stats__close" onClick={onClose}>
-          X
-        </span>
-      </h2>
+    <div className="str-video__call-stats">
       {callStatsReport && (
         <>
           <h3>Call Latency</h3>

--- a/packages/react-sdk/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-sdk/src/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
-import { PropsWithChildren, useState } from 'react';
-import { PopperProps, usePopper } from 'react-popper';
+import { PropsWithChildren, useEffect } from 'react';
 import clsx from 'clsx';
+import { useFloatingUIPreset } from '../../hooks';
+import { Placement } from '@floating-ui/react';
 
 export type TooltipProps<T extends HTMLElement> = PropsWithChildren<{
   /** Reference element to which the tooltip should attach to */
@@ -10,42 +11,39 @@ export type TooltipProps<T extends HTMLElement> = PropsWithChildren<{
   /** Popper's modifier (offset) property - [xAxis offset, yAxis offset], default [0, 10] */
   offset?: [number, number];
   /** Popper's placement property defining default position of the tooltip, default 'top' */
-  tooltipPlacement?: PopperProps<unknown>['placement'];
+  tooltipPlacement?: Placement;
   /** Tells component whether to render its contents */
   visible?: boolean;
 }>;
 
 export const Tooltip = <T extends HTMLElement>({
   children,
-  offset = [0, 10],
   referenceElement,
   tooltipClassName,
   tooltipPlacement = 'top',
   visible = false,
 }: TooltipProps<T>) => {
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
-    null,
-  );
-  const { attributes, styles } = usePopper(referenceElement, popperElement, {
-    modifiers: [
-      {
-        name: 'offset',
-        options: {
-          offset,
-        },
-      },
-    ],
+  const { refs, x, y, strategy } = useFloatingUIPreset({
     placement: tooltipPlacement,
+    strategy: 'absolute',
   });
+
+  useEffect(() => {
+    refs.setReference(referenceElement);
+  }, [referenceElement, refs]);
 
   if (!visible) return null;
 
   return (
     <div
       className={clsx('str-video__tooltip', tooltipClassName)}
-      ref={setPopperElement}
-      style={styles.popper}
-      {...attributes.popper}
+      ref={refs.setFloating}
+      style={{
+        position: strategy,
+        top: y ?? 0,
+        left: x ?? 0,
+        overflowY: 'auto',
+      }}
     >
       {children}
     </div>

--- a/packages/react-sdk/src/hooks/index.ts
+++ b/packages/react-sdk/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useRtcStats';
+export * from './useFloatingUIPreset';

--- a/packages/react-sdk/src/hooks/useFloatingUIPreset.ts
+++ b/packages/react-sdk/src/hooks/useFloatingUIPreset.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import {
+  offset,
+  autoUpdate,
+  size,
+  useFloating,
+  shift,
+} from '@floating-ui/react';
+import type { UseFloatingProps } from '@floating-ui/react';
+
+export const useFloatingUIPreset = ({
+  placement,
+  strategy,
+}: Pick<UseFloatingProps, 'placement' | 'strategy'>) => {
+  const {
+    refs,
+    x,
+    y,
+    update,
+    elements: { domReference, floating },
+  } = useFloating({
+    placement,
+    strategy,
+    middleware: [
+      offset(10),
+      shift(),
+      size({
+        padding: 10,
+        apply({ availableHeight, elements }) {
+          Object.assign(elements.floating.style, {
+            maxHeight: `${availableHeight}px`,
+          });
+        },
+      }),
+    ],
+  });
+
+  // handle window resizing
+  useEffect(() => {
+    if (!domReference || !floating) return;
+
+    const cleanup = autoUpdate(domReference, floating, update);
+
+    return () => cleanup();
+  }, [domReference, floating, update]);
+
+  return { refs, x, y, domReference, floating, strategy };
+};

--- a/packages/styling/src/CallStats.scss
+++ b/packages/styling/src/CallStats.scss
@@ -1,9 +1,15 @@
 .str-video__call-stats {
   background-color: var(--str-video__background-color1);
   border-radius: var(--str-video__border-radius1);
-  padding: 0.625rem 1rem;
-  width: 30%;
-  z-index: 1;
+  padding: 0.75rem;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  h3 {
+    margin: unset;
+  }
 
   &.str-video__call-stats-angular {
     width: 400px;
@@ -14,29 +20,12 @@
     }
   }
 
-  .str-video__call-stats__title {
-    .str-video__call-stats__close {
-      float: right;
-      font-size: 1.25rem;
-      color: var(--str-video__text-color2);
-      cursor: pointer;
-      width: 2rem;
-      text-align: center;
-      border-radius: var(--str-video__border-radius1);
-
-      &:hover {
-        background-color: var(--str-video__background-color1);
-      }
-    }
-  }
-
   .str-video__call-stats__card-container {
     --gap: 1rem;
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
     gap: var(--gap);
-    padding: 0 0 1rem 0;
   }
 
   .str-video__call-stats__card {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8661,25 +8661,19 @@ __metadata:
     "@floating-ui/react": ^0.22.0
     "@nivo/core": ^0.80.0
     "@nivo/line": ^0.80.0
-    "@popperjs/core": ^2.11.6
     "@stream-io/i18n": "workspace:^"
     "@stream-io/video-client": "workspace:^"
     "@stream-io/video-react-bindings": "workspace:^"
     "@stream-io/video-styling": "workspace:^"
-    "@types/lodash.throttle": ^4
     "@types/rimraf": ^3.0.2
-    "@types/uuid": ^9.0.0
     clsx: ^1.2.1
-    lodash.throttle: ^4.1.1
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-popper: ^2.3.0
     replace-in-file: ^6.3.5
     rimraf: ^3.0.2
     rxjs: ~7.5.7
     typedoc: ^0.23.24
     typescript: ^4.9.5
-    uuid: ^9.0.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
@@ -9390,16 +9384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash.throttle@npm:^4":
-  version: 4.1.7
-  resolution: "@types/lodash.throttle@npm:4.1.7"
-  dependencies:
-    "@types/lodash": "*"
-  checksum: 6e1b3836488fecbdc537b6ad9b3fe4855c7336b0fa388773cd57d486619f565a48cabc04b28677fd3819be3f2d13d2bb8f9d4428aa5632885c86cb99729bfd69
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:*, @types/lodash@npm:^4.14.167":
+"@types/lodash@npm:^4.14.167":
   version: 4.14.192
   resolution: "@types/lodash@npm:4.14.192"
   checksum: 31e1f0543a04158d2c429c45efd7c77882736630d0652f82eb337d6159ec0c249c5d175c0af731537b53271e665ff8d76f43221d75d03646d31cb4bd6f0056b1


### PR DESCRIPTION
Part of this PR is a simplification of the `CallStats` component:
![image](https://user-images.githubusercontent.com/43254280/235150865-5ebcdfa2-b3a6-412b-9cab-66e4b65e7b64.png)
