### PR TITLE
fix: prevent unmute after reconnect

### DIFF
--- a/packages/react-sdk/src/core/hooks/useAudioPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useAudioPublisher.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { map } from 'rxjs';
 import {
   CallingState,
@@ -58,13 +58,23 @@ export const useAudioPublisher = ({
     }
   }, [audioDeviceId, call]);
 
+  const initialPublishRun = useRef(false);
   useEffect(() => {
-    if (callingState === CallingState.JOINED && !initialAudioMuted) {
-      publishAudioStream().catch((e) => {
-        console.error('Failed to publish audio stream', e);
-      });
+    if (callingState === CallingState.JOINED) {
+      if (
+        (!initialAudioMuted && !initialPublishRun.current) ||
+        (isPublishingAudio && initialPublishRun.current)
+      ) {
+        // automatic publishing should happen only when:
+        // - joining the call from the lobby, and the audio is not muted
+        // - reconnecting to the call with the audio already published
+        publishAudioStream().catch((e) => {
+          console.error('Failed to publish audio stream', e);
+        });
+        initialPublishRun.current = true;
+      }
     }
-  }, [callingState, initialAudioMuted, publishAudioStream]);
+  }, [callingState, initialAudioMuted, isPublishingAudio, publishAudioStream]);
 
   useEffect(() => {
     if (!localParticipant$ || !canObserveAudio) return;

--- a/packages/react-sdk/src/core/hooks/useAudioPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useAudioPublisher.ts
@@ -60,21 +60,20 @@ export const useAudioPublisher = ({
 
   const initialPublishRun = useRef(false);
   useEffect(() => {
-    if (callingState === CallingState.JOINED) {
-      if (
-        (!initialAudioMuted && !initialPublishRun.current) ||
-        (isPublishingAudio && initialPublishRun.current)
-      ) {
-        // automatic publishing should happen only when:
-        // - joining the call from the lobby, and the audio is not muted
-        // - reconnecting to the call with the audio already published
-        publishAudioStream().catch((e) => {
-          console.error('Failed to publish audio stream', e);
-        });
-        initialPublishRun.current = true;
-      }
+    if (
+      callingState === CallingState.JOINED &&
+      !initialAudioMuted &&
+      !initialPublishRun.current
+    ) {
+      // automatic publishing should happen only when:
+      // - joining the call from the lobby, and the audio is not muted
+      // - reconnecting to the call with the audio already published
+      publishAudioStream().catch((e) => {
+        console.error('Failed to publish audio stream', e);
+      });
+      initialPublishRun.current = true;
     }
-  }, [callingState, initialAudioMuted, isPublishingAudio, publishAudioStream]);
+  }, [callingState, initialAudioMuted, publishAudioStream]);
 
   useEffect(() => {
     if (!localParticipant$ || !canObserveAudio) return;

--- a/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
@@ -77,21 +77,20 @@ export const useVideoPublisher = ({
 
   const initialPublishRun = useRef(false);
   useEffect(() => {
-    if (callingState === CallingState.JOINED) {
-      if (
-        (!initialVideoMuted && !initialPublishRun.current) ||
-        (isPublishingVideo && initialPublishRun.current)
-      ) {
-        // automatic publishing should happen only when:
-        // - joining the call from the lobby, and the video is not muted
-        // - reconnecting to the call with the video already published
-        publishVideoStream().catch((e) => {
-          console.error('Failed to publish video stream', e);
-        });
-        initialPublishRun.current = true;
-      }
+    if (
+      callingState === CallingState.JOINED &&
+      !initialVideoMuted &&
+      !initialPublishRun.current
+    ) {
+      // automatic publishing should happen only when:
+      // - joining the call from the lobby, and the video is not muted
+      // - reconnecting to the call with the video already published
+      publishVideoStream().catch((e) => {
+        console.error('Failed to publish video stream', e);
+      });
+      initialPublishRun.current = true;
     }
-  }, [callingState, initialVideoMuted, isPublishingVideo, publishVideoStream]);
+  }, [callingState, initialVideoMuted, publishVideoStream]);
 
   useEffect(() => {
     if (!localParticipant$ || !canObserveVideo) return;

--- a/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { map } from 'rxjs';
 import {
   CallingState,
@@ -75,13 +75,23 @@ export const useVideoPublisher = ({
     videoSettings?.camera_facing,
   ]);
 
+  const initialPublishRun = useRef(false);
   useEffect(() => {
-    if (callingState === CallingState.JOINED && !initialVideoMuted) {
-      publishVideoStream().catch((e) => {
-        console.error('Failed to publish video stream', e);
-      });
+    if (callingState === CallingState.JOINED) {
+      if (
+        (!initialVideoMuted && !initialPublishRun.current) ||
+        (isPublishingVideo && initialPublishRun.current)
+      ) {
+        // automatic publishing should happen only when:
+        // - joining the call from the lobby, and the video is not muted
+        // - reconnecting to the call with the video already published
+        publishVideoStream().catch((e) => {
+          console.error('Failed to publish video stream', e);
+        });
+        initialPublishRun.current = true;
+      }
     }
-  }, [callingState, initialVideoMuted, publishVideoStream]);
+  }, [callingState, initialVideoMuted, isPublishingVideo, publishVideoStream]);
 
   useEffect(() => {
     if (!localParticipant$ || !canObserveVideo) return;


### PR DESCRIPTION
### Overview

Audio and Video mute states used to restore to their initial values set in the Lobby when a reconnect event occurs although the participant might muted self throughout the call.
This PR ensures that automatic audio/video publishing happens only when:
- joining the call from the Lobby screen with audio or video enabled
- reconnecting to a call while audio or video streams are still in "publish" state