### PR TITLE
docs: Core components overview

### DIFF
--- a/packages/react-dogfood/components/DisabledVideoPreview.tsx
+++ b/packages/react-dogfood/components/DisabledVideoPreview.tsx
@@ -1,6 +1,6 @@
 import {
+  DefaultVideoPlaceholder,
   StreamVideoParticipant,
-  VideoPlaceholder,
 } from '@stream-io/video-react-sdk';
 import { useSession } from 'next-auth/react';
 
@@ -8,6 +8,8 @@ export const DisabledVideoPreview = () => {
   const { data: session } = useSession();
 
   return (
-    <VideoPlaceholder participant={session?.user as StreamVideoParticipant} />
+    <DefaultVideoPlaceholder
+      participant={session?.user as StreamVideoParticipant}
+    />
   );
 };

--- a/packages/react-sdk/docusaurus/docs/React/01-basics/04-core-components.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/01-basics/04-core-components.mdx
@@ -1,0 +1,198 @@
+---
+title: Core Components
+description: A brief overview of the core components that Stream React Video SDK provides.
+---
+
+## Introduction
+
+This chapter provides an overview of the core components that Stream Video React SDK provides.
+These components play an important role in the SDK as they are the main building blocks, and integrators can use them to build their custom UIs.
+
+:::note
+In the rest of the documentation chapters, you will see many examples that use these core components.
+It is crucial to understand how they work and what they do.
+:::
+
+## StreamVideo
+
+The `<StreamVideo/>` component is the root component of the SDK.
+It serves as a context provider that allows child components to utilize the
+[`useStreamVideoClient`](../../call-engine/hooks-and-contexts#usestreamvideoclient) hook and access the [`StreamVideoClient`](../../call-engine/StreamVideoClient) public API.
+It also initializes an [i18n instance for localization purposes](../../advanced/i18n).
+
+```tsx
+import {
+  StreamVideo,
+  useCreateStreamVideoClient,
+} from '@stream-io/video-react-sdk';
+
+export const App = () => {
+  const client = useCreateStreamVideoClient(/* ... */);
+  return (
+    // highlight-next-line
+    <StreamVideo client={client}>
+      <MyUI />
+    </StreamVideo>
+  );
+};
+```
+
+## StreamCall
+
+The `<StreamCall />` component is a declarative component wrapper around [`Call`](../../call-engine/Call) objects.
+
+It can be initialized with either `callType` and `callId` or a `call` instance.
+When `callType` and `callId` are provided, a new call will be created on the backend. The contents of the `data` prop will be sent to the backend.
+
+It has two additional props:
+
+- `autoJoin` to immediately join the provided or newly created call (defaults to `false`), and
+- `autoLoad` to optionally create and load the call's metadata from the backend (defaults to `true`). This prop also creates a subscription to the event bus on the backend to receive events for the given call.
+
+```tsx
+import {
+  StreamCall,
+  StreamVideo,
+  useCreateStreamVideoClient,
+} from '@stream-io/video-react-sdk';
+
+export const App = () => {
+  const client = useCreateStreamVideoClient(/* ... */);
+  return (
+    <StreamVideo client={client}>
+      // highlight-next-line
+      <StreamCall callType="default" callId="my-call-id">
+        <MyUI />
+      </StreamCall>
+    </StreamVideo>
+  );
+};
+```
+
+Additionally, the `<StreamCall />` component sets up a [`MediaDevicesProvider`](../../guides/camera-and-microphone) instance, making device management (microphone, camera) easier for integrators.
+
+## ParticipantView
+
+The `<ParticipantView/>` component is a core component that renders a participant's video and plays the participant's audio.
+
+It handles the participant's visibility state in a defined viewport,
+subscribes to the most appropriate video track quality and resolution (dynascale), and
+can toggle between video and avatar based on the participant's video state.
+
+It requires a `participant` prop to be provided. This prop should be an instance of [`StreamVideoParticipant`](TODO: link)
+
+:::note
+It is recommended to use this component as provided, as custom implementation would require re-implementing many of the SDK's internal features.
+
+However, the UI it renders is fully customizable. Keep reading further to learn how.
+:::
+
+The `<ParticipantView/>` component accepts the following props (all optional) that can be used to customize its visual appearance:
+
+- `ParticipantViewUI`: A React component or an element for UI customization (default: `DefaultParticipantViewUI`)
+- `VideoPlaceholder`: A React component or an element used as a placeholder for video (default: `DefaultVideoPlaceholder`)
+
+```tsx
+import {
+  ParticipantView,
+  StreamCall,
+  StreamVideo,
+  useCreateStreamVideoClient,
+  useParticipants,
+} from '@stream-io/video-react-sdk';
+
+export const App = () => {
+  const client = useCreateStreamVideoClient(/* ... */);
+  return (
+    <StreamVideo client={client}>
+      <StreamCall callType="default" callId="my-call-id">
+        // highlight-next-line
+        <MyCustomLayout />
+      </StreamCall>
+    </StreamVideo>
+  );
+};
+
+export const MyCustomLayout = () => {
+  const participants = useParticipants();
+  return (
+    <div className="my-custom-layout">
+      {participants.map((participant) => (
+        // highlight-next-line
+        <ParticipantView
+          participant={participant}
+          key={participant.sessionId}
+        />
+      ))}
+    </div>
+  );
+};
+```
+
+:::note
+You can further customize the visual look of the `<ParticipantView/>` component. To learn how, see the following guide: [ParticipantView Customization](../../ui-cookbook/participant-view-customizations/).
+:::
+
+## Default UI Layouts
+
+The Stream Video React SDK provides several default UI layouts that apps can use out of the box.
+
+### SpeakerLayout
+
+The `<SpeakerLayout>` component is a layout that puts the dominant speaker in focus (center stage) while rendering other participants in a scrollable bar at the bottom of the screen.
+
+```tsx
+import {
+  SpeakerLayout,
+  StreamCall,
+  StreamVideo,
+  useCreateStreamVideoClient,
+} from '@stream-io/video-react-sdk';
+
+export const App = () => {
+  const client = useCreateStreamVideoClient(/* ... */);
+  return (
+    <StreamVideo client={client}>
+      <StreamCall callType="default" callId="my-call-id">
+        // highlight-next-line
+        <SpeakerLayout />
+      </StreamCall>
+    </StreamVideo>
+  );
+};
+```
+
+### PaginatedGridLayout
+
+The `<PaginatedGridLayout>` component is a layout that renders participants in a grid, with a default size of 4x4.
+The grid can paginate left and right to accommodate more participants. Active participants (speakers) are positioned on the first page by default.
+
+```tsx
+import {
+  PaginatedGridLayout,
+  StreamCall,
+  StreamVideo,
+  useCreateStreamVideoClient,
+} from '@stream-io/video-react-sdk';
+
+export const App = () => {
+  const client = useCreateStreamVideoClient(/* ... */);
+  return (
+    <StreamVideo client={client}>
+      <StreamCall callType="default" callId="my-call-id">
+        // highlight-next-line
+        <PaginatedGridLayout />
+      </StreamCall>
+    </StreamVideo>
+  );
+};
+```
+
+:::tip
+These layouts are provided as a convenience for integrators to quickly get started with the SDK.
+They do offer some customization options that can be found in the following guide: [ParticipantView Customization](../../ui-cookbook/participant-view-customizations/).
+:::
+
+:::tip
+The default sorting of the participants can be customized as well. See the following guide for more information: [Participant Sorting](../../guides/sorting-api/).
+:::

--- a/packages/react-sdk/docusaurus/docs/React/01-basics/04-core-components.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/01-basics/04-core-components.mdx
@@ -133,9 +133,9 @@ export const MyCustomLayout = () => {
 You can further customize the visual look of the `<ParticipantView/>` component. To learn how, see the following guide: [ParticipantView Customization](../../ui-cookbook/participant-view-customizations/).
 :::
 
-## Default UI Layouts
+## Default Call Layouts
 
-The Stream Video React SDK provides several default UI layouts that apps can use out of the box.
+The Stream Video React SDK provides several default call layouts that apps can use out of the box.
 
 ### SpeakerLayout
 

--- a/packages/react-sdk/src/components/StreamCall/index.ts
+++ b/packages/react-sdk/src/components/StreamCall/index.ts
@@ -2,4 +2,3 @@ export * from './Stage';
 
 export * from './CallParticipantsView';
 export * from './CallParticipantsScreenView';
-export * from './StreamCall';

--- a/packages/react-sdk/src/components/Video/index.ts
+++ b/packages/react-sdk/src/components/Video/index.ts
@@ -1,4 +1,4 @@
 export * from '../../core/components/Video/Video';
 export * from '../../core/components/Video/BaseVideo';
-export * from '../../core/components/Video/VideoPlaceholder';
+export * from '../../core/components/Video/DefaultVideoPlaceholder';
 export * from './VideoPreview';

--- a/packages/react-sdk/src/core/components/StreamCall/StreamCall.tsx
+++ b/packages/react-sdk/src/core/components/StreamCall/StreamCall.tsx
@@ -5,7 +5,10 @@ import {
   useConnectedUser,
   useStreamVideoClient,
 } from '@stream-io/video-react-bindings';
-import { MediaDevicesProvider, MediaDevicesProviderProps } from '../../core';
+import {
+  MediaDevicesProvider,
+  MediaDevicesProviderProps,
+} from '../../contexts';
 
 type InitWithCallCID = {
   /**

--- a/packages/react-sdk/src/core/components/StreamCall/index.ts
+++ b/packages/react-sdk/src/core/components/StreamCall/index.ts
@@ -1,0 +1,1 @@
+export * from './StreamCall';

--- a/packages/react-sdk/src/core/components/Video/DefaultVideoPlaceholder.tsx
+++ b/packages/react-sdk/src/core/components/Video/DefaultVideoPlaceholder.tsx
@@ -5,7 +5,7 @@ export type VideoPlaceholderProps = {
   participant: StreamVideoParticipant;
 } & ComponentPropsWithRef<'div'>;
 
-export const VideoPlaceholder = forwardRef<
+export const DefaultVideoPlaceholder = forwardRef<
   HTMLDivElement,
   VideoPlaceholderProps
 >(({ participant, style }, ref) => {

--- a/packages/react-sdk/src/core/components/Video/Video.tsx
+++ b/packages/react-sdk/src/core/components/Video/Video.tsx
@@ -1,10 +1,10 @@
 import {
+  ComponentPropsWithoutRef,
   ComponentType,
   useCallback,
   useEffect,
   useRef,
   useState,
-  ComponentPropsWithoutRef,
 } from 'react';
 import {
   DebounceType,
@@ -14,9 +14,9 @@ import {
 } from '@stream-io/video-client';
 import clsx from 'clsx';
 import {
-  VideoPlaceholder as DefaultVideoPlaceholder,
+  DefaultVideoPlaceholder,
   VideoPlaceholderProps,
-} from './VideoPlaceholder';
+} from './DefaultVideoPlaceholder';
 import { BaseVideo } from './BaseVideo';
 import { useCall } from '@stream-io/video-react-bindings';
 

--- a/packages/react-sdk/src/core/components/index.ts
+++ b/packages/react-sdk/src/core/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Audio';
 export * from './ParticipantView';
+export * from './StreamCall';
 
 export { Video } from './Video';
 export type { BaseVideoProps, VideoProps } from './Video';


### PR DESCRIPTION
### Overview

Adds an introductory chapter in the docs which covers the core components of the React SDK that are used almost through every other chapter.

As part of this PR:
- the SDK's `StreamCall` component has been promoted to the `/core/components` package.
- `VideoPlaceholder` got renamed to `DefaultVideoPlaceholder` in order to match with `DefaultParticipantViewUI`
