### PR TITLE
refactor(react-bindings): remove availableGrants from RestrictedProps

### DIFF
--- a/packages/react-bindings/src/wrappers/Restricted.tsx
+++ b/packages/react-bindings/src/wrappers/Restricted.tsx
@@ -10,10 +10,6 @@ type RestrictedProps = PropsWithChildren<{
    */
   requiredGrants: OwnCapability[];
   /**
-   * OwnCapabilities of the participant - grants they have available
-   */
-  availableGrants?: OwnCapability[];
-  /**
    * Render children only if user can request capability, but does not have it
    */
   canRequestOnly?: boolean;
@@ -29,7 +25,6 @@ type RestrictedProps = PropsWithChildren<{
 }>;
 
 export const Restricted = ({
-  availableGrants: availableGrantsFromProps,
   canRequestOnly,
   hasPermissionsOnly,
   requiredGrants,
@@ -38,9 +33,8 @@ export const Restricted = ({
 }: RestrictedProps) => {
   const call = useCall();
   const ownCapabilities = useOwnCapabilities();
-  const availableGrants = availableGrantsFromProps ?? ownCapabilities;
   const hasPermissions = requiredGrants[requireAll ? 'every' : 'some'](
-    (capability) => availableGrants.includes(capability),
+    (capability) => ownCapabilities.includes(capability),
   );
 
   if (hasPermissionsOnly) return hasPermissions ? <>{children}</> : null;

--- a/packages/react-sdk/src/components/CallParticipantsList/CallParticipantsList.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/CallParticipantsList.tsx
@@ -9,7 +9,6 @@ import {
   Restricted,
   useCall,
   useCallMetadata,
-  useOwnCapabilities,
   useParticipants,
 } from '@stream-io/video-react-bindings';
 import {
@@ -45,7 +44,7 @@ type CallParticipantListProps = {
   activeUsersSearchFn?: UseSearchParams<StreamVideoParticipant>['searchFn'];
   /** Custom function to override the searching logic of blocked users */
   blockedUsersSearchFn?: UseSearchParams<string>['searchFn'];
-  /** Interval in ms, during which the participant search calls will be throttled. The default value is 200ms. */
+  /** Interval in ms, during which the participant search calls will be debounced. The default value is 200ms. */
   debounceSearchInterval?: number;
 };
 
@@ -114,7 +113,6 @@ const CallParticipantListContentHeader = ({
     React.SetStateAction<keyof typeof UserListTypes>
   >;
 }) => {
-  const ownCapabilities = useOwnCapabilities();
   const call = useCall();
 
   const muteAll = () => {
@@ -142,8 +140,8 @@ const CallParticipantListContentHeader = ({
         <span>{UserListTypes[userListType]}</span>
         {userListType === 'active' && (
           <Restricted
-            availableGrants={ownCapabilities} // TODO: remove this line once Oliver's PR lands
             requiredGrants={[OwnCapability.MUTE_USERS]}
+            hasPermissionsOnly
           >
             <TextButton onClick={muteAll}>Mute all</TextButton>
           </Restricted>


### PR DESCRIPTION
The prop was used in a single place and relied on the same source of data. According to todo note, the plan was to remove it.