### PR TITLE
feat: server-side participant counting

### DIFF
--- a/packages/client/src/events/callEventHandlers.ts
+++ b/packages/client/src/events/callEventHandlers.ts
@@ -34,6 +34,7 @@ export const registerEventHandlers = (
   const eventHandlers = [
     watchChangePublishQuality(dispatcher, call),
     watchConnectionQualityChanged(dispatcher, state),
+    watchConnectionQualityChanged(dispatcher, state),
 
     watchParticipantJoined(dispatcher, state),
     watchParticipantLeft(dispatcher, state),

--- a/packages/client/src/events/callEventHandlers.ts
+++ b/packages/client/src/events/callEventHandlers.ts
@@ -19,6 +19,7 @@ import {
   watchConnectionQualityChanged,
   watchDominantSpeakerChanged,
   watchNewReactions,
+  watchParticipantCountChanged,
   watchParticipantJoined,
   watchParticipantLeft,
   watchTrackPublished,
@@ -34,7 +35,7 @@ export const registerEventHandlers = (
   const eventHandlers = [
     watchChangePublishQuality(dispatcher, call),
     watchConnectionQualityChanged(dispatcher, state),
-    watchConnectionQualityChanged(dispatcher, state),
+    watchParticipantCountChanged(dispatcher, state),
 
     watchParticipantJoined(dispatcher, state),
     watchParticipantLeft(dispatcher, state),

--- a/packages/client/src/events/internal.ts
+++ b/packages/client/src/events/internal.ts
@@ -45,3 +45,18 @@ export const watchConnectionQualityChanged = (
     );
   });
 };
+
+/**
+ * Updates the approximate number of participants in the call by peeking at the
+ * health check events that our SFU sends.
+ */
+export const watchParticipantCountChanged = (
+  dispatcher: Dispatcher,
+  state: CallState,
+) => {
+  return dispatcher.on('healthCheckResponse', (e) => {
+    if (e.eventPayload.oneofKind !== 'healthCheckResponse') return;
+    const healthCheckResponse = e.eventPayload.healthCheckResponse;
+    state.setParticipantCount(healthCheckResponse.participantCount);
+  });
+};

--- a/packages/client/src/rtc/Dispatcher.ts
+++ b/packages/client/src/rtc/Dispatcher.ts
@@ -27,12 +27,6 @@ export const isSfuEvent = (
   return Object.prototype.hasOwnProperty.call(sfuEventKinds, eventName);
 };
 
-export type SfuEventKindMap = {
-  [key in SfuEventKinds]: {
-    eventPayload: Extract<SfuEvent['eventPayload'], { oneofKind: key }>;
-  };
-};
-
 export type SfuEventListener = (event: SfuEvent) => void;
 
 export class Dispatcher {
@@ -56,20 +50,20 @@ export class Dispatcher {
     }
   };
 
-  on = (eventName: string, fn: SfuEventListener) => {
+  on = (eventName: SfuEventKinds, fn: SfuEventListener) => {
     (this.subscribers[eventName] ??= []).push(fn);
     return () => {
       this.off(eventName, fn);
     };
   };
 
-  off = (eventName: string, fn: SfuEventListener) => {
+  off = (eventName: SfuEventKinds, fn: SfuEventListener) => {
     this.subscribers[eventName] = (this.subscribers[eventName] || []).filter(
       (f) => f !== fn,
     );
   };
 
-  offAll = (eventName?: string) => {
+  offAll = (eventName?: SfuEventKinds) => {
     if (eventName) {
       this.subscribers[eventName] = [];
     } else {

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -101,6 +101,14 @@ export class CallState {
   );
 
   /**
+   * The server-side counted number of participants connected to the current call.
+   * This number includes the anonymous participants as well.
+   *
+   * @internal
+   */
+  private participantCountSubject = new BehaviorSubject<number>(0);
+
+  /**
    * All participants of the current call (including the logged-in user).
    *
    * @internal
@@ -139,13 +147,19 @@ export class CallState {
   >(undefined);
 
   // Derived state
+
+  /**
+   * The server-side counted number of participants connected to the current call.
+   * This number includes the anonymous participants as well.
+   */
+  participantCount$: Observable<number>;
+
   /**
    * All participants of the current call (this includes the current user and other participants as well).
    */
   participants$: Observable<
     (StreamVideoParticipant | StreamVideoLocalParticipant)[]
   >;
-  /**
 
   /**
    * Remote participants of the current call (this includes every participant except the logged-in user).
@@ -255,6 +269,8 @@ export class CallState {
       distinctUntilChanged(),
     );
 
+    this.participantCount$ = this.participantCountSubject.asObservable();
+
     this.callStatsReport$ = this.callStatsReportSubject.asObservable();
     this.callPermissionRequest$ =
       this.callPermissionRequestSubject.asObservable();
@@ -296,6 +312,24 @@ export class CallState {
    * @return the updated value.
    */
   setCurrentValue = RxUtils.setCurrentValue;
+
+  /**
+   * The server-side counted number of participants connected to the current call.
+   * This number includes the anonymous participants as well.
+   */
+  get participantCount() {
+    return this.getCurrentValue(this.participantCount$);
+  }
+
+  /**
+   * Sets the number of participants in the current call.
+   *
+   * @internal
+   * @param count the number of participants.
+   */
+  setParticipantCount = (count: Patch<number>) => {
+    return this.setCurrentValue(this.participantCountSubject, count);
+  };
 
   /**
    * The list of participants in the current call.

--- a/packages/react-bindings/src/hooks/participants.ts
+++ b/packages/react-bindings/src/hooks/participants.ts
@@ -55,3 +55,12 @@ export const useRemoteParticipants = () => {
   const { remoteParticipants$ } = useCallState();
   return useObservableValue(remoteParticipants$);
 };
+
+/**
+ * Returns the approximate participant count of the active call.
+ * This includes the anonymous users as well, and it is computed on the server.
+ */
+export const useParticipantCount = () => {
+  const { participantCount$ } = useCallState();
+  return useObservableValue(participantCount$);
+};

--- a/packages/react-bindings/src/hooks/participants.ts
+++ b/packages/react-bindings/src/hooks/participants.ts
@@ -59,6 +59,8 @@ export const useRemoteParticipants = () => {
 /**
  * Returns the approximate participant count of the active call.
  * This includes the anonymous users as well, and it is computed on the server.
+ *
+ * @category Call State
  */
 export const useParticipantCount = () => {
   const { participantCount$ } = useCallState();


### PR DESCRIPTION
### Overview

The SFU reports the total number of connected participants to the call through regular health-check messages.
This information is now stored on the CallState and exposed via a React Hook to the SDKs.

A typical use-case for this feature is live streams with a lot of anonymous users who can't be counted on the client side as they would be excluded from the client-side participant list.