### PR TITLE
fix: proper media stream disposal for rn webrtc

### DIFF
--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -342,4 +342,9 @@ export const disposeOfMediaStream = (stream: MediaStream) => {
     track.stop();
     stream.removeTrack(track);
   });
+  // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the stream
+  if (typeof stream.release === 'function') {
+    // @ts-expect-error
+    stream.release();
+  }
 };


### PR DESCRIPTION
Got from https://github.com/react-native-webrtc/react-native-webrtc/issues/1364

without this we get `android.hardware.camera2.CameraAccessException: CAMERA_ERROR (3): cancelRequest:601: Camera 1: Error clearing streaming request: Function not implemented (-38)` randomly on Android