### PR TITLE
fix(styling): set min-height to ParticipantView in the legacy grid

### DIFF
--- a/packages/styling/src/CallParticipantsView.scss
+++ b/packages/styling/src/CallParticipantsView.scss
@@ -10,6 +10,10 @@
   height: 100%;
   min-height: 0;
 
+  .str-video__participant-view {
+    min-height: 0;
+  }
+
   &.str-video__grid-1 {
     grid-template-columns: repeat(1, 1fr);
     grid-template-rows: repeat(1, 1fr);


### PR DESCRIPTION
- prevents element overflows