### PR TITLE
feat: Adjust OwnCapabilities handling

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -252,6 +252,7 @@ export class StreamVideoClient {
         type: c.call.type,
         metadata: c.call,
         members: c.members,
+        ownCapabilities: c.own_capabilities,
         watching: data.watch,
         clientStore: this.writeableStateStore,
       });

--- a/packages/client/src/events/__tests__/call-permissions.test.ts
+++ b/packages/client/src/events/__tests__/call-permissions.test.ts
@@ -42,7 +42,7 @@ describe('Call Permission Events', () => {
       },
     });
 
-    expect(state.metadata?.own_capabilities).toEqual([
+    expect(state.ownCapabilities).toEqual([
       OwnCapability.SEND_AUDIO,
       OwnCapability.SEND_VIDEO,
     ]);
@@ -61,9 +61,7 @@ describe('Call Permission Events', () => {
         teams: [],
       },
     });
-    expect(state.metadata?.own_capabilities).toEqual([
-      OwnCapability.SEND_VIDEO,
-    ]);
+    expect(state.ownCapabilities).toEqual([OwnCapability.SEND_VIDEO]);
   });
 
   it('handles sfu.callGrantsUpdated', () => {
@@ -83,7 +81,7 @@ describe('Call Permission Events', () => {
       },
     });
 
-    expect(state.metadata?.own_capabilities).toEqual([
+    expect(state.ownCapabilities).toEqual([
       OwnCapability.SEND_AUDIO,
       OwnCapability.SEND_VIDEO,
       OwnCapability.SCREENSHARE,
@@ -102,8 +100,6 @@ describe('Call Permission Events', () => {
         },
       },
     });
-    expect(state.metadata?.own_capabilities).toEqual([
-      OwnCapability.SEND_AUDIO,
-    ]);
+    expect(state.ownCapabilities).toEqual([OwnCapability.SEND_AUDIO]);
   });
 });

--- a/packages/client/src/events/__tests__/sessions.test.ts
+++ b/packages/client/src/events/__tests__/sessions.test.ts
@@ -24,7 +24,6 @@ describe('call.session events', () => {
 
     expect(state.metadata).toEqual({
       cid: 'cid',
-      own_capabilities: [],
       session: {
         id: 'session-id',
       },
@@ -46,7 +45,6 @@ describe('call.session events', () => {
     });
     expect(state.metadata).toEqual({
       cid: 'cid',
-      own_capabilities: [],
       session: {
         id: 'session-id',
       },

--- a/packages/client/src/events/call-permissions.ts
+++ b/packages/client/src/events/call-permissions.ts
@@ -22,10 +22,7 @@ export const watchCallPermissionsUpdated = (state: CallState) => {
     if (event.type !== 'call.permissions_updated') return;
     const { localParticipant } = state;
     if (event.user.id === localParticipant?.userId) {
-      state.setMetadata((metadata) => ({
-        ...metadata!,
-        own_capabilities: event.own_capabilities,
-      }));
+      state.setOwnCapabilities(event.own_capabilities);
     }
   };
 };
@@ -49,7 +46,7 @@ export const watchCallGrantsUpdated = (state: CallState) => {
         [OwnCapability.SCREENSHARE]: canScreenshare,
       };
 
-      const nextCapabilities = (state.metadata?.own_capabilities || []).filter(
+      const nextCapabilities = state.ownCapabilities.filter(
         (capability) => update[capability] !== false,
       );
       Object.entries(update).forEach(([capability, value]) => {
@@ -58,12 +55,7 @@ export const watchCallGrantsUpdated = (state: CallState) => {
         }
       });
 
-      state.setMetadata((metadata) => {
-        return {
-          ...metadata!,
-          own_capabilities: nextCapabilities,
-        };
-      });
+      state.setOwnCapabilities(nextCapabilities);
     }
   };
 };

--- a/packages/client/src/events/sessions.ts
+++ b/packages/client/src/events/sessions.ts
@@ -9,12 +9,7 @@ import { StreamVideoEvent } from '../coordinator/connection/types';
 export const watchCallSessionStarted = (state: CallState) => {
   return function onCallSessionStarted(event: StreamVideoEvent) {
     if (event.type !== 'call.session_started') return;
-    const { call } = event;
-    state.setMetadata((metadata) => ({
-      ...call,
-      // FIXME OL: temporary, until the backend sends the own_capabilities
-      own_capabilities: metadata?.own_capabilities || [],
-    }));
+    state.setMetadata(event.call);
   };
 };
 
@@ -26,12 +21,7 @@ export const watchCallSessionStarted = (state: CallState) => {
 export const watchCallSessionEnded = (state: CallState) => {
   return function onCallSessionEnded(event: StreamVideoEvent) {
     if (event.type !== 'call.session_ended') return;
-    const { call } = event;
-    state.setMetadata((metadata) => ({
-      ...call,
-      // FIXME OL: temporary, until the backend sends the own_capabilities
-      own_capabilities: metadata?.own_capabilities || [],
-    }));
+    state.setMetadata(event.call);
   };
 };
 

--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -1029,12 +1029,6 @@ export interface CallResponse {
    */
   ingress: CallIngressResponse;
   /**
-   * The capabilities of the current user
-   * @type {Array<OwnCapability>}
-   * @memberof CallResponse
-   */
-  own_capabilities: Array<OwnCapability>;
-  /**
    *
    * @type {boolean}
    * @memberof CallResponse
@@ -1475,6 +1469,12 @@ export interface CallStateResponseFields {
    * @memberof CallStateResponseFields
    */
   membership?: MemberResponse;
+  /**
+   *
+   * @type {Array<OwnCapability>}
+   * @memberof CallStateResponseFields
+   */
+  own_capabilities: Array<OwnCapability>;
 }
 /**
  *
@@ -2051,62 +2051,6 @@ export interface GeofenceSettingsRequest {
 /**
  *
  * @export
- * @interface GetCallEdgeServerRequest
- */
-export interface GetCallEdgeServerRequest {
-  /**
-   *
-   * @type {{ [key: string]: Array<number>; }}
-   * @memberof GetCallEdgeServerRequest
-   */
-  latency_measurements: { [key: string]: Array<number> };
-}
-/**
- *
- * @export
- * @interface GetCallEdgeServerResponse
- */
-export interface GetCallEdgeServerResponse {
-  /**
-   *
-   * @type {Array<UserResponse>}
-   * @memberof GetCallEdgeServerResponse
-   */
-  blocked_users: Array<UserResponse>;
-  /**
-   *
-   * @type {CallResponse}
-   * @memberof GetCallEdgeServerResponse
-   */
-  call: CallResponse;
-  /**
-   *
-   * @type {Credentials}
-   * @memberof GetCallEdgeServerResponse
-   */
-  credentials: Credentials;
-  /**
-   * Duration of the request in human-readable format
-   * @type {string}
-   * @memberof GetCallEdgeServerResponse
-   */
-  duration: string;
-  /**
-   *
-   * @type {Array<MemberResponse>}
-   * @memberof GetCallEdgeServerResponse
-   */
-  members: Array<MemberResponse>;
-  /**
-   *
-   * @type {MemberResponse}
-   * @memberof GetCallEdgeServerResponse
-   */
-  membership?: MemberResponse;
-}
-/**
- *
- * @export
  * @interface GetCallResponse
  */
 export interface GetCallResponse {
@@ -2140,6 +2084,12 @@ export interface GetCallResponse {
    * @memberof GetCallResponse
    */
   membership?: MemberResponse;
+  /**
+   *
+   * @type {Array<OwnCapability>}
+   * @memberof GetCallResponse
+   */
+  own_capabilities: Array<OwnCapability>;
 }
 /**
  *
@@ -2282,6 +2232,12 @@ export interface GetOrCreateCallResponse {
    * @memberof GetOrCreateCallResponse
    */
   membership?: MemberResponse;
+  /**
+   *
+   * @type {Array<OwnCapability>}
+   * @memberof GetOrCreateCallResponse
+   */
+  own_capabilities: Array<OwnCapability>;
 }
 /**
  *
@@ -2468,6 +2424,12 @@ export interface JoinCallResponse {
    * @memberof JoinCallResponse
    */
   membership?: MemberResponse;
+  /**
+   *
+   * @type {Array<OwnCapability>}
+   * @memberof JoinCallResponse
+   */
+  own_capabilities: Array<OwnCapability>;
 }
 /**
  *

--- a/packages/client/src/rtc/flows/join.ts
+++ b/packages/client/src/rtc/flows/join.ts
@@ -24,13 +24,14 @@ export const join = async (
   await httpClient.connectionIdPromise;
 
   const joinCallResponse = await doJoin(httpClient, type, id, data);
-  const { call, credentials, members } = joinCallResponse;
+  const { call, credentials, members, own_capabilities } = joinCallResponse;
   return {
     connectionConfig: toRtcConfiguration(credentials.ice_servers),
     sfuServer: credentials.server,
     token: credentials.token,
     metadata: call,
     members,
+    ownCapabilities: own_capabilities,
   };
 };
 

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -14,6 +14,7 @@ import {
   CallRecording,
   CallResponse,
   MemberResponse,
+  OwnCapability,
   PermissionRequestEvent,
 } from '../gen/coordinator';
 import { TrackType } from '../gen/video/sfu/models/models';
@@ -90,6 +91,13 @@ export class CallState {
    * @internal
    */
   private membersSubject = new BehaviorSubject<MemberResponse[]>([]);
+
+  /**
+   * The list of capabilities of the current user.
+   *
+   * @private
+   */
+  private ownCapabilitiesSubject = new BehaviorSubject<OwnCapability[]>([]);
 
   /**
    * The calling state.
@@ -250,6 +258,11 @@ export class CallState {
   members$: Observable<MemberResponse[]>;
 
   /**
+   * The list of capabilities of the current user.
+   */
+  ownCapabilities$: Observable<OwnCapability[]>;
+
+  /**
    * The calling state.
    */
   callingState$: Observable<CallingState>;
@@ -307,6 +320,7 @@ export class CallState {
     this.callRecordingList$ = this.callRecordingListSubject.asObservable();
     this.metadata$ = this.metadataSubject.asObservable();
     this.members$ = this.membersSubject.asObservable();
+    this.ownCapabilities$ = this.ownCapabilitiesSubject.asObservable();
     this.callingState$ = this.callingStateSubject.asObservable();
   }
 
@@ -553,6 +567,23 @@ export class CallState {
    */
   setMembers = (members: Patch<MemberResponse[]>) => {
     this.setCurrentValue(this.membersSubject, members);
+  };
+
+  /**
+   * The capabilities of the current user for the current call.
+   */
+  get ownCapabilities() {
+    return this.getCurrentValue(this.ownCapabilities$);
+  }
+
+  /**
+   * Sets the own capabilities.
+   *
+   * @internal
+   * @param capabilities the capabilities to set.
+   */
+  setOwnCapabilities = (capabilities: Patch<OwnCapability[]>) => {
+    return this.setCurrentValue(this.ownCapabilitiesSubject, capabilities);
   };
 
   /**

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -6,6 +6,7 @@ import type {
   CallResponse,
   JoinCallRequest,
   MemberResponse,
+  OwnCapability,
   ReactionResponse,
 } from './gen/coordinator';
 import type { StreamClient } from './coordinator/connection/client';
@@ -183,6 +184,13 @@ export type CallConstructor = {
    * This is useful when initializing a new "pending call" from an event.
    */
   members?: MemberResponse[];
+
+  /**
+   * An optional list of {@link OwnCapability} coming from the backed.
+   * If provided, the call will be initialized with the data from this object.
+   * This is useful when initializing a new "pending call" from an event.
+   */
+  ownCapabilities?: OwnCapability[];
 
   /**
    * Flags the call as a ringing call.

--- a/packages/react-bindings/src/hooks/permissions.ts
+++ b/packages/react-bindings/src/hooks/permissions.ts
@@ -1,5 +1,4 @@
 import { OwnCapability, PermissionRequestEvent } from '@stream-io/video-client';
-import { useCallMetadata } from './call';
 import { useCallState } from './store';
 import { useObservableValue } from './helpers/useObservableValue';
 
@@ -10,12 +9,9 @@ import { useObservableValue } from './helpers/useObservableValue';
  *
  * @category Call State
  */
-export const useHasPermissions = (...permissions: OwnCapability[]) => {
-  const metadata = useCallMetadata();
-  if (!metadata) return false;
-  return permissions.every((permission) =>
-    metadata.own_capabilities.includes(permission),
-  );
+export const useHasPermissions = (...permissions: OwnCapability[]): boolean => {
+  const capabilities = useOwnCapabilities();
+  return permissions.every((permission) => capabilities.includes(permission));
 };
 
 /**
@@ -24,8 +20,8 @@ export const useHasPermissions = (...permissions: OwnCapability[]) => {
  * @category Call State
  */
 export const useOwnCapabilities = (): OwnCapability[] => {
-  const metadata = useCallMetadata();
-  return metadata?.own_capabilities || [];
+  const { ownCapabilities$ } = useCallState();
+  return useObservableValue(ownCapabilities$);
 };
 
 /**

--- a/sample-apps/react/react-video-demo/src/utils/useMeasureLatencyReponse.ts
+++ b/sample-apps/react/react-video-demo/src/utils/useMeasureLatencyReponse.ts
@@ -1,5 +1,3 @@
-import { GetCallEdgeServerRequest } from '@stream-io/video-react-sdk';
-
 const toSeconds = (ms: number) => ms / 1000;
 
 /**
@@ -64,7 +62,7 @@ export const measureLatencyToEdges = async (
     measureTimeoutAfterMs?: number;
   } = {},
 ) => {
-  const latencyByEdge: GetCallEdgeServerRequest['latency_measurements'] = {};
+  const latencyByEdge: Record<string, number[]> = {};
   const measurements: Promise<void>[] = [];
   const start = Date.now();
   for (let attempt = 0; attempt < attempts; attempt++) {


### PR DESCRIPTION
### Overview

Adjusts the React SDK to the latest changes around `own_capabilities` handling: https://github.com/GetStream/chat/pull/5075

`ownCapabilities` are now part of the client call state and they update independently from the rest of the call metadata.

As part of this, the deprecated `getEdgeServer` API method is also removed.