### PR TITLE
fix: safeguard against potential race conditions during join-flow

### DIFF
--- a/packages/client/src/events/__tests__/participant.test.ts
+++ b/packages/client/src/events/__tests__/participant.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { Dispatcher } from '../../rtc';
 import { CallState } from '../../store';
-import { VisibilityState } from '../../types';
 import { TrackType } from '../../gen/video/sfu/models/models';
 import {
   watchParticipantJoined,
@@ -13,15 +11,12 @@ import {
 describe('Participant events', () => {
   describe('participantJoined / participantLeft', () => {
     it('adds and removes the participant to the list of participants', () => {
-      const dispatcher = new Dispatcher();
       const state = new CallState();
 
-      const offParticipantJoined = watchParticipantJoined(dispatcher, state);
-      const offParticipantLeft = watchParticipantLeft(dispatcher, state);
-      expect(offParticipantJoined).toBeDefined();
-      expect(offParticipantLeft).toBeDefined();
+      const onParticipantJoined = watchParticipantJoined(state);
+      const onParticipantLeft = watchParticipantLeft(state);
 
-      dispatcher.dispatch({
+      onParticipantJoined({
         eventPayload: {
           oneofKind: 'participantJoined',
           participantJoined: {
@@ -38,11 +33,10 @@ describe('Participant events', () => {
         {
           userId: 'user-id',
           sessionId: 'session-id',
-          viewportVisibilityState: VisibilityState.UNKNOWN,
         },
       ]);
 
-      dispatcher.dispatch({
+      onParticipantLeft({
         eventPayload: {
           oneofKind: 'participantLeft',
           participantLeft: {
@@ -61,15 +55,13 @@ describe('Participant events', () => {
 
   describe('trackPublished', () => {
     it('updates the participant track list', () => {
-      const dispatcher = new Dispatcher();
       const state = new CallState();
-      const handler = watchTrackPublished(dispatcher, state);
-      expect(handler).toBeDefined();
+      const handler = watchTrackPublished(state);
 
       // @ts-ignore setup one participant
       state.setParticipants([{ sessionId: 'session-id', publishedTracks: [] }]);
 
-      dispatcher.dispatch({
+      handler({
         eventPayload: {
           oneofKind: 'trackPublished',
           // @ts-ignore
@@ -87,12 +79,10 @@ describe('Participant events', () => {
     });
 
     it('adds the participant to the list of participants if provided', () => {
-      const dispatcher = new Dispatcher();
       const state = new CallState();
-      const handler = watchTrackPublished(dispatcher, state);
-      expect(handler).toBeDefined();
+      const handler = watchTrackPublished(state);
 
-      dispatcher.dispatch({
+      handler({
         eventPayload: {
           oneofKind: 'trackPublished',
           // @ts-ignore
@@ -117,10 +107,8 @@ describe('Participant events', () => {
     });
 
     it('updates the participant info if the provided participant already exists', () => {
-      const dispatcher = new Dispatcher();
       const state = new CallState();
-      const handler = watchTrackPublished(dispatcher, state);
-      expect(handler).toBeDefined();
+      const handler = watchTrackPublished(state);
 
       state.setParticipants([
         // @ts-ignore setup one participant
@@ -131,7 +119,7 @@ describe('Participant events', () => {
         },
       ]);
 
-      dispatcher.dispatch({
+      handler({
         eventPayload: {
           oneofKind: 'trackPublished',
           // @ts-ignore
@@ -159,17 +147,15 @@ describe('Participant events', () => {
 
   describe('trackUnpublished', () => {
     it('updates the participant track list', () => {
-      const dispatcher = new Dispatcher();
       const state = new CallState();
-      const handler = watchTrackUnpublished(dispatcher, state);
-      expect(handler).toBeDefined();
+      const handler = watchTrackUnpublished(state);
 
       state.setParticipants([
         // @ts-ignore setup one participant
         { sessionId: 'session-id', publishedTracks: [TrackType.VIDEO] },
       ]);
 
-      dispatcher.dispatch({
+      handler({
         eventPayload: {
           oneofKind: 'trackUnpublished',
           // @ts-ignore
@@ -187,12 +173,10 @@ describe('Participant events', () => {
     });
 
     it('adds the participant to the list of participants if provided', () => {
-      const dispatcher = new Dispatcher();
       const state = new CallState();
-      const handler = watchTrackUnpublished(dispatcher, state);
-      expect(handler).toBeDefined();
+      const handler = watchTrackUnpublished(state);
 
-      dispatcher.dispatch({
+      handler({
         eventPayload: {
           oneofKind: 'trackUnpublished',
           // @ts-ignore
@@ -217,10 +201,8 @@ describe('Participant events', () => {
     });
 
     it('updates the participant info if the provided participant already exists', () => {
-      const dispatcher = new Dispatcher();
       const state = new CallState();
-      const handler = watchTrackUnpublished(dispatcher, state);
-      expect(handler).toBeDefined();
+      const handler = watchTrackUnpublished(state);
 
       state.setParticipants([
         // @ts-ignore setup one participant
@@ -232,7 +214,7 @@ describe('Participant events', () => {
         },
       ]);
 
-      dispatcher.dispatch({
+      handler({
         eventPayload: {
           oneofKind: 'trackUnpublished',
           // @ts-ignore

--- a/packages/client/src/events/__tests__/participant.test.ts
+++ b/packages/client/src/events/__tests__/participant.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CallState } from '../../store';
+import { VisibilityState } from '../../types';
 import { TrackType } from '../../gen/video/sfu/models/models';
 import {
   watchParticipantJoined,
@@ -33,6 +34,7 @@ describe('Participant events', () => {
         {
           userId: 'user-id',
           sessionId: 'session-id',
+          viewportVisibilityState: VisibilityState.UNKNOWN,
         },
       ]);
 

--- a/packages/client/src/events/callEventHandlers.ts
+++ b/packages/client/src/events/callEventHandlers.ts
@@ -98,11 +98,11 @@ export const registerEventHandlers = (
     watchConnectionQualityChanged(dispatcher, state),
     watchParticipantCountChanged(dispatcher, state),
 
-    watchParticipantJoined(dispatcher, state),
-    watchParticipantLeft(dispatcher, state),
+    call.on('participantJoined', watchParticipantJoined(state)),
+    call.on('participantLeft', watchParticipantLeft(state)),
 
-    watchTrackPublished(dispatcher, state),
-    watchTrackUnpublished(dispatcher, state),
+    call.on('trackPublished', watchTrackPublished(state)),
+    call.on('trackUnpublished', watchTrackUnpublished(state)),
 
     watchAudioLevelChanged(dispatcher, state),
     watchDominantSpeakerChanged(dispatcher, state),

--- a/packages/client/src/events/participant.ts
+++ b/packages/client/src/events/participant.ts
@@ -1,33 +1,31 @@
-import { Dispatcher } from '../rtc';
-import { VisibilityState } from '../types';
+import { SfuEvent } from '../gen/video/sfu/event/events';
 import { CallState } from '../store';
 
 /**
  * An event responder which handles the `participantJoined` event.
  */
-export const watchParticipantJoined = (
-  dispatcher: Dispatcher,
-  state: CallState,
-) => {
-  return dispatcher.on('participantJoined', (e) => {
+export const watchParticipantJoined = (state: CallState) => {
+  return function onParticipantJoined(e: SfuEvent) {
     if (e.eventPayload.oneofKind !== 'participantJoined') return;
     const { participant } = e.eventPayload.participantJoined;
     if (!participant) return;
-    state.setParticipants((participants) => [
-      ...participants,
-      { ...participant, viewportVisibilityState: VisibilityState.UNKNOWN },
-    ]);
-  });
+    // `state.updateOrAddParticipant` acts as a safeguard against
+    // potential duplicate events from the SFU.
+    //
+    // Although the SFU should not send duplicate events, we have seen
+    // some race conditions in the past during the `join-flow` where
+    // the SFU would send participant info as part of the `join`
+    // response and then follow up with a `participantJoined` event for
+    // already announced participants.
+    state.updateOrAddParticipant(participant.sessionId, participant);
+  };
 };
 
 /**
  * An event responder which handles the `participantLeft` event.
  */
-export const watchParticipantLeft = (
-  dispatcher: Dispatcher,
-  state: CallState,
-) => {
-  return dispatcher.on('participantLeft', (e) => {
+export const watchParticipantLeft = (state: CallState) => {
+  return function onParticipantLeft(e: SfuEvent) {
     if (e.eventPayload.oneofKind !== 'participantLeft') return;
     const { participant } = e.eventPayload.participantLeft;
     if (!participant) return;
@@ -35,18 +33,15 @@ export const watchParticipantLeft = (
     state.setParticipants((participants) =>
       participants.filter((p) => p.sessionId !== participant.sessionId),
     );
-  });
+  };
 };
 
 /**
  * An event responder which handles the `trackPublished` event.
  * The SFU will send this event when a participant publishes a track.
  */
-export const watchTrackPublished = (
-  dispatcher: Dispatcher,
-  state: CallState,
-) => {
-  return dispatcher.on('trackPublished', (e) => {
+export const watchTrackPublished = (state: CallState) => {
+  return function onTrackPublished(e: SfuEvent) {
     if (e.eventPayload.oneofKind !== 'trackPublished') return;
     const {
       trackPublished: { type, sessionId, participant },
@@ -57,24 +52,21 @@ export const watchTrackPublished = (
     // events, and instead, it would only provide the participant's information
     // once they start publishing a track.
     if (participant) {
-      state.updateOrAddParticipant(participant.sessionId, participant);
+      state.updateOrAddParticipant(sessionId, participant);
     } else {
       state.updateParticipant(sessionId, (p) => ({
         publishedTracks: [...p.publishedTracks, type].filter(unique),
       }));
     }
-  });
+  };
 };
 
 /**
  * An event responder which handles the `trackUnpublished` event.
  * The SFU will send this event when a participant unpublishes a track.
  */
-export const watchTrackUnpublished = (
-  dispatcher: Dispatcher,
-  state: CallState,
-) => {
-  return dispatcher.on('trackUnpublished', (e) => {
+export const watchTrackUnpublished = (state: CallState) => {
+  return function onTrackUnpublished(e: SfuEvent) {
     if (e.eventPayload.oneofKind !== 'trackUnpublished') return;
     const {
       trackUnpublished: { type, sessionId, participant },
@@ -82,13 +74,13 @@ export const watchTrackUnpublished = (
 
     // An optimization for large calls. See `watchTrackPublished`.
     if (participant) {
-      state.updateOrAddParticipant(participant.sessionId, participant);
+      state.updateOrAddParticipant(sessionId, participant);
     } else {
       state.updateParticipant(sessionId, (p) => ({
         publishedTracks: p.publishedTracks.filter((t) => t !== type),
       }));
     }
-  });
+  };
 };
 
 const unique = <T>(v: T, i: number, arr: T[]) => arr.indexOf(v) === i;

--- a/packages/client/src/events/participant.ts
+++ b/packages/client/src/events/participant.ts
@@ -1,4 +1,5 @@
 import { SfuEvent } from '../gen/video/sfu/event/events';
+import { StreamVideoParticipant, VisibilityState } from '../types';
 import { CallState } from '../store';
 
 /**
@@ -17,7 +18,15 @@ export const watchParticipantJoined = (state: CallState) => {
     // the SFU would send participant info as part of the `join`
     // response and then follow up with a `participantJoined` event for
     // already announced participants.
-    state.updateOrAddParticipant(participant.sessionId, participant);
+    state.updateOrAddParticipant(
+      participant.sessionId,
+      Object.assign<StreamVideoParticipant, Partial<StreamVideoParticipant>>(
+        participant,
+        {
+          viewportVisibilityState: VisibilityState.UNKNOWN,
+        },
+      ),
+    );
   };
 };
 


### PR DESCRIPTION
### Overview

Although the SFU should not send duplicate events, we have seen some race conditions in the past during the `join-flow` where the SFU would send participant info as part of the `join` response and then follow up with a `participantJoined` event for already announced participants.

As part of this PR, I also took the time to decouple the event listener subscription from the actual event handler.