### PR TITLE
feat: conditional target video bitrate downscaling

### DIFF
--- a/packages/client/src/rtc/publisher.ts
+++ b/packages/client/src/rtc/publisher.ts
@@ -137,10 +137,10 @@ export class Publisher {
 
     if (!transceiver) {
       const metadata = this.state.metadata;
-      const maxBitrate = metadata?.settings.video.target_resolution.bitrate;
+      const targetResolution = metadata?.settings.video.target_resolution;
       const videoEncodings =
         trackType === TrackType.VIDEO
-          ? findOptimalVideoLayers(track, maxBitrate)
+          ? findOptimalVideoLayers(track, targetResolution)
           : undefined;
 
       const codecPreferences = this.getCodecPreferences(
@@ -360,7 +360,7 @@ export class Publisher {
     await this.publisher.setLocalDescription(offer);
 
     const metadata = this.state.metadata;
-    const maxBitrate = metadata?.settings.video.target_resolution.bitrate;
+    const targetResolution = metadata?.settings.video.target_resolution;
     const trackInfos = this.publisher
       .getTransceivers()
       .filter((t) => t.direction === 'sendonly' && !!t.sender.track)
@@ -374,7 +374,7 @@ export class Publisher {
         const track = transceiver.sender.track!;
         const optimalLayers =
           trackType === TrackType.VIDEO
-            ? findOptimalVideoLayers(track, maxBitrate)
+            ? findOptimalVideoLayers(track, targetResolution)
             : trackType === TrackType.SCREEN_SHARE
             ? findOptimalScreenSharingLayers(track)
             : [];

--- a/packages/client/src/rtc/videoLayers.ts
+++ b/packages/client/src/rtc/videoLayers.ts
@@ -1,16 +1,33 @@
+import { TargetResolution } from '../gen/coordinator';
+
 export type OptimalVideoLayer = RTCRtpEncodingParameters & {
   width: number;
   height: number;
 };
 
+const DEFAULT_BITRATE = 1250000;
+const defaultTargetResolution: TargetResolution = {
+  bitrate: DEFAULT_BITRATE,
+  width: 1280,
+  height: 720,
+};
+
+/**
+ * Determines the most optimal video layers for simulcasting
+ * for the given track.
+ *
+ * @param videoTrack the video track to find optimal layers for.
+ * @param targetResolution the expected target resolution.
+ */
 export const findOptimalVideoLayers = (
   videoTrack: MediaStreamTrack,
-  maxBitrate: number = 1250000,
+  targetResolution: TargetResolution = defaultTargetResolution,
 ) => {
   const optimalVideoLayers: OptimalVideoLayer[] = [];
   const settings = videoTrack.getSettings();
   const { width: w = 0, height: h = 0 } = settings;
 
+  const maxBitrate = getComputedMaxBitrate(targetResolution, w, h);
   let downscaleFactor = 1;
   ['f', 'h', 'q'].forEach((rid) => {
     // Reversing the order [f, h, q] to [q, h, f] as Chrome uses encoding index
@@ -19,9 +36,9 @@ export const findOptimalVideoLayers = (
     optimalVideoLayers.unshift({
       active: true,
       rid,
-      width: w / downscaleFactor,
-      height: h / downscaleFactor,
-      maxBitrate: maxBitrate / downscaleFactor,
+      width: Math.round(w / downscaleFactor),
+      height: Math.round(h / downscaleFactor),
+      maxBitrate: Math.round(maxBitrate / downscaleFactor),
       scaleResolutionDownBy: downscaleFactor,
       maxFramerate: {
         f: 30,
@@ -35,6 +52,34 @@ export const findOptimalVideoLayers = (
   // for simplicity, we start with all layers enabled, then this function
   // will clear/reassign the layers that are not needed
   return withSimulcastConstraints(settings, optimalVideoLayers);
+};
+
+/**
+ * Computes the maximum bitrate for a given resolution.
+ * If the current resolution is lower than the target resolution,
+ * we want to proportionally reduce the target bitrate.
+ * If the current resolution is higher than the target resolution,
+ * we want to use the target bitrate.
+ *
+ * @param targetResolution the target resolution.
+ * @param currentWidth the current width of the track.
+ * @param currentHeight the current height of the track.
+ */
+export const getComputedMaxBitrate = (
+  targetResolution: TargetResolution,
+  currentWidth: number,
+  currentHeight: number,
+): number => {
+  // if the current resolution is lower than the target resolution,
+  // we want to proportionally reduce the target bitrate
+  const { width: targetWidth, height: targetHeight } = targetResolution;
+  if (currentWidth < targetWidth || currentHeight < targetHeight) {
+    const currentPixels = currentWidth * currentHeight;
+    const targetPixels = targetWidth * targetHeight;
+    const reductionFactor = currentPixels / targetPixels;
+    return Math.round(targetResolution.bitrate * reductionFactor);
+  }
+  return targetResolution.bitrate;
 };
 
 /**


### PR DESCRIPTION
### Overview

A follow-up improvement on #516.

With this change, the server-side target bitrate is considered the upper-most limit and would be used only if the current video track's resolution matches the specs requested from the server.

In case the current track's resolution is lower than the requested one (i.e. the user doesn't have a video camera capable of 1920x1080 recording), the target bitrate lowers proportionally.

Example:
Target: 1920x1080p = 2073600 pixels, 3000000 target bitrate (3Mbps)
Actual: 1280x720p = 921.600 pixels
Calculated target bitrate: 1333333 (1.3Mbps) because 720p resolution has around 44% fewer pixels than 1080p.
