### PR TITLE
feat: Support for server-side driven stream resolution

### DIFF
--- a/packages/client/src/rtc/__tests__/videoLayers.test.ts
+++ b/packages/client/src/rtc/__tests__/videoLayers.test.ts
@@ -1,0 +1,101 @@
+import './mocks/webrtc.mocks';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  findOptimalScreenSharingLayers,
+  findOptimalVideoLayers,
+} from '../videoLayers';
+
+describe('videoLayers', () => {
+  it('should find optimal screen sharing layers', () => {
+    const track = new MediaStreamTrack();
+    vi.spyOn(track, 'getSettings').mockReturnValue({
+      width: 1920,
+      height: 1080,
+    });
+
+    const layers = findOptimalScreenSharingLayers(track);
+    expect(layers).toEqual([
+      {
+        active: true,
+        rid: 'q',
+        width: 1920,
+        height: 1080,
+        maxBitrate: 3000000,
+        scaleResolutionDownBy: 1,
+        maxFramerate: 30,
+      },
+    ]);
+  });
+
+  it('should find optimal video layers', () => {
+    const track = new MediaStreamTrack();
+    const width = 1920;
+    const height = 1080;
+    const targetBitrate = 3000000;
+    vi.spyOn(track, 'getSettings').mockReturnValue({ width, height });
+
+    const layers = findOptimalVideoLayers(track, targetBitrate);
+    expect(layers).toEqual([
+      {
+        active: true,
+        rid: 'q',
+        width: width / 4,
+        height: height / 4,
+        maxBitrate: targetBitrate / 4,
+        scaleResolutionDownBy: 4,
+        maxFramerate: 20,
+      },
+      {
+        active: true,
+        rid: 'h',
+        width: width / 2,
+        height: height / 2,
+        maxBitrate: targetBitrate / 2,
+        scaleResolutionDownBy: 2,
+        maxFramerate: 25,
+      },
+      {
+        active: true,
+        rid: 'f',
+        width: width,
+        height: height,
+        maxBitrate: targetBitrate,
+        scaleResolutionDownBy: 1,
+        maxFramerate: 30,
+      },
+    ]);
+  });
+
+  it('should announce one simulcast layer for resolutions less than 320px wide', () => {
+    const track = new MediaStreamTrack();
+    const width = 320;
+    const height = 240;
+    vi.spyOn(track, 'getSettings').mockReturnValue({ width, height });
+    const layers = findOptimalVideoLayers(track);
+    expect(layers.length).toBe(1);
+    expect(layers[0].rid).toBe('q');
+  });
+
+  it('should announce two simulcast layers for resolutions less than 640px wide', () => {
+    const track = new MediaStreamTrack();
+    const width = 640;
+    const height = 480;
+    vi.spyOn(track, 'getSettings').mockReturnValue({ width, height });
+    const layers = findOptimalVideoLayers(track);
+    expect(layers.length).toBe(2);
+    expect(layers[0].rid).toBe('q');
+    expect(layers[1].rid).toBe('h');
+  });
+
+  it('should announce three simulcast layers for resolutions greater than 640px wide', () => {
+    const track = new MediaStreamTrack();
+    const width = 1280;
+    const height = 720;
+    vi.spyOn(track, 'getSettings').mockReturnValue({ width, height });
+    const layers = findOptimalVideoLayers(track);
+    expect(layers.length).toBe(3);
+    expect(layers[0].rid).toBe('q');
+    expect(layers[1].rid).toBe('h');
+    expect(layers[2].rid).toBe('f');
+  });
+});

--- a/packages/client/src/rtc/publisher.ts
+++ b/packages/client/src/rtc/publisher.ts
@@ -136,9 +136,11 @@ export class Publisher {
     };
 
     if (!transceiver) {
+      const metadata = this.state.metadata;
+      const maxBitrate = metadata?.settings.video.target_resolution.bitrate;
       const videoEncodings =
         trackType === TrackType.VIDEO
-          ? findOptimalVideoLayers(track)
+          ? findOptimalVideoLayers(track, maxBitrate)
           : undefined;
 
       const codecPreferences = this.getCodecPreferences(
@@ -357,6 +359,8 @@ export class Publisher {
     offer.sdp = sdp;
     await this.publisher.setLocalDescription(offer);
 
+    const metadata = this.state.metadata;
+    const maxBitrate = metadata?.settings.video.target_resolution.bitrate;
     const trackInfos = this.publisher
       .getTransceivers()
       .filter((t) => t.direction === 'sendonly' && !!t.sender.track)
@@ -370,7 +374,7 @@ export class Publisher {
         const track = transceiver.sender.track!;
         const optimalLayers =
           trackType === TrackType.VIDEO
-            ? findOptimalVideoLayers(track)
+            ? findOptimalVideoLayers(track, maxBitrate)
             : trackType === TrackType.SCREEN_SHARE
             ? findOptimalScreenSharingLayers(track)
             : [];
@@ -395,7 +399,7 @@ export class Publisher {
           // FIXME OL: adjust these values
           stereo: false,
           dtx: this.isDtxEnabled,
-          red: false,
+          red: this.isRedEnabled,
         };
       });
 

--- a/packages/client/src/rtc/videoLayers.ts
+++ b/packages/client/src/rtc/videoLayers.ts
@@ -5,7 +5,7 @@ export type OptimalVideoLayer = RTCRtpEncodingParameters & {
 
 export const findOptimalVideoLayers = (
   videoTrack: MediaStreamTrack,
-  maxBitrate: number = 3000000,
+  maxBitrate: number = 1250000,
 ) => {
   const optimalVideoLayers: OptimalVideoLayer[] = [];
   const settings = videoTrack.getSettings();

--- a/packages/client/src/rtc/videoLayers.ts
+++ b/packages/client/src/rtc/videoLayers.ts
@@ -1,52 +1,37 @@
 export type OptimalVideoLayer = RTCRtpEncodingParameters & {
   width: number;
   height: number;
-
-  // defined here until we have this prop included in TypeScript
-  // https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1380
-  maxFramerate?: number;
 };
 
-export const findOptimalVideoLayers = (videoTrack: MediaStreamTrack) => {
-  const steps: [number, number, number][] = [
-    [1920, 1080, 3000000],
-    [1280, 720, 1250000],
-    [960, 540, 975000],
-    [640, 480, 500000],
-    [320, 240, 250000],
-    [160, 120, 125000],
-  ];
-
+export const findOptimalVideoLayers = (
+  videoTrack: MediaStreamTrack,
+  maxBitrate: number = 3000000,
+) => {
   const optimalVideoLayers: OptimalVideoLayer[] = [];
   const settings = videoTrack.getSettings();
-  for (let step = 0; step < steps.length; step++) {
-    const [w, h, maxBitrate] = steps[step];
-    // found ideal layer
-    if (w === settings.width && h === settings.height) {
-      let scaleFactor: number = 1;
-      ['f', 'h', 'q'].forEach((rid) => {
-        // Reversing the order [f, h, q] to [q, h, f] as Chrome uses encoding index
-        // when deciding which layer to disable when CPU or bandwidth is constrained.
-        // Encodings should be ordered in increasing spatial resolution order.
-        optimalVideoLayers.unshift({
-          active: true,
-          rid,
-          width: w / scaleFactor,
-          height: h / scaleFactor,
-          maxBitrate: maxBitrate / scaleFactor,
-          scaleResolutionDownBy: scaleFactor,
-          maxFramerate: {
-            f: 30,
-            h: 25,
-            q: 20,
-          }[rid],
-        });
-        scaleFactor *= 2;
-      });
+  const { width: w = 0, height: h = 0 } = settings;
 
-      break;
-    }
-  }
+  let downscaleFactor = 1;
+  ['f', 'h', 'q'].forEach((rid) => {
+    // Reversing the order [f, h, q] to [q, h, f] as Chrome uses encoding index
+    // when deciding which layer to disable when CPU or bandwidth is constrained.
+    // Encodings should be ordered in increasing spatial resolution order.
+    optimalVideoLayers.unshift({
+      active: true,
+      rid,
+      width: w / downscaleFactor,
+      height: h / downscaleFactor,
+      maxBitrate: maxBitrate / downscaleFactor,
+      scaleResolutionDownBy: downscaleFactor,
+      maxFramerate: {
+        f: 30,
+        h: 25,
+        q: 20,
+      }[rid],
+    });
+    downscaleFactor *= 2;
+  });
+
   // for simplicity, we start with all layers enabled, then this function
   // will clear/reassign the layers that are not needed
   return withSimulcastConstraints(settings, optimalVideoLayers);

--- a/packages/react-sdk/src/components/Notification/SpeakingWhileMutedNotification.tsx
+++ b/packages/react-sdk/src/components/Notification/SpeakingWhileMutedNotification.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { createSoundDetector, SfuModels } from '@stream-io/video-client';
 import { useLocalParticipant } from '@stream-io/video-react-bindings';
 
-import { useMediaDevices } from '../../core/contexts';
+import { useMediaDevices } from '../../core';
 import { Notification } from './Notification';
 import { ChildrenOnly } from '../../types';
 
@@ -18,13 +18,14 @@ export const SpeakingWhileMutedNotification = ({ children }: ChildrenOnly) => {
   useEffect(() => {
     // do nothing when not muted
     if (!isAudioMute) return;
-    const disposeSoundDetector = getAudioStream(audioDeviceId).then(
-      (audioStream) =>
-        createSoundDetector(audioStream, (isSpeechDetected) => {
-          setIsSpeakingWhileMuted((isNotified) =>
-            isNotified ? isNotified : isSpeechDetected,
-          );
-        }),
+    const disposeSoundDetector = getAudioStream({
+      deviceId: audioDeviceId,
+    }).then((audioStream) =>
+      createSoundDetector(audioStream, (isSpeechDetected) => {
+        setIsSpeakingWhileMuted((isNotified) =>
+          isNotified ? isNotified : isSpeechDetected,
+        );
+      }),
     );
     disposeSoundDetector.catch((err) => {
       console.error('Error while creating sound detector', err);

--- a/packages/react-sdk/src/components/Video/VideoPreview.tsx
+++ b/packages/react-sdk/src/components/Video/VideoPreview.tsx
@@ -69,7 +69,7 @@ export const VideoPreview = ({
   useEffect(() => {
     if (!initialVideoState.enabled) return;
 
-    getVideoStream(selectedVideoDeviceId)
+    getVideoStream({ deviceId: selectedVideoDeviceId })
       .then((s) => {
         setStream((previousStream) => {
           if (previousStream) {

--- a/packages/react-sdk/src/core/contexts/MediaDevicesContext.tsx
+++ b/packages/react-sdk/src/core/contexts/MediaDevicesContext.tsx
@@ -88,8 +88,8 @@ const DEFAULT_DEVICE_ID = 'default';
  */
 export type MediaDevicesContextAPI = {
   disposeOfMediaStream: (stream: MediaStream) => void;
-  getAudioStream: (deviceId?: string) => Promise<MediaStream>;
-  getVideoStream: (deviceId?: string) => Promise<MediaStream>;
+  getAudioStream: typeof getAudioStream;
+  getVideoStream: typeof getVideoStream;
   isAudioOutputChangeSupported: boolean;
   initialAudioEnabled: boolean;
   initialVideoState: DeviceState;

--- a/packages/react-sdk/src/core/hooks/useAudioPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useAudioPublisher.ts
@@ -47,7 +47,9 @@ export const useAudioPublisher = ({
       throw new Error(`No permission to publish audio`);
     }
     try {
-      const audioStream = await getAudioStream(audioDeviceId);
+      const audioStream = await getAudioStream({
+        deviceId: audioDeviceId,
+      });
       await call.publishAudioStream(audioStream);
     } catch (e) {
       console.log('Failed to publish audio stream', e);
@@ -95,14 +97,18 @@ export const useAudioPublisher = ({
         // We need to stop the original track first in order
         // we can retrieve the new default device stream
         track.stop();
-        const audioStream = await getAudioStream('default');
+        const audioStream = await getAudioStream({
+          deviceId: 'default',
+        });
         await call.publishAudioStream(audioStream);
       },
     );
 
     const handleTrackEnded = async () => {
       if (selectedAudioDeviceId === audioDeviceId) {
-        const audioStream = await getAudioStream(audioDeviceId);
+        const audioStream = await getAudioStream({
+          deviceId: audioDeviceId,
+        });
         await call.publishAudioStream(audioStream);
       }
     };

--- a/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
@@ -11,6 +11,7 @@ import {
 import {
   useCall,
   useCallCallingState,
+  useCallMetadata,
   useCallState,
   useLocalParticipant,
 } from '@stream-io/video-react-bindings';
@@ -43,6 +44,8 @@ export const useVideoPublisher = ({
     SfuModels.TrackType.VIDEO,
   );
 
+  const metadata = useCallMetadata();
+  const targetResolution = metadata?.settings.video.target_resolution;
   const publishVideoStream = useCallback(async () => {
     if (!call) return;
     if (!call.permissionsContext.hasPermission(OwnCapability.SEND_VIDEO)) {
@@ -51,12 +54,20 @@ export const useVideoPublisher = ({
     try {
       const videoStream = await getVideoStream({
         deviceId: videoDeviceId,
+        width: targetResolution?.width,
+        height: targetResolution?.height,
       });
       await call.publishVideoStream(videoStream, { preferredCodec });
     } catch (e) {
       console.log('Failed to publish video stream', e);
     }
-  }, [call, preferredCodec, videoDeviceId]);
+  }, [
+    call,
+    preferredCodec,
+    targetResolution?.height,
+    targetResolution?.width,
+    videoDeviceId,
+  ]);
 
   useEffect(() => {
     if (callingState === CallingState.JOINED && !initialVideoMuted) {

--- a/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
@@ -5,6 +5,7 @@ import {
   getVideoStream,
   OwnCapability,
   SfuModels,
+  VideoSettingsCameraFacingEnum,
   watchForAddedDefaultVideoDevice,
   watchForDisconnectedVideoDevice,
 } from '@stream-io/video-client';
@@ -45,7 +46,8 @@ export const useVideoPublisher = ({
   );
 
   const metadata = useCallMetadata();
-  const targetResolution = metadata?.settings.video.target_resolution;
+  const videoSettings = metadata?.settings.video;
+  const targetResolution = videoSettings?.target_resolution;
   const publishVideoStream = useCallback(async () => {
     if (!call) return;
     if (!call.permissionsContext.hasPermission(OwnCapability.SEND_VIDEO)) {
@@ -56,6 +58,7 @@ export const useVideoPublisher = ({
         deviceId: videoDeviceId,
         width: targetResolution?.width,
         height: targetResolution?.height,
+        facingMode: toFacingMode(videoSettings?.camera_facing),
       });
       await call.publishVideoStream(videoStream, { preferredCodec });
     } catch (e) {
@@ -67,6 +70,7 @@ export const useVideoPublisher = ({
     targetResolution?.height,
     targetResolution?.width,
     videoDeviceId,
+    videoSettings?.camera_facing,
   ]);
 
   useEffect(() => {
@@ -134,4 +138,15 @@ export const useVideoPublisher = ({
   }, [videoDeviceId, call, participant?.videoStream, isPublishingVideo]);
 
   return publishVideoStream;
+};
+
+const toFacingMode = (value: VideoSettingsCameraFacingEnum | undefined) => {
+  switch (value) {
+    case VideoSettingsCameraFacingEnum.FRONT:
+      return 'user';
+    case VideoSettingsCameraFacingEnum.BACK:
+      return 'environment';
+    default:
+      return undefined;
+  }
 };

--- a/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
@@ -49,7 +49,9 @@ export const useVideoPublisher = ({
       throw new Error(`No permission to publish video`);
     }
     try {
-      const videoStream = await getVideoStream(videoDeviceId);
+      const videoStream = await getVideoStream({
+        deviceId: videoDeviceId,
+      });
       await call.publishVideoStream(videoStream, { preferredCodec });
     } catch (e) {
       console.log('Failed to publish video stream', e);
@@ -97,14 +99,18 @@ export const useVideoPublisher = ({
         // We need to stop the original track first in order
         // we can retrieve the new default device stream
         track.stop();
-        const videoStream = await getVideoStream('default');
+        const videoStream = await getVideoStream({
+          deviceId: 'default',
+        });
         await call.publishVideoStream(videoStream);
       },
     );
 
     const handleTrackEnded = async () => {
       if (selectedVideoDeviceId === videoDeviceId) {
-        const videoStream = await getVideoStream(videoDeviceId);
+        const videoStream = await getVideoStream({
+          deviceId: videoDeviceId,
+        });
         await call.publishVideoStream(videoStream);
       }
     };

--- a/sample-apps/react/zoom-clone/src/components/Preview.tsx
+++ b/sample-apps/react/zoom-clone/src/components/Preview.tsx
@@ -99,7 +99,7 @@ export const Preview = {
 
       if (initialAudioMuted) return;
 
-      getAudioStream(selectedAudioInputDeviceId)
+      getAudioStream({ deviceId: selectedAudioInputDeviceId })
         .then((ms) => {
           if (interrupted) return disposeOfMediaStream(ms);
 
@@ -148,7 +148,7 @@ export const Preview = {
 
       if (initialVideoMuted) return;
 
-      getVideoStream(selectedVideoDeviceId)
+      getVideoStream({ deviceId: selectedVideoDeviceId })
         .then((ms) => {
           if (interrupted) return disposeOfMediaStream(ms);
 


### PR DESCRIPTION
### Overview

Enables server-side-driven video stream resolution.

### Changes
- The DevicesAPI now accepts a broader set of MediaTrackConstraints
- The `useVideoPublisherHook` gives precedence to the call's provided target resolution, otherwise it uses a default one