### PR TITLE
docs: create UI component pages

### DIFF
--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/01-overview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/01-overview.mdx
@@ -8,7 +8,13 @@ description: Overview of the UI components
 There are different ways to use the React Video SDK to build out UI. It comes with powerful built-in components ready for use.
 In addition, it allows for styling and custom theming options with custom CSS.
 
-For custom use cases it is also possible to create your own components to fully tailor the SDK to your needs. Please note that we suggest not to override a few, core components as those contain complex, low-level logic related to performance, the list of these components can be found in the [Core Components page](../../basics/core-components/).
+For custom use cases it is also possible to create your own components to fully tailor the SDK to your needs.
+
+:::note
+
+Please note that we suggest not to override a few, core components as those contain complex, low-level logic related to performance, the list of these components can be found in the [Core Components page](../../basics/core-components/).
+
+:::
 
 This page guides you through all the options you have with increasing levels of customization.
 

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/01-overview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/01-overview.mdx
@@ -3,10 +3,6 @@ title: Overview
 description: Overview of the UI components
 ---
 
-:::warning
-TODO create pages for the components
-:::
-
 ## Introduction
 
 There are different ways to use the React Video SDK to build out UI. It comes with powerful built-in components ready for use.

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/_category_.json
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Call",
+  "position": 4
+}

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/call-controls.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/call-controls.mdx
@@ -1,0 +1,10 @@
+---
+id: call-controls
+title: Call controls
+---
+
+:::warning
+
+TODO: Write about `CallControls` component + individual call control buttons https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/CallControls
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/call-recording-list.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/call-recording-list.mdx
@@ -1,0 +1,10 @@
+---
+id: call-recordings-list
+title: Call recordings list
+---
+
+:::warning
+
+TODO: Write about https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/CallRecordingList
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/pending-call-panel.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/pending-call-panel.mdx
@@ -1,0 +1,10 @@
+---
+id: pending-call-panel
+title: Pending call panel
+---
+
+:::warning
+
+TODO: write about https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/PendingCallPanel
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/_category_.json
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Core",
+  "position": 3
+}

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/call-layout.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/call-layout.mdx
@@ -1,0 +1,10 @@
+---
+id: call-layout
+title: Call layout
+---
+
+:::warning
+
+TODO: write about https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/core/components/CallLayout
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/participant-view.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/participant-view.mdx
@@ -1,0 +1,10 @@
+---
+id: participant-view
+title: Participant
+---
+
+:::warning
+
+TODO: write about: https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/core/components/ParticipantView
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/stream-call.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/stream-call.mdx
@@ -1,0 +1,10 @@
+---
+id: stream-call
+title: StreamCall
+---
+
+:::warning
+
+TODO: write about https://github.com/GetStream/stream-video-js/blob/main/packages/react-sdk/src/core/components/StreamCall/StreamCall.tsx
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/_category_.json
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Participants",
+  "position": 5
+}

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/call-participants-list.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/call-participants-list.mdx
@@ -1,0 +1,8 @@
+---
+id: call-participants-list
+title: Participants list
+---
+
+:::warning
+TODO: write about: Call participants + blocked users list https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/CallParticipantsList
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/device-settings.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/device-settings.mdx
@@ -1,0 +1,10 @@
+---
+id: device-settings
+title: Device settings
+---
+
+:::warning
+
+TODO: write about https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/DeviceSettings
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/video-preview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/video-preview.mdx
@@ -1,0 +1,10 @@
+---
+id: video-preview
+title: Video preview
+---
+
+:::warning
+
+TODO: write about https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/Video
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/_category_.json
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Utility",
+  "position": 6
+}

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/avatar.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/avatar.mdx
@@ -1,0 +1,10 @@
+---
+id: avatar
+title: Avatar
+---
+
+:::warning
+
+TODO: write about: https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/Avatar
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/call-stats.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/call-stats.mdx
@@ -1,0 +1,10 @@
+---
+id: call-statistics
+title: Call statistics
+---
+
+:::warning
+
+TODO: write about: https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/CallStats
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/permission-notification.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/permission-notification.mdx
@@ -1,0 +1,10 @@
+---
+id: permission-notification
+title: Permission notification
+---
+
+:::warning
+
+TODO: write about: https://github.com/GetStream/stream-video-js/blob/main/packages/react-sdk/src/components/Notification/PermissionNotification.tsx
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/permission-requests.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/permission-requests.mdx
@@ -1,0 +1,10 @@
+---
+id: permission-requests
+title: Permission requests
+---
+
+:::warning
+
+TODO: write about: https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/Permissions
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/reaction.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/reaction.mdx
@@ -1,0 +1,10 @@
+---
+id: reaction
+title: Reaction
+---
+
+:::warning
+
+TODO: write about https://github.com/GetStream/stream-video-js/blob/main/packages/react-sdk/src/components/Reaction/Reaction.tsx
+
+:::

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/speaking-while-muted-notification.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/speaking-while-muted-notification.mdx
@@ -1,0 +1,10 @@
+---
+id: speaking-while-muted-notification
+title: Speaking while muted notification
+---
+
+:::warning
+
+TODO: write about https://github.com/GetStream/stream-video-js/blob/main/packages/react-sdk/src/components/Notification/SpeakingWhileMutedNotification.tsx
+
+:::


### PR DESCRIPTION
## What's in this PR?

Empty doc pages for UI Components

## Guidelines
1. Not all components have a page
- The logic mainly follows the component folder structure in the source code, for example, in the source code, we have the `CallParticipantsList` folder, and we have a doc page called `Participants list`, but there is no separate page for example for the `CallParticipantsList/EmptyParticipantSearchList` component
- Some component folders are not included in the docs, for example the `Icon`. My logic was this: I've excluded all components that don't contain stream-video specific logic. While I can imagine a use-case where someone wants to use the `Icon` component to create their own UI, but it seems rather rare, and I think the component list would be rather long if we were to include all small components.
2. The ToC follows this structure
- Core - our core components
- Call - call-related components (except participant-related components)
- Participant - participant-related components
- Utility - misc call/participant related components - these are either not connected very tightly to calls (for example `Avatar`) or they are expected to be used less frequently (for example `CallStatistics`) 

![image](https://github.com/GetStream/stream-video-js/assets/6690098/009ab7a8-48c6-434b-a410-f72c9a1fd544)

Let me know what you think about the structure. @DaemonLoki I'm especially interested in your opinion because I know you've already given this area some thought.

Once we have the structure, I'll update the existing TODO component links in a separate PR.