### PR TITLE
docs: Restructure device management guide

### DIFF
--- a/packages/react-sdk/docusaurus/docs/React/02-guides/04-camera-and-microphone.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/04-camera-and-microphone.mdx
@@ -4,55 +4,202 @@ title: Camera & Microphone
 description: Docs on the media manager
 ---
 
-:::warning
-INTERNAL NOTE: add links to tutorials on how to build custom UI components using the API described in this article
-:::
+Handling audio and video devices in a web application means working with [`MediaStream`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream), [`MediaDeviceInfo`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo) and other WebRTC API objects. We did our best to hide this complexity inside the `MediaDevicesProvider`. The easiest way to set up the provider is by using the [`StreamCall`](../../ui-components/core/stream-call), but it's also possible to use the `MediaDevicesProvider` directly.
 
-Handling audio and video devices in a web application means working with [`MediaStream`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream), [`MediaDeviceInfo`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo) and other WebRTC API objects. We did our best to hide this complexity away by providing a set of tools we will discuss in this article.
+## Camera management
 
-The device management as we understand it encompasses the following:
+### Call settings
 
-- Enumeration of currently connected devices
-- Handling device removal or addition of a device
-- Handling unavailability of certain kind of device (video or audio)
-- Switching the devices
-- Enabling and disabling media
-- Publishing our media streams (audio, video) so that other call participants can hear and see us
+The default state of the camera is determined by the call settings:
 
-### Device management API provider
+```typescript
+const metadata = useCallMetadata();
 
-The React SDK comes with the main device state API context provider component [`MediaDevicesProvider`](../../call-engine/hooks-and-contexts#mediadevicesprovider). It exposes an API [`MediaDevicesContextAPI`](../../call-engine/hooks-and-contexts#mediadevicescontextapi) to handle the main part of the above listed features. You may use [`MediaDevicesProvider`](../../call-engine/hooks-and-contexts/#mediadevicesprovider) to build custom components. The provider is also used internally by SDK's pre-built [`StreamCall`](../../ui-components/core/stream-call) component.
-å
-:::warning
-If you decide to use `StreamCall` component in your app, **make sure not to render [`MediaDevicesProvider`](../../call-engine/hooks-and-contexts/#mediadevicesprovider) in any of its child components again**. This would lead to [`MediaDevicesProvider`](../../call-engine/hooks-and-contexts/#mediadevicesprovider) being rendered multiple times and would result in redundant stream publishing and audio / video malfunctioning.
-:::
+metadata?.settings?.video.camera_default_on;
+```
 
-Internally, [`MediaDevicesProvider`](../../call-engine/hooks-and-contexts/#mediadevicesprovider) puts in place mechanisms that:
+### Start-stop camera
 
-1. fall back to selecting a default device when trying to switch to a non-existent device
-2. fall back to a default device when an active device is disconnected
-3. stop publishing a media stream when a non-default device is disconnected
-4. republish a media stream from the newly connected default device
-5. republish a media stream when a new device is selected
+```typescript
+const localParticipant = useLocalParticipant();
+const isVideoMute = !localParticipant?.publishedTracks.includes(
+  SfuModels.TrackType.VIDEO,
+);
+const { toggleVideoMuteState } = useToggleVideoMuteState();
 
-On the other hand, [`MediaDevicesProvider`](../../call-engine/hooks-and-contexts/#mediadevicesprovider) exposes in [`MediaDevicesContextAPI`](../../call-engine/hooks-and-contexts#mediadevicescontextapi) functions that allow the integrators to handle:
+console.log(`Camera is ${isVideoMute ? 'off' : 'on'}`);
+toggleVideoMuteState();
+```
 
-1. the initial device state enablement (for example for lobby scenario)
-2. media stream retrieval and disposal
-3. media stream publishing
-4. specific device selection
+### List and select devices
 
-### Device enumeration
+```typescript
+const { selectedVideoDeviceId, switchDevice } = useMediaDevices();
+const videoDevices = useVideoDevices(); // This will prompt for camera access
 
-Besides [`MediaDevicesProvider`](../../call-engine/hooks-and-contexts/#mediadevicesprovider) there are the following device enumeration hooks that keep an up-to-date list of connected devices of a given kind:
+console.log(`Current device: ${selectedVideoDeviceId}`);
+console.log('Video devices: ', videoDevices);
+switchDevice('videoinput', '<device id>');
+```
 
-- [`useVideoDevices`](../../call-engine/hooks-and-contexts#usevideodevices)
-- [`useAudioInputDevices`](../../call-engine/hooks-and-contexts#useaudioinputdevices)
-- [`useAudioOutputDevices`](../../call-engine/hooks-and-contexts#useaudiooutputdevices)
+### Lobby preview
 
-:::info
-We use these hooks in pre-built components like [`VideoPreview`](../../ui-components/participants/video-preview) and [`DeviceSelector` components](../../ui-components/participants/device-settings).
-:::
+Here is how to setup a video preview displayed before joining the call:
+
+```typescript
+const [stream, setStream] = useState<MediaStream>();
+const {
+  selectedVideoDeviceId,
+  getVideoStream,
+  initialVideoState,
+  setInitialVideoState,
+} = useMediaDevices();
+
+const videoDevices = useVideoDevices();
+
+useEffect(() => {
+  if (!initialVideoState.enabled) return;
+
+  getVideoStream({ deviceId: selectedVideoDeviceId })
+    .then((s) => {
+      setStream((previousStream) => {
+        if (previousStream) {
+          disposeOfMediaStream(previousStream);
+        }
+        return s;
+      });
+    })
+    .catch((e) =>
+      setInitialVideoState({
+        ...DEVICE_STATE.error,
+        message: (e as Error).message,
+      }),
+    );
+  return () => {
+    setStream(undefined);
+  };
+}, [
+  initialVideoState,
+  getVideoStream,
+  selectedVideoDeviceId,
+  setInitialVideoState,
+  videoDevices.length,
+]);
+```
+
+### Client-side settings
+
+It's possible to preselect the camera device and its state. A potential use-case would be to apply the user's previous choices loaded from `localStorage`.
+
+```tsx
+export const App = () => {
+  const call = /* ... */;
+
+  return (
+    <StreamCall call={call} mediaDevicesProviderProps={{
+        initialVideoEnabled: true, // This will override the state from call settings
+        initialVideoInputDeviceId: '...'
+    }}>
+      <MyUI />
+    </StreamCall>
+  );
+};
+```
+
+## Microphone management
+
+### Call settings
+
+The default state of the microphone is determined by the call settings:
+
+```typescript
+const metadata = useCallMetadata();
+
+metadata?.settings?.audio.mic_default_on;
+```
+
+### Start-stop microphone
+
+```typescript
+const localParticipant = useLocalParticipant();
+const isAudioMute = !localParticipant?.publishedTracks.includes(
+  SfuModels.TrackType.AUDIO,
+);
+
+console.log(`Mic is ${isAudioMute ? 'off' : 'on'}`);
+const { toggleAudioMuteState } = useToggleAudioMuteState();
+```
+
+### List and select devices
+
+```typescript
+const { selectedAudioInputDeviceId, switchDevice } = useMediaDevices();
+const audioInputDevices = useAudioInputDevices(); // This will prompt for microphone access
+
+console.log(`Current device: ${selectedAudioInputDeviceId}`);
+console.log('Audio devices: ', audioInputDevices);
+switchDevice('audioinput', '<device id>');
+```
+
+### Client-side settings
+
+It's possible to preselect the microphone device and its state. A potential use-case would be to apply the user's previous choices loaded from `localStorage`.
+
+```tsx
+export const App = () => {
+  const call = /* ... */;
+
+  return (
+    <StreamCall call={call} mediaDevicesProviderProps={{
+        initialAudioEnabled: true, // This will override the state from call settings
+        initialAudioInputDeviceId: '...'
+    }}>
+      <MyUI />
+    </StreamCall>
+  );
+};
+```
+
+## Speaker management
+
+### Browser support
+
+Selecting audio output device for the call [isn't supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/sinkId), this is how you can check the availability:
+
+```typescript
+const { isAudioOutputChangeSupported } = useMediaDevices();
+```
+
+### List and select devices
+
+```typescript
+const { selectedAudioOutputDeviceId, switchDevice } = useMediaDevices();
+const audioOutputDevices = useAudioOutputDevices(); // This will prompt for microphone access
+
+console.log(`Current device: ${selectedAudioOutputDeviceId}`);
+console.log('Audio output devices: ', audioOutputDevices);
+switchDevice('audiooutput', '<device id>');
+```
+
+### Client-side settings
+
+It's possible to preselect the speaker device. A potential use-case would be to apply the user's previous choices loaded from `localStorage`.
+
+```tsx
+export const App = () => {
+  const call = /* ... */;
+
+  return (
+    <StreamCall call={call} mediaDevicesProviderProps={{
+        initialAudioOutputDeviceId: '...'
+    }}>
+      <MyUI />
+    </StreamCall>
+  );
+};
+```
+
+## Advanced
 
 ### Device unavailability
 
@@ -66,62 +213,9 @@ It may happen, that we would like to react to a situation, when there is no devi
 The `useOnUnavailableVideoDevices` hook is used in a pre-build component [`VideoPreview`](../../ui-components/participants/video-preview). Even after video device reconnection, the video preview is not restarted automatically and has to be enabled back manually by a user.
 :::
 
-## Device management
+### Sound detection
 
-In the next few sections we will revisit the device management topic in more depth. All the features are supported by [`MediaDevicesContextAPI`](../../call-engine/hooks-and-contexts#mediadevicescontextapi).
-
-:::info
-We can access the [`MediaDevicesContextAPI`](../../call-engine/hooks-and-contexts#mediadevicescontextapi) context object with context consumer [`useMediaDevices`](../../call-engine/hooks-and-contexts#usemediadevices).
-:::
-
-### Initial device state
-
-An example, where we might want to control initial device state is a lobby page, where user prepares for joining a call. The initial device state can be configured through the [`MediaDevicesProviderProps`](../../call-engine/hooks-and-contexts/#mediadevicesproviderprops). Overriding the default audio (microphone) and video (camera) enablement or device selection can come handy when we have in place a custom logic. An example could be applying the previous user preferences stored in `localStorage`.
-
-Taking this further, [`MediaDevicesContextAPI`](../../call-engine/hooks-and-contexts#mediadevicescontextapi) exposes the following functions that allow us to change the defaults by user interacting with the app's components before joining a call.
-
-To control the initial device enablement, please, use the following functions (we include a reference to where these are already used):
-
-| Function                      | Used in pre-built component                                                                                                                                            |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setInitialAudioEnabled`      | [`ToggleAudioPublishingButton`](../../ui-components/call/call-controls/#toggleaudiopublishingbutton)                                                                   |
-| `setInitialVideoState`        | [`VideoPreview`](../../ui-components/participants/video-preview), [`ToggleVideoPublishingButton`](../../ui-components/call/call-controls/#togglevideopublishingbutton) |
-| `toggleInitialAudioMuteState` | [`ToggleAudioPreviewButton`](../../ui-components/call/call-controls/#toggleaudiopreviewbutton)                                                                         |
-| `toggleInitialVideoMuteState` | [`ToggleVideoPreviewButton`](../../ui-components/call/call-controls/#togglevideopreviewbutton)                                                                         |
-
-To control device selection, even in the preview/initial mode, the [`MediaDevicesContextAPI`](../../call-engine/hooks-and-contexts#mediadevicescontextapi) exposes function `switchDevice`. We will learn more about switching devices in the upcoming section.
-
-### Switching devices
-
-The device change in both the preview and active call scenario should be done by calling `switchDevice`. [`MediaDevicesProvider`](../../call-engine/hooks-and-contexts/#mediadevicesprovider) will handle both changing the value of selected device id (`selectedAudioInputDeviceId`, `selectedAudioOutputDeviceId` or `selectedVideoDeviceId` depending on `kind` argument) as well as republishing the stream corresponding to the given device id.
-
-The prebuilt components that make use of `switchDevice` function are:
-
-- [`DeviceSelectorAudioInput`](../../ui-components/participants/device-settings)
-- [`DeviceSelectorAudioOutput`](../../ui-components/participants/device-settings/)
-- [`DeviceSelectorVideo`](../../ui-components/participants/device-settings/)
-
-### Publishing media streams
-
-In case we would like to implement custom device controls for publishing video and audio stream, we will have to surely use the following functions from `MediaDevicesContextAPI`:
-
-| Function                                    | Used in pre-built component                                                                          |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `publishAudioStream`, `stopPublishingAudio` | [`ToggleAudioPublishingButton`](../../ui-components/call/call-controls/#toggleaudiopublishingbutton) |
-| `publishVideoStream`, `stopPublishingVideo` | [`ToggleVideoPublishingButton`](../../ui-components/call/call-controls/#togglevideopublishingbutton) |
-
-### Working with media streams
-
-If need be, we can even start working on lower level by retrieving media streams and dispose of them. This can come handy when the aim is to create custom components like [`VideoPreview`](../../ui-components/participants/video-preview). By providing selected device id, we can hook into the device's [media stream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) and start reacting to events emitted, or handling component state.
-
-The functions we provide to access the media streams are:
-
-- `disposeOfMediaStream`
-- `getAudioStream`
-- `getVideoStream`
-
-## Sound detection
-An important topic related to media devices management is sound detection. A feature often needed in a call scenario (volume detection, speaking-while-muted notification). We can start detecting the audio input level changes using the utility function [`createSoundDetector`](https://github.com/GetStream/stream-video-js/tree/main/packages/client/src/helpers/sound-detector.ts).  The function requires an instance of [`MediaStream`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) object of type `audioinput` and attaches sound analysers to it. The `MediaStream` can be retrieved by the SDK's `getAudioStream` utility function. Then it periodically collects audio frequency data. We can access this data by providing the `onSoundDetectedStateChanged` callback function. The callback function will be passed and object of type [`SoundDetectorState`](https://github.com/GetStream/stream-video-js/tree/main/packages/client/src/helpers/sound-detector.ts) as argument. From the object we can extract the information about the audio level (`audioLevel`) or a more simplified general flag that tells us, whether sound was detected (`isSoundDetected`).
+An important topic related to media devices management is sound detection. A feature often needed in a call scenario (volume detection, speaking-while-muted notification). We can start detecting the audio input level changes using the utility function [`createSoundDetector`](https://github.com/GetStream/stream-video-js/tree/main/packages/client/src/helpers/sound-detector.ts). The function requires an instance of [`MediaStream`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) object of type `audioinput` and attaches sound analysers to it. The `MediaStream` can be retrieved by the SDK's `getAudioStream` utility function. Then it periodically collects audio frequency data. We can access this data by providing the `onSoundDetectedStateChanged` callback function. The callback function will be passed and object of type [`SoundDetectorState`](https://github.com/GetStream/stream-video-js/tree/main/packages/client/src/helpers/sound-detector.ts) as argument. From the object we can extract the information about the audio level (`audioLevel`) or a more simplified general flag that tells us, whether sound was detected (`isSoundDetected`).
 
 It is also possible to configure the data collection algorithm with the third [`options` parameter](https://github.com/GetStream/stream-video-js/tree/main/packages/client/src/helpers/sound-detector.ts).
 


### PR DESCRIPTION
## Aim of the PR
- Match structure with Android SDK (ours is still a bit more verbose)
- Provide more code examples and less explanatory text

## Sidenote

While writing the docs I noticed a few things:
- The API calls/data is scattered around a lot of places: we have the `useMediaDevices` for switching, we have the `useToggle...MuteState` for start/stop, and we have the `useLocalParticipant` for getting the device state.
- There is duplication between the `useMediaDevices` hook and between the `useToggle...MuteState` hooks - both can be used for starting/stopping camera/mic, it's confusing.
- We have totally separate API for device management for the lobby screen and after we joined a call. This basically means that our API is 2x the size it could be. I think we should hide that complexity.