### PR TITLE
feat(react-native): align call participants list with figma

### DIFF
--- a/packages/react-native-sdk/__tests__/components/CallParticipantsView.test.tsx
+++ b/packages/react-native-sdk/__tests__/components/CallParticipantsView.test.tsx
@@ -73,6 +73,11 @@ describe('CallParticipantsView', () => {
     expect(
       participant1.getByLabelText(A11yComponents.PARTICIPANT_MEDIA_STREAM),
     ).toHaveProp('streamURL', 'audio-test-url');
+
+    // flat list should not be rendered for 2 participants as we should not wrap them in a grid
+    expect(
+      screen.queryByLabelText(A11yComponents.CALL_PARTICIPANTS_LIST),
+    ).toBeNull();
   });
   it('should render an call participants view with spotlight mode with 2 participants', async () => {
     const call = mockCall(mockClientWithUser(), [
@@ -103,6 +108,11 @@ describe('CallParticipantsView', () => {
       await screen.findByLabelText(
         A11yComponents.CALL_PARTICIPANTS_SPOTLIGHT_VIEW,
       ),
+    ).toBeVisible();
+
+    // Since it has a screen share and thereby spotlight, we should render the flatlist even with 2 participants
+    expect(
+      await screen.findByLabelText(A11yComponents.CALL_PARTICIPANTS_LIST),
     ).toBeVisible();
   });
 

--- a/packages/react-native-sdk/__tests__/components/CallParticipantsView.test.tsx
+++ b/packages/react-native-sdk/__tests__/components/CallParticipantsView.test.tsx
@@ -15,6 +15,7 @@ enum P_IDS {
   LOCAL_1 = 'local-1',
   REMOTE_1 = 'remote-1',
   REMOTE_2 = 'remote-2',
+  REMOTE_3 = 'remote-3',
 }
 
 const simulateOnViewableItemsChanged = async (
@@ -43,7 +44,7 @@ describe('CallParticipantsView', () => {
         userId: P_IDS.LOCAL_1,
       }),
       mockParticipant({
-        publishedTracks: [SfuModels.TrackType.AUDIO, SfuModels.TrackType.VIDEO],
+        publishedTracks: [SfuModels.TrackType.AUDIO],
         sessionId: P_IDS.REMOTE_1,
         userId: P_IDS.REMOTE_1,
       }),
@@ -56,6 +57,22 @@ describe('CallParticipantsView', () => {
     expect(
       await screen.findByLabelText(A11yComponents.CALL_PARTICIPANTS_GRID_VIEW),
     ).toBeVisible();
+
+    // Locating and verifying that all ParticipantViews are rendered
+    const localParticipant = within(
+      screen.getByLabelText(A11yComponents.LOCAL_PARTICIPANT),
+    );
+    const participant1 = within(
+      screen.getByLabelText(`participant-${P_IDS.REMOTE_1}`),
+    );
+
+    expect(
+      localParticipant.getByLabelText(A11yComponents.PARTICIPANT_MEDIA_STREAM),
+    ).toHaveProp('streamURL', 'video-test-url');
+
+    expect(
+      participant1.getByLabelText(A11yComponents.PARTICIPANT_MEDIA_STREAM),
+    ).toHaveProp('streamURL', 'audio-test-url');
   });
   it('should render an call participants view with spotlight mode with 2 participants', async () => {
     const call = mockCall(mockClientWithUser(), [
@@ -89,7 +106,7 @@ describe('CallParticipantsView', () => {
     ).toBeVisible();
   });
 
-  it('should render an active call with 3 partic. local partic., partic. 2 muted video, partic. 3 muted audio', async () => {
+  it('should render an active call with 4 participants. partic. 1 local partic., partic. 2 muted video, partic. 3 muted audio, partic. 4 muted audio', async () => {
     const call = mockCall(mockClientWithUser(), [
       mockParticipant({
         isLocalParticipant: true,
@@ -107,6 +124,12 @@ describe('CallParticipantsView', () => {
         audioStream: null,
         sessionId: P_IDS.REMOTE_2,
         userId: P_IDS.REMOTE_2,
+      }),
+      mockParticipant({
+        publishedTracks: [SfuModels.TrackType.VIDEO],
+        audioStream: null,
+        sessionId: P_IDS.REMOTE_3,
+        userId: P_IDS.REMOTE_3,
       }),
     ]);
 
@@ -134,6 +157,10 @@ describe('CallParticipantsView', () => {
       screen.getByLabelText(`participant-${P_IDS.REMOTE_2}`),
     );
 
+    const participant3 = within(
+      screen.getByLabelText(`participant-${P_IDS.REMOTE_3}`),
+    );
+
     // Verifying that the local partic.'s video/audio are rendered within their respective participant
     expect(
       localParticipant.getByLabelText(A11yComponents.PARTICIPANT_MEDIA_STREAM),
@@ -144,9 +171,12 @@ describe('CallParticipantsView', () => {
     expect(
       participant2.getByLabelText(A11yComponents.PARTICIPANT_MEDIA_STREAM),
     ).toHaveProp('streamURL', 'video-test-url');
+    expect(
+      participant3.getByLabelText(A11yComponents.PARTICIPANT_MEDIA_STREAM),
+    ).toHaveProp('streamURL', 'video-test-url');
     // Verifying no extra/unknown RTCViews are rendered
     expect(
       screen.getAllByLabelText(A11yComponents.PARTICIPANT_MEDIA_STREAM),
-    ).toHaveLength(3);
+    ).toHaveLength(4);
   });
 });

--- a/packages/react-native-sdk/src/components/CallParticipantsList.tsx
+++ b/packages/react-native-sdk/src/components/CallParticipantsList.tsx
@@ -106,11 +106,11 @@ export const CallParticipantsList = (props: CallParticipantsListProps) => {
   }).current;
 
   // NOTE: key must be sessionId always as it is used to track viewable participants
-  const keyExtractor = useRef<FlatListProps['keyExtractor']>(
+  const keyExtractor = useRef<NonNullable<FlatListProps['keyExtractor']>>(
     (item) => item.sessionId,
   ).current;
 
-  const onLayout = useRef<FlatListProps['onLayout']>((event) => {
+  const onLayout = useRef<NonNullable<FlatListProps['onLayout']>>((event) => {
     const { height, width } = event.nativeEvent.layout;
     setContainerLayout((prev) => {
       if (prev.height === height && prev.width === width) {
@@ -160,12 +160,13 @@ export const CallParticipantsList = (props: CallParticipantsListProps) => {
   if (!shouldWrapByColumns) {
     return (
       <>
-        {participants.map((participant) => (
+        {participants.map((participant, index) => (
           <ParticipantView
             participant={participant}
             containerStyle={styles.flexed}
             kind="video"
             isVisible={true}
+            key={keyExtractor(participant, index)}
           />
         ))}
       </>

--- a/packages/react-native-sdk/src/components/CallParticipantsList.tsx
+++ b/packages/react-native-sdk/src/components/CallParticipantsList.tsx
@@ -155,7 +155,7 @@ export const CallParticipantsList = (props: CallParticipantsListProps) => {
 
   // in vertical mode, only when there are more than 2 participants in a call, the participants should be displayed in a grid
   // else we display them both in a stretched row on the screen
-  const shouldWrapByColumns = horizontal || participants.length > 2;
+  const shouldWrapByColumns = !!horizontal || participants.length > 2;
 
   if (!shouldWrapByColumns) {
     return (

--- a/packages/react-native-sdk/src/components/CallParticipantsSpotlightView.tsx
+++ b/packages/react-native-sdk/src/components/CallParticipantsSpotlightView.tsx
@@ -47,12 +47,13 @@ export const CallParticipantsSpotlightView = () => {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   participantView: {
-    flex: 1,
+    flex: 2,
     overflow: 'hidden',
     borderRadius: theme.rounded.sm,
     marginHorizontal: theme.padding.sm,
   },
   participantVideoContainer: {
+    flex: 1,
     paddingVertical: theme.padding.sm,
   },
 });

--- a/sample-apps/react-native/dogfood/src/components/ActiveCall.tsx
+++ b/sample-apps/react-native/dogfood/src/components/ActiveCall.tsx
@@ -7,10 +7,14 @@ import {
   useCall,
   useIncallManager,
 } from '@stream-io/video-react-native-sdk';
-import { ActivityIndicator, SafeAreaView, StyleSheet } from 'react-native';
+import { ActivityIndicator, StyleSheet } from 'react-native';
 import { appTheme } from '../theme';
 import { useChannelWatch } from '../hooks/useChannelWatch';
 import { useUnreadCount } from '../hooks/useUnreadCount';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 
 type ActiveCallProps = {
   chatButton?: {
@@ -39,12 +43,14 @@ export const ActiveCall = ({ chatButton }: ActiveCallProps) => {
    */
   useIncallManager({ media: 'video', auto: true });
 
+  const { bottom } = useSafeAreaInsets();
+
   if (!call) {
     return <ActivityIndicator size={'large'} style={StyleSheet.absoluteFill} />;
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
       <CallParticipantsBadge style={styles.iconGroup} />
       <CallParticipantsView />
       <CallControlsView
@@ -54,7 +60,10 @@ export const ActiveCall = ({ chatButton }: ActiveCallProps) => {
           },
           unreadBadgeCountIndicator,
         }}
-        style={styles.callControlsWrapper}
+        style={[
+          styles.callControlsWrapper,
+          { paddingBottom: Math.max(bottom, appTheme.spacing.lg) },
+        ]}
       />
     </SafeAreaView>
   );
@@ -65,17 +74,14 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: appTheme.colors.static_grey,
   },
-  callControlsWrapper: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    padding: appTheme.spacing.lg,
-  },
   iconGroup: {
     position: 'absolute',
     top: appTheme.spacing.lg,
     right: appTheme.spacing.sm,
     zIndex: appTheme.zIndex.IN_FRONT,
+  },
+  callControlsWrapper: {
+    paddingTop: appTheme.spacing.lg,
+    paddingHorizontal: appTheme.spacing.sm,
   },
 });

--- a/sample-apps/react-native/dogfood/src/components/ActiveCall.tsx
+++ b/sample-apps/react-native/dogfood/src/components/ActiveCall.tsx
@@ -43,7 +43,7 @@ export const ActiveCall = ({ chatButton }: ActiveCallProps) => {
    */
   useIncallManager({ media: 'video', auto: true });
 
-  const { bottom } = useSafeAreaInsets();
+  const { bottom, top } = useSafeAreaInsets();
 
   if (!call) {
     return <ActivityIndicator size={'large'} style={StyleSheet.absoluteFill} />;
@@ -51,7 +51,7 @@ export const ActiveCall = ({ chatButton }: ActiveCallProps) => {
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
-      <CallParticipantsBadge style={styles.iconGroup} />
+      <CallParticipantsBadge style={[styles.iconGroup, { top }]} />
       <CallParticipantsView />
       <CallControlsView
         chatButton={{
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
   },
   iconGroup: {
     position: 'absolute',
-    top: appTheme.spacing.lg,
+    marginTop: appTheme.spacing.lg,
     right: appTheme.spacing.sm,
     zIndex: appTheme.zIndex.IN_FRONT,
   },

--- a/sample-apps/react-native/dogfood/src/components/MeetingUI.tsx
+++ b/sample-apps/react-native/dogfood/src/components/MeetingUI.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useCall } from '@stream-io/video-react-native-sdk';
 import { MeetingStackParamList, ScreenTypes } from '../../types';
-import { Button, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { Button, StyleSheet, Text, View } from 'react-native';
 import { LobbyViewComponent } from './LobbyViewComponent';
 import { appTheme } from '../theme';
 import { ActiveCall } from './ActiveCall';

--- a/sample-apps/react-native/dogfood/src/components/MeetingUI.tsx
+++ b/sample-apps/react-native/dogfood/src/components/MeetingUI.tsx
@@ -53,15 +53,13 @@ export const MeetingUI = ({
     );
   } else {
     return (
-      <SafeAreaView style={styles.wrapper}>
-        <ActiveCall
-          chatButton={{
-            onPressHandler: () => {
-              navigation.navigate('ChatScreen', { callId });
-            },
-          }}
-        />
-      </SafeAreaView>
+      <ActiveCall
+        chatButton={{
+          onPressHandler: () => {
+            navigation.navigate('ChatScreen', { callId });
+          },
+        }}
+      />
     );
   }
 };
@@ -70,10 +68,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    backgroundColor: appTheme.colors.static_grey,
-  },
-  wrapper: {
-    flex: 1,
     backgroundColor: appTheme.colors.static_grey,
   },
   buttonsContainer: {


### PR DESCRIPTION
The changes: https://www.loom.com/share/b1065f4762bd4bf88ebdb790fc21ad75?sid=9fd5f403-958a-4368-913d-c0d25ed53858

In figma, on 1:1 calls the video stream takes the full space. This pattern can be seen in 2:1 calls too. 4:1 and then 6:1. 

When its more than 6 participants we start to scroll.

This PR implements the above behavior. 