### PR TITLE
feat: missing WS events and endpoints

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -707,7 +707,12 @@ export class Call {
             this.streamClient.options.preferredVideoCodec,
           ),
         )
-        .then((sdp) => sfuClient.join({ subscriberSdp: sdp || '' }));
+        .then((sdp) =>
+          sfuClient.join({
+            subscriberSdp: sdp || '',
+            clientDetails,
+          }),
+        );
 
       // 2. in parallel, wait for the SFU to send us the "joinResponse"
       // this will throw an error if the SFU rejects the join request or

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -355,6 +355,7 @@ export class Call {
    * Leave the call and stop the media streams that were published by the call.
    */
   leave = async ({ reject = false }: CallLeaveOptions = {}) => {
+    // TODO: handle case when leave is called during JOINING
     const callingState = this.state.callingState;
     if (callingState === CallingState.LEFT) {
       throw new Error('Cannot leave call that has already been left.');

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -34,6 +34,7 @@ import {
   MuteUsersRequest,
   MuteUsersResponse,
   OwnCapability,
+  QueryMembersRequest,
   RequestPermissionRequest,
   RequestPermissionResponse,
   SendEventRequest,
@@ -1395,6 +1396,19 @@ export class Call {
   setParticipantPinnedAt = (sessionId: string, pinnedAt?: number): void => {
     this.state.updateParticipant(sessionId, {
       pinnedAt,
+    });
+  };
+
+  /**
+   * Query call members with filter query. The result won't be stored in call state.
+   * @param request
+   * @returns
+   */
+  queryMembers = (request: Omit<QueryMembersRequest, 'type' | 'id'>) => {
+    return this.streamClient.post<QueryMembersRequest>('/call/members', {
+      ...request,
+      id: this.id,
+      type: this.type,
     });
   };
 

--- a/packages/client/src/events/__tests__/backstage.test.ts
+++ b/packages/client/src/events/__tests__/backstage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { CallState } from '../../store';
+import { watchCallLiveStarted } from '../backstage';
+
+describe('backstage events', () => {
+  it('handles call.live_started events', () => {
+    const state = new CallState();
+    const handler = watchCallLiveStarted(state);
+    // @ts-ignore
+    handler({
+      type: 'call.live_started',
+    });
+    expect(state.metadata?.backstage).toBe(false);
+  });
+});

--- a/packages/client/src/events/__tests__/call.test.ts
+++ b/packages/client/src/events/__tests__/call.test.ts
@@ -148,7 +148,7 @@ describe('Call ringing events', () => {
       expect(call.leave).toHaveBeenCalled();
     });
 
-    it(`will not leave the call if joined`, async () => {
+    it(`will leave the call if joined`, async () => {
       const call = fakeCall();
       vi.spyOn(call, 'join').mockImplementation(async () => {
         console.log(`TEST: join() called`);
@@ -167,12 +167,29 @@ describe('Call ringing events', () => {
       // @ts-ignore
       await handler(event);
 
+      expect(call.leave).toHaveBeenCalled();
+    });
+
+    it(`will not leave the call if idle`, async () => {
+      const ringing = false;
+      const call = fakeCall(ringing);
+      vi.spyOn(call, 'leave').mockImplementation(async () => {
+        console.log(`TEST: leave() called`);
+      });
+
+      const handler = watchCallEnded(call);
+
+      // @ts-ignore
+      const event: CallEndedEvent = { type: 'call.ended' };
+      // @ts-ignore
+      await handler(event);
+
       expect(call.leave).not.toHaveBeenCalled();
     });
   });
 });
 
-const fakeCall = () => {
+const fakeCall = (ring = true) => {
   const store = new StreamVideoWriteableStateStore();
   store.setConnectedUser({
     id: 'test-user-id',
@@ -183,6 +200,6 @@ const fakeCall = () => {
     id: '12345',
     clientStore: store,
     streamClient: client,
-    ringing: true,
+    ringing: ring,
   });
 };

--- a/packages/client/src/events/__tests__/members.test.ts
+++ b/packages/client/src/events/__tests__/members.test.ts
@@ -88,8 +88,8 @@ describe('member events', () => {
     handler({
       type: 'call.member_updated_permission',
       members: [
-        { ...user0, user: { role: 'host' } },
-        { ...user1, user: { role: 'viewer' } },
+        { ...user1, role: 'viewer' },
+        { ...user0, role: 'host' },
       ],
     } as StreamVideoEvent);
 

--- a/packages/client/src/events/__tests__/members.test.ts
+++ b/packages/client/src/events/__tests__/members.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { CallMemberRemovedEvent, MemberResponse } from '../../gen/coordinator';
+import { CallState } from '../../store';
+import {
+  watchCallMemberAdded,
+  watchCallMemberRemoved,
+  watchCallMemberUpdated,
+  watchCallMemberUpdatedPermission,
+} from '../members';
+import { StreamVideoEvent } from '../../coordinator/connection/types';
+
+describe('member events', () => {
+  it('handles call.member_added events', () => {
+    const state = new CallState();
+    const initialMembers: MemberResponse[] = [
+      {
+        user_id: 'user0',
+      } as MemberResponse,
+    ];
+    state.setMembers(initialMembers);
+    const handler = watchCallMemberAdded(state);
+    handler({
+      type: 'call.member_added',
+      members: [
+        { user_id: 'user1' } as MemberResponse,
+        { user_id: 'user2' } as MemberResponse,
+      ],
+    } as StreamVideoEvent);
+
+    const updatedMembers = state.members;
+    updatedMembers.forEach((member, index) =>
+      expect(member.user_id).toBe(`user${index}`),
+    );
+  });
+
+  it('handles call.member_removed events', () => {
+    const state = new CallState();
+    const initialMembers: MemberResponse[] = [
+      {
+        user_id: 'user0',
+      } as MemberResponse,
+      {
+        user_id: 'user1',
+      } as MemberResponse,
+      {
+        user_id: 'user2',
+      } as MemberResponse,
+    ];
+    state.setMembers(initialMembers);
+    const removedMembers = ['user1'];
+    const handler = watchCallMemberRemoved(state);
+    handler({
+      type: 'call.member_removed',
+      members: removedMembers,
+    } as StreamVideoEvent);
+
+    const updatedMembers = state.members;
+    expect(updatedMembers[0].user_id).toBe('user0');
+    expect(updatedMembers[1].user_id).toBe('user2');
+    expect(updatedMembers.length).toBe(
+      initialMembers.length - removedMembers.length,
+    );
+  });
+
+  it('handles call.member_updated_permission events', () => {
+    const state = new CallState();
+    const user0 = {
+      user_id: 'user0',
+      user: {
+        role: 'viewer',
+      },
+    } as MemberResponse;
+    const user1 = {
+      user_id: 'user1',
+      user: {
+        role: 'host',
+      },
+    } as MemberResponse;
+    const user2 = {
+      user_id: 'user2',
+      user: {
+        role: 'viewer',
+      },
+    } as MemberResponse;
+    const initialMembers: MemberResponse[] = [user0, user1, user2];
+    state.setMembers(initialMembers);
+    const handler = watchCallMemberUpdatedPermission(state);
+    handler({
+      type: 'call.member_updated_permission',
+      members: [
+        { ...user0, user: { role: 'host' } },
+        { ...user1, user: { role: 'viewer' } },
+      ],
+    } as StreamVideoEvent);
+
+    const updatedMembers = state.members;
+    expect(updatedMembers[0].user.role).toBe('host');
+    expect(updatedMembers[1].user.role).toBe('viewer');
+    expect(updatedMembers[2].user.role).toBe('viewer');
+  });
+
+  it('handles call.member_updated events', () => {
+    const state = new CallState();
+    const user0 = {
+      user_id: 'user0',
+      user: {
+        name: 'Jane',
+      },
+    } as MemberResponse;
+    const user1 = {
+      user_id: 'user1',
+      user: {
+        name: 'Jack',
+      },
+    } as MemberResponse;
+    const user2 = {
+      user_id: 'user2',
+      user: {
+        name: 'Adam',
+      },
+    } as MemberResponse;
+    const initialMembers: MemberResponse[] = [user0, user1, user2];
+    state.setMembers(initialMembers);
+    const handler = watchCallMemberUpdated(state);
+    handler({
+      type: 'call.member_updated',
+      members: [{ ...user1, user: { name: 'John' } }],
+    } as StreamVideoEvent);
+
+    const updatedMembers = state.members;
+    expect(updatedMembers[0].user.name).toBe('Jane');
+    expect(updatedMembers[1].user.name).toBe('John');
+    expect(updatedMembers[2].user.name).toBe('Adam');
+  });
+});

--- a/packages/client/src/events/backstage.ts
+++ b/packages/client/src/events/backstage.ts
@@ -5,7 +5,7 @@ import { CallState } from '../store';
  * Watches for `call.live_started` events.
  */
 export const watchCallLiveStarted = (state: CallState) => {
-  return function onCallRecordingStarted(event: StreamVideoEvent) {
+  return function onCallLiveStarted(event: StreamVideoEvent) {
     if (event.type !== 'call.live_started') return;
     state.setMetadata((metadata) => ({
       ...metadata!,

--- a/packages/client/src/events/backstage.ts
+++ b/packages/client/src/events/backstage.ts
@@ -1,0 +1,15 @@
+import { StreamVideoEvent } from '../coordinator/connection/types';
+import { CallState } from '../store';
+
+/**
+ * Watches for `call.live_started` events.
+ */
+export const watchCallLiveStarted = (state: CallState) => {
+  return function onCallRecordingStarted(event: StreamVideoEvent) {
+    if (event.type !== 'call.live_started') return;
+    state.setMetadata((metadata) => ({
+      ...metadata!,
+      backstage: false,
+    }));
+  };
+};

--- a/packages/client/src/events/call.ts
+++ b/packages/client/src/events/call.ts
@@ -47,7 +47,11 @@ export const watchCallRejected = (call: Call) => {
 export const watchCallEnded = (call: Call) => {
   return async function onCallCancelled(event: StreamVideoEvent) {
     if (event.type !== 'call.ended') return;
-    if (call.state.callingState === CallingState.RINGING) {
+    if (
+      call.state.callingState === CallingState.RINGING ||
+      call.state.callingState === CallingState.JOINED ||
+      call.state.callingState === CallingState.JOINING
+    ) {
       await call.leave();
     }
   };

--- a/packages/client/src/events/callEventHandlers.ts
+++ b/packages/client/src/events/callEventHandlers.ts
@@ -56,7 +56,7 @@ export const registerEventHandlers = (
   dispatcher: Dispatcher,
 ) => {
   const coordinatorEvents: {
-    [key in AllCallEvents]: (e: StreamCallEvent) => void;
+    [key in AllCallEvents]: (e: StreamCallEvent) => any;
   } = {
     'call.blocked_user': watchBlockedUser(state),
     'call.broadcasting_started': watchCallBroadcastingStarted(state),
@@ -117,7 +117,7 @@ export const registerEventHandlers = (
 
 export const registerRingingCallEventHandlers = (call: Call) => {
   const coordinatorRingEvents: {
-    [key in RingCallEvents]: (e: StreamCallEvent) => void;
+    [key in RingCallEvents]: (e: StreamCallEvent) => any;
   } = {
     'call.accepted': watchCallAccepted(call),
     'call.rejected': watchCallRejected(call),

--- a/packages/client/src/events/members.ts
+++ b/packages/client/src/events/members.ts
@@ -35,7 +35,7 @@ export const watchCallMemberUpdatedPermission = (state: CallState) => {
           (m) => m.user_id === member.user_id,
         );
         if (memberUpdate) {
-          member.user.role = memberUpdate.user.role;
+          member.user.role = memberUpdate.role!;
           member = { ...member };
         }
         return member;

--- a/packages/client/src/events/members.ts
+++ b/packages/client/src/events/members.ts
@@ -5,7 +5,7 @@ import { CallState } from '../store';
  * Watches for `call.member_added` events.
  */
 export const watchCallMemberAdded = (state: CallState) => {
-  return function onCallRecordingStarted(event: StreamVideoEvent) {
+  return function onCallMemberAdded(event: StreamVideoEvent) {
     if (event.type !== 'call.member_added') return;
     state.setMembers((members) => [...members, ...event.members]);
   };
@@ -15,7 +15,7 @@ export const watchCallMemberAdded = (state: CallState) => {
  * Watches for `call.member_removed` events.
  */
 export const watchCallMemberRemoved = (state: CallState) => {
-  return function onCallRecordingStarted(event: StreamVideoEvent) {
+  return function onCallMemberRemoved(event: StreamVideoEvent) {
     if (event.type !== 'call.member_removed') return;
     state.setMembers((members) =>
       members.filter((m) => event.members.indexOf(m.user_id) === -1),
@@ -27,7 +27,7 @@ export const watchCallMemberRemoved = (state: CallState) => {
  * Watches for `call.member_updated_permission` events.
  */
 export const watchCallMemberUpdatedPermission = (state: CallState) => {
-  return function onCallRecordingStarted(event: StreamVideoEvent) {
+  return function onCallMemberUpdated(event: StreamVideoEvent) {
     if (event.type !== 'call.member_updated_permission') return;
     state.setMembers((members) =>
       members.map((member) => {
@@ -48,7 +48,7 @@ export const watchCallMemberUpdatedPermission = (state: CallState) => {
  * Watches for `call.member_updated` events.
  */
 export const watchCallMemberUpdated = (state: CallState) => {
-  return function onCallRecordingStarted(event: StreamVideoEvent) {
+  return function onCallMemberUpdated(event: StreamVideoEvent) {
     if (event.type !== 'call.member_updated') return;
     state.setMembers((members) =>
       members.map((member) => {

--- a/packages/client/src/events/members.ts
+++ b/packages/client/src/events/members.ts
@@ -1,0 +1,62 @@
+import { StreamVideoEvent } from '../coordinator/connection/types';
+import { CallState } from '../store';
+
+/**
+ * Watches for `call.member_added` events.
+ */
+export const watchCallMemberAdded = (state: CallState) => {
+  return function onCallRecordingStarted(event: StreamVideoEvent) {
+    if (event.type !== 'call.member_added') return;
+    state.setMembers((members) => [...members, ...event.members]);
+  };
+};
+
+/**
+ * Watches for `call.member_removed` events.
+ */
+export const watchCallMemberRemoved = (state: CallState) => {
+  return function onCallRecordingStarted(event: StreamVideoEvent) {
+    if (event.type !== 'call.member_removed') return;
+    state.setMembers((members) =>
+      members.filter((m) => event.members.indexOf(m.user_id) === -1),
+    );
+  };
+};
+
+/**
+ * Watches for `call.member_updated_permission` events.
+ */
+export const watchCallMemberUpdatedPermission = (state: CallState) => {
+  return function onCallRecordingStarted(event: StreamVideoEvent) {
+    if (event.type !== 'call.member_updated_permission') return;
+    state.setMembers((members) =>
+      members.map((member) => {
+        const memberUpdate = event.members.find(
+          (m) => m.user_id === member.user_id,
+        );
+        if (memberUpdate) {
+          member.user.role = memberUpdate.user.role;
+          member = { ...member };
+        }
+        return member;
+      }),
+    );
+  };
+};
+
+/**
+ * Watches for `call.member_updated` events.
+ */
+export const watchCallMemberUpdated = (state: CallState) => {
+  return function onCallRecordingStarted(event: StreamVideoEvent) {
+    if (event.type !== 'call.member_updated') return;
+    state.setMembers((members) =>
+      members.map((member) => {
+        const memberUpdate = event.members.find(
+          (m) => m.user_id === member.user_id,
+        );
+        return memberUpdate ? memberUpdate : member;
+      }),
+    );
+  };
+};

--- a/packages/react-bindings/src/hooks/call.ts
+++ b/packages/react-bindings/src/hooks/call.ts
@@ -22,6 +22,16 @@ export const useIsCallBroadcastingInProgress = () => {
 };
 
 /**
+ * Utility hook which provides information whether the current call is live.
+ *
+ * @category Call State
+ */
+export const useIsCallLive = () => {
+  const metadata = useCallMetadata();
+  return !metadata?.backstage;
+};
+
+/**
  * Utility hook which provides a boolean indicating whether there is
  * a participant in the current call which shares their screen.
  *

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/02-call-lifecycle.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/02-call-lifecycle.mdx
@@ -7,13 +7,6 @@ import CallAcceptedDiagram from '../assets/02-guides_02-call-lifecycle/ring-call
 import CallRejectedDiagram from '../assets/02-guides_02-call-lifecycle/ring-call-sequence-diagram_call-rejected.png';
 import CallEndedDiagram from '../assets/02-guides_02-call-lifecycle/ring-call-sequence-diagram_call-ended.png';
 
-:::warning
-This page needs more refinement, concretely:
-
-- Explain backstage mode
-
-:::
-
 ## Introduction
 
 In the following sections, we will describe the flow of the two basic call scenarios:
@@ -25,7 +18,7 @@ In the following sections, we will describe the flow of the two basic call scena
 
 Before we start to describe the individual call scenarios, we should get acquainted with the agents participating in the call flow. A user, that connects to a call is using a client (application) that communicates with Stream's back-end services. The call creation and intention to connect to a call is handled by a service we call simply `back-end`. Once it is clarified with the `back-end` service, who intends to join a specific type of call, the client connects to a service we call `SFU` (Selective Forwarding Unit). The `back-end` tells the client, to which `SFU` it should connect. The `SFU` server is where the call actually takes place. All the data exchanged during the call (audio, video, etc.) flows through the assigned `SFU`. The data is forwarded through the `SFU` between the clients.
 
-### Call room
+## Call room
 
 The call room scenario refers to a setup, where participants can join a call asynchronously. That means that the call can be (re)joined or left at any time by any number of participants. However, once the call is **ended**, the call cannot be re-joined. This scenario is useful if you want to create calls that work similarly to Google Meet or Zoom calls.
 
@@ -33,7 +26,7 @@ The call room scenario refers to a setup, where participants can join a call asy
 You can end a call by calling [`endCall()` method](../04-call-engine/Call.md#endcall) of the `Call` class.
 :::
 
-#### Call room lifecycle
+### Call room lifecycle
 
 The asynchronous nature of the call room makes it easy to create and join a call. There is no need to wait for other participants. The member initiating the call can create and join it in one single step by calling [`join()` method](../04-call-engine/Call.md#join) of a `Call` instance:
 
@@ -48,24 +41,44 @@ To leave the call without interrupting it, simply call [`leave()` method](../04-
 
 Call can be ended immediately and also prevented from being re-joined permanently by calling the [`endCall()` method](../04-call-engine/Call.md#endcall) of the `Call` class.
 
-#### Application State
+### Backstage mode
+
+Backstage mode can be used to decide who can join a call. When backstage mode is on, only users with [`join-backstage` capability](../../guides/permissions-and-moderation/#capabilities-1) can join the call. This is typically used for live streams where the hosts gather before the streaming is started.
+
+Here is how you can toggle the backstage mode:
+
+```typescript
+let call: Call;
+
+// Turn off backstage mode, anyone can join
+call.goLive();
+
+// Turn on backstage mode, only specific users can join
+call.stopLive();
+```
+
+You can use the [`useCallIsLive()`](../../call-engine/hooks-and-contexts/#useiscalllive) hook to know if the call is live or not.
+
+Backstage mode is only available for calls with [call types](../../guides/10-configuring-call-types) that have `backstage_enabled: true`.
+
+### Application State
 
 We recommend you to keep the `Call` instance in your app's local state to have access to its API.
 
-### Ring call
+## Ring call
 
 The ring call scenario is analogous to the classic phone call. A person calls another person and does not join the call, until the call is accepted on the other side. For this scenario it is typical to show outgoing and incoming call screens and possibly play ring sounds or display ringing elements in the UI. Of course, the call can be terminated before it is accepted. The original caller can decide to **cancel** the outgoing call or the receiving side can **reject** the incoming call.
 
 If the incoming call is accepted, both parties join the call and start exchanging media streams (audio and video). The call is then terminated by one of the participants and both leave the call. The ring call is synchronous in the meaning that all the participants have to be available to join the call during the time between it was initiated and left by the last participant. Once it is ended, it cannot be rejoined.
 
-#### Signalling
+### Signalling
 
 The communication between the clients follow these principles in the ring scenario:
 
 1. A client sends HTTP requests to the service (initiate a call, accept a call, ...)
 2. Service propagates the information in the form of a WS event to other clients
 
-#### Ring call lifecycle
+### Ring call lifecycle
 
 We have to explicitly opt in to ring mode when creating (starting) a call:
 
@@ -85,7 +98,7 @@ We distinguish between call members and call participants. Members are considere
 
 Once the call is created by Client A, there are three possible paths:
 
-##### **1. Client B accepts the call**
+#### **1. Client B accepts the call**
 
 This is the happy path, when both parties join the active call. The
 
@@ -115,7 +128,7 @@ sequenceDiagram
   width="800"
 />
 
-##### **2. Client B rejects the call**
+#### **2. Client B rejects the call**
 
 This scenario takes place, when the **Client B** sends the rejection request to the `back-end` service. The service then communicates this information to the **Client A** through a WebSocket event `call.rejected`. Note that `SFU` is not assigned and thus not taking part in this process.
 
@@ -136,7 +149,7 @@ sequenceDiagram
   width="800"
 />
 
-##### **3. Client A cancels the call**
+#### **3. Client A cancels the call**
 
 This scenario takes place, when the **Client A** hangs up before the user using **Client B** reacts to the incoming call notification. The service then communicates this information to the **Client B** through a WebSocket event `call.ended`. Note that `SFU` is not assigned and thus not taking part in this process.
 
@@ -157,12 +170,12 @@ sequenceDiagram
   width="800"
 />
 
-#### Automatic call cancellation
+### Automatic call cancellation
 
 At times, the called in user may not respond to the incoming call by accepting or rejecting it. In that case the call is automatically rejected by the client based on the configuration parameter `settings.ring.auto_reject_timeout_ms`. The configuration parameter is provided with the `CallCreated.call` object delivered with `call.created` event.
 Symmetrically the configuration parameter `settings.ring.auto_cancel_timeout_ms` is provided to the client initiating the call when the call is created (`GetOrCreateCallResponse.call`). The default timeout is 15 seconds for both parameters.
 
-#### Application State
+### Application State
 
 We allow the SDKs to observe the call flow changes and adjust the UI by emitting the relevant values tracked by the `StreamVideoClient`'s state store which are:
 
@@ -172,13 +185,13 @@ TODO: do we want to allow multiple active calls? The store implementation will p
 2. **Accepted call** - the app can start the process of joining the outgoing call
 3. **Active call** - the app shows the active call UI
 
-### Call calling state
+## Call calling state
 
 In an individual call lifespan various situations can occur that are then reflected in something we named **calling state**. Thus, a call can be in state of joining, reconnection, left etc.
 This is reflected within the [`Call` objects internal state](../../call-engine/Call#state).
 
-### Reconnections
+## Reconnections
 
-### Hybrid scenarios
+## Hybrid scenarios
 
 TODO: do we want to describe those? For example Slack call is a hybrid of the 2 above.

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/08-permissions-and-moderation.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/08-permissions-and-moderation.mdx
@@ -17,7 +17,7 @@ that can be used to control the behavior of participants in a call.
 
 ### Roles
 
-The Stream Video API allows assigning roles to users. Each user has an application-level role, and they will also have a call-level role for each call they join. The Stream Video API provides a set of predefined roles, but it's also possible to create your own roles.
+The Stream Video API allows assigning roles to users. Each user has a global role, and they will also have a call-level role for each call they join. The Stream Video API provides a set of predefined roles, but it's also possible to create your own roles.
 
 ### Call types
 


### PR DESCRIPTION
- Watch for `member_added`, `member_removed`, `member_updated_permission` and `call.member_updated` events
- Watch for `live_started` event, `useIsCallLive` hook added
- `call.ended` event handler fix: watch this for all calls, not just for ring calls
- Send client details in SFU join
- Implement `queryMembers` function -> it doesn't store the result in the state, as I don't know how that data can be merged with the members from join/create response
- Small docs updates