### PR TITLE
fix: bugfixes in event handling and blocking users

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -83,7 +83,11 @@ import { ViewportTracker } from './helpers/ViewportTracker';
 import { PermissionsContext } from './permissions';
 import { CallTypes } from './CallType';
 import { StreamClient } from './coordinator/connection/client';
-import { retryInterval, sleep } from './coordinator/connection/utils';
+import {
+  KnownCodes,
+  retryInterval,
+  sleep,
+} from './coordinator/connection/utils';
 import {
   CallEventHandler,
   CallEventTypes,
@@ -604,7 +608,10 @@ export class Call {
     sfuClient.signalReady.then(() => {
       sfuClient.signalWs.addEventListener('close', (e) => {
         // do nothing if the connection was closed on purpose
-        if (e.code === 1000) return;
+        if (e.code === KnownCodes.WS_CLOSED_SUCCESS) return;
+        // do nothing if the connection was closed because of a policy violation
+        // e.g., the user has been blocked by an admin or moderator
+        if (e.code === KnownCodes.WS_POLICY_VIOLATION) return;
         if (this.reconnectAttempts < this.maxReconnectAttempts) {
           rejoin().catch(() => {
             console.log(

--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -376,8 +376,6 @@ export class StreamClient {
     await this.closeConnection(timeout);
 
     this.tokenManager.reset();
-    // drop all event listeners on user disconnect
-    this.listeners = {};
   };
 
   /**

--- a/packages/client/src/coordinator/connection/utils.ts
+++ b/packages/client/src/coordinator/connection/utils.ts
@@ -16,6 +16,7 @@ export function isFunction<T>(value: Function | T): value is Function {
 export const KnownCodes = {
   TOKEN_EXPIRED: 40,
   WS_CLOSED_SUCCESS: 1000,
+  WS_POLICY_VIOLATION: 1008,
 };
 
 /**

--- a/packages/react-dogfood/components/Lobby.tsx
+++ b/packages/react-dogfood/components/Lobby.tsx
@@ -25,7 +25,7 @@ const subtitles = [
 
 type LobbyProps = {
   onJoin: () => void;
-  callId: string;
+  callId?: string;
   enablePreview?: boolean;
 };
 export const Lobby = ({ onJoin, callId, enablePreview = true }: LobbyProps) => {

--- a/packages/react-dogfood/hooks/useWatchChannel.ts
+++ b/packages/react-dogfood/hooks/useWatchChannel.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { Event, StreamChat } from 'stream-chat';
 
 import { CHANNEL_TYPE } from '../components';
@@ -9,12 +9,10 @@ export const useWatchChannel = ({
   channelId,
 }: {
   chatClient?: StreamChat | null;
-  channelId: string;
+  channelId?: string;
   channelType?: string;
 }) => {
   const [channelWatched, setChannelWatched] = useState(false);
-
-  const cid = `${channelType}:${channelId}`;
 
   useEffect(() => {
     if (!client) return;
@@ -32,7 +30,7 @@ export const useWatchChannel = ({
 
   useEffect(() => {
     if (!client) return;
-
+    const cid = `${channelType}:${channelId}`;
     const handleEvent = (event: Event) => {
       if (event?.cid === cid) setChannelWatched(true);
     };
@@ -41,7 +39,7 @@ export const useWatchChannel = ({
     return () => {
       client.off('user.watching.start', handleEvent);
     };
-  }, [client, cid]);
+  }, [client, channelType, channelId]);
 
   return channelWatched;
 };

--- a/packages/react-dogfood/pages/guest/join/[guestCallId].tsx
+++ b/packages/react-dogfood/pages/guest/join/[guestCallId].tsx
@@ -1,5 +1,6 @@
 import { GetServerSidePropsContext } from 'next';
 import {
+  StreamMeeting,
   StreamVideo,
   useCreateStreamVideoClient,
   UserResponse,
@@ -65,11 +66,9 @@ export default function GuestCallRoom(props: GuestCallRoomProps) {
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
       <StreamVideo client={client}>
-        <MeetingUI
-          callId={callId}
-          callType={callType}
-          enablePreview={mode !== 'anon'}
-        />
+        <StreamMeeting callId={callId} callType={callType} autoJoin={false}>
+          <MeetingUI enablePreview={mode !== 'anon'} />
+        </StreamMeeting>
       </StreamVideo>
     </>
   );

--- a/packages/react-dogfood/pages/join/[callId].tsx
+++ b/packages/react-dogfood/pages/join/[callId].tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useRouter } from 'next/router';
 import {
+  StreamMeeting,
   StreamVideo,
   useCreateStreamVideoClient,
 } from '@stream-io/video-react-sdk';
@@ -68,11 +69,9 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
         language={language}
         translationsOverrides={translations}
       >
-        <MeetingUI
-          chatClient={chatClient}
-          callId={callId}
-          callType={callType}
-        />
+        <StreamMeeting callId={callId} callType={callType} autoJoin={false}>
+          <MeetingUI chatClient={chatClient} />
+        </StreamMeeting>
       </StreamVideo>
     </>
   );

--- a/packages/react-sample-app/src/App.tsx
+++ b/packages/react-sample-app/src/App.tsx
@@ -122,6 +122,7 @@ const App = () => {
                     callId={callId}
                     callType={callType}
                     data={callInput}
+                    autoJoin
                   >
                     <MeetingUI />
                   </StreamMeeting>

--- a/packages/react-sdk/src/components/StreamMeeting/StreamMeeting.tsx
+++ b/packages/react-sdk/src/components/StreamMeeting/StreamMeeting.tsx
@@ -52,8 +52,8 @@ export const StreamMeeting = ({
 }: PropsWithChildren<StreamMeetingProps>) => {
   const client = useStreamVideoClient();
   const [activeCall, setActiveCall] = useState<Call | undefined>(() => {
-    if (!client || call) return call;
-    if (!callId || !callType) return;
+    if (call) return call;
+    if (!client || !callId || !callType) return;
     return client.call(callType, callId);
   });
 

--- a/packages/react-sdk/src/components/StreamMeeting/StreamMeeting.tsx
+++ b/packages/react-sdk/src/components/StreamMeeting/StreamMeeting.tsx
@@ -23,10 +23,10 @@ type InitStreamMeeting = InitWithCallCID | InitWithCallInstance;
 export type StreamMeetingProps = InitStreamMeeting & {
   /**
    * If true, the call will be joined automatically.
-   * Usually, in the "ring" scenario, this flag should be set to false as
-   * the callee should decide whether to join the call or not.
+   * Set it to true if you want to join the call immediately.
+   * Useful for scenarios where you want to skip prompting the user to join the call.
    *
-   * @default true.
+   * @default false.
    */
   autoJoin?: boolean;
 
@@ -46,12 +46,16 @@ export const StreamMeeting = ({
   callId,
   callType,
   call,
-  autoJoin = true,
+  autoJoin = false,
   data,
   mediaDevicesProviderProps,
 }: PropsWithChildren<StreamMeetingProps>) => {
   const client = useStreamVideoClient();
-  const [activeCall, setActiveCall] = useState<Call | undefined>(call);
+  const [activeCall, setActiveCall] = useState<Call | undefined>(() => {
+    if (!client || call) return call;
+    if (!callId || !callType) return;
+    return client.call(callType, callId);
+  });
 
   useEffect(() => {
     if (!client) return;

--- a/sample-apps/react/cookbook-participant-list/src/App.tsx
+++ b/sample-apps/react/cookbook-participant-list/src/App.tsx
@@ -48,6 +48,7 @@ const App = () => {
               callId={callId}
               callType="default"
               data={{ create: true }}
+              autoJoin
             >
               <SpeakerView />
             </StreamMeeting>

--- a/sample-apps/react/zoom-clone/src/components/Call.tsx
+++ b/sample-apps/react/zoom-clone/src/components/Call.tsx
@@ -14,6 +14,7 @@ export const Call = () => {
         callId={callId!}
         callType="default"
         data={{ create: true }}
+        autoJoin
       >
         <MeetingUI>
           <button


### PR DESCRIPTION
### Overview

1. Preserve event listeners through user re-connects as these events aren't user-specific
2. When a user is blocked, the Call engine incorrectly triggered the rejoin flow
3. `<StreamMeeting />` now eagerly creates a new `Call` instance (before: the call was created after the initial render phase has finished)
4. Watch for `CallingState.LEFT` and navigate to the homepage whenever the user leaves the call (by pressing the end call button or after being kicked out of the call).

I'd recommend checking the commits individually :)

