### PR TITLE
feat: Participant Count and Call StartedAt

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -710,7 +710,7 @@ export class Call {
       // 2. in parallel, wait for the SFU to send us the "joinResponse"
       // this will throw an error if the SFU rejects the join request or
       // fails to respond in time
-      const { callState } = await this.waitForJoinResponse();
+      const { callState, participantCount } = await this.waitForJoinResponse();
       const currentParticipants = callState?.participants || [];
       this.state.setParticipants(
         currentParticipants.map<StreamVideoParticipant>((participant) => ({
@@ -719,6 +719,7 @@ export class Call {
           viewportVisibilityState: VisibilityState.UNKNOWN,
         })),
       );
+      this.state.setParticipantCount(participantCount);
 
       this.reconnectAttempts = 0; // reset the reconnect attempts counter
       this.state.setCallingState(CallingState.JOINED);

--- a/packages/client/src/events/internal.ts
+++ b/packages/client/src/events/internal.ts
@@ -56,7 +56,10 @@ export const watchParticipantCountChanged = (
 ) => {
   return dispatcher.on('healthCheckResponse', (e) => {
     if (e.eventPayload.oneofKind !== 'healthCheckResponse') return;
-    const healthCheckResponse = e.eventPayload.healthCheckResponse;
-    state.setParticipantCount(healthCheckResponse.participantCount);
+    const { participantCount } = e.eventPayload.healthCheckResponse;
+    if (participantCount) {
+      state.setParticipantCount(participantCount.total);
+      state.setAnonymousParticipantCount(participantCount.anonymous);
+    }
   });
 };

--- a/packages/client/src/gen/video/sfu/event/events.ts
+++ b/packages/client/src/gen/video/sfu/event/events.ts
@@ -25,6 +25,7 @@ import {
   Error as Error$,
   ICETrickle as ICETrickle$,
   Participant,
+  ParticipantCount,
   PeerType,
   TrackType,
   TrackUnpublishReason,
@@ -208,9 +209,9 @@ export interface HealthCheckRequest {}
  */
 export interface HealthCheckResponse {
   /**
-   * @generated from protobuf field: uint32 participant_count = 1;
+   * @generated from protobuf field: stream.video.sfu.models.ParticipantCount participant_count = 1;
    */
-  participantCount: number;
+  participantCount?: ParticipantCount;
 }
 /**
  * @generated from protobuf message stream.video.sfu.event.TrackPublished
@@ -304,10 +305,6 @@ export interface JoinResponse {
    * @generated from protobuf field: stream.video.sfu.models.CallState call_state = 1;
    */
   callState?: CallState;
-  /**
-   * @generated from protobuf field: uint32 participant_count = 2;
-   */
-  participantCount: number;
 }
 /**
  * ParticipantJoined is fired when a user joins a call
@@ -1367,13 +1364,13 @@ class HealthCheckResponse$Type extends MessageType<HealthCheckResponse> {
       {
         no: 1,
         name: 'participant_count',
-        kind: 'scalar',
-        T: 13 /*ScalarType.UINT32*/,
+        kind: 'message',
+        T: () => ParticipantCount,
       },
     ]);
   }
   create(value?: PartialMessage<HealthCheckResponse>): HealthCheckResponse {
-    const message = { participantCount: 0 };
+    const message = {};
     globalThis.Object.defineProperty(message, MESSAGE_TYPE, {
       enumerable: false,
       value: this,
@@ -1393,8 +1390,13 @@ class HealthCheckResponse$Type extends MessageType<HealthCheckResponse> {
     while (reader.pos < end) {
       let [fieldNo, wireType] = reader.tag();
       switch (fieldNo) {
-        case /* uint32 participant_count */ 1:
-          message.participantCount = reader.uint32();
+        case /* stream.video.sfu.models.ParticipantCount participant_count */ 1:
+          message.participantCount = ParticipantCount.internalBinaryRead(
+            reader,
+            reader.uint32(),
+            options,
+            message.participantCount,
+          );
           break;
         default:
           let u = options.readUnknownField;
@@ -1420,9 +1422,13 @@ class HealthCheckResponse$Type extends MessageType<HealthCheckResponse> {
     writer: IBinaryWriter,
     options: BinaryWriteOptions,
   ): IBinaryWriter {
-    /* uint32 participant_count = 1; */
-    if (message.participantCount !== 0)
-      writer.tag(1, WireType.Varint).uint32(message.participantCount);
+    /* stream.video.sfu.models.ParticipantCount participant_count = 1; */
+    if (message.participantCount)
+      ParticipantCount.internalBinaryWrite(
+        message.participantCount,
+        writer.tag(1, WireType.LengthDelimited).fork(),
+        options,
+      ).join();
     let u = options.writeUnknownFields;
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(
@@ -1790,16 +1796,10 @@ class JoinResponse$Type extends MessageType<JoinResponse> {
   constructor() {
     super('stream.video.sfu.event.JoinResponse', [
       { no: 1, name: 'call_state', kind: 'message', T: () => CallState },
-      {
-        no: 2,
-        name: 'participant_count',
-        kind: 'scalar',
-        T: 13 /*ScalarType.UINT32*/,
-      },
     ]);
   }
   create(value?: PartialMessage<JoinResponse>): JoinResponse {
-    const message = { participantCount: 0 };
+    const message = {};
     globalThis.Object.defineProperty(message, MESSAGE_TYPE, {
       enumerable: false,
       value: this,
@@ -1826,9 +1826,6 @@ class JoinResponse$Type extends MessageType<JoinResponse> {
             options,
             message.callState,
           );
-          break;
-        case /* uint32 participant_count */ 2:
-          message.participantCount = reader.uint32();
           break;
         default:
           let u = options.readUnknownField;
@@ -1861,9 +1858,6 @@ class JoinResponse$Type extends MessageType<JoinResponse> {
         writer.tag(1, WireType.LengthDelimited).fork(),
         options,
       ).join();
-    /* uint32 participant_count = 2; */
-    if (message.participantCount !== 0)
-      writer.tag(2, WireType.Varint).uint32(message.participantCount);
     let u = options.writeUnknownFields;
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/src/gen/video/sfu/models/models.ts
+++ b/packages/client/src/gen/video/sfu/models/models.ts
@@ -20,13 +20,52 @@ import { Struct } from '../../../google/protobuf/struct';
 import { Timestamp } from '../../../google/protobuf/timestamp';
 
 /**
+ * CallState is the current state of the call
+ * as seen by an SFU.
+ *
  * @generated from protobuf message stream.video.sfu.models.CallState
  */
 export interface CallState {
   /**
+   * participants is the list of participants in the call.
+   * In large calls, the list could be truncated in which
+   * case, the list of participants contains fewer participants
+   * than the counts returned in participant_count. Anonymous
+   * participants are **NOT** included in the list.
+   *
    * @generated from protobuf field: repeated stream.video.sfu.models.Participant participants = 1;
    */
   participants: Participant[];
+  /**
+   * started_at is the time the call session actually started.
+   *
+   * @generated from protobuf field: google.protobuf.Timestamp started_at = 2;
+   */
+  startedAt?: Timestamp;
+  /**
+   * participant_count contains the summary of the counts.
+   *
+   * @generated from protobuf field: stream.video.sfu.models.ParticipantCount participant_count = 3;
+   */
+  participantCount?: ParticipantCount;
+}
+/**
+ * @generated from protobuf message stream.video.sfu.models.ParticipantCount
+ */
+export interface ParticipantCount {
+  /**
+   * Total number of participants in the call including
+   * the anonymous participants.
+   *
+   * @generated from protobuf field: uint32 total = 1;
+   */
+  total: number;
+  /**
+   * Total number of anonymous participants in the call.
+   *
+   * @generated from protobuf field: uint32 anonymous = 2;
+   */
+  anonymous: number;
 }
 /**
  * those who are online in the call
@@ -604,6 +643,13 @@ class CallState$Type extends MessageType<CallState> {
         repeat: 1 /*RepeatType.PACKED*/,
         T: () => Participant,
       },
+      { no: 2, name: 'started_at', kind: 'message', T: () => Timestamp },
+      {
+        no: 3,
+        name: 'participant_count',
+        kind: 'message',
+        T: () => ParticipantCount,
+      },
     ]);
   }
   create(value?: PartialMessage<CallState>): CallState {
@@ -630,6 +676,22 @@ class CallState$Type extends MessageType<CallState> {
         case /* repeated stream.video.sfu.models.Participant participants */ 1:
           message.participants.push(
             Participant.internalBinaryRead(reader, reader.uint32(), options),
+          );
+          break;
+        case /* google.protobuf.Timestamp started_at */ 2:
+          message.startedAt = Timestamp.internalBinaryRead(
+            reader,
+            reader.uint32(),
+            options,
+            message.startedAt,
+          );
+          break;
+        case /* stream.video.sfu.models.ParticipantCount participant_count */ 3:
+          message.participantCount = ParticipantCount.internalBinaryRead(
+            reader,
+            reader.uint32(),
+            options,
+            message.participantCount,
           );
           break;
         default:
@@ -663,6 +725,20 @@ class CallState$Type extends MessageType<CallState> {
         writer.tag(1, WireType.LengthDelimited).fork(),
         options,
       ).join();
+    /* google.protobuf.Timestamp started_at = 2; */
+    if (message.startedAt)
+      Timestamp.internalBinaryWrite(
+        message.startedAt,
+        writer.tag(2, WireType.LengthDelimited).fork(),
+        options,
+      ).join();
+    /* stream.video.sfu.models.ParticipantCount participant_count = 3; */
+    if (message.participantCount)
+      ParticipantCount.internalBinaryWrite(
+        message.participantCount,
+        writer.tag(3, WireType.LengthDelimited).fork(),
+        options,
+      ).join();
     let u = options.writeUnknownFields;
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(
@@ -677,6 +753,85 @@ class CallState$Type extends MessageType<CallState> {
  * @generated MessageType for protobuf message stream.video.sfu.models.CallState
  */
 export const CallState = new CallState$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ParticipantCount$Type extends MessageType<ParticipantCount> {
+  constructor() {
+    super('stream.video.sfu.models.ParticipantCount', [
+      { no: 1, name: 'total', kind: 'scalar', T: 13 /*ScalarType.UINT32*/ },
+      { no: 2, name: 'anonymous', kind: 'scalar', T: 13 /*ScalarType.UINT32*/ },
+    ]);
+  }
+  create(value?: PartialMessage<ParticipantCount>): ParticipantCount {
+    const message = { total: 0, anonymous: 0 };
+    globalThis.Object.defineProperty(message, MESSAGE_TYPE, {
+      enumerable: false,
+      value: this,
+    });
+    if (value !== undefined)
+      reflectionMergePartial<ParticipantCount>(this, message, value);
+    return message;
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: ParticipantCount,
+  ): ParticipantCount {
+    let message = target ?? this.create(),
+      end = reader.pos + length;
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag();
+      switch (fieldNo) {
+        case /* uint32 total */ 1:
+          message.total = reader.uint32();
+          break;
+        case /* uint32 anonymous */ 2:
+          message.anonymous = reader.uint32();
+          break;
+        default:
+          let u = options.readUnknownField;
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`,
+            );
+          let d = reader.skip(wireType);
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d,
+            );
+      }
+    }
+    return message;
+  }
+  internalBinaryWrite(
+    message: ParticipantCount,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions,
+  ): IBinaryWriter {
+    /* uint32 total = 1; */
+    if (message.total !== 0)
+      writer.tag(1, WireType.Varint).uint32(message.total);
+    /* uint32 anonymous = 2; */
+    if (message.anonymous !== 0)
+      writer.tag(2, WireType.Varint).uint32(message.anonymous);
+    let u = options.writeUnknownFields;
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer,
+      );
+    return writer;
+  }
+}
+/**
+ * @generated MessageType for protobuf message stream.video.sfu.models.ParticipantCount
+ */
+export const ParticipantCount = new ParticipantCount$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class Participant$Type extends MessageType<Participant> {
   constructor() {

--- a/packages/client/src/rtc/signal.ts
+++ b/packages/client/src/rtc/signal.ts
@@ -22,12 +22,21 @@ export const createWebSocketSignalChannel = (opts: {
 
   if (onMessage) {
     ws.addEventListener('message', (e) => {
-      const message =
-        e.data instanceof ArrayBuffer
-          ? SfuEvent.fromBinary(new Uint8Array(e.data))
-          : SfuEvent.fromJsonString(e.data);
+      try {
+        const message =
+          e.data instanceof ArrayBuffer
+            ? SfuEvent.fromBinary(new Uint8Array(e.data))
+            : SfuEvent.fromJsonString(e.data);
 
-      onMessage(message);
+        onMessage(message);
+      } catch (err) {
+        console.error(
+          'Failed to decode a message. Check whether the Proto models match.',
+          e.data,
+          e,
+          err,
+        );
+      }
     });
   }
   return ws;

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -101,12 +101,27 @@ export class CallState {
   );
 
   /**
+   * The time the call session actually started.
+   *
+   * @internal
+   */
+  private startedAtSubject = new BehaviorSubject<Date | undefined>(undefined);
+
+  /**
    * The server-side counted number of participants connected to the current call.
    * This number includes the anonymous participants as well.
    *
    * @internal
    */
   private participantCountSubject = new BehaviorSubject<number>(0);
+
+  /**
+   * The server-side counted number of anonymous participants connected to the current call.
+   * This number excludes the regular participants.
+   *
+   * @internal
+   */
+  private anonymousParticipantCountSubject = new BehaviorSubject<number>(0);
 
   /**
    * All participants of the current call (including the logged-in user).
@@ -149,10 +164,22 @@ export class CallState {
   // Derived state
 
   /**
+   * The time the call session actually started.
+   * Useful for displaying the call duration.
+   */
+  startedAt$: Observable<Date | undefined>;
+
+  /**
    * The server-side counted number of participants connected to the current call.
    * This number includes the anonymous participants as well.
    */
   participantCount$: Observable<number>;
+
+  /**
+   * The server-side counted number of anonymous participants connected to the current call.
+   * This number excludes the regular participants.
+   */
+  anonymousParticipantCount$: Observable<number>;
 
   /**
    * All participants of the current call (this includes the current user and other participants as well).
@@ -269,7 +296,10 @@ export class CallState {
       distinctUntilChanged(),
     );
 
+    this.startedAt$ = this.startedAtSubject.asObservable();
     this.participantCount$ = this.participantCountSubject.asObservable();
+    this.anonymousParticipantCount$ =
+      this.anonymousParticipantCountSubject.asObservable();
 
     this.callStatsReport$ = this.callStatsReportSubject.asObservable();
     this.callPermissionRequest$ =
@@ -329,6 +359,42 @@ export class CallState {
    */
   setParticipantCount = (count: Patch<number>) => {
     return this.setCurrentValue(this.participantCountSubject, count);
+  };
+
+  /**
+   * The time the call session actually started.
+   * Useful for displaying the call duration.
+   */
+  get startedAt() {
+    return this.getCurrentValue(this.startedAt$);
+  }
+
+  /**
+   * Sets the time the call session actually started.
+   *
+   * @internal
+   * @param startedAt the time the call session actually started.
+   */
+  setStartedAt = (startedAt: Patch<Date | undefined>) => {
+    return this.setCurrentValue(this.startedAtSubject, startedAt);
+  };
+
+  /**
+   * The server-side counted number of anonymous participants connected to the current call.
+   * This number includes the anonymous participants as well.
+   */
+  get anonymousParticipantCount() {
+    return this.getCurrentValue(this.anonymousParticipantCount$);
+  }
+
+  /**
+   * Sets the number of anonymous participants in the current call.
+   *
+   * @internal
+   * @param count the number of anonymous participants.
+   */
+  setAnonymousParticipantCount = (count: Patch<number>) => {
+    return this.setCurrentValue(this.anonymousParticipantCountSubject, count);
   };
 
   /**

--- a/packages/react-bindings/src/hooks/call.ts
+++ b/packages/react-bindings/src/hooks/call.ts
@@ -134,3 +134,14 @@ export const useCallCallingState = () => {
   const { callingState$ } = useCallState();
   return useObservableValue(callingState$);
 };
+
+/**
+ * Utility hook providing the actual start time of the call.
+ * Useful for calculating the call duration.
+ *
+ * @category Call State
+ */
+export const useStartedAt = () => {
+  const { startedAt$ } = useCallState();
+  return useObservableValue(startedAt$);
+};

--- a/packages/react-bindings/src/hooks/call.ts
+++ b/packages/react-bindings/src/hooks/call.ts
@@ -141,7 +141,7 @@ export const useCallCallingState = () => {
  *
  * @category Call State
  */
-export const useStartedAt = () => {
+export const useCallStartedAt = () => {
   const { startedAt$ } = useCallState();
   return useObservableValue(startedAt$);
 };

--- a/packages/react-bindings/src/hooks/participants.ts
+++ b/packages/react-bindings/src/hooks/participants.ts
@@ -66,3 +66,14 @@ export const useParticipantCount = () => {
   const { participantCount$ } = useCallState();
   return useObservableValue(participantCount$);
 };
+
+/**
+ * Returns the approximate anonymous participant count of the active call.
+ * The regular participants are not included in this count. It is computed on the server.
+ *
+ * @category Call State
+ */
+export const useAnonymousParticipantCount = () => {
+  const { anonymousParticipantCount$ } = useCallState();
+  return useObservableValue(anonymousParticipantCount$);
+};


### PR DESCRIPTION
### Overview

Initialize the server-side participant count right after joining a call. Support for `call.startedAt`.