### PR TITLE
feat(client): do not unregister left calls from client store

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -401,7 +401,6 @@ export class Call {
     // Call all leave call hooks, e.g. to clean up global event handlers
     this.leaveCallHooks.forEach((hook) => hook());
 
-    this.clientStore.unregisterCall(this);
     this.state.setCallingState(CallingState.LEFT);
   };
 

--- a/packages/react-native-call-starter-kit/src/components/MessengerWrapper.tsx
+++ b/packages/react-native-call-starter-kit/src/components/MessengerWrapper.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import {
   ActiveCall,
+  CallingState,
   IncomingCallView,
   OutgoingCallView,
   StreamCall,
@@ -66,15 +67,15 @@ export const Calls = () => {
     );
   }, [calls]);
 
-  // Reset the state of the show variable when there are no calls.
   useEffect(() => {
-    if (!calls.length) {
-      setShow('none');
-    }
-    if (calls.length > 1) {
+    const activeCalls = calls.filter(
+      call => call.state.callingState !== CallingState.LEFT,
+    );
+    // Trigger an alert for more than one active calls
+    if (activeCalls.length > 1) {
       handleMoreCalls();
     }
-  }, [calls.length, handleMoreCalls]);
+  }, [calls, handleMoreCalls]);
 
   const onCallJoined = useCallback(() => {
     setShow('active-call');
@@ -119,11 +120,18 @@ export const Calls = () => {
   ]);
 
   return (
-    calls[0] && (
-      <StreamCall call={calls[0]} callCycleHandlers={callCycleHandlers}>
-        <CallPanel show={show} />
-      </StreamCall>
-    )
+    <>
+      {calls.map(call => {
+        return (
+          <StreamCall
+            key={call.cid}
+            call={call}
+            callCycleHandlers={callCycleHandlers}>
+            <CallPanel show={show} />
+          </StreamCall>
+        );
+      })}
+    </>
   );
 };
 

--- a/packages/react-native-dogfood/src/navigators/Call.tsx
+++ b/packages/react-native-dogfood/src/navigators/Call.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import JoinCallScreen from '../screens/Call/JoinCallScreen';
 
 import {
+  CallingState,
   IncomingCallView,
   OutgoingCallView,
   StreamCall,
@@ -55,15 +56,15 @@ const Calls = () => {
     );
   }, [calls]);
 
-  // Reset the state of the show variable when there are no calls.
   useEffect(() => {
-    if (!calls.length) {
-      setShow('none');
-    }
-    if (calls.length > 1) {
+    const activeCalls = calls.filter(
+      (call) => call.state.callingState !== CallingState.LEFT,
+    );
+    // Trigger an alert for more than one active calls
+    if (activeCalls.length > 1) {
       handleMoreCalls();
     }
-  }, [calls.length, handleMoreCalls]);
+  }, [calls, handleMoreCalls]);
 
   const onCallJoined = React.useCallback(() => {
     setShow('active-call');
@@ -107,16 +108,20 @@ const Calls = () => {
     onCallJoining,
   ]);
 
-  const firstCall = calls[0];
-
-  if (!firstCall) {
-    return null;
-  }
-
   return (
-    <StreamCall call={calls[0]} callCycleHandlers={callCycleHandlers}>
-      <CallPanel show={show} />
-    </StreamCall>
+    <>
+      {calls.map((call) => {
+        return (
+          <StreamCall
+            key={call.cid}
+            call={call}
+            callCycleHandlers={callCycleHandlers}
+          >
+            <CallPanel show={show} />
+          </StreamCall>
+        );
+      })}
+    </>
   );
 };
 


### PR DESCRIPTION
Unregistering leads to `calls` array returned from `useCalls()` not containing the left call.