### PR TITLE
feat: User connect and types

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -27,6 +27,7 @@ import type {
   StreamClientOptions,
   TokenOrProvider,
   User,
+  UserWithId,
 } from './coordinator/connection/types';
 
 /**
@@ -70,12 +71,12 @@ export class StreamVideoClient {
    * @param tokenOrProvider a token or a function that returns a token.
    */
   async connectUser(
-    user: User | (Partial<Pick<User, 'id'>> & User & { type: 'anonymous' }),
+    user: User,
     token: TokenOrProvider,
   ): Promise<void | ConnectedEvent> {
     if (user.type === 'anonymous') {
       user.id = '!anon';
-      return this.connectAnonymousUser(user, token);
+      return this.connectAnonymousUser(user as UserWithId, token);
     }
     if (user.type === 'guest') {
       const response = await this.createGuestUser({
@@ -414,7 +415,7 @@ export class StreamVideoClient {
    * @param tokenOrProvider a token or a function that returns a token.
    */
   private connectAnonymousUser = async (
-    user: User,
+    user: UserWithId,
     tokenOrProvider: TokenOrProvider,
   ) => {
     const connectAnonymousUser = () =>

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -71,11 +71,7 @@ export class StreamVideoClient {
    */
   connectUser = async (user: User, tokenOrProvider: TokenOrProvider) => {
     const connectUser = () => {
-      return this.streamClient.connectUser(
-        // @ts-expect-error
-        user,
-        tokenOrProvider,
-      );
+      return this.streamClient.connectUser(user, tokenOrProvider);
     };
     this.connectionPromise = this.disconnectionPromise
       ? this.disconnectionPromise.then(() => connectUser())
@@ -83,7 +79,10 @@ export class StreamVideoClient {
 
     this.connectionPromise?.finally(() => (this.connectionPromise = undefined));
     const connectUserResponse = await this.connectionPromise;
-    this.writeableStateStore.setConnectedUser(user);
+    // connectUserResponse will be void if connectUser called twice for the same user
+    if (connectUserResponse?.me) {
+      this.writeableStateStore.setConnectedUser(connectUserResponse.me);
+    }
 
     this.eventHandlersToUnregister.push(
       this.on('connection.changed', (e) => {
@@ -175,7 +174,6 @@ export class StreamVideoClient {
     tokenOrProvider: TokenOrProvider,
   ) => {
     const connectAnonymousUser = () =>
-      // @ts-expect-error
       this.streamClient.connectAnonymousUser(user, tokenOrProvider);
     this.connectionPromise = this.disconnectionPromise
       ? this.disconnectionPromise.then(() => connectAnonymousUser())

--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -27,15 +27,15 @@ import {
   ErrorFromResponse,
   EventHandler,
   Logger,
-  OwnUserResponse,
   StreamClientOptions,
   StreamVideoEvent,
   TokenOrProvider,
+  User,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 
 export class StreamClient {
-  _user?: OwnUserResponse;
+  _user?: User;
   anonymous: boolean;
   persistUserOnConnectionFailure?: boolean;
   axiosInstance: AxiosInstance;
@@ -52,7 +52,7 @@ export class StreamClient {
   secret?: string;
   setUserPromise: ConnectAPIResponse | null;
   tokenManager: TokenManager;
-  user?: OwnUserResponse;
+  user?: User;
   userAgent?: string;
   userID?: string;
   wsBaseURL?: string;
@@ -183,15 +183,12 @@ export class StreamClient {
   /**
    * connectUser - Set the current user and open a WebSocket connection
    *
-   * @param {OwnUserResponse} user Data about this user. IE {name: "john"}
+   * @param user Data about this user. IE {name: "john"}
    * @param {TokenOrProvider} userTokenOrProvider Token or provider
    *
    * @return {ConnectAPIResponse} Returns a promise that resolves when the connection is setup
    */
-  connectUser = async (
-    user: OwnUserResponse,
-    userTokenOrProvider: TokenOrProvider,
-  ) => {
+  connectUser = async (user: User, userTokenOrProvider: TokenOrProvider) => {
     if (!user.id) {
       throw new Error('The "id" field on the user is missing');
     }
@@ -253,7 +250,7 @@ export class StreamClient {
   };
 
   _setToken = (
-    user: OwnUserResponse,
+    user: User,
     userTokenOrProvider: TokenOrProvider,
     isAnonymous: boolean,
   ) =>
@@ -263,7 +260,7 @@ export class StreamClient {
       isAnonymous,
     );
 
-  _setUser(user: OwnUserResponse) {
+  _setUser(user: User) {
     /**
      * This one is used by the frontend. This is a copy of the current user object stored on backend.
      * It contains reserved properties and own user properties which are not present in `this._user`.
@@ -382,7 +379,7 @@ export class StreamClient {
    * connectAnonymousUser - Set an anonymous user and open a WebSocket connection
    */
   connectAnonymousUser = async (
-    user: OwnUserResponse,
+    user: User,
     tokenOrProvider: TokenOrProvider,
   ) => {
     this.anonymous = true;

--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -36,7 +36,7 @@ import { InsightMetrics, postInsights } from './insights';
 
 export class StreamClient {
   _user?: User;
-  anonymous?: boolean;
+  anonymous: boolean;
   persistUserOnConnectionFailure?: boolean;
   axiosInstance: AxiosInstance;
   baseURL?: string;

--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -30,12 +30,12 @@ import {
   StreamClientOptions,
   StreamVideoEvent,
   TokenOrProvider,
-  User,
+  UserWithId,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 
 export class StreamClient {
-  _user?: User;
+  _user?: UserWithId;
   anonymous: boolean;
   persistUserOnConnectionFailure?: boolean;
   axiosInstance: AxiosInstance;
@@ -52,7 +52,7 @@ export class StreamClient {
   secret?: string;
   setUserPromise: ConnectAPIResponse | null;
   tokenManager: TokenManager;
-  user?: User;
+  user?: UserWithId;
   userAgent?: string;
   userID?: string;
   wsBaseURL?: string;
@@ -188,7 +188,10 @@ export class StreamClient {
    *
    * @return {ConnectAPIResponse} Returns a promise that resolves when the connection is setup
    */
-  connectUser = async (user: User, userTokenOrProvider: TokenOrProvider) => {
+  connectUser = async (
+    user: UserWithId,
+    userTokenOrProvider: TokenOrProvider,
+  ) => {
     if (!user.id) {
       throw new Error('The "id" field on the user is missing');
     }
@@ -250,7 +253,7 @@ export class StreamClient {
   };
 
   _setToken = (
-    user: User,
+    user: UserWithId,
     userTokenOrProvider: TokenOrProvider,
     isAnonymous: boolean,
   ) =>
@@ -260,7 +263,7 @@ export class StreamClient {
       isAnonymous,
     );
 
-  _setUser(user: User) {
+  _setUser(user: UserWithId) {
     /**
      * This one is used by the frontend. This is a copy of the current user object stored on backend.
      * It contains reserved properties and own user properties which are not present in `this._user`.
@@ -303,7 +306,7 @@ export class StreamClient {
   openConnection = async () => {
     if (!this.userID) {
       throw Error(
-        'User is not set on client, use client.connectUser or client.connectAnonymousUser instead',
+        'UserWithId is not set on client, use client.connectUser or client.connectAnonymousUser instead',
       );
     }
 
@@ -379,7 +382,7 @@ export class StreamClient {
    * connectAnonymousUser - Set an anonymous user and open a WebSocket connection
    */
   connectAnonymousUser = async (
-    user: User,
+    user: UserWithId,
     tokenOrProvider: TokenOrProvider,
   ) => {
     this.anonymous = true;
@@ -814,7 +817,7 @@ export class StreamClient {
    * createToken - Creates a token to authenticate this user. This function is used server side.
    * The resulting token should be passed to the client side when the users registers or logs in.
    *
-   * @param {string} userID The User ID
+   * @param {string} userID The UserWithId ID
    * @param {number} [exp] The expiration time for the token expressed in the number of seconds since the epoch
    * @param call_cids for anonymous tokens you have to provide the call cids the use can join
    *

--- a/packages/client/src/coordinator/connection/token_manager.ts
+++ b/packages/client/src/coordinator/connection/token_manager.ts
@@ -1,7 +1,7 @@
 import { Secret } from 'jsonwebtoken';
 import { JWTServerToken, JWTUserToken, UserFromToken } from './signing';
 import { isFunction } from './utils';
-import type { TokenOrProvider, User } from './types';
+import type { TokenOrProvider, UserWithId } from './types';
 
 /**
  * TokenManager
@@ -14,7 +14,7 @@ export class TokenManager {
   secret?: Secret;
   token?: string;
   tokenProvider?: TokenOrProvider;
-  user?: User;
+  user?: UserWithId;
   /**
    * Constructor
    *
@@ -43,7 +43,7 @@ export class TokenManager {
    */
   setTokenOrProvider = async (
     tokenOrProvider: TokenOrProvider,
-    user: User,
+    user: UserWithId,
     isAnonymous: boolean,
   ) => {
     this.validateToken(tokenOrProvider, user, isAnonymous);
@@ -80,7 +80,7 @@ export class TokenManager {
   // Validates the user token.
   validateToken = (
     tokenOrProvider: TokenOrProvider,
-    user: User,
+    user: UserWithId,
     isAnonymous: boolean,
   ) => {
     // allow empty token for anon user
@@ -88,7 +88,7 @@ export class TokenManager {
 
     // Don't allow empty token for non-server side client.
     if (!this.secret && !tokenOrProvider) {
-      throw new Error('User token can not be empty');
+      throw new Error('UserWithId token can not be empty');
     }
 
     if (

--- a/packages/client/src/coordinator/connection/token_manager.ts
+++ b/packages/client/src/coordinator/connection/token_manager.ts
@@ -1,7 +1,7 @@
 import { Secret } from 'jsonwebtoken';
 import { JWTServerToken, JWTUserToken, UserFromToken } from './signing';
 import { isFunction } from './utils';
-import type { OwnUserResponse, TokenOrProvider } from './types';
+import type { TokenOrProvider, User } from './types';
 
 /**
  * TokenManager
@@ -14,7 +14,7 @@ export class TokenManager {
   secret?: Secret;
   token?: string;
   tokenProvider?: TokenOrProvider;
-  user?: OwnUserResponse;
+  user?: User;
   /**
    * Constructor
    *
@@ -43,7 +43,7 @@ export class TokenManager {
    */
   setTokenOrProvider = async (
     tokenOrProvider: TokenOrProvider,
-    user: OwnUserResponse,
+    user: User,
     isAnonymous: boolean,
   ) => {
     this.validateToken(tokenOrProvider, user, isAnonymous);
@@ -80,7 +80,7 @@ export class TokenManager {
   // Validates the user token.
   validateToken = (
     tokenOrProvider: TokenOrProvider,
-    user: OwnUserResponse,
+    user: User,
     isAnonymous: boolean,
   ) => {
     // allow empty token for anon user

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -1,18 +1,19 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { StableWSConnection } from './connection';
-import { ConnectedEvent, VideoEvent } from '../../gen/coordinator';
+import {
+  ConnectedEvent,
+  OwnUserResponse,
+  VideoEvent,
+} from '../../gen/coordinator';
 
 export type UR = Record<string, unknown>;
 
-export type User = {
-  id: string;
-  name?: string;
-  role?: string;
-  teams?: string[];
-  username?: string;
-  image?: string;
-  custom?: { [key: string]: any };
-};
+export type UserType = 'regular' | 'anonymous' | 'guest';
+
+export type User = Pick<OwnUserResponse, 'id'> &
+  Partial<
+    Pick<OwnUserResponse, 'custom' | 'image' | 'name' | 'role' | 'teams'>
+  > & { type?: UserType };
 
 export type { OwnUserResponse } from '../../gen/coordinator';
 

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -7,6 +7,14 @@ export type UR = Record<string, unknown>;
 export type User =
   | (UserRequest & { type?: 'authenticated' })
   | (UserRequest & { type: 'guest' })
+  | (Omit<UserRequest, 'id'> & {
+      id?: '!anon';
+      type: 'anonymous';
+    });
+
+export type UserWithId =
+  | (UserRequest & { type?: 'authenticated' })
+  | (UserRequest & { type: 'guest' })
   | (UserRequest & {
       id: '!anon';
       type: 'anonymous';

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -1,19 +1,16 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { StableWSConnection } from './connection';
-import {
-  ConnectedEvent,
-  OwnUserResponse,
-  VideoEvent,
-} from '../../gen/coordinator';
+import { ConnectedEvent, UserRequest, VideoEvent } from '../../gen/coordinator';
 
 export type UR = Record<string, unknown>;
 
-export type UserType = 'regular' | 'anonymous' | 'guest';
-
-export type User = Pick<OwnUserResponse, 'id'> &
-  Partial<
-    Pick<OwnUserResponse, 'custom' | 'image' | 'name' | 'role' | 'teams'>
-  > & { type?: UserType };
+export type User =
+  | (UserRequest & { type?: 'authenticated' })
+  | (UserRequest & { type: 'guest' })
+  | (UserRequest & {
+      id: '!anon';
+      type: 'anonymous';
+    });
 
 export type { OwnUserResponse } from '../../gen/coordinator';
 

--- a/packages/client/src/events/__tests__/call.test.ts
+++ b/packages/client/src/events/__tests__/call.test.ts
@@ -282,6 +282,12 @@ const fakeCall = ({ ring = true, currentUserId = 'test-user-id' } = {}) => {
   const store = new StreamVideoWriteableStateStore();
   store.setConnectedUser({
     id: currentUserId,
+    created_at: '',
+    updated_at: '',
+    role: '',
+    custom: {},
+    teams: [],
+    devices: [],
   });
   const client = new StreamClient('api-key');
   return new Call({

--- a/packages/client/src/store/stateStore.ts
+++ b/packages/client/src/store/stateStore.ts
@@ -3,14 +3,16 @@ import { combineLatestWith, map } from 'rxjs/operators';
 import type { Patch } from './rxUtils';
 import * as RxUtils from './rxUtils';
 import { Call } from '../Call';
-import type { User } from '../coordinator/connection/types';
+import type { OwnUserResponse } from '../coordinator/connection/types';
 import { CallingState } from './CallState';
 
 export class StreamVideoWriteableStateStore {
   /**
    * A store keeping data of a successfully connected user over WS to the coordinator server.
    */
-  connectedUserSubject = new BehaviorSubject<User | undefined>(undefined);
+  connectedUserSubject = new BehaviorSubject<OwnUserResponse | undefined>(
+    undefined,
+  );
 
   /**
    * A list of {@link Call} objects created/tracked by this client.
@@ -88,7 +90,7 @@ export class StreamVideoWriteableStateStore {
   /**
    * The currently connected user.
    */
-  get connectedUser(): User | undefined {
+  get connectedUser(): OwnUserResponse | undefined {
     return this.getCurrentValue(this.connectedUserSubject);
   }
 
@@ -98,7 +100,7 @@ export class StreamVideoWriteableStateStore {
    * @internal
    * @param user the user to set as connected.
    */
-  setConnectedUser = (user: Patch<User | undefined>) => {
+  setConnectedUser = (user: Patch<OwnUserResponse | undefined>) => {
     return this.setCurrentValue(this.connectedUserSubject, user);
   };
 
@@ -173,7 +175,7 @@ export class StreamVideoReadOnlyStateStore {
   /**
    * Data describing a user successfully connected over WS to coordinator server.
    */
-  connectedUser$: Observable<User | undefined>;
+  connectedUser$: Observable<OwnUserResponse | undefined>;
 
   /**
    * A list of {@link Call} objects created/tracked by this client.
@@ -213,7 +215,7 @@ export class StreamVideoReadOnlyStateStore {
   /**
    * The current user connected over WS to the backend.
    */
-  get connectedUser(): User | undefined {
+  get connectedUser(): OwnUserResponse | undefined {
     return RxUtils.getCurrentValue(this.connectedUser$);
   }
 

--- a/packages/react-dogfood/hooks/useGleap.ts
+++ b/packages/react-dogfood/hooks/useGleap.ts
@@ -15,7 +15,7 @@ export const useGleap = (
   useEffect(() => {
     if (gleapApiKey) {
       Gleap.initialize(gleapApiKey);
-      Gleap.identify(user.name || user.id, {
+      Gleap.identify(user.name || user.id || '!anon', {
         name: user.name,
       });
     }

--- a/packages/react-dogfood/pages/join/[callId].tsx
+++ b/packages/react-dogfood/pages/join/[callId].tsx
@@ -20,6 +20,7 @@ import {
   DeviceSettingsCaptor,
   getDeviceSettings,
 } from '../../components/DeviceSettingsCaptor';
+import { User } from '@stream-io/video-react-sdk';
 
 const CallRoom = (props: ServerSideCredentialsProps) => {
   const router = useRouter();
@@ -39,7 +40,7 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
       '/api/auth/create-token?' +
         new URLSearchParams({
           api_key: apiKey,
-          user_id: user.id,
+          user_id: user.id || '!anon',
           exp: String(4 * 60 * 60), // 4 hours
         }),
     ).then((res) => res.json());
@@ -62,7 +63,7 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
   const chatClient = useCreateStreamChatClient({
     apiKey,
     tokenOrProvider: userToken,
-    userData: user,
+    userData: { id: '!anon', ...(user as Omit<User, 'type'>) },
   });
 
   useEffect(() => {

--- a/packages/react-native-call-starter-kit/src/components/ChatWrapper.tsx
+++ b/packages/react-native-call-starter-kit/src/components/ChatWrapper.tsx
@@ -6,6 +6,7 @@ import {STREAM_API_KEY} from 'react-native-dotenv';
 import {useStreamChatTheme} from '../../useStreamChatTheme';
 import {AuthProgressLoader} from './AuthProgressLoader';
 import {StreamChatGenerics} from '../types';
+import {User} from '@stream-io/video-react-native-sdk';
 
 const streami18n = new Streami18n({
   language: 'en',
@@ -13,10 +14,14 @@ const streami18n = new Streami18n({
 
 export const ChatWrapper = ({children}: PropsWithChildren<{}>) => {
   const {user} = useAppContext();
+  const chatUser: (Omit<User, 'type'> & {id: string}) | undefined = {
+    id: '!anon',
+    ...user,
+  };
   const chatClient = useChatClient({
     apiKey: STREAM_API_KEY,
-    userData: user,
-    tokenOrProvider: user?.custom && user?.custom.token,
+    userData: chatUser,
+    tokenOrProvider: chatUser?.custom && chatUser?.custom.token,
   });
   const theme = useStreamChatTheme();
 

--- a/packages/react-native-dogfood/src/screens/Meeting/GuestMeetingScreen.tsx
+++ b/packages/react-native-dogfood/src/screens/Meeting/GuestMeetingScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import {
   StreamCall,
@@ -28,14 +28,25 @@ export const GuestMeetingScreen = (props: Props) => {
   } = props.route;
   const guestCallType = 'default';
 
-  const [userToConnect, setUserToConnect] = useState<User>({
-    id: '!anon',
-    type: 'anonymous',
-  });
   const [tokenToUse, setTokenToUse] = useState<TokenOrProvider>(undefined);
   const [show, setShow] = useState<ScreenTypes>('lobby');
   const { navigation } = props;
   const activeCall = useCall();
+
+  const userToConnect: User = useMemo(
+    () =>
+      mode === 'guest'
+        ? {
+            id: guestUserId,
+            name: guestUserId,
+            type: 'guest',
+          }
+        : {
+            id: '!anon',
+            type: 'anonymous',
+          },
+    [mode, guestUserId],
+  );
 
   const onJoin = () => {
     setShow('active-call');
@@ -63,25 +74,6 @@ export const GuestMeetingScreen = (props: Props) => {
     tokenOrProvider: tokenToUse,
     user: userToConnect,
   });
-
-  useEffect(() => {
-    if (mode !== 'guest') {
-      return;
-    }
-    const setGuestUserDetails = async () => {
-      if (!guestUserId) {
-        return;
-      }
-      const user: User = {
-        id: guestUserId,
-        name: guestUserId,
-        type: 'guest',
-      };
-      setUserToConnect(user);
-    };
-
-    setGuestUserDetails();
-  }, [client, guestUserId, mode]);
 
   useEffect(() => {
     if (!activeCall) {

--- a/packages/react-native-dogfood/src/screens/Meeting/GuestMeetingScreen.tsx
+++ b/packages/react-native-dogfood/src/screens/Meeting/GuestMeetingScreen.tsx
@@ -33,7 +33,6 @@ export const GuestMeetingScreen = (props: Props) => {
     type: 'anonymous',
   });
   const [tokenToUse, setTokenToUse] = useState<TokenOrProvider>(undefined);
-  const [isAnonymous, setIsAnonymous] = useState(true);
   const [show, setShow] = useState<ScreenTypes>('lobby');
   const { navigation } = props;
   const activeCall = useCall();
@@ -63,7 +62,6 @@ export const GuestMeetingScreen = (props: Props) => {
     apiKey,
     tokenOrProvider: tokenToUse,
     user: userToConnect,
-    isAnonymous: isAnonymous,
   });
 
   useEffect(() => {
@@ -74,17 +72,12 @@ export const GuestMeetingScreen = (props: Props) => {
       if (!guestUserId) {
         return;
       }
-      try {
-        const user: User = {
-          id: guestUserId,
-          name: guestUserId,
-          type: 'guest',
-        };
-        setUserToConnect(user);
-        setIsAnonymous(false);
-      } catch (error) {
-        console.log('Error setting guest user credentials:', error);
-      }
+      const user: User = {
+        id: guestUserId,
+        name: guestUserId,
+        type: 'guest',
+      };
+      setUserToConnect(user);
     };
 
     setGuestUserDetails();

--- a/packages/react-native-dogfood/src/screens/Meeting/GuestMeetingScreen.tsx
+++ b/packages/react-native-dogfood/src/screens/Meeting/GuestMeetingScreen.tsx
@@ -4,7 +4,7 @@ import {
   StreamCall,
   StreamVideo,
   TokenOrProvider,
-  UserResponse,
+  User,
   useCall,
   useCreateStreamVideoClient,
 } from '@stream-io/video-react-native-sdk';
@@ -28,13 +28,9 @@ export const GuestMeetingScreen = (props: Props) => {
   } = props.route;
   const guestCallType = 'default';
 
-  const [userToConnect, setUserToConnect] = useState<UserResponse>({
-    id: `anonymous-${Math.random().toString(36).substring(2, 15)}`,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-    role: 'guest',
-    teams: [],
-    custom: {},
+  const [userToConnect, setUserToConnect] = useState<User>({
+    id: '!anon',
+    type: 'anonymous',
   });
   const [tokenToUse, setTokenToUse] = useState<TokenOrProvider>(undefined);
   const [isAnonymous, setIsAnonymous] = useState(true);
@@ -79,16 +75,12 @@ export const GuestMeetingScreen = (props: Props) => {
         return;
       }
       try {
-        const response = await client.createGuestUser({
-          user: {
-            id: guestUserId,
-            name: guestUserId,
-            role: 'guest',
-          },
-        });
-        const { user, access_token } = response;
+        const user: User = {
+          id: guestUserId,
+          name: guestUserId,
+          type: 'guest',
+        };
         setUserToConnect(user);
-        setTokenToUse(access_token);
         setIsAnonymous(false);
       } catch (error) {
         console.log('Error setting guest user credentials:', error);

--- a/packages/react-native-dogfood/src/screens/Meeting/GuestModeScreen.tsx
+++ b/packages/react-native-dogfood/src/screens/Meeting/GuestModeScreen.tsx
@@ -35,6 +35,7 @@ export const GuestModeScreen = ({
     navigation.navigate('GuestMeetingScreen', {
       mode: 'anon',
       guestCallId: callId,
+      guestUserId: '!anon',
     });
   };
 

--- a/packages/react-native-dogfood/types.ts
+++ b/packages/react-native-dogfood/types.ts
@@ -115,7 +115,7 @@ export interface RTCDataChannel extends EventTarget {
 export type EventHandler = (event: SfuEvent) => void;
 
 export type GuestMeetingScreenParams = {
-  guestUserId?: string;
+  guestUserId: string;
   guestCallId: string;
   mode: string;
 };

--- a/packages/react-native-sdk/src/hooks/useCreateStreamVideoClient.tsx
+++ b/packages/react-native-sdk/src/hooks/useCreateStreamVideoClient.tsx
@@ -51,11 +51,9 @@ export const useCreateStreamVideoClient = ({
   useEffect(() => {
     const connectionPromise = disconnectRef.current.then(() => {
       if (isAnonymous) {
-        return client
-          .connectAnonymousUser(user, tokenOrProvider)
-          .catch((err) => {
-            console.error(`Failed to establish connection`, err);
-          });
+        return client.connectUser(user, tokenOrProvider).catch((err) => {
+          console.error(`Failed to establish connection`, err);
+        });
       }
       return client.connectUser(user, tokenOrProvider).catch((err) => {
         console.error(`Failed to establish connection`, err);

--- a/packages/react-native-sdk/src/hooks/useCreateStreamVideoClient.tsx
+++ b/packages/react-native-sdk/src/hooks/useCreateStreamVideoClient.tsx
@@ -43,18 +43,12 @@ export const useCreateStreamVideoClient = ({
   tokenOrProvider,
   user,
   options,
-  isAnonymous = false,
 }: StreamVideoClientInit) => {
   const [client] = useState(() => new StreamVideoClient(apiKey, options));
 
   const disconnectRef = useRef(Promise.resolve());
   useEffect(() => {
     const connectionPromise = disconnectRef.current.then(() => {
-      if (isAnonymous) {
-        return client.connectUser(user, tokenOrProvider).catch((err) => {
-          console.error(`Failed to establish connection`, err);
-        });
-      }
       return client.connectUser(user, tokenOrProvider).catch((err) => {
         console.error(`Failed to establish connection`, err);
       });
@@ -69,7 +63,7 @@ export const useCreateStreamVideoClient = ({
     };
     // we want to re-run this effect only in some special cases
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiKey, tokenOrProvider, client, isAnonymous, user?.id]);
+  }, [apiKey, tokenOrProvider, client, user?.id]);
 
   return client;
 };

--- a/sample-apps/react/livestream-app/src/viewers/WebRTCLivestream.tsx
+++ b/sample-apps/react/livestream-app/src/viewers/WebRTCLivestream.tsx
@@ -5,6 +5,7 @@ import {
   StreamCall,
   StreamVideo,
   StreamVideoClient,
+  User,
 } from '@stream-io/video-react-sdk';
 import { useParams } from 'react-router-dom';
 import { ViewerHeader } from './ui/ViewerHeader';
@@ -41,11 +42,11 @@ export const WebRTCLivestream = () => {
       return;
     }
 
-    const user = {
-      id: 'anonymous',
+    const user: User = {
+      type: 'anonymous',
     };
     client
-      .connectAnonymousUser(user, tokenProvider)
+      .connectUser(user, tokenProvider)
       .catch((err) => console.error('Failed to establish connection', err));
 
     return () => {

--- a/sample-apps/react/messenger-clone/src/types/chat.ts
+++ b/sample-apps/react/messenger-clone/src/types/chat.ts
@@ -7,7 +7,7 @@ export type CommandType = LiteralStringForUnion;
 export type EventType = UR;
 export type MessageType = UR;
 export type ReactionType = UR;
-export type UserType = User;
+export type UserType = Omit<User, 'type'>;
 
 export type StreamChatType = {
   attachmentType: AttachmentType;

--- a/sample-apps/react/react-video-demo/src/App.tsx
+++ b/sample-apps/react/react-video-demo/src/App.tsx
@@ -73,7 +73,7 @@ const Init: FC<Props> = ({ incomingCallId, logo, user, token, apiKey }) => {
     apiKey,
     tokenOrProvider: token,
     userData: {
-      id: user.id,
+      id: user.id || '!anon',
       name: user.name,
       image: user.image,
     },


### PR DESCRIPTION
## Fix the problem with user type definitions
- `User` type is used for `connectUser`
- `OwnUserResponse` is used for `useConnectedUser`

## Update `connectUser` signature

- Regular/guest/anon authentication all done using `connectUser`, `type` param is used to tell if we want to connect a regular, guest or anonymous user
- Guest users are now created by `connectUser`, no need to create them beforehand

Docs update will be in separate PR