### PR TITLE
docs: Remove Angular-specific links from client

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -710,7 +710,6 @@ export class Call {
    * Consecutive calls to this method will replace the previously published stream.
    * The previous video stream will be stopped.
    *
-   * @angular It's recommended to use the [`InCallDeviceManagerService`](./InCallDeviceManagerService.md) that takes care of this operation for you.
    *
    * @param videoStream the video stream to publish.
    * @param opts the options to use when publishing the stream.
@@ -746,7 +745,6 @@ export class Call {
    * Consecutive calls to this method will replace the audio stream that is currently being published.
    * The previous audio stream will be stopped.
    *
-   * @angular It's recommended to use the [`InCallDeviceManagerService`](./InCallDeviceManagerService.md) that takes care of this operation for you.
    *
    * @param audioStream the audio stream to publish.
    */
@@ -779,7 +777,6 @@ export class Call {
    * Consecutive calls to this method will replace the previous screen-share stream.
    * The previous screen-share stream will be stopped.
    *
-   * @angular It's recommended to use the [`InCallDeviceManagerService`](./InCallDeviceManagerService.md) that takes care of this operation for you.
    *
    * @param screenShareStream the screen-share stream to publish.
    */
@@ -809,7 +806,6 @@ export class Call {
    *
    * The `audioDeviceId`/`videoDeviceId` property of the [`localParticipant$`](./StreamVideoClient.md/#readonlystatestore) won't be updated, you can do that by calling the [`setAudioDevice`](#setaudiodevice)/[`setVideoDevice`](#setvideodevice) method.
    *
-   * @angular It's recommended to use the [`InCallDeviceManagerService`](./InCallDeviceManagerService.md) that takes care of this operation for you.
    *
    * @param trackType the track type to stop publishing.
    */
@@ -932,7 +928,6 @@ export class Call {
    *
    * This method only stores the selection, if you're using custom UI components, you'll have to implement the audio switching, for more information see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/sinkId.
    *
-   * @angular It's recommended to use the [`InCallDeviceManagerService`](./InCallDeviceManagerService.md) that takes care of this operation for you.
    *
    * @param deviceId the selected device, `undefined` means the user wants to use the system's default audio output
    */
@@ -947,7 +942,6 @@ export class Call {
    *
    * This method only stores the selection, if you want to start publishing a media stream call the [`publishAudioStream` method](#publishaudiostream) that will set `audioDeviceId` as well.
    *
-   * @angular It's recommended to use the [`InCallDeviceManagerService`](./InCallDeviceManagerService.md) that takes care of this operation for you.
    *
    * @param deviceId the selected device, pass `undefined` to clear the device selection
    */
@@ -961,8 +955,6 @@ export class Call {
    * Sets the `videoDeviceId` property of the [`localParticipant$`](./StreamVideoClient.md/#readonlystatestore).
    *
    * This method only stores the selection, if you want to start publishing a media stream call the [`publishVideoStream` method](#publishvideostream) that will set `videoDeviceId` as well.
-   *
-   * @angular It's recommended to use the [`InCallDeviceManagerService`](./InCallDeviceManagerService.md) that takes care of this operation for you.
    *
    * @param deviceId the selected device, pass `undefined` to clear the device selection
    */

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -41,7 +41,6 @@ import { StreamClient } from './coordinator/connection/client';
 export class StreamVideoClient {
   /**
    * A reactive store that exposes all the state variables in a reactive manner - you can subscribe to changes of the different state variables. Our library is built in a way that all state changes are exposed in this store, so all UI changes in your application should be handled by subscribing to these variables.
-   * @angular If you're using our Angular SDK, you shouldn't be interacting with the state store directly, instead, you should be using the [`StreamVideoService`](./StreamVideoService.md).
    */
   readonly readOnlyStateStore: StreamVideoReadOnlyStateStore;
   private readonly writeableStateStore: StreamVideoWriteableStateStore;
@@ -49,7 +48,6 @@ export class StreamVideoClient {
 
   /**
    * You should create only one instance of `StreamVideoClient`.
-   * @angular If you're using our Angular SDK, you shouldn't be calling the `constructor` directly, instead you should be using [`StreamVideoService`](./StreamVideoService.md/#init).
    * @param apiKey your Stream API key
    * @param opts the options for the client.
    */


### PR DESCRIPTION
These are causing invalid links in the docs. Although they won't cause problems (we don't need Angular links in React and RN docs) but they cause [invalid link warnings](https://github.com/GetStream/stream-video-js/actions/runs/4861406970/jobs/8666412964#step:8:77) making it harder to detect real invalid links. Once the Angular SDK is active again we can see if we still need them in the docs.