### PR TITLE
fix: prevent misleading "stop publish" log messages upon call instantiation

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -278,8 +278,7 @@ export class Call {
           const hasPermission = this.permissionsContext.hasPermission(
             permission as OwnCapability,
           );
-          const isPublishingTrack = this.publisher.isPublishing(trackType);
-          if (!hasPermission && isPublishingTrack) {
+          if (!hasPermission && this.publisher.isPublishing(trackType)) {
             this.stopPublish(trackType).catch((err) => {
               console.error('Error stopping publish', trackType, err);
             });

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -264,22 +264,27 @@ export class Call {
         // update the permission context.
         this.permissionsContext.setPermissions(ownCapabilities);
 
+        if (!this.publisher) return;
+
         // check if the user still has publishing permissions and stop publishing if not.
         const permissionToTrackType = {
           [OwnCapability.SEND_AUDIO]: TrackType.AUDIO,
           [OwnCapability.SEND_VIDEO]: TrackType.VIDEO,
           [OwnCapability.SCREENSHARE]: TrackType.SCREEN_SHARE,
         };
-        Object.entries(permissionToTrackType).forEach(([permission, type]) => {
+        for (const [permission, trackType] of Object.entries(
+          permissionToTrackType,
+        )) {
           const hasPermission = this.permissionsContext.hasPermission(
             permission as OwnCapability,
           );
-          if (!hasPermission) {
-            this.stopPublish(type).catch((err) => {
-              console.error('Error stopping publish', type, err);
+          const isPublishingTrack = this.publisher.isPublishing(trackType);
+          if (!hasPermission && isPublishingTrack) {
+            this.stopPublish(trackType).catch((err) => {
+              console.error('Error stopping publish', trackType, err);
             });
           }
-        });
+        }
       }),
 
       // handles the case when the user is blocked by the call owner.

--- a/packages/client/src/rtc/publisher.ts
+++ b/packages/client/src/rtc/publisher.ts
@@ -219,11 +219,11 @@ export class Publisher {
    *
    * @param trackType the track type to check.
    */
-  isPublishing = (trackType: TrackType) => {
+  isPublishing = (trackType: TrackType): boolean => {
     const transceiverForTrackType = this.transceiverRegistry[trackType];
     if (transceiverForTrackType && transceiverForTrackType.sender) {
       const sender = transceiverForTrackType.sender;
-      return sender.track && sender.track.readyState === 'live';
+      return !!sender.track && sender.track.readyState === 'live';
     }
     return false;
   };

--- a/packages/client/src/rtc/publisher.ts
+++ b/packages/client/src/rtc/publisher.ts
@@ -214,6 +214,20 @@ export class Publisher {
     }
   };
 
+  /**
+   * Returns true if the given track type is currently being published to the SFU.
+   *
+   * @param trackType the track type to check.
+   */
+  isPublishing = (trackType: TrackType) => {
+    const transceiverForTrackType = this.transceiverRegistry[trackType];
+    if (transceiverForTrackType && transceiverForTrackType.sender) {
+      const sender = transceiverForTrackType.sender;
+      return sender.track && sender.track.readyState === 'live';
+    }
+    return false;
+  };
+
   private notifyTrackMuteStateChanged = async (
     mediaStream: MediaStream | undefined,
     track: MediaStreamTrack,


### PR DESCRIPTION
### Overview

Bail out from invoking `stopPublish(trackType)` unless the current user already publishes a track.
This change eliminates the misleading `Stop publishing <KIND>` messages upon call instantiation or load.