### PR TITLE
fix: preserve own capabilities when call session starts

### DIFF
--- a/packages/client/src/events/__tests__/sessions.test.ts
+++ b/packages/client/src/events/__tests__/sessions.test.ts
@@ -24,6 +24,7 @@ describe('call.session events', () => {
 
     expect(state.metadata).toEqual({
       cid: 'cid',
+      own_capabilities: [],
       session: {
         id: 'session-id',
       },
@@ -45,6 +46,7 @@ describe('call.session events', () => {
     });
     expect(state.metadata).toEqual({
       cid: 'cid',
+      own_capabilities: [],
       session: {
         id: 'session-id',
       },

--- a/packages/client/src/events/sessions.ts
+++ b/packages/client/src/events/sessions.ts
@@ -10,7 +10,11 @@ export const watchCallSessionStarted = (state: CallState) => {
   return function onCallSessionStarted(event: StreamVideoEvent) {
     if (event.type !== 'call.session_started') return;
     const { call } = event;
-    state.setMetadata(call);
+    state.setMetadata((metadata) => ({
+      ...call,
+      // FIXME OL: temporary, until the backend sends the own_capabilities
+      own_capabilities: metadata?.own_capabilities || [],
+    }));
   };
 };
 
@@ -23,7 +27,11 @@ export const watchCallSessionEnded = (state: CallState) => {
   return function onCallSessionEnded(event: StreamVideoEvent) {
     if (event.type !== 'call.session_ended') return;
     const { call } = event;
-    state.setMetadata(call);
+    state.setMetadata((metadata) => ({
+      ...call,
+      // FIXME OL: temporary, until the backend sends the own_capabilities
+      own_capabilities: metadata?.own_capabilities || [],
+    }));
   };
 };
 


### PR DESCRIPTION
follow up on #551 
The backend doesn't provide `own_capabilities` as part of the `call.session_started` and `call.session_ended`.
Until the issue is fixed on the backend, we will just keep the previous capabilities.