### PR TITLE
feat: Make it possible to opt-out from Sentry tracking

### DIFF
--- a/packages/react-dogfood/sentry.server.config.js
+++ b/packages/react-dogfood/sentry.server.config.js
@@ -11,7 +11,13 @@ Sentry.init({
     SENTRY_DSN ||
     'https://fe0b0bd8c3244e9fa3cb8e252f4a4ceb@o14368.ingest.sentry.io/4504044576374784',
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
+  tracesSampler: samplingContext => {
+    if (Object.keys(samplingContext.request?.headers || {}).includes('x-react-dogfood-no-trace')) {
+      return 0.0;
+    } else {
+      return 1.0;
+    }
+  }
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
If a React Dogfood request has the header `x-react-dogfood-no-trace` we won't sent the request data to Sentry.