### PR TITLE
fix: do not send ring to backend if call was not created by the user

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -469,21 +469,22 @@ export class Call {
    * @param params.ring if set to true, a `call.ring` event will be sent to the call members.
    * @param params.notify if set to true, a `call.notification` event will be sent to the call members.
    * @param params.members_limit the members limit.
+   * @param makeRinging if set to true, the `state.callingState` will change to 'ringing'.
    */
-  get = async (params?: {
-    ring?: boolean;
-    notify?: boolean;
-    members_limit?: number;
-  }) => {
+  get = async (
+    params?: {
+      ring?: boolean;
+      notify?: boolean;
+      members_limit?: number;
+    },
+    makeRinging = false,
+  ) => {
     const response = await this.streamClient.get<GetCallResponse>(
       this.streamClientBasePath,
-      {
-        ...params,
-        ring: this.isCreatedByMe ? params?.ring : false,
-      },
+      params,
     );
 
-    if (params?.ring && !this.ringing) {
+    if ((params?.ring || makeRinging) && !this.ringing) {
       this.ringingSubject.next(true);
     }
 

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -477,7 +477,10 @@ export class Call {
   }) => {
     const response = await this.streamClient.get<GetCallResponse>(
       this.streamClientBasePath,
-      params,
+      {
+        ...params,
+        ring: this.isCreatedByMe ? params?.ring : false,
+      },
     );
 
     if (params?.ring && !this.ringing) {

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -469,22 +469,18 @@ export class Call {
    * @param params.ring if set to true, a `call.ring` event will be sent to the call members.
    * @param params.notify if set to true, a `call.notification` event will be sent to the call members.
    * @param params.members_limit the members limit.
-   * @param makeRinging if set to true, the `state.callingState` will change to 'ringing'.
    */
-  get = async (
-    params?: {
-      ring?: boolean;
-      notify?: boolean;
-      members_limit?: number;
-    },
-    makeRinging = false,
-  ) => {
+  get = async (params?: {
+    ring?: boolean;
+    notify?: boolean;
+    members_limit?: number;
+  }) => {
     const response = await this.streamClient.get<GetCallResponse>(
       this.streamClientBasePath,
       params,
     );
 
-    if ((params?.ring || makeRinging) && !this.ringing) {
+    if (params?.ring && !this.ringing) {
       this.ringingSubject.next(true);
     }
 

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -210,7 +210,7 @@ export class StreamVideoClient {
         }
 
         // we fetch the latest metadata for the call from the server
-        await theCall.get({ ring: true });
+        await theCall.get(undefined, true);
         this.writeableStateStore.registerCall(theCall);
       }),
     );

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -195,7 +195,7 @@ export class StreamVideoClient {
 
         // The call might already be tracked by the client,
         // if `call.created` was received before `call.ring`.
-        // In that case, we cleanup reuse the already tracked call.
+        // In that case, we cleanup the already tracked call.
         const prevCall = this.writeableStateStore.findCall(call.type, call.id);
         await prevCall?.leave();
         // we create a new call

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -195,22 +195,20 @@ export class StreamVideoClient {
 
         // The call might already be tracked by the client,
         // if `call.created` was received before `call.ring`.
-        // In that case, we just reuse the already tracked call.
-        let theCall = this.writeableStateStore.findCall(call.type, call.id);
-        if (!theCall) {
-          // otherwise, we create a new call
-          theCall = new Call({
-            streamClient: this.streamClient,
-            type: call.type,
-            id: call.id,
-            members,
-            clientStore: this.writeableStateStore,
-            ringing: true,
-          });
-        }
-
+        // In that case, we cleanup reuse the already tracked call.
+        const prevCall = this.writeableStateStore.findCall(call.type, call.id);
+        await prevCall?.leave();
+        // we create a new call
+        const theCall = new Call({
+          streamClient: this.streamClient,
+          type: call.type,
+          id: call.id,
+          members,
+          clientStore: this.writeableStateStore,
+          ringing: true,
+        });
         // we fetch the latest metadata for the call from the server
-        await theCall.get(undefined, true);
+        await theCall.get();
         this.writeableStateStore.registerCall(theCall);
       }),
     );


### PR DESCRIPTION
Without this fix, while ringing the BE keeps on sending call.ring events, it causes an infinite loop until joined/rejected as below 

```
call.ring -> send ring to BE -> call.ring -> send ring to BE call.ring -> send ring to BE  ......... until call is joined or rejected
```

Now if ring param is set.. only the ringing rx subject is set to true and we don't send to BE. This ensures that we have a local state of ringing.