### PR TITLE
fix: prevent duplicate video publishing

### DIFF
--- a/sample-apps/react/react-video-demo/src/components/ControlMenu/ControlMenu.tsx
+++ b/sample-apps/react/react-video-demo/src/components/ControlMenu/ControlMenu.tsx
@@ -2,10 +2,8 @@ import { FC, useCallback, useState } from 'react';
 import classnames from 'classnames';
 import {
   SfuModels,
-  useAudioPublisher,
   useLocalParticipant,
   useMediaDevices,
-  useVideoPublisher,
 } from '@stream-io/video-react-sdk';
 
 import ControlButton, { PanelButton } from '../ControlButton';
@@ -43,6 +41,8 @@ export const ControlMenu: FC<Props> = ({
     switchDevice,
     toggleAudioMuteState,
     toggleVideoMuteState,
+    publishVideoStream,
+    publishAudioStream,
     initialVideoState,
     initialAudioEnabled,
     isAudioOutputChangeSupported,
@@ -57,16 +57,6 @@ export const ControlMenu: FC<Props> = ({
   const isAudioMuted = preview
     ? !initialAudioEnabled
     : !localParticipant?.publishedTracks.includes(SfuModels.TrackType.AUDIO);
-
-  const publishVideoStream = useVideoPublisher({
-    initialVideoMuted,
-    videoDeviceId: selectedVideoDeviceId,
-  });
-
-  const publishAudioStream = useAudioPublisher({
-    initialAudioMuted,
-    audioDeviceId: selectedAudioInputDeviceId,
-  });
 
   const disableVideo = useCallback(() => {
     call.stopPublish(SfuModels.TrackType.VIDEO);

--- a/sample-apps/react/react-video-demo/src/components/Views/MeetingView/MeetingView.tsx
+++ b/sample-apps/react/react-video-demo/src/components/Views/MeetingView/MeetingView.tsx
@@ -4,7 +4,6 @@ import { StreamChat } from 'stream-chat';
 import {
   Call,
   getScreenShareStream,
-  MediaDevicesProvider,
   SfuModels,
   useCurrentCallStatsReport,
   useHasOngoingScreenShare,
@@ -198,9 +197,5 @@ export const View: FC<Props & Meeting> = ({
 
 export const MeetingView: FC<Props> = (props) => {
   const { call: activeCall, ...rest } = props;
-  return (
-    <MediaDevicesProvider enumerate>
-      <View call={activeCall} {...rest} />
-    </MediaDevicesProvider>
-  );
+  return <View call={activeCall} {...rest} />;
 };


### PR DESCRIPTION
### Overview

The demo app used two stateful hooks, `useVideoPublisher` and `useAudioPublisher`.
These hooks were instantiated three times:
- in the root <MediaDevicesProvider /> by the React SDK
- in the <MeetingView /> another <MediaDevicesProvider /> has been instantiated
- <ControlMenu /> used these two internal hooks directly.

Because of recent changes in the SDKs, these hooks were trying to publish a video stream, whenever the current user joins a call, hence, creating a race condition that was causing an error on the SFU side (announced tracks weren't matching with the published tracks).

This PR removes the extra <MediaDevicesProvider /> and updates the <ControlMenu /> component to use the Public API of the SDK.
