### PR TITLE
fix(client): do not allow to re-join left call

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -579,6 +579,12 @@ export class Call {
       throw new Error(`Illegal State: Already joined.`);
     }
 
+    if (this.state.callingState === CallingState.LEFT) {
+      throw new Error(
+        'Illegal State: Cannot join already left call. Create a new Call instance to join a call.',
+      );
+    }
+
     const previousCallingState = this.state.callingState;
     this.state.setCallingState(CallingState.JOINING);
 


### PR DESCRIPTION
Rejoining of a left call with the same Call instance does not reinstantiate the event handlers and so until we figure out, how to properly clean up the state, we should not allow to re-join a call with the same Call instance.

Applications that keep Call instances in the app state would not react to events arriving over the WS.

A new instance should be added to the app state as follows:

```ts
await call.leave();
  const newCall = client.call(call.type, call.id);
  await newCall.get();

  setCalls((prevCalls) => [
    ...prevCalls.map((c) => {
      return c.cid === call.cid ? newCall : c;
    }),
  ]);
```

