### PR TITLE
docs(react-sdk): add lobby preview UI cookbook documentation

### DIFF
--- a/packages/react-dogfood/components/Lobby.tsx
+++ b/packages/react-dogfood/components/Lobby.tsx
@@ -11,6 +11,7 @@ import {
 import { LobbyHeader } from './LobbyHeader';
 import { Box, Button, Stack, Typography } from '@mui/material';
 import { DisabledVideoPreview } from './DisabledVideoPreview';
+import { ParticipantsPreview } from './ParticipantsPreview';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -61,6 +62,15 @@ export const Lobby = ({ onJoin, callId, enablePreview = true }: LobbyProps) => {
         spacing={2}
         flexGrow={1}
       >
+        <Box
+          sx={{
+            position: 'fixed',
+            left: '1rem',
+            top: '80px',
+          }}
+        >
+          <ParticipantsPreview />
+        </Box>
         <Stack spacing={2} alignItems="center">
           <Box padding={2}>
             <Typography variant="h2" textAlign="center">
@@ -70,7 +80,6 @@ export const Lobby = ({ onJoin, callId, enablePreview = true }: LobbyProps) => {
             <Typography textAlign="center" variant="subtitle1">
               {subtitle}
             </Typography>
-
             {enablePreview && (
               <VideoPreview DisabledVideoPreview={DisabledVideoPreview} />
             )}

--- a/packages/react-dogfood/components/ParticipantsPreview.tsx
+++ b/packages/react-dogfood/components/ParticipantsPreview.tsx
@@ -1,0 +1,41 @@
+import { Avatar, useCallMetadata } from '@stream-io/video-react-sdk';
+import { Stack, Typography } from '@mui/material';
+
+export const ParticipantsPreview = () => {
+  const callMetadata = useCallMetadata();
+
+  if (
+    !(
+      callMetadata?.session?.participants &&
+      callMetadata?.session?.participants.length
+    )
+  )
+    return null;
+  return (
+    <Stack sx={{ gap: '0.75rem', margin: 0 }}>
+      <Typography sx={{ fontSize: '1.125rem', fontWeight: '700' }}>
+        Already in call ({callMetadata.session.participants.length}):
+      </Typography>
+      <Stack
+        direction="row"
+        sx={{
+          flexWrap: 'wrap',
+          overflowY: 'auto',
+          maxHeight: '300px',
+          maxWidth: '200px',
+          gap: '0.5rem',
+        }}
+      >
+        {callMetadata.session.participants.map((participant) => (
+          <Stack alignItems="center">
+            <Avatar
+              name={participant.user.name}
+              imageSrc={participant.user.image}
+            />
+            {participant.user.name && <div>{participant.user.name}</div>}
+          </Stack>
+        ))}
+      </Stack>
+    </Stack>
+  );
+};

--- a/packages/react-dogfood/pages/join/[callId].tsx
+++ b/packages/react-dogfood/pages/join/[callId].tsx
@@ -71,7 +71,6 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
           callId={callId}
           callType={callType}
           autoJoin={false}
-          autoLoad={true}
           mediaDevicesProviderProps={{
             initialAudioEnabled: !settings?.isAudioMute,
             initialVideoEnabled: !settings?.isVideoMute,

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/02-joining-creating-calls.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/02-joining-creating-calls.mdx
@@ -1,4 +1,5 @@
 ---
+id: joining-and-creating-calls
 title: Joining & Creating Calls
 description: An overview of how to create calls and join them
 ---

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/04-camera-and-microphone.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/04-camera-and-microphone.mdx
@@ -105,7 +105,7 @@ In case we would like to implement custom device controls for publishing video a
 
 
 ### Working with media streams
-If need be, we can even start working on lower level by retrieving media streams and dispose of them. This can come handy when the aim is to create custom components like [`VideoPreview`]. By providing selected device id, we can hook into the device's [media stream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) and start reacting to events emitted, or handling component state.
+If need be, we can even start working on lower level by retrieving media streams and dispose of them. This can come handy when the aim is to create custom components like [`VideoPreview`](todo docs link). By providing selected device id, we can hook into the device's [media stream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) and start reacting to events emitted, or handling component state.
 
 The functions we provide to access the media streams are:
 

--- a/packages/react-sdk/docusaurus/docs/React/02-tutorials/03-livestream.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-tutorials/03-livestream.mdx
@@ -184,7 +184,7 @@ It is a good practice to show a loading indicator while the operation is in prog
 There are two ways how we can do that:
 
 - have a `useEffect` that would run whenever we have initiated a change in the broadcasting state of the call until the value of `isBroadcasting` toggles.
-- attach an event listener to the call object and follow the delivery of `call.broadcasting_started` and `call.broadcasting_stopped` events. Read more about events [here.](../10-advanced/06-events.mdx)
+- attach an event listener to the call object and follow the delivery of `call.broadcasting_started` and `call.broadcasting_stopped` events. Read more about events [here.](../../advanced/events)
 
 :::
 

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/06-lobby-preview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/06-lobby-preview.mdx
@@ -18,7 +18,7 @@ To do that, we follow these steps:
 - Install the Stream React Video SDK:
 - `npm install @stream-io/video-react-sdk`
 - `yarn add @stream-io/video-react-sdk`
-- [Initialize the SDK](../guides/client-auth) by passing in your API key, token and user information:
+- [Initialize the SDK](../../guides/client-auth) by passing in your API key, token and user information:
 
 :::note
 For the token generation, you can use our [Token Generator](https://getstream.io/chat/docs/token_generator/).
@@ -31,14 +31,14 @@ We would like to show some basic information about the call, when users arrive t
 - who is invited
 - who already joined
 
-The initial call information is retrieved internally by [`StreamCall`](todo docs link) component and passed down with the [`StreamCallProvider`](../call-engine/hooks-and-contexts/#streamcallprovider). Wrapping our UI with [`StreamCall`](todo docs link) allows us to access the call data in our UI components with hooks:
+The initial call information is retrieved internally by [`StreamCall`](todo docs link) component and passed down with the [`StreamCallProvider`](../../call-engine/hooks-and-contexts/#streamcallprovider). Wrapping our UI with [`StreamCall`](todo docs link) allows us to access the call data in our UI components with hooks:
 
-- [`useCallMetadata`](../call-engine/hooks-and-contexts#usecallmetadata)
-- [`useCallMembers`](../call-engine/hooks-and-contexts#usecallmembers)
+- [`useCallMetadata`](../../call-engine/hooks-and-contexts#usecallmetadata)
+- [`useCallMembers`](../../call-engine/hooks-and-contexts#usecallmembers)
 
-These hooks make sure, that the information about call metadata or call members is updated in real time. The updates are made automatically in response to [Stream's WebSocket events](../advanced/events) arriving from the backend.
+These hooks make sure, that the information about call metadata or call members is updated in real time. The updates are made automatically in response to [Stream's WebSocket events](../../advanced/events) arriving from the backend.
 
-Learn more about setting up the boilerplate of joining a call room in our [Joining and Creating Calls](../guides/joining-creating-calls/#call-room) guide.
+Learn more about setting up the boilerplate of joining a call room in our [Joining and Creating Calls](../../guides/joining-and-creating-calls/#call-room) guide.
 
 ### Video input preview
 The SDK comes with a pre-build [`VideoPreview`](todo docs link) component that handles video input stream retrieval and disposal. It also presents various UIs based on video playing state (starting, playing, error, unavailable video devices). In the example below, we are assembling a custom video preview using SDK's [`VideoPreview`](todo docs link) component and our custom UI components for each playing state.
@@ -111,15 +111,15 @@ const StartingCameraPreview = () => (
 Microphone configuration in the lobby may consist of checking, whether our microphone works and deciding, whether it will be enabled, when we join the call.
 
 :::note
-Learn how to build a toggle button for call preview pages in [Call controls tutorial](./replacing-call-controls/#toggling-audio).
+Learn how to build a toggle button for call preview pages in [Call controls tutorial](../replacing-call-controls/#toggling-audio).
 :::
 
 :::note
-We build our custom sound detector in the [dedicated tutorial about Audio Volume Indicator](./audio-volume-indicator).
+We build our custom sound detector in the [dedicated tutorial about Audio Volume Indicator](../audio-volume-indicator).
 :::
 
 ### Device selection
-Switching devices is handled by `switchDevice()` function provided by [`MediaDevicesContextAPI`](../call-engine/hooks-and-contexts#mediadevicescontextapi). We speak a bit more about the function and the pre-built components in the [media devices guide](../guides/camera-and-microphone).
+Switching devices is handled by `switchDevice()` function provided by [`MediaDevicesContextAPI`](../../call-engine/hooks-and-contexts#mediadevicescontextapi). We speak a bit more about the function and the pre-built components in the [media devices guide](../../guides/camera-and-microphone).
 
 **Device selector example**
 
@@ -210,7 +210,7 @@ export const VideoInputDeviceSelector = () => {
 ```
 
 ### Participants in a call
-We can retrieve the list of members, that already joined the call (participants), by inspecting the call metadata object (`callMetadata.session.participants`). The object is provided and maintained up-to-date by [`useCallMetadata`](../call-engine/hooks-and-contexts#usecallmetadata) hook.
+We can retrieve the list of members, that already joined the call (participants), by inspecting the call metadata object (`callMetadata.session.participants`). The object is provided and maintained up-to-date by [`useCallMetadata`](../../call-engine/hooks-and-contexts#usecallmetadata) hook.
 
 ```tsx
 import { Avatar, useCallMetadata } from '@stream-io/video-react-sdk';
@@ -246,5 +246,5 @@ export const ParticipantsPreview = () => {
 ```
 
 ### Joining the call button
-Lastly, to join a call we simply invoke `call.join()`. Learn more about the topic in the dedicated [Joining & Creating Calls guide](../guides/joining-and-creating-calls).
+Lastly, to join a call we simply invoke `call.join()`. Learn more about the topic in the dedicated [Joining & Creating Calls guide](../../guides/joining-and-creating-calls).
 

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/06-lobby-preview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/06-lobby-preview.mdx
@@ -31,7 +31,7 @@ We would like to show some basic information about the call, when users arrive t
 - who is invited
 - who already joined
 
-The initial call information is retrieved internally by [`StreamCall`](todo docs link) component and passed down with the [`StreamCallContext`](../call-engine/hooks-and-contexts/#streamcallprovider). Wrapping our UI with [`StreamCall`](todo docs link) allows us to access the call data in our UI components with hooks:
+The initial call information is retrieved internally by [`StreamCall`](todo docs link) component and passed down with the [`StreamCallProvider`](../call-engine/hooks-and-contexts/#streamcallprovider). Wrapping our UI with [`StreamCall`](todo docs link) allows us to access the call data in our UI components with hooks:
 
 - [`useCallMetadata`](../call-engine/hooks-and-contexts#usecallmetadata)
 - [`useCallMembers`](../call-engine/hooks-and-contexts#usecallmembers)
@@ -148,7 +148,7 @@ export const DeviceSelector = ({ devices, deviceKind, selectedDeviceId }: Device
       {devices.map((device) => {
         return (
           <div
-            className={`option${selectedDeviceId === device.deviceId ? 'option--selected' : ''}`}
+            className={`option ${selectedDeviceId === device.deviceId ? 'option--selected' : ''}`}
             key={device.deviceId}
             // highlight-next-line
             onClick={ () => switchDevice(deviceKind, device.deviceId) }

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/06-lobby-preview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/06-lobby-preview.mdx
@@ -3,5 +3,248 @@ title: Lobby Preview
 description: Lobby Preview
 ---
 
-Example of how to build your own call lobby screen.
-IE a screen to setup your audio/video before joining the call.
+In this article, we will discuss key considerations for creating an inviting and user-friendly entrance to your application. We will delve into the various elements that can enhance the user experience and ensure a smooth transition from the lobby to the video call itself. By implementing effective lobby page design principles, you can elevate the overall user satisfaction. We consider lobby to be place, where the user acquires information about the call to be joined and can configure own media devices.
+
+:::note
+The approach to visualise the components will differ from application to application. Therefore, in this guide, we will focus only on the principles of building components and plugging them with right data sources. We will not focus on the styling (CSS) part.
+:::
+
+## Prerequisites
+
+Before we can join a call, we need to connect to Stream's edge infrastructure.
+To do that, we follow these steps:
+
+- [Register for a Stream account](https://getstream.io/try-for-free/) and obtain our API key and secret.
+- Install the Stream React Video SDK:
+- `npm install @stream-io/video-react-sdk`
+- `yarn add @stream-io/video-react-sdk`
+- [Initialize the SDK](../guides/client-auth) by passing in your API key, token and user information:
+
+:::note
+For the token generation, you can use our [Token Generator](https://getstream.io/chat/docs/token_generator/).
+:::
+
+### The call data
+We would like to show some basic information about the call, when users arrive to the lobby. For example:
+
+- call name
+- who is invited
+- who already joined
+
+The initial call information is retrieved internally by [`StreamCall`](todo docs link) component and passed down with the [`StreamCallContext`](../call-engine/hooks-and-contexts/#streamcallprovider). Wrapping our UI with [`StreamCall`](todo docs link) allows us to access the call data in our UI components with hooks:
+
+- [`useCallMetadata`](../call-engine/hooks-and-contexts#usecallmetadata)
+- [`useCallMembers`](../call-engine/hooks-and-contexts#usecallmembers)
+
+These hooks make sure, that the information about call metadata or call members is updated in real time. The updates are made automatically in response to [Stream's WebSocket events](../advanced/events) arriving from the backend.
+
+Learn more about setting up the boilerplate of joining a call room in our [Joining and Creating Calls](../guides/joining-creating-calls/#call-room) guide.
+
+### Video input preview
+The SDK comes with a pre-build [`VideoPreview`](todo docs link) component that handles video input stream retrieval and disposal. It also presents various UIs based on video playing state (starting, playing, error, unavailable video devices). In the example below, we are assembling a custom video preview using SDK's [`VideoPreview`](todo docs link) component and our custom UI components for each playing state.
+
+```tsx
+import {
+  useConnectedUser,
+  DefaultVideoPlaceholder,
+  StreamVideoParticipant,
+  VideoPreview
+} from '@stream-io/video-react-sdk';
+
+import {
+  CameraIcon,
+  ErrorIcon,
+  LoadingIndicator
+} from '../icons';
+
+export const Lobby = () => {
+  return (
+    <div>
+    {/* ... other components */}
+      <VideoPreview
+        DisabledVideoPreview={DisabledVideoPreview}
+        NoCameraPreview={NoCameraPreview}
+        VideoErrorPreview={VideoErrorPreview}
+        StartingCameraPreview={StartingCameraPreview}
+      />
+    {/* ... other components */}
+    </div>
+  );
+}
+
+export const DisabledVideoPreview = () => {
+  const connectedUser = useConnectedUser();
+  if (!connectedUser) return null;
+
+  return (
+    <DefaultVideoPlaceholder
+      participant={
+        {
+          image: connectedUser.image,
+          name: connectedUser.name,
+        } as StreamVideoParticipant
+      }
+    />
+  );
+};
+
+const NoCameraPreview = () => (
+  <div>
+    <CameraIcon />
+  </div>
+);
+
+const VideoErrorPreview = () => (
+  <div>
+    <ErrorIcon />
+  </div>
+);
+
+const StartingCameraPreview = () => (
+  <div>
+    <LoadingIndicator />
+  </div>
+);
+```
+
+### Audio input preview
+Microphone configuration in the lobby may consist of checking, whether our microphone works and deciding, whether it will be enabled, when we join the call.
+
+:::note
+Learn how to build a toggle button for call preview pages in [Call controls tutorial](./replacing-call-controls/#toggling-audio).
+:::
+
+:::note
+We build our custom sound detector in the [dedicated tutorial about Audio Volume Indicator](./audio-volume-indicator).
+:::
+
+### Device selection
+Switching devices is handled by `switchDevice()` function provided by [`MediaDevicesContextAPI`](../call-engine/hooks-and-contexts#mediadevicescontextapi). We speak a bit more about the function and the pre-built components in the [media devices guide](../guides/camera-and-microphone).
+
+**Device selector example**
+
+The selectors can be thought of as dropdowns in our example.
+
+```tsx
+import {
+  useAudioInputDevices,
+  useAudioOutputDevices,
+  useMediaDevices,
+  useVideoDevices,
+} from '@stream-io/video-react-sdk';
+
+type DeviceSelectorProps = {
+  devices: MediaDeviceInfo[];
+  deviceKind: MediaDeviceKind;
+  selectedDeviceId?: string;
+};
+
+export const DeviceSelector = ({ devices, deviceKind, selectedDeviceId }: DeviceSelectorProps) => {
+  // highlight-next-line
+  const { switchDevice } = useMediaDevices();
+
+  return (
+    <div className="selector">
+      {devices.map((device) => {
+        return (
+          <div
+            className={`option${selectedDeviceId === device.deviceId ? 'option--selected' : ''}`}
+            key={device.deviceId}
+            // highlight-next-line
+            onClick={ () => switchDevice(deviceKind, device.deviceId) }
+          >
+            {device.label}
+          </div>
+        )
+      })}
+    </div>
+  );
+}
+
+export const AudioInputDeviceSelector = () => {
+  const { selectedAudioInputDeviceId } = useMediaDevices();
+  // maintains an up-to-date array of MediaDeviceInfo objects of kind "audioinput"
+  const audioInputDevices = useAudioInputDevices();
+
+  return (
+    <DeviceSelector
+      devices={ audioInputDevices }
+      deviceKind="audioinput"
+      selectedDeviceId={ selectedAudioInputDeviceId }
+    />
+  );
+}
+
+export const AudioOutputDeviceSelector = () => {
+  const {
+    isAudioOutputChangeSupported,
+    selectedAudioOutputDeviceId,
+  } = useMediaDevices();
+  // maintains an up-to-date array of MediaDeviceInfo objects of kind "audiooutput"
+  const audioOutputDevices = useAudioOutputDevices();
+
+  if (!isAudioOutputChangeSupported) return null;
+
+  return (
+    <DeviceSelector
+      devices={ audioOutputDevices }
+      deviceKind="audiooutput"
+      selectedDeviceId={ selectedAudioOutputDeviceId }
+    />
+  );
+}
+
+export const VideoInputDeviceSelector = () => {
+  const { selectedVideoDeviceId } = useMediaDevices();
+  // maintains an up-to-date array of MediaDeviceInfo objects of kind "videoinput"
+  const videoDevices = useVideoDevices();
+
+  return (
+    <DeviceSelector
+      devices={ videoDevices }
+      deviceKind="videoinput"
+      selectedDeviceId={ selectedVideoDeviceId }
+    />
+  );
+}
+```
+
+### Participants in a call
+We can retrieve the list of members, that already joined the call (participants), by inspecting the call metadata object (`callMetadata.session.participants`). The object is provided and maintained up-to-date by [`useCallMetadata`](../call-engine/hooks-and-contexts#usecallmetadata) hook.
+
+```tsx
+import { Avatar, useCallMetadata } from '@stream-io/video-react-sdk';
+
+export const ParticipantsPreview = () => {
+  const callMetadata = useCallMetadata();
+
+  if (
+    !(
+      callMetadata?.session?.participants &&
+      callMetadata?.session?.participants.length
+    )
+  )
+    return null;
+
+  return (
+    <div>
+      <div>Already in call ({callMetadata.session.participants.length}):</div>
+      <div style={{ display: 'flex' }}>
+        {callMetadata.session.participants.map((participant) => (
+          <div>
+            <Avatar
+              name={participant.user.name}
+              imageSrc={participant.user.image}
+            />
+            {participant.user.name && <div>{participant.user.name}</div>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+```
+
+### Joining the call button
+Lastly, to join a call we simply invoke `call.join()`. Learn more about the topic in the dedicated [Joining & Creating Calls guide](../guides/joining-and-creating-calls).
+

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/09-audio-volume-indicator.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/09-audio-volume-indicator.mdx
@@ -1,4 +1,5 @@
 ---
+id: audio-volume-indicator
 title: Audio Volume Indicator
 description: Audio Volume Indicator
 ---

--- a/packages/react-sdk/docusaurus/docs/React/10-advanced/06-events.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/10-advanced/06-events.mdx
@@ -1,4 +1,5 @@
 ---
+id: events
 title: Events
 description: How to listen to events
 ---

--- a/packages/react-sdk/src/components/Video/VideoPreview.tsx
+++ b/packages/react-sdk/src/components/Video/VideoPreview.tsx
@@ -37,10 +37,25 @@ const DefaultVideoErrorPreview = ({ message }: VideoErrorPreviewProps) => {
 };
 
 export type VideoPreviewProps = {
+  /**
+   * Enforces mirroring of the video on the X axis. Defaults to true.
+   */
   mirror?: boolean;
+  /**
+   * Component rendered when user turns off the video.
+   */
   DisabledVideoPreview?: ComponentType;
+  /**
+   * Component rendered when no camera devices are available.
+   */
   NoCameraPreview?: ComponentType;
+  /**
+   * Component rendered above the BaseVideo until the video is ready (meaning until the play event is emitted).
+   */
   StartingCameraPreview?: ComponentType;
+  /**
+   * Component rendered when the video stream could not be retrieved.
+   */
   VideoErrorPreview?: ComponentType<VideoErrorPreviewProps>;
 };
 


### PR DESCRIPTION
- Add documentation
- Add ParticipantsPreview component to React dogfood app

**Note**
The participants preview is not shown on initial Lobby page load, because we are not getting participants in call query response.

<details><summary>Participants preview in dogfood lobby</summary>
<p>

<img width="1359" alt="image" src="https://github.com/GetStream/stream-video-js/assets/32706194/702a594f-ea61-45de-9007-0229cfe5707a">


</p>
</details> 