### PR TITLE
fix: support for call_cids in user tokens

### DIFF
--- a/packages/react-dogfood/pages/api/auth/create-token.ts
+++ b/packages/react-dogfood/pages/api/auth/create-token.ts
@@ -48,6 +48,13 @@ const createJwtToken = async (req: NextApiRequest, res: NextApiResponse) => {
     params.exp = String(expiration);
   }
 
+  if (params.call_cids) {
+    try {
+      // support `?call_cids=["cid:1","cid:2"]` query param
+      params.call_cids = JSON.parse(params.call_cids as string);
+    } catch (e) {}
+  }
+
   const token = createToken(userId, secretKey, params);
   return res.status(200).json({
     userId,

--- a/packages/react-dogfood/pages/api/auth/create-token.ts
+++ b/packages/react-dogfood/pages/api/auth/create-token.ts
@@ -24,13 +24,9 @@ const secretKeyLookup = apiKeyAndSecretWhitelist
   );
 
 const createJwtToken = async (req: NextApiRequest, res: NextApiResponse) => {
-  const {
-    user_id: userId,
-    api_key: apiKey,
-    ...params
-  } = req.query as Record<string, string>;
+  const { user_id: userId, api_key: apiKey, ...params } = req.query;
 
-  if (!apiKey) {
+  if (!apiKey || typeof apiKey !== 'string') {
     return error(res, `'api_key' parameter is a mandatory query parameter.`);
   }
 
@@ -39,7 +35,7 @@ const createJwtToken = async (req: NextApiRequest, res: NextApiResponse) => {
     return error(res, `'api_key' parameter is invalid.`);
   }
 
-  if (!userId) {
+  if (!userId || typeof userId !== 'string') {
     return error(res, `'user_id' is a mandatory query parameter.`);
   }
 
@@ -48,14 +44,28 @@ const createJwtToken = async (req: NextApiRequest, res: NextApiResponse) => {
     params.exp = String(expiration);
   }
 
-  if (params.call_cids) {
+  // by default, we support repeated query params:
+  // - ?call_cids=cid:1&call_cids=cid:2
+  // but, we also support other formats:
+  // - comma separated ?call_cids=cid:1,cid:2
+  // - json encoded ?call_cids=["cid:1","cid:2"]
+  if (typeof params.call_cids === 'string') {
     try {
       // support `?call_cids=["cid:1","cid:2"]` query param
-      params.call_cids = JSON.parse(params.call_cids as string);
-    } catch (e) {}
+      params.call_cids = JSON.parse(params.call_cids);
+    } catch (e) {
+      // support ?call_cids=cid:1,cid:2 query param
+      params.call_cids = (params.call_cids as string)
+        .split(',')
+        .map((cid) => cid.trim());
+    }
   }
 
-  const token = createToken(userId, secretKey, params);
+  const token = createToken(
+    userId,
+    secretKey,
+    params as Record<string, string | string[]>,
+  );
   return res.status(200).json({
     userId,
     token,


### PR DESCRIPTION
### Overview

Special handling of `call_cids` parameter:
- repeated: `?call_cids=default:123&call_cids=default:456`
- comma separarated: `?call_cids=default:123,default:456`
- JSON encoded: `?call_cids=["default:123", "default:456"]`

This enables generating anon user tokens correctly.