### PR TITLE
fix: preserve last used session-id when reconnecting

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -613,12 +613,14 @@ export class Call {
       sfuWsUrl = sfuWsUrlParam || sfuServer.ws_endpoint;
     }
 
-    const sfuClient = (this.sfuClient = new StreamSfuClient(
-      this.dispatcher,
-      sfuUrl,
-      sfuWsUrl,
-      sfuToken,
-    ));
+    const previousSessionId = this.sfuClient?.sessionId;
+    const sfuClient = (this.sfuClient = new StreamSfuClient({
+      dispatcher: this.dispatcher,
+      url: sfuUrl,
+      wsEndpoint: sfuWsUrl,
+      token: sfuToken,
+      sessionId: previousSessionId,
+    }));
 
     /**
      * A closure which hides away the re-connection logic.

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -24,6 +24,34 @@ import {
   sleep,
 } from './coordinator/connection/utils';
 
+export type StreamSfuClientConstructor = {
+  /**
+   * The event dispatcher instance to use.
+   */
+  dispatcher: Dispatcher;
+
+  /**
+   * The URL of the SFU to connect to.
+   */
+  url: string;
+
+  /**
+   * The WebSocket endpoint of the SFU to connect to.
+   */
+  wsEndpoint: string;
+
+  /**
+   * The JWT token to use for authentication.
+   */
+  token: string;
+
+  /**
+   * An optional `sessionId` to use for the connection.
+   * If not provided, a random UUIDv4 will be generated.
+   */
+  sessionId?: string;
+};
+
 /**
  * The client used for exchanging information with the SFU.
  */
@@ -64,14 +92,16 @@ export class StreamSfuClient {
    * @param url the URL of the SFU.
    * @param wsEndpoint the WebSocket endpoint of the SFU.
    * @param token the JWT token to use for authentication.
+   * @param sessionId the `sessionId` of the currently connected participant.
    */
-  constructor(
-    dispatcher: Dispatcher,
-    url: string,
-    wsEndpoint: string,
-    token: string,
-  ) {
-    this.sessionId = generateUUIDv4();
+  constructor({
+    dispatcher,
+    url,
+    wsEndpoint,
+    token,
+    sessionId,
+  }: StreamSfuClientConstructor) {
+    this.sessionId = sessionId || generateUUIDv4();
     this.token = token;
     this.rpc = createSignalClient({
       baseUrl: url,

--- a/packages/client/src/rtc/__tests__/publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/publisher.test.ts
@@ -35,12 +35,12 @@ describe('Publisher', () => {
 
   beforeEach(() => {
     const dispatcher = new Dispatcher();
-    sfuClient = new StreamSfuClient(
+    sfuClient = new StreamSfuClient({
       dispatcher,
-      'https://getstream.io/',
-      'https://getstream.io/ws',
-      'token',
-    );
+      url: 'https://getstream.io/',
+      wsEndpoint: 'https://getstream.io/ws',
+      token: 'token',
+    });
 
     // @ts-ignore
     sfuClient['sessionId'] = sessionId;

--- a/packages/client/src/rtc/videoLayers.ts
+++ b/packages/client/src/rtc/videoLayers.ts
@@ -25,7 +25,10 @@ export const findOptimalVideoLayers = (
 ) => {
   const optimalVideoLayers: OptimalVideoLayer[] = [];
   const settings = videoTrack.getSettings();
-  const { width: w = 0, height: h = 0 } = settings;
+  const {
+    width: w = targetResolution.width,
+    height: h = targetResolution.height,
+  } = settings;
 
   const maxBitrate = getComputedMaxBitrate(targetResolution, w, h);
   let downscaleFactor = 1;


### PR DESCRIPTION
### Overview

`sessionId` of the current participant will be preserved across reconnects.
Additionally, fallback to the "target resolution" of the video track in case when the browser fails to report the correct track dimensions.