### PR TITLE
docs: Update state store code examples

### DIFF
--- a/packages/react-bindings/src/contexts/StreamCallContext.tsx
+++ b/packages/react-bindings/src/contexts/StreamCallContext.tsx
@@ -18,6 +18,8 @@ export interface StreamCallProviderProps {
  * @returns
  *
  * @category Call State
+ *
+ * @react If you're using the React SDK we recommend using the `StreamMeeting` component that wraps the `StreamCallProvider`. You only need to use the `StreamCallProvider` for advanced use-cases.
  */
 export const StreamCallProvider = (
   props: PropsWithChildren<StreamCallProviderProps>,

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/02-joining-creating-calls.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/02-joining-creating-calls.mdx
@@ -71,24 +71,9 @@ If you set the `autoJoin` prop to `false` the call won't be joined (nor will it 
 This is what call join looks like under the hood:
 
 ```ts
-import {
-  StreamVideoClient,
-  TokenOrProvider,
-  User,
-} from '@stream-io/video-client';
-
-const user: User = {
-  id: '<user id>'
-};
-
-const tokenProvider: TokenOrProvider = <token provider>
-
-const videoClient = new StreamVideoClient('MY_API_KEY');
-await videoClient.connectUser(user, tokenProvider);
-
 const callType = 'default';
 const callId = 'test-call';
-await videoClient.call(callType, callId).join({create: true});
+await videoClient.call(callType, callId).join({ create: true });
 ```
 
 To see possible call configuration options (for example, call members), go to the [`join` method reference](../../call-engine/Call/#join).

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
@@ -3,27 +3,34 @@ title: Call & Participant State
 description: How the state is exposed
 ---
 
-:::warning
-
-TODO: add better code snippets
-:::
-
 Our SDK uses a design pattern that we refer to as a reactive state store.
 
-The `StreamVideoClient` instance manages its own state store (this contains information about the connected user and the list of incoming, outgoing and active calls) and each `Call` instance has its own state store (this contains information about the call itself, for example the list of participants) as well.
+The [`StreamVideoClient`](../../call-engine/StreamVideoClient/) instance manages its own state store (this contains information about the connected user and the list of incoming, outgoing and active calls). Additionally each [`Call`](../../call-engine/Call/) instance has its own state store (this contains information about the call itself, for example, the list of participants).
 
-The state stores are updated after each API call/WebSocket event. The reactive state store makes it possible to observe the state from anywhere in your application. You can access the state store using hooks. This guide will help you understand how state management work which is useful if you want to attach custom logic upon state changes or if you want to create custom components.
+The state stores are updated after each API call/WebSocket event. The reactive state store makes it possible to observe the state from anywhere in your application. You can access the state store using hooks. This guide will help you understand how state management works which is helpful if you want to attach custom logic upon state changes or if you want to create custom components.
 
 ## Create client
 
-Before we can explore the state management mechanism we need to have a `StreamVideoClient` instance, to create it we can use the [`useCreateStreamVideoClient`](../../call-engine/hooks-and-contexts#usecreatestreamvideoclient) hook.
+Before we can explore the state management mechanism, we need to have a `StreamVideoClient` instance, to create it we can use the [`useCreateStreamVideoClient`](../../call-engine/hooks-and-contexts#usecreatestreamvideoclient) hook.
 
-```typescript
-const client = useCreateStreamVideoClient({
-    <your API key>,
-    <user token>,
-    <user>,
-});
+```tsx
+import {
+  useCreateStreamVideoClient,
+  StreamVideo,
+  useConnectedUser,
+} from '@stream-io/video-react-sdk';
+
+export default function App() {
+  const client = useCreateStreamVideoClient({
+    apiKey: '<Your API key>',
+    tokenOrProvider: '<token provider>',
+    user: {
+      id: '<user id>',
+      name: '<name>',
+    },
+  });
+  return ();
+}
 ```
 
 ## Observe client state
@@ -31,24 +38,59 @@ const client = useCreateStreamVideoClient({
 To observe client state you need to use the [`StreamVideo`](../../call-engine/hooks-and-contexts#streamvideo) context provider:
 
 ```tsx
-const client = useCreateStreamVideoClient({
-    <your API key>,
-    <user token>,
-    <user>,
-});
+import {
+  useCreateStreamVideoClient,
+  StreamVideo,
+  useConnectedUser,
+} from '@stream-io/video-react-sdk';
 
-<StreamVideo client="{client}">
-    <!-- Video UI -->
-</StreamVideo>
+export default function App() {
+  const client = useCreateStreamVideoClient({
+    apiKey: '<Your API key>',
+    tokenOrProvider: '<token provider>',
+    user: {
+      id: '<user id>',
+      name: '<name>',
+    },
+  });
+  return <StreamVideo client={client}></StreamVideo>;
+}
 ```
 
-Then you'll be able to use the [client state hooks](../../call-engine/hooks-and-contexts#client-state) to easily access the client state anywhere in your application. These hooks are updated when a relevant client state change occurs.
+Then you'll be able to use the [client state hooks](../../call-engine/hooks-and-contexts/#client-state) to easily access the client state anywhere in your application. These hooks are updated when a relevant client state change occurs.
 
 Let's see an example:
 
-If you want to watch for incoming calls to display a notification you can use the `useCalls` hook.
+If you want to observe the connected user you can use the [`useConnectedUser`](../../call-engine/hooks-and-contexts/#useconnecteduser) hook.
 
-TODO give example for `useCalls` once the refactor is done
+```tsx
+import {
+  useCreateStreamVideoClient,
+  StreamVideo,
+  useConnectedUser,
+} from '@stream-io/video-react-sdk';
+
+export default function App() {
+  const client = useCreateStreamVideoClient({
+    apiKey: '<Your API key>',
+    tokenOrProvider: '<token provider>',
+    user: {
+      id: '<user id>',
+      name: '<name>',
+    },
+  });
+  return (
+    <StreamVideo client={client}>
+      <Header></Header>
+    </StreamVideo>
+  );
+}
+
+const Header = () => {
+  const user = useConnectedUser();
+  return <div>{user ? `Logged in: ${user.name}` : 'Logged out'}</div>;
+};
+```
 
 This approach makes it possible to access the client state and be notified about changes anywhere in your application without having to manually subscribe to WebSocket events.
 
@@ -56,36 +98,98 @@ The full list of available client state hooks are available in the [Hooks and Co
 
 ## Observe call state
 
-To observe call state you need to use the [`StreamCallProvider`](../../call-engine/hooks-and-contexts#streamcallprovider):
+To observe call state you can use [`StreamMeeting` component](TODO link):
 
 ```tsx
-const client = useCreateStreamVideoClient({
-    <your API key>,
-    <user token>,
-    <user>,
-});
+import {
+  useCreateStreamVideoClient,
+  StreamVideo,
+  useConnectedUser,
+} from '@stream-io/video-react-sdk';
 
-const activeCall = // this should change with the refactor
+export default function App() {
+  const client = useCreateStreamVideoClient({
+    apiKey: '<Your API key>',
+    tokenOrProvider: '<token provider>',
+    user: {
+      id: '<user id>',
+      name: '<name>',
+    },
+  });
 
-<StreamVideo client="{client}">
-  <StreamCallProvider call="{activeCall}">
-    <!-- Video UI -->
-  </StreamCallProvider>
-</StreamVideo>
+  return (
+    <StreamVideo client={client}>
+      <Header></Header>
+      <StreamMeeting
+        callType="default"
+        callId="test-call"
+        autoJoin={true}
+        data={{ create: true }}
+      ></StreamMeeting>
+    </StreamVideo>
+  );
+}
+
+const Header = () => {
+  const user = useConnectedUser();
+  return <div>{user ? `Logged in: ${user.name}` : 'Logged out'}</div>;
+};
 ```
 
-Then you'll be able to use the [call state hooks](../../call-engine/hooks-and-contexts#call-state) to easily access the client state anywhere in your application. These hooks are updated when a relevant call state change occurs.
+Let's see an example where we use the [`useCall`](../../call-engine/hooks-and-contexts/#usecall) and [`useCallCallingState`](../../call-engine/hooks-and-contexts/#usecallcallingstate) hooks to display some basic information about the call:
 
-Let's see an example:
+```tsx
+import {
+  useCreateStreamVideoClient,
+  StreamVideo,
+  useConnectedUser,
+} from '@stream-io/video-react-sdk';
 
-If you want to display a notification when a recording is started or ended you can use the [`useIsCallRecordingInProgress`](../../call-engine/hooks-and-contexts#useiscallrecordinginprogress) hook.
+export default function App() {
+  const client = useCreateStreamVideoClient({
+    apiKey: '<Your API key>',
+    tokenOrProvider: '<token provider>',
+    user: {
+      id: '<user id>',
+      name: '<name>',
+    },
+  });
 
-```typescript
-const isCallRecordingInProgress = useIsCallRecordingInProgress();
+  return (
+    <StreamVideo client={client}>
+      <Header></Header>
+      <StreamMeeting
+        callType="default"
+        callId="test-call"
+        autoJoin={true}
+        data={{ create: true }}
+      >
+        <Call />
+      </StreamMeeting>
+    </StreamVideo>
+  );
+}
 
-// Display notification based on recording state
+const Header = () => {
+  const user = useConnectedUser();
+  return <div>{user ? `Logged in: ${user.name}` : 'Logged out'}</div>;
+};
+
+const Call = () => {
+  const call = useCall();
+  const callingState = useCallCallingState();
+
+  return (
+    <div>
+      <div>Call: {call?.data?.cid}</div>
+      <div>State: {callingState}</div>
+    </div>
+  );
+};
 ```
 
 This approach makes it possible to access the call state and be notified about changes anywhere in your application without having to manually subscribe to WebSocket events.
 
-The full list of available client state hooks are available in the [Hooks and Contexts page](../../call-engine/hooks-and-contexts#call-state).
+The list of call state hooks can be found on the [Hooks and Contexts page](../../call-engine/hooks-and-contexts#call-state).
+
+The `StreamMeeting` component uses the [`StreamCallProvider`](../../call-engine/hooks-and-contexts/#streamcallprovider) under the hood.

--- a/packages/react-sdk/docusaurus/docs/React/04-call-engine/01-overview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/04-call-engine/01-overview.mdx
@@ -5,9 +5,7 @@ title: Overview
 
 import SDKSpecific from '../SDKSpecific';
 
-The "Call Engine" section lists all the available API operations and utility functions, hooks, and contexts.
-
-The "Call Engine" consists of the following:
+This section lists all the available API operations and utility functions, hooks, and contexts.
 
 ## StreamVideoClient
 


### PR DESCRIPTION
- Remove TODOs from state store docs
- Update code examples to use `StreamMeeting` instead of `StreamCallProvider`