### PR TITLE
feat: reflect updateCall response data into call's state

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1412,10 +1412,17 @@ export class Call {
    * @param updates the updates to apply to the call.
    */
   update = async (updates: UpdateCallRequest) => {
-    return this.streamClient.patch<UpdateCallResponse, UpdateCallRequest>(
-      `${this.streamClientBasePath}`,
-      updates,
-    );
+    const response = await this.streamClient.patch<
+      UpdateCallResponse,
+      UpdateCallRequest
+    >(`${this.streamClientBasePath}`, updates);
+
+    const { call, members, own_capabilities } = response;
+    this.state.setMetadata(call);
+    this.state.setMembers(members);
+    this.state.setOwnCapabilities(own_capabilities);
+
+    return response;
   };
 
   /**

--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -3709,6 +3709,12 @@ export interface UpdateCallRequest {
 export interface UpdateCallResponse {
   /**
    *
+   * @type {Array<UserResponse>}
+   * @memberof UpdateCallResponse
+   */
+  blocked_users: Array<UserResponse>;
+  /**
+   *
    * @type {CallResponse}
    * @memberof UpdateCallResponse
    */
@@ -3719,6 +3725,24 @@ export interface UpdateCallResponse {
    * @memberof UpdateCallResponse
    */
   duration: string;
+  /**
+   *
+   * @type {Array<MemberResponse>}
+   * @memberof UpdateCallResponse
+   */
+  members: Array<MemberResponse>;
+  /**
+   *
+   * @type {MemberResponse}
+   * @memberof UpdateCallResponse
+   */
+  membership?: MemberResponse;
+  /**
+   *
+   * @type {Array<OwnCapability>}
+   * @memberof UpdateCallResponse
+   */
+  own_capabilities: Array<OwnCapability>;
 }
 /**
  *


### PR DESCRIPTION
### Overview

Whenever a call is updated, we store the response values within the call's state.