### PR TITLE
chore: Fix concurrent release problem

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -1,0 +1,63 @@
+name: Version and release
+env:
+  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: version-and-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-and-release:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+
+      - name: ESLint Cache
+        uses: actions/cache@v3
+        with:
+          path: './.eslintcache'
+          key: ${{ runner.os }}-eslintcache-${{ github.ref_name }}-${{ hashFiles('.eslintcache') }}
+
+      - name: Install Dependencies
+        run: yarn install --immutable
+
+      - name: Lint Packages
+        run: yarn lint:ci:all
+
+      - name: Build packages
+        run: NODE_ENV=production yarn build:all
+
+      - name: Test packages
+        run: yarn test:ci:all
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+
+      - name: Version and release packages
+        if: ${{ github.ref_name == 'main' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          yarn config set npmRegistryServer https://registry.npmjs.org/
+          yarn config set npmAuthToken ${{ secrets.NPM_TOKEN }}
+          yarn release

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: Test and release
+name: Test and deploy dogfood
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -52,18 +52,6 @@ jobs:
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
-
-      - name: Version and release packages
-        if: ${{ github.ref_name == 'main' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          yarn config set npmRegistryServer https://registry.npmjs.org/
-          yarn config set npmAuthToken ${{ secrets.NPM_TOKEN }}
-          yarn release
 
       # Vercel deployment: Dogfood (Preview)
       - name: Vercel Pull Configuration Dogfood (Preview)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "generate-docs:react-native:sdk": "yarn workspace @stream-io/video-react-native-sdk run generate-docs",
     "start:docs:react": "yarn workspace @stream-io/video-react-sdk run start:docs ",
     "bootstrap": "scripts/bootstrap-rn.sh",
-    "release": "nx affected --target version --base=origin/main~1 --head=origin/main --parallel=1",
+    "release": "nx run-many --target version --parallel=1",
     "release:18n": "yarn workspace @stream-io/i18n npm publish --access=public",
     "release:react-bindings": "yarn workspace @stream-io/video-react-bindings npm publish --access=public",
     "release:react-sdk": "yarn workspace @stream-io/video-react-sdk npm publish --access=public"


### PR DESCRIPTION
- Create a separate workflow for release -> only allow one concurrent run from this workflow
- Previously, we only ran versioning for the packages that were affected by the last commit to `main`, this is now changed to run versioning to all packages -> in prerelease mode (which is what we are in currently), this will make a release from each package. In release mode this will work as expected, only changed packages will get a new release. Open GH issue about the prerelease porblem: https://github.com/jscutlery/semver/discussions/385