### PR TITLE
fix: preserve last used deviceId when muting

### DIFF
--- a/packages/client/src/rtc/__tests__/mocks/webrtc.mocks.ts
+++ b/packages/client/src/rtc/__tests__/mocks/webrtc.mocks.ts
@@ -1,0 +1,42 @@
+import { vi } from 'vitest';
+
+const RTCPeerConnectionMock = vi.fn((): Partial<RTCPeerConnection> => {
+  return {
+    addEventListener: vi.fn(),
+    getTransceivers: vi.fn(),
+    addTransceiver: vi.fn(),
+  };
+});
+vi.stubGlobal('RTCPeerConnection', RTCPeerConnectionMock);
+
+const MediaStreamMock = vi.fn((): Partial<MediaStream> => {
+  return {
+    getTracks: vi.fn(),
+    addTrack: vi.fn(),
+  };
+});
+vi.stubGlobal('MediaStream', MediaStreamMock);
+
+const MediaStreamTrackMock = vi.fn((): Partial<MediaStreamTrack> => {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    getSettings: vi.fn(),
+    stop: vi.fn(),
+    readyState: 'live',
+    kind: 'video',
+  };
+});
+vi.stubGlobal('MediaStreamTrack', MediaStreamTrackMock);
+
+const RTCRtpTransceiverMock = vi.fn((): Partial<RTCRtpTransceiver> => {
+  return {
+    // @ts-ignore
+    sender: {
+      track: null,
+      replaceTrack: vi.fn(),
+    },
+    setCodecPreferences: vi.fn(),
+  };
+});
+vi.stubGlobal('RTCRtpTransceiver', RTCRtpTransceiverMock);

--- a/packages/client/src/rtc/__tests__/publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/publisher.test.ts
@@ -1,0 +1,142 @@
+import './mocks/webrtc.mocks';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Publisher } from '../publisher';
+import { CallState } from '../../store';
+import { StreamSfuClient } from '../../StreamSfuClient';
+import { Dispatcher } from '../Dispatcher';
+import { TrackType } from '../../gen/video/sfu/models/models';
+
+vi.mock('../../StreamSfuClient', () => {
+  console.log('MOCKING StreamSfuClient');
+  return {
+    StreamSfuClient: vi.fn(),
+  };
+});
+
+vi.mock('../codecs', () => {
+  return {
+    getPreferredCodecs: vi.fn((): RTCRtpCodecCapability[] => [
+      {
+        channels: 1,
+        clockRate: 48000,
+        mimeType: 'video/h264',
+        sdpFmtpLine: 'profile-level-id=42e01f',
+      },
+    ]),
+  };
+});
+
+describe('Publisher', () => {
+  const sessionId = 'session-id-test';
+  let publisher: Publisher;
+  let sfuClient: StreamSfuClient;
+  let state: CallState;
+
+  beforeEach(() => {
+    const dispatcher = new Dispatcher();
+    sfuClient = new StreamSfuClient(
+      dispatcher,
+      'https://getstream.io/',
+      'token',
+    );
+
+    // @ts-ignore
+    sfuClient['sessionId'] = sessionId;
+
+    state = new CallState();
+    publisher = new Publisher({
+      sfuClient,
+      state,
+      isDtxEnabled: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('can publish, re-publish and un-publish a stream', async () => {
+    const mediaStream = new MediaStream();
+    const track = new MediaStreamTrack();
+    mediaStream.addTrack(track);
+
+    state.setParticipants([
+      // @ts-ignore
+      {
+        isLoggedInUser: true,
+        userId: 'test-user-id',
+        sessionId: sessionId,
+        publishedTracks: [],
+      },
+    ]);
+
+    vi.spyOn(track, 'getSettings').mockReturnValue({
+      width: 640,
+      height: 480,
+      deviceId: 'test-device-id',
+    });
+
+    const transceiver = new RTCRtpTransceiver();
+    vi.spyOn(transceiver.sender, 'track', 'get').mockReturnValue(track);
+    vi.spyOn(publisher['publisher'], 'addTransceiver').mockReturnValue(
+      transceiver,
+    );
+    vi.spyOn(publisher['publisher'], 'getTransceivers').mockReturnValue([
+      transceiver,
+    ]);
+
+    sfuClient.updateMuteState = vi.fn();
+
+    // initial publish
+    await publisher.publishStream(mediaStream, track, TrackType.VIDEO);
+
+    expect(state.localParticipant?.videoDeviceId).toEqual('test-device-id');
+    expect(state.localParticipant?.publishedTracks).toContain(TrackType.VIDEO);
+    expect(state.localParticipant?.videoStream).toEqual(mediaStream);
+    expect(transceiver.setCodecPreferences).toHaveBeenCalled();
+    expect(sfuClient.updateMuteState).toHaveBeenCalledWith(
+      TrackType.VIDEO,
+      false,
+    );
+    expect(track.addEventListener).toHaveBeenCalledWith(
+      'ended',
+      expect.any(Function),
+    );
+
+    // re-publish a new track
+    const newMediaStream = new MediaStream();
+    const newTrack = new MediaStreamTrack();
+    newMediaStream.addTrack(newTrack);
+
+    vi.spyOn(newTrack, 'getSettings').mockReturnValue({
+      width: 1280,
+      height: 720,
+      deviceId: 'test-device-id-2',
+    });
+
+    await publisher.publishStream(newMediaStream, newTrack, TrackType.VIDEO);
+    vi.spyOn(transceiver.sender, 'track', 'get').mockReturnValue(newTrack);
+
+    expect(track.stop).toHaveBeenCalled();
+    expect(track.removeEventListener).toHaveBeenCalledWith(
+      'ended',
+      expect.any(Function),
+    );
+    expect(newTrack.addEventListener).toHaveBeenCalledWith(
+      'ended',
+      expect.any(Function),
+    );
+    expect(transceiver.sender.replaceTrack).toHaveBeenCalledWith(newTrack);
+    expect(state.localParticipant?.videoDeviceId).toEqual('test-device-id-2');
+
+    // stop publishing
+    await publisher.unpublishStream(TrackType.VIDEO);
+    expect(newTrack.stop).toHaveBeenCalled();
+    expect(state.localParticipant?.publishedTracks).not.toContain(
+      TrackType.VIDEO,
+    );
+    expect(state.localParticipant?.videoDeviceId).toEqual('test-device-id-2');
+  });
+});

--- a/packages/client/src/rtc/helpers/tracks.ts
+++ b/packages/client/src/rtc/helpers/tracks.ts
@@ -1,5 +1,8 @@
 import { TrackType } from '../../gen/video/sfu/models/models';
-import type { StreamVideoParticipant } from '../../types';
+import type {
+  StreamVideoLocalParticipant,
+  StreamVideoParticipant,
+} from '../../types';
 
 export const trackTypeToParticipantStreamKey = (
   trackType: TrackType,
@@ -11,6 +14,21 @@ export const trackTypeToParticipantStreamKey = (
       return 'videoStream';
     case TrackType.AUDIO:
       return 'audioStream';
+    default:
+      throw new Error(`Unknown track type: ${trackType}`);
+  }
+};
+
+export const trackTypeToDeviceIdKey = (
+  trackType: TrackType,
+): keyof StreamVideoLocalParticipant | undefined => {
+  switch (trackType) {
+    case TrackType.AUDIO:
+      return 'audioDeviceId';
+    case TrackType.VIDEO:
+      return 'videoDeviceId';
+    case TrackType.SCREEN_SHARE:
+      return undefined;
     default:
       throw new Error(`Unknown track type: ${trackType}`);
   }


### PR DESCRIPTION
### Overview

https://github.com/GetStream/stream-video-js/pull/441 introduced a regression in the area of persisting the last used `deviceId` of any media track.
This PR restores the missing functionality and adds a test that verifies the behavior is correct.

On the testing side, I had to mock many of the WebRTC APIs as they aren't natively available in Node nor in the "fake" DOM testing environments like `jsdom` and `happy-dom`. I'd appreciate if you can have a look at this and let me know if you have some better idea how to approach WebRTC unit testing.
