### PR TITLE
docs: Add reference tables to state docs

### DIFF
--- a/packages/react-bindings/src/hooks/call.ts
+++ b/packages/react-bindings/src/hooks/call.ts
@@ -2,7 +2,7 @@ import { useObservableValue } from './helpers/useObservableValue';
 import { useCallState, useStore } from './store';
 
 /**
- * Utility hook which provides information whether the current call is being recorded.
+ * Utility hook which provides information whether the current call is being recorded. It will return `true` if the call is being recorded.
  *
  * @category Call State
  */
@@ -112,7 +112,7 @@ export const useCallRecordings = () => {
 };
 
 /**
- * Utility hook providing the current calling state of the call.
+ * Utility hook providing the current calling state of the call. For example, `RINGING` or `JOINED`.
  *
  * @category Call State
  */
@@ -122,7 +122,7 @@ export const useCallCallingState = () => {
 };
 
 /**
- * Utility hook providing the actual start time of the call.
+ * Utility hook providing the actual start time of the current session.
  * Useful for calculating the call duration.
  *
  * @category Call State

--- a/packages/react-bindings/src/hooks/permissions.ts
+++ b/packages/react-bindings/src/hooks/permissions.ts
@@ -3,7 +3,7 @@ import { useCallState } from './store';
 import { useObservableValue } from './helpers/useObservableValue';
 
 /**
- * Hook that returns true if the current user has all the given permissions.
+ * Hook that returns true if the local participant has all the given permissions.
  *
  * @param permissions the permissions to check.
  *
@@ -15,7 +15,7 @@ export const useHasPermissions = (...permissions: OwnCapability[]): boolean => {
 };
 
 /**
- * A hook which returns the current user's own capabilities.
+ * A hook which returns the local participant's own capabilities.
  *
  * @category Call State
  */

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
@@ -39,14 +39,57 @@ This approach makes it possible to access the call state and be notified about c
 
 The `StreamCall` component uses the `StreamCallProvider` under the hood.
 
+Here are all the call-related state hooks:
+
+| Name                              | Description                                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `useCall`                         | The `Call` instance that is registered with `StreamCall`. You need the `Call` instance to initiate API calls. |
+| `useIsCallRecordingInProgress`    | It's' `true` if the call is being recorded.                                                                   |
+| `useIsCallBroadcastingInProgress` | It's `true` if the call is being broadcasted.                                                                 |
+| `useIsCallLive`                   | It's `true` if the call is currently live.                                                                    |
+| `useCallMembers`                  | The list of call members                                                                                      |
+| `useCallCallingState`             | Provides information about the call state. For example, `RINGING`, `JOINED` or `RECONNECTING`.                |
+| `useCallStartedAt`                | The actual start time of the current call session.                                                            |
+| `useCallStatsReport`              | When stats gathering is enabled, this observable will emit a new value at a regular (configurable) interval.  |
+| `useCallMetadata`                 | The `CallResponse`, see below for more information.                                                           |
+| `useCallRecordings`               | The latest list of recordings performed during the call.                                                      |
+| `useHasOngoingScreenShare`        | It will return `true` if at least one participant is sharing their screen.                                    |
+| `useDominantSpeaker`              | The participant that is the current dominant speaker of the call.                                             |
+| `useOwnCapabilities`              | The capabilities of the local participant.                                                                    |
+| `useHasPermissions`               | Returns `true` if the local participant has all the given permissions.                                        |
+| `useCallPermissionRequest`        | The latest call permission request.                                                                           |
+
+The `CallResponse` object contains the following information:
+
+| Name               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `backstage`        | It's `true` if the call is in backstage mode.           |
+| `blocked_user_ids` | The users who are blocked from this call.               |
+| `created_at`       | The time the call was created.                          |
+| `created_by`       | The creator of the call.                                |
+| `custom`           | Custom data attached to the call.                       |
+| `egress`           | Broadcasting related information.                       |
+| `ended_at`         | When the call was ended.                                |
+| `ingress`          | RTMP publishing related information.                    |
+| `recording`        | It's `true` if the call is being recorded.              |
+| `session`          | Information related to the current session of the call. |
+| `settings`         | The settings for this call.                             |
+| `starts_at`        | The scheduled start time of the call.                   |
+| `team`             | Team that the call is restricted to.                    |
+| `type`             | The type of the call.                                   |
+| `updated_at`       | When the call was updated.                              |
+
 ## Participant state
 
 If you want to display information about the joined participants of the call you can use these hooks:
 
-- `useLocalParticipant`: the local participant is the logged-in user
-- `useRemoteParticipants`: all participants except the local participant
-- `useParticipants`: all participants, including local and remote participants
-- `useParticipantCount`: the approximate participant count of the active call. This includes the [anonymous users](../client-auth/#anonymous-users) as well, it is computed on the server-side.
+| Name                           | Description                                                                                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useLocalParticipant`          | The local participant is the logged-in user.                                                                                                                           |
+| `useRemoteParticipants`        | All participants except the local participant.                                                                                                                         |
+| `useParticipants`              | All participants, including local and remote participants.                                                                                                             |
+| `useParticipantCount`          | The approximate participant count of the active call. This includes the [anonymous users](../client-auth/#anonymous-users) as well, it is computed on the server-side. |
+| `useAnonymousParticipantCount` | The approximate participant count of anonymous users in the active call.                                                                                               |
 
 ```tsx
 export default function App() {
@@ -71,6 +114,32 @@ const CallUI = () => {
   );
 };
 ```
+
+The `StreamVideoParticipant` object contains the following information:
+
+| Name                 | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| `user`               | The user object for this participant.                                       |
+| `publishedTracks`    | The track types the participant is currently publishing                     |
+| `joinedAt`           | The time the participant joined the call.                                   |
+| `connectionQuality`  | The participant's connection quality.                                       |
+| `isSpeaking`         | It's `true` if the participant is currently speaking.                       |
+| `isDominantSpeaker`  | It's `true` if the participant is the current dominant speaker in the call. |
+| `audioLevel`         | The audio level of the participant.                                         |
+| `audioStream`        | The published audio `MediaStream`.                                          |
+| `videoStream`        | The published video `MediaStream`.                                          |
+| `screenShareStream`  | The published screen share `MediaStream`.                                   |
+| `isLocalParticipant` | It's `true` if the participant is the local participant.                    |
+| `pinnedAt`           | The time the participant was pinned.                                        |
+| `reaction`           | The last reaction this user has sent to this call.                          |
+
+The `StreamVideoLocalParticipant` has these additional properties:
+
+| Name                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `audioDeviceId`       | The device ID of the currently selected audio input device.  |
+| `videoDeviceId`       | The device ID of the currently selected video input device.  |
+| `audioOutputDeviceId` | The device ID of the currently selected audio output device. |
 
 ## Client state
 
@@ -98,3 +167,26 @@ const Header = () => {
 ```
 
 This approach makes it possible to access the client state and be notified about changes anywhere in your application without having to manually subscribe to WebSocket events.
+
+Here are the list of client-state hooks:
+
+| Name                   | Description                                                                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useStreamVideoClient` | The `StreamVideoClient` instance.                                                                                                           |
+| `useConnectedUser`     | Returns the connected user.                                                                                                                 |
+| `useCalls`             | A list of all notifications about created calls. These calls can be outgoing (I have called somebody) or incoming (somebody has called me). |
+
+The `UserResponse` contains the following properties:
+
+| Name         | Description                                           |
+| ------------ | ----------------------------------------------------- |
+| `created_at` | The time the user was created.                        |
+| `custom`     | Custom user data.                                     |
+| `deleted_at` | The time the user was deleted.                        |
+| `devices`    | The registered push notification devices of the user. |
+| `id`         | The id of the user.                                   |
+| `image`      | The profile image of the user.                        |
+| `name`       | The name of the user.                                 |
+| `role`       | The role of the user.                                 |
+| `teams`      | The teams the user belongs to.                        |
+| `updated_at` | The time when the user was updated.                   |


### PR DESCRIPTION
Based on: https://staging.getstream.io/video/docs/android/guides/call-and-participant-state/

From now on we should make sure to update these tables when something in the code changes.

cc @vanGalilea 