### PR TITLE
feat(react-dogfood): add "beforeunload" event handler

### DIFF
--- a/sample-apps/react/react-dogfood/components/MeetingUI.tsx
+++ b/sample-apps/react/react-dogfood/components/MeetingUI.tsx
@@ -33,7 +33,11 @@ import {
   UnreadCountBadge,
 } from '.';
 import { ActiveCallHeader } from './ActiveCallHeader';
-import { useKeyboardShortcuts, useWatchChannel } from '../hooks';
+import {
+  useBeforeUnload,
+  useKeyboardShortcuts,
+  useWatchChannel,
+} from '../hooks';
 import { DEFAULT_LAYOUT, getLayoutSettings, LayoutMap } from './LayoutSelector';
 import { Stage } from './Stage';
 import { ToggleParticipantListButton } from './ToggleParticipantListButton';
@@ -106,6 +110,11 @@ export const MeetingUI = ({ chatClient, enablePreview }: MeetingUIProps) => {
       setShow('error-leave');
     }
   }, [router]);
+
+  useBeforeUnload(
+    callState === CallingState.JOINED,
+    'Call in progress, are you sure you want to leave?',
+  );
 
   useEffect(() => {
     if (callState === CallingState.LEFT) {

--- a/sample-apps/react/react-dogfood/hooks/index.ts
+++ b/sample-apps/react/react-dogfood/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useChatClient';
 export * from './useWatchChannel';
 export * from './useKeyboardShortcuts';
+export * from './useBeforeUnload';

--- a/sample-apps/react/react-dogfood/hooks/useBeforeUnload.ts
+++ b/sample-apps/react/react-dogfood/hooks/useBeforeUnload.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export const useBeforeUnload = (enabled: boolean, message: string) => {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleBeforeUnload = (e: Event) => {
+      e.preventDefault(); // <- this does not work even though it's preffered way
+
+      // window.confirm does not work to display custom message
+      // @ts-expect-error
+      return (e.returnValue = message);
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [enabled, message]);
+};


### PR DESCRIPTION
This PR adds "beforeunload" handler which prompts users upon website reload or leave to prevent unwanted call leaves.

Known limitations:
- `event.returnValue` is deprecated, documentation suggests using `event.preventDefault()` which does not work - documentation also suggest using return value - which (surprise, surprise) also does not work ([compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#browser_compatibility))
- does not respect navigation changes (NextJS router ~solutions work~ - but prompt you twice)

Read more: https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#compatibility_notes