### PR TITLE
feat: call broadcasting events and apis

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -546,9 +546,6 @@ export class Call {
     this.watching = true;
     this.clientStore.registerCall(this);
 
-    // FIXME OL: convert to a derived state
-    this.state.setCallRecordingInProgress(call.metadata.recording);
-
     // FIXME OL: remove once cascading is implemented
     let sfuUrl = call.sfuServer.url;
     if (
@@ -1349,6 +1346,26 @@ export class Call {
   stopLive = async () => {
     return this.streamClient.post<StopLiveResponse>(
       `${this.streamClientBasePath}/stop_live`,
+      {},
+    );
+  };
+
+  /**
+   * Starts the broadcasting of the call.
+   */
+  startBroadcasting = async () => {
+    return this.streamClient.post(
+      `${this.streamClientBasePath}/start_broadcasting`,
+      {},
+    );
+  };
+
+  /**
+   * Stops the broadcasting of the call.
+   */
+  stopBroadcasting = async () => {
+    return this.streamClient.post(
+      `${this.streamClientBasePath}/stop_broadcasting`,
       {},
     );
   };

--- a/packages/client/src/events/__tests__/recording.test.ts
+++ b/packages/client/src/events/__tests__/recording.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { CallState } from '../../store';
+import {
+  watchCallBroadcastingStarted,
+  watchCallBroadcastingStopped,
+  watchCallRecordingStarted,
+  watchCallRecordingStopped,
+} from '../recording';
+
+describe('recording and broadcasting events', () => {
+  it('handles call.recording_started events', () => {
+    const state = new CallState();
+    const handler = watchCallRecordingStarted(state);
+    // @ts-ignore
+    handler({
+      type: 'call.recording_started',
+    });
+    expect(state.metadata?.recording).toBe(true);
+  });
+
+  it('handles call.recording_stopped events', () => {
+    const state = new CallState();
+    const handler = watchCallRecordingStopped(state);
+    // @ts-ignore
+    handler({
+      type: 'call.recording_stopped',
+    });
+    expect(state.metadata?.recording).toBe(false);
+  });
+
+  it('handles call.broadcasting_started events', () => {
+    const state = new CallState();
+    const handler = watchCallBroadcastingStarted(state);
+    // @ts-ignore
+    handler({
+      type: 'call.broadcasting_started',
+      hls_playlist_url: 'https://example.com/playlist.m3u8',
+    });
+    expect(state.metadata?.broadcasting).toBe(true);
+    expect(state.metadata?.hls_playlist_url).toBe(
+      'https://example.com/playlist.m3u8',
+    );
+  });
+
+  it('handles call.broadcasting_stopped events', () => {
+    const state = new CallState();
+    const handler = watchCallBroadcastingStopped(state);
+    // @ts-ignore
+    handler({
+      type: 'call.broadcasting_stopped',
+    });
+    expect(state.metadata?.broadcasting).toBe(false);
+  });
+});

--- a/packages/client/src/events/callEventHandlers.ts
+++ b/packages/client/src/events/callEventHandlers.ts
@@ -5,6 +5,8 @@ import {
   watchAudioLevelChanged,
   watchBlockedUser,
   watchCallAccepted,
+  watchCallBroadcastingStarted,
+  watchCallBroadcastingStopped,
   watchCallEnded,
   watchCallGrantsUpdated,
   watchCallPermissionRequest,
@@ -51,6 +53,8 @@ export const registerEventHandlers = (
 
     call.on('call.recording_started', watchCallRecordingStarted(state)),
     call.on('call.recording_stopped', watchCallRecordingStopped(state)),
+    call.on('call.broadcasting_started', watchCallBroadcastingStarted(state)),
+    call.on('call.broadcasting_stopped', watchCallBroadcastingStopped(state)),
 
     call.on('call.permission_request', watchCallPermissionRequest(state)),
     call.on('call.permissions_updated', watchCallPermissionsUpdated(state)),

--- a/packages/client/src/events/recording.ts
+++ b/packages/client/src/events/recording.ts
@@ -7,7 +7,10 @@ import { StreamVideoEvent } from '../coordinator/connection/types';
 export const watchCallRecordingStarted = (state: CallState) => {
   return function onCallRecordingStarted(event: StreamVideoEvent) {
     if (event.type !== 'call.recording_started') return;
-    state.setCallRecordingInProgress(true);
+    state.setMetadata((metadata) => ({
+      ...metadata!,
+      recording: true,
+    }));
   };
 };
 
@@ -17,6 +20,33 @@ export const watchCallRecordingStarted = (state: CallState) => {
 export const watchCallRecordingStopped = (state: CallState) => {
   return function onCallRecordingStopped(event: StreamVideoEvent) {
     if (event.type !== 'call.recording_stopped') return;
-    state.setCallRecordingInProgress(false);
+    state.setMetadata((metadata) => ({
+      ...metadata!,
+      recording: false,
+    }));
+  };
+};
+
+/**
+ * Watches for `call.broadcasting_started` events.
+ */
+export const watchCallBroadcastingStarted = (state: CallState) => {
+  return function onCallBroadcastingStarted(event: StreamVideoEvent) {
+    if (event.type !== 'call.broadcasting_started') return;
+    state.setMetadata((metadata) => ({
+      ...metadata!,
+      broadcasting: true,
+      hls_playlist_url: event.hls_playlist_url,
+    }));
+  };
+};
+
+export const watchCallBroadcastingStopped = (state: CallState) => {
+  return function onCallBroadcastingStopped(event: StreamVideoEvent) {
+    if (event.type !== 'call.broadcasting_stopped') return;
+    state.setMetadata((metadata) => ({
+      ...metadata!,
+      broadcasting: false,
+    }));
   };
 };

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -124,14 +124,6 @@ export class CallState {
   >(undefined);
 
   /**
-   * Emits a boolean indicating whether a call recording is currently in progress.
-   *
-   * @internal
-   */
-  // FIXME OL: might be derived from `this.call.recording`.
-  private callRecordingInProgressSubject = new BehaviorSubject<boolean>(false);
-
-  /**
    * Emits a list of details about recordings performed for the current call.
    */
   private callRecordingListSubject = new BehaviorSubject<CallRecording[]>([]);
@@ -195,11 +187,6 @@ export class CallState {
    * in case they want to show historical stats data.
    */
   callStatsReport$: Observable<CallStatsReport | undefined>;
-
-  /**
-   * Emits a boolean indicating whether a call recording is currently in progress.
-   */
-  callRecordingInProgress$: Observable<boolean>;
 
   /**
    * Emits a list of details about recordings performed for the current call
@@ -269,8 +256,6 @@ export class CallState {
     );
 
     this.callStatsReport$ = this.callStatsReportSubject.asObservable();
-    this.callRecordingInProgress$ =
-      this.callRecordingInProgressSubject.asObservable();
     this.callPermissionRequest$ =
       this.callPermissionRequestSubject.asObservable();
     this.callRecordingList$ = this.callRecordingListSubject.asObservable();
@@ -397,25 +382,6 @@ export class CallState {
    */
   setCallRecordingsList = (recordings: Patch<CallRecording[]>) => {
     return this.setCurrentValue(this.callRecordingListSubject, recordings);
-  };
-
-  /**
-   * Tells whether a call recording is in progress.
-   */
-  get callRecordingInProgress() {
-    return this.getCurrentValue(this.callRecordingInProgress$);
-  }
-
-  /**
-   * Sets whether a call recording is in progress.
-   *
-   * @param inProgress whether a call recording is in progress.
-   */
-  setCallRecordingInProgress = (inProgress: Patch<boolean>) => {
-    return this.setCurrentValue(
-      this.callRecordingInProgressSubject,
-      inProgress,
-    );
   };
 
   /**

--- a/packages/react-bindings/src/hooks/call.ts
+++ b/packages/react-bindings/src/hooks/call.ts
@@ -7,8 +7,18 @@ import { useCallState, useStore } from './store';
  * @category Call State
  */
 export const useIsCallRecordingInProgress = () => {
-  const { callRecordingInProgress$ } = useCallState();
-  return useObservableValue(callRecordingInProgress$);
+  const metadata = useCallMetadata();
+  return !!metadata?.recording;
+};
+
+/**
+ * Utility hook which provides information whether the current call is broadcasting.
+ *
+ * @category Call State
+ */
+export const useIsCallBroadcastingInProgress = () => {
+  const metadata = useCallMetadata();
+  return !!metadata?.broadcasting;
 };
 
 /**


### PR DESCRIPTION
### Overview

Adds the missing APIs and event handlers for call broadcasting.
As part of this PR, the redundant `recording` state removed and now it is derived from the call's metadata.