### PR TITLE
chore: adjust default token expiration

### DIFF
--- a/packages/react-dogfood/helpers/jwt.ts
+++ b/packages/react-dogfood/helpers/jwt.ts
@@ -1,5 +1,12 @@
 import { JWTUserToken } from 'stream-chat';
 
+/**
+ * The maximum validity of a token, in seconds.
+ * Defaults to 7 days.
+ */
+export const maxTokenValidityInSeconds: number =
+  Number(process.env.MAX_TOKEN_EXP_IN_SECONDS) || 7 * 24 * 60 * 60; // 7 days
+
 export const createToken = (
   userId: string,
   jwtSecret: string,
@@ -10,12 +17,12 @@ export const createToken = (
     ...rest
   } = params;
 
-  const maxValidityInSeconds = 3 * 60 * 60;
   const expiryFromNowInSeconds = exp
     ? parseInt(exp as string, 10)
-    : maxValidityInSeconds;
+    : maxTokenValidityInSeconds;
   const expiration = Math.round(
-    Date.now() / 1000 + Math.min(expiryFromNowInSeconds, maxValidityInSeconds),
+    Date.now() / 1000 +
+      Math.min(expiryFromNowInSeconds, maxTokenValidityInSeconds),
   );
 
   const payload: Record<string, unknown> = {

--- a/packages/react-dogfood/pages/api/auth/create-token.ts
+++ b/packages/react-dogfood/pages/api/auth/create-token.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { createToken } from '../../../helpers/jwt';
+import { createToken, maxTokenValidityInSeconds } from '../../../helpers/jwt';
 
 const apiKeyAndSecretWhitelist =
   (process.env.STREAM_API_KEY_AND_SECRET_WHITE_LIST as string) || '';
@@ -40,8 +40,7 @@ const createJwtToken = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   if (!params.exp) {
-    const expiration = 3 * 60 * 60;
-    params.exp = String(expiration);
+    params.exp = String(maxTokenValidityInSeconds);
   }
 
   // by default, we support repeated query params:

--- a/packages/react-dogfood/pages/join/[callId].tsx
+++ b/packages/react-dogfood/pages/join/[callId].tsx
@@ -40,8 +40,8 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
         new URLSearchParams({
           api_key: apiKey,
           user_id: user.id,
+          exp: String(4 * 60 * 60), // 4 hours
         }),
-      {},
     ).then((res) => res.json());
     return token as string;
   }, [apiKey, user.id]);


### PR DESCRIPTION
### Overview

By default, all tokens issued by our service will have an expiry date set 7 days from now.
The expiration can be explicitly specified through the `?exp=<numberOfSecondsFromNow>` query parameter.
Example: `?exp=3600` - will create a token that expires in 1 hour.

**Note**: explicit expiration requests that span longer than 7 days, will be capped to 7 days.

For test purposes, you can issue an "expired" token by providing a negative value in the `?exp=` parameter. 
Example: `?exp=-60` - will create a token that expired 1 minute ago.