### PR TITLE
fix(permissions): add shortcut APIs

### DIFF
--- a/packages/client/docusaurus/docs/client/05-advanced/03-permissions-and-capabilities.mdx
+++ b/packages/client/docusaurus/docs/client/05-advanced/03-permissions-and-capabilities.mdx
@@ -65,16 +65,16 @@ Whenever a user requests a certain permission, a `call.permission_request` event
 You can listen to this event and approve the request.
 
 ```ts
-import { PermissionRequestEvent } from '@stream-io/video-client';
+import {
+  PermissionRequestEvent,
+  StreamCallEvent,
+} from '@stream-io/video-client';
 
 const call = streamVideoClient.call(type, id);
-call.on('call.permission_request', (event: StreamCallEvent) => {
+call.on('call.permission_request', async (event: StreamCallEvent) => {
   const request = event as PermissionRequestEvent;
   if (shouldApproveRequest(request)) {
-    await call.updateUserPermissions({
-      user_id: request.user_id,
-      grant_permissions: [...request.permissions],
-    });
+    await call.grantPermissions(request.user_id, request.permissions);
   }
 });
 ```
@@ -92,6 +92,15 @@ await call.updateUserPermissions({
   grant_permission: [OwnCapability.SEND_AUDIO, OwnCapability.SEND_VIDEO],
   revoke_permissions: [OwnCapability.SCREENSHARE],
 });
+
+// alternate API for granting user permissions:
+await call.grantPermissions('demo-user', [
+  OwnCapability.SEND_AUDIO,
+  OwnCapability.SEND_VIDEO,
+]);
+
+// alternate API for revoking user permissions:
+await call.revokePermissions('demo-user', [OwnCapability.SCREENSHARE]);
 ```
 
 The end user would get notified via a WebSocket event with a type: `call.permissions_updated`.

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1272,6 +1272,44 @@ export class Call {
   };
 
   /**
+   * Allows you to grant certain permissions to a user in a call.
+   * The permissions are specific to the call experience and do not survive the call itself.
+   *
+   * Supported permissions that can be granted are:
+   * - `send-audio`
+   * - `send-video`
+   * - `screenshare`
+   *
+   * @param userId the id of the user to grant permissions to.
+   * @param permissions the permissions to grant.
+   */
+  grantPermissions = async (userId: string, permissions: string[]) => {
+    return this.updateUserPermissions({
+      user_id: userId,
+      grant_permissions: permissions,
+    });
+  };
+
+  /**
+   * Allows you to revoke certain permissions from a user in a call.
+   * The permissions are specific to the call experience and do not survive the call itself.
+   *
+   * Supported permissions that can be revoked are:
+   * - `send-audio`
+   * - `send-video`
+   * - `screenshare`
+   *
+   * @param userId the id of the user to revoke permissions from.
+   * @param permissions the permissions to revoke.
+   */
+  revokePermissions = async (userId: string, permissions: string[]) => {
+    return this.updateUserPermissions({
+      user_id: userId,
+      revoke_permissions: permissions,
+    });
+  };
+
+  /**
    * Allows you to grant or revoke a specific permission to a user in a call. The permissions are specific to the call experience and do not survive the call itself.
    *
    * When revoking a permission, this endpoint will also mute the relevant track from the user. This is similar to muting a user with the difference that the user will not be able to unmute afterwards.

--- a/packages/react-sdk/src/components/Permissions/PermissionRequests.tsx
+++ b/packages/react-sdk/src/components/Permissions/PermissionRequests.tsx
@@ -53,15 +53,9 @@ export const PermissionRequests = () => {
     return async () => {
       const { user, permissions } = request;
       if (allow) {
-        await call?.updateUserPermissions({
-          user_id: user.id,
-          grant_permissions: permissions,
-        });
+        await call?.grantPermissions(user.id, permissions);
       } else {
-        await call?.updateUserPermissions({
-          user_id: user.id,
-          revoke_permissions: permissions,
-        });
+        await call?.revokePermissions(user.id, permissions);
       }
       setPermissionRequests((requests) =>
         requests.filter((r) => r !== request),


### PR DESCRIPTION
### Overview

Alignment with other SDKs. Provides two new shortcut methods on the `Call` instance:
- `grantPermissions(userId, permissions[])`
- `revokePermissions(userId, permissions[])`