### PR TITLE
feat(latency): breadth-first time-boxed latency measurement

### DIFF
--- a/packages/client/src/rtc/flows/__tests__/latency.test.ts
+++ b/packages/client/src/rtc/flows/__tests__/latency.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from 'vitest';
+import { measureLatencyToEdges } from '../latency';
+import { DatacenterResponse } from '../../../gen/coordinator';
+
+describe('Latency', () => {
+  const edges: DatacenterResponse[] = [
+    {
+      name: 'eqx-nyc1',
+      latency_url:
+        'https://sfu-9f0306f.eqx-nyc1.stream-io-video.com/latency_test.png',
+      coordinates: {
+        latitude: 40.712778,
+        longitude: -74.006111,
+      },
+    },
+    {
+      name: 'blu-tal1',
+      latency_url:
+        'https://sfu-a69b58a.blu-tal1.stream-io-video.com/latency_test.png',
+      coordinates: {
+        latitude: 59.43696,
+        longitude: 24.75353,
+      },
+    },
+    {
+      name: 'ovh-lon1',
+      latency_url:
+        'https://sfu-9c050b4.ovh-lon1.stream-io-video.com/latency_test.png',
+      coordinates: {
+        latitude: 51.507359,
+        longitude: -0.136439,
+      },
+    },
+  ];
+
+  // for integration purposes, disabled on CI
+  it.skip('measure latency', async () => {
+    const start = performance.now();
+    const latencyByEdge = await measureLatencyToEdges(edges, {
+      attempts: 3,
+      attemptTimeoutAfterMs: 750,
+      measureTimeoutAfterMs: 1000,
+    });
+    console.log('total time in ms:', performance.now() - start, latencyByEdge);
+  });
+});

--- a/packages/client/src/rtc/flows/join.ts
+++ b/packages/client/src/rtc/flows/join.ts
@@ -6,7 +6,7 @@ import {
   JoinCallRequest,
   JoinCallResponse,
 } from '../../gen/coordinator';
-import { measureResourceLoadLatencyTo } from './latency';
+import { measureLatencyToEdges } from './latency';
 import { StreamClient } from '../../coordinator/connection/client';
 
 const getCascadingModeParams = () => {
@@ -75,17 +75,8 @@ const getCallEdgeServer = async (
   id: string,
   edges: DatacenterResponse[],
 ) => {
-  const latencyByEdge: GetCallEdgeServerRequest['latency_measurements'] = {};
-  await Promise.all(
-    edges.map(async (edge) => {
-      latencyByEdge[edge.name] = await measureResourceLoadLatencyTo(
-        edge.latency_url,
-      );
-    }),
-  );
-
   const data = {
-    latency_measurements: latencyByEdge,
+    latency_measurements: await measureLatencyToEdges(edges),
   };
   // FIXME OL: remove this once cascading is enabled by default
   const cascadingModeParams = getCascadingModeParams();

--- a/packages/client/src/rtc/flows/latency.ts
+++ b/packages/client/src/rtc/flows/latency.ts
@@ -25,7 +25,7 @@ export const measureResourceLoadLatencyTo = async (
     src.searchParams.set('r', `js_${Math.random() * 10000000}`);
     await fetch(src.toString(), {
       signal: controller.signal,
-    }).then((response) => response.blob());
+    });
     const latency = Date.now() - start;
     return toSeconds(latency);
   } catch (e) {


### PR DESCRIPTION
### Overview

An attempt to make the "measure latencies" step more predictable and reliable.
This new flow will run all latency measurements in parallel, for all provided edges. Every measurement attempt is time-boxed to 1s and the whole measuring process can't take longer than 1.2 seconds.

The coordinator might receive none, or incomplete measurements as a side-effect of this new flow.