### PR TITLE
docs: Unify UI components structure

### DIFF
--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/call-controls.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/call-controls.mdx
@@ -43,12 +43,6 @@ const CallUI = () => {
 
 A callback to be called after the call is left using the hangup button.
 
-## Customization
-
-You can create your own custom component using the [built-in call controls](#built-in-call-controls) as building blocks.
-
-If you want to create custom call controls, follow the [Call Controls UI Cookbook guide](../../../ui-cookbook/replacing-call-controls/) for more information.
-
 ## Built-in call controls
 
 Each call control is available as a separate UI component. Each component takes care of authorization.
@@ -174,3 +168,9 @@ The component can be used to show/hide the [call statistics](../../../ui-compone
 #### Props
 
 None
+
+## Customization
+
+You can create your own custom component using the [built-in call controls](#built-in-call-controls) as building blocks.
+
+If you want to create custom call controls, follow the [Call Controls UI Cookbook guide](../../../ui-cookbook/replacing-call-controls/) for more information.

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/call-recording-list.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/call-recording-list.mdx
@@ -14,48 +14,63 @@ The [`CallRecordingList`](https://github.com/GetStream/stream-video-js/tree/main
 - `EmptyCallRecordingList`
 - `LoadingCallRecordingList`
 
+<ImageShowcase
+  items={[
+    {
+      image: EmptyCallRecordingList,
+      caption: 'Empty call recording list',
+      alt: 'Empty call recording list',
+    },
+    {
+      image: LoadingCallRecordingList,
+      caption: 'Loading call recording list',
+      alt: 'Loading call recording list',
+    },
+  ]}
+/>
+
+## General usage
+
+```tsx
+import { CallRecording, CallRecordingList } from '@stream-io/video-react-sdk';
+
+const CallRecordings = () => {
+  let callRecordings: CallRecording[];
+
+  return <CallRecordingList callRecordings={callRecordings} />;
+};
+```
+
 :::note
 The `CallRecordingList` component just displays the data. It does not retrieve the call recordings data. See the [call recording guide](../../../advanced/recording) to learn more about retrieving the call recording data.
 :::
 
-<ImageShowcase
-    items={[
-        {
-            image: EmptyCallRecordingList,
-            caption: 'Empty call recording list',
-            alt: 'Empty call recording list',
-        },
-        {
-            image: LoadingCallRecordingList,
-            caption: 'Loading call recording list',
-            alt: 'Loading call recording list',
-        },
-    ]}
-/>
-
 ## Call recording list components
+
 The components rendered by [`CallRecordingList`](https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk/src/components/CallRecordingList) can be overridden through `CallRecordingListProps`. The default components descriptions follow.
 
-
 ### CallRecordingListHeader
+
 Component rendering title and call recordings count as well as a button to query the latest state of call recordings.
 
 #### Props
 
 | Name             | Description                    | Type              |
-|------------------|--------------------------------|-------------------|
+| ---------------- | ------------------------------ | ----------------- |
 | `callRecordings` | Array of CallRecording objects | `CallRecording[]` |
 
 ### CallRecordingListItem
+
 Component displays download link, copy-to-clipboard link button and recording date as a recording identifier.
 
 #### Props
 
 | Name            | Description                       | Type            |
-|-----------------|-----------------------------------|-----------------|
+| --------------- | --------------------------------- | --------------- |
 | `callRecording` | CallRecording object to represent | `CallRecording` |
 
 ### EmptyCallRecordingList
+
 Component displayed instead of `CallRecordingListItem` list if there are no recordings associated with the given call.
 
 #### Props
@@ -63,64 +78,65 @@ Component displayed instead of `CallRecordingListItem` list if there are no reco
 None
 
 ### LoadingCallRecordingList
+
 Component displayed while the latest call recordings data is queried. The default implementation renders the current call recording list and a loading indicator at the bottom.
 
 #### Props
 
 | Name             | Description                                     | Type              |
-|------------------|-------------------------------------------------|-------------------|
+| ---------------- | ----------------------------------------------- | ----------------- |
 | `callRecordings` | Array of currently loaded CallRecording objects | `CallRecording[]` |
-
 
 ## Props
 
 ### `callRecordings`
 
 | Type              |
-|-------------------|
+| ----------------- |
 | `CallRecording[]` |
-
 
 Array of CallRecording objects to be displayed.
 
 ### `CallRecordingListHeader`
 
 | Type                                                         |
-|--------------------------------------------------------------|
+| ------------------------------------------------------------ |
 | `ComponentType<CallRecordingListHeaderProps>` \| `undefined` |
-
 
 Custom component to replace the default header implementation.
 
 ### `CallRecordingListItem`
 
-| Type                                                         |
-|--------------------------------------------------------------|
-| `ComponentType<CallRecordingListItemProps>` \| `undefined`   |
-
+| Type                                                       |
+| ---------------------------------------------------------- |
+| `ComponentType<CallRecordingListItemProps>` \| `undefined` |
 
 Custom component to replace the default list item implementation.
 
 ### `EmptyCallRecordingList`
 
-| Type                             |
-|----------------------------------|
-| `ComponentType` \| `undefined`   |
+| Type                           |
+| ------------------------------ |
+| `ComponentType` \| `undefined` |
 
 Custom component to replace the default empty list component implementation.
 
 ### `loading`
 
-| Type                       |
-|----------------------------|
-| `boolean` \| `undefined`   |
+| Type                     |
+| ------------------------ |
+| `boolean` \| `undefined` |
 
 Signals that a request for new list of CallRecording object has been initiated.
 
 ### `LoadingCallRecordingList`
 
-| Type                                                            |
-|-----------------------------------------------------------------|
-| `ComponentType<LoadingCallRecordingListProps>` \| `undefined`   |
+| Type                                                          |
+| ------------------------------------------------------------- |
+| `ComponentType<LoadingCallRecordingListProps>` \| `undefined` |
 
 Custom component to be rendered when `loading` is true.
+
+## Customization
+
+The `CallRecordingList` component accepts UI components as [props](#props-4) to override parts of the displayed UI. It's also possible to build your own call recordings UI from scratch.

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/pending-call-panel.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/call/pending-call-panel.mdx
@@ -28,9 +28,21 @@ The component [`PendingCallPanel`](https://github.com/GetStream/stream-video-js/
   ]}
 />
 
-:::note
-To learn more about creating custom pending call panel, have a look at our [pending call panel customization guide](../../../ui-cookbook/pending-call).
-:::
+## General usage
+
+```tsx
+import { Call, PendingCallPanel, StreamCall } from '@stream-io/video-react-sdk';
+
+const PendingCall = () => {
+  let call: Call;
+
+  return (
+    <StreamCall call={call}>
+      <PendingCallPanel />
+    </StreamCall>
+  );
+};
+```
 
 ## Pending call controls
 
@@ -57,3 +69,7 @@ The maximum number of members to show.
 ## Props PendingCallControls
 
 None
+
+## Customization
+
+If you want to create your own pending call panel, have a look at our [pending call panel customization guide](../../../ui-cookbook/pending-call).

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/call-layout.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/call-layout.mdx
@@ -67,10 +67,6 @@ const MyApp = () => {
 };
 ```
 
-## Customization
-
-Both [built-in layouts](#built-in-layouts) allow for some customization of the layout via props. However, it's also possible to create your own layout, see our [Custom Call Layout guide](../../../ui-cookbook/video-layout) for more information.
-
 ## Built-in Layouts
 
 ### `PaginatedGridLayout`
@@ -95,3 +91,7 @@ Both [built-in layouts](#built-in-layouts) allow for some customization of the l
 | `ParticipantViewUISpotlight` | The participant UI for the spotlight view, [see `ParticipantView` documentation](../../../ui-components/core/participant-view/#participantviewui)          | [See `ParticipantView` documentation](../../../ui-components/core/participant-view/#participantviewui) |
 | `ParticipantViewUIBar`       | The participant UI for the participants in the bar, [see `ParticipantView` documentation](../../../ui-components/core/participant-view/#participantviewui) | [See `ParticipantView` documentation](../../../ui-components/core/participant-view/#participantviewui) |
 | `VideoPlaceholder`           | [See `ParticipantView` documentation](../../../ui-components/core/participant-view/#videoplaceholder)                                                      | [See `ParticipantView` documentation](../../../ui-components/core/participant-view/#videoplaceholder)  |
+
+## Customization
+
+If the [built-in layouts](#built-in-layouts) aren't what you're looking for, it's also possible to create your own layout, see our [Custom Call Layout guide](../../../ui-cookbook/video-layout) for more information.

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/stream-video.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/core/stream-video.mdx
@@ -1,0 +1,55 @@
+---
+id: stream-video
+title: StreamVideo
+---
+
+The `<StreamVideo />` provider makes the [client and its state](../../../guides/call-and-participant-state) available to all child components and initializes [internationalization](../../../advanced/i18n/)
+
+## General usage
+
+```tsx
+import { StreamVideo, StreamVideoClient } from '@stream-io/video-react-sdk';
+
+export const App = () => {
+  const client = new StreamVideoClient(/* ... */);
+
+  return (
+    // highlight-next-line
+    <StreamVideo client={client}>
+      <MyUI />
+    </StreamVideo>
+  );
+};
+```
+
+## Props
+
+### `client`
+
+| Type                |
+| ------------------- |
+| `StreamVideoClient` |
+
+### `i18nInstance`
+
+| Type                        |
+| --------------------------- |
+| `StreamI18n` \| `undefined` |
+
+The `StreamI18n` instance to use, if `undefined` is provided, a new instance will be created. For more information, see our [Internationalization guide](../../../advanced/i18n/).
+
+### `language`
+
+| Type                    | Default |
+| ----------------------- | ------- |
+| `string` \| `undefined` | en      |
+
+The language to translate UI labels. For more information, see our [Internationalization guide](../../../advanced/i18n/).
+
+### `translationsOverrides`
+
+| Type                             |
+| -------------------------------- |
+| `TranslationsMap` \| `undefined` |
+
+Custom translations that will be merged with the defaults provided by the library. For more information, see our [Internationalization guide](../../../advanced/i18n/).

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/call-participants-list.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/call-participants-list.mdx
@@ -4,29 +4,30 @@ title: Participants list
 ---
 
 import ImageShowcase from '@site/src/components/ImageShowcase';
-import CallParticipantsList  from '../../assets/03-ui-components/call-participant-list/call-participant-list.png';
-import CallParticipantsListWithAdminActions  from '../../assets/03-ui-components/call-participant-list/call-participant-list-with-admin-actions-menu.png';
-import CallParticipantsListWithUserActions  from '../../assets/03-ui-components/call-participant-list/call-participant-list-with-user-actions-menu.png';
+import CallParticipantsList from '../../assets/03-ui-components/call-participant-list/call-participant-list.png';
+import CallParticipantsListWithAdminActions from '../../assets/03-ui-components/call-participant-list/call-participant-list-with-admin-actions-menu.png';
+import CallParticipantsListWithUserActions from '../../assets/03-ui-components/call-participant-list/call-participant-list-with-user-actions-menu.png';
 
 The SDK provides a default implementation for listing call participants in `CallParticipantsList` component.
+
 <ImageShowcase
-    items={[
-        {
-            image: CallParticipantsList,
-            caption: 'Default UI of call participant list',
-            alt: 'Default UI of call participant list',
-        },
-        {
-            image: CallParticipantsListWithAdminActions,
-            caption: 'Default UI of call participant list with admin actions menu',
-            alt: 'Default UI of call participant list with admin actions menu',
-        },
-        {
-            image: CallParticipantsListWithUserActions,
-            caption: 'Default UI of call participant list with user actions menu',
-            alt: 'Default UI of call participant list with user actions menu',
-        },
-    ]}
+  items={[
+    {
+      image: CallParticipantsList,
+      caption: 'Default UI of call participant list',
+      alt: 'Default UI of call participant list',
+    },
+    {
+      image: CallParticipantsListWithAdminActions,
+      caption: 'Default UI of call participant list with admin actions menu',
+      alt: 'Default UI of call participant list with admin actions menu',
+    },
+    {
+      image: CallParticipantsListWithUserActions,
+      caption: 'Default UI of call participant list with user actions menu',
+      alt: 'Default UI of call participant list with user actions menu',
+    },
+  ]}
 />
 
 The component supports the following features:
@@ -37,36 +38,60 @@ The component supports the following features:
 - mute all users by call owners
 - per user actions like pin, block etc. (depends on each participant's permissions)
 
+## General usage
+
+```tsx
+import {
+  Call,
+  CallParticipantsList,
+  StreamCall,
+} from '@stream-io/video-react-sdk';
+
+const ParticipantList = () => {
+  let call: Call;
+
+  return (
+    <StreamCall call={call}>
+      <CallParticipantsList />
+    </StreamCall>
+  );
+};
+```
+
 ## Props
 
 ### `activeUsersSearchFn`
 
-| Type                    |
-| ----------------------- |
+| Type                                                                        |
+| --------------------------------------------------------------------------- |
 | `(searchQuery: string) => Promise<StreamVideoParticipant[]>` \| `undefined` |
 
 Custom function to override the searching logic of active participants.
 
 ### `blockedUsersSearchFn`
 
-| Type                    |
-| ----------------------- |
+| Type                                                        |
+| ----------------------------------------------------------- |
 | `(searchQuery: string) => Promise<string[]>` \| `undefined` |
 
 Custom function to override the searching logic of blocked users.
 
 ### `debounceSearchInterval`
 
-| Type                    | Default             |
-| ----------------------- | ------------------- |
-| `number` \| `undefined` |        `200`        |
+| Type                    | Default |
+| ----------------------- | ------- |
+| `number` \| `undefined` | `200`   |
 
 Interval in ms, during which the participant search calls will be debounced.
 
 ### `onClose`
 
 | Type         |
-|--------------|
+| ------------ |
 | `() => void` |
 
 Click event listener function to be invoked in order to dismiss/hide the CallParticipantsList from the UI.
+
+## Customization
+
+You can create your own participant list using the SDK's [participant hooks](../../../guides/call-and-participant-state/#participant-state).

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/device-settings.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/device-settings.mdx
@@ -17,12 +17,6 @@ The SDK's default implementation of device settings components consists of audio
 
 There is also a composing component `DeviceSettings` putting these together.
 
-All the selector components make use of [`MediaDevicesContextAPI`](../../../guides/camera-and-microphone) to switch the device. To list the devices, each selector component relies on corresponding hook for listing devices by media kind:
-
-- `useVideoDevices`
-- `useAudioInputDevices`
-- `useAudioOutputDevices`
-
 <ImageShowcase
   items={[
     {
@@ -47,6 +41,44 @@ All the selector components make use of [`MediaDevicesContextAPI`](../../../guid
     },
   ]}
 />
+
+## General usage
+
+```tsx
+import { Call, DeviceSettings, StreamCall } from '@stream-io/video-react-sdk';
+
+const DevicePanel = () => {
+  let call: Call;
+
+  return (
+    <StreamCall call={call}>
+      <DeviceSettings />
+    </StreamCall>
+  );
+};
+```
+
+Or use the components individually:
+
+```tsx
+import {
+  Call,
+  DeviceSelectorAudioInput,
+  DeviceSelectorVideo,
+  StreamCall,
+} from '@stream-io/video-react-sdk';
+
+const DevicePanel = () => {
+  let call: Call;
+
+  return (
+    <StreamCall call={call}>
+      <DeviceSelectorVideo />
+      <DeviceSelectorAudioInput />
+    </StreamCall>
+  );
+};
+```
 
 ## Props
 
@@ -83,3 +115,7 @@ String displayed at the top of the selector component.
 | `string` \| `undefined` | `'Select Speakers'` |
 
 String displayed at the top of the selector component.
+
+## Customization
+
+If you want to create your own component, you can make use of [`MediaDevicesContextAPI`](../../../guides/camera-and-microphone) to list and select devices.

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/video-preview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/video-preview.mdx
@@ -8,11 +8,7 @@ import ErrorVideoPreview from '../../assets/03-ui-components/video-preview/error
 import NoCameraPreview from '../../assets/03-ui-components/video-preview/no-camera-found-video-preview.png';
 import StartingCameraPreview from '../../assets/03-ui-components/video-preview/starting-camera-video-preview.png';
 
-
-The aim of the `VideoPreview` component is to offer a glimpse into how we appear to others before joining a call. This component is suitable for call lobby scenario. The component allows for UI customisation and at the same time handles the starting, playing and error handling logic for us. It is important to note that, the component relies on the state and API provided by the [`MediaDevicesProvider`](../../../guides/camera-and-microphone). That means that the video will be playing only if:
-
-- the `VideoPreview` component is a child of `MediaDevicesProvider`
-- the `initialVideoState.enabled` (from `MediaDevicesContextAPI` value provided by `MediaDevicesProvider`) is `true` (the default is however `false`).
+The aim of the `VideoPreview` component is to offer a glimpse into how we appear to others before joining a call. This component is suitable for call lobby scenario. The component allows for UI customisation and at the same time handles the starting, playing and error handling logic for us.
 
 You can customize what is displayed, when:
 
@@ -22,6 +18,22 @@ You can customize what is displayed, when:
 4. error when retrieving the video stream is thrown
 
 The custom components should be passed to `VideoPreview` props. See the [Props](./#props) section for more details.
+
+## General usage
+
+```tsx
+import { Call, VideoPreview, StreamCall } from '@stream-io/video-react-sdk';
+
+const DevicePanel = () => {
+  let call: Call;
+
+  return (
+    <StreamCall call={call}>
+      <VideoPreview />
+    </StreamCall>
+  );
+};
+```
 
 ## Props
 
@@ -33,16 +45,19 @@ The custom components should be passed to `VideoPreview` props. See the [Props](
 
 Component rendered when user turns off the video.
 
-<img src={DisabledVideoPreview} alt="Default component for DisabledVideoPreview" width={300}/>
+<img
+  src={DisabledVideoPreview}
+  alt="Default component for DisabledVideoPreview"
+  width={300}
+/>
 
 ### `mirror`
 
-| Type                    | Default |
-| ----------------------- | ------- |
-| `boolean` \| `undefined` | `true` |
+| Type                     | Default |
+| ------------------------ | ------- |
+| `boolean` \| `undefined` | `true`  |
 
 Enforces mirroring of the video on the X axis.
-
 
 ### `NoCameraPreview`
 
@@ -52,7 +67,11 @@ Enforces mirroring of the video on the X axis.
 
 Component rendered when no camera devices are available.
 
-<img src={NoCameraPreview} alt="Default component for NoCameraPreview" width={300}/>
+<img
+  src={NoCameraPreview}
+  alt="Default component for NoCameraPreview"
+  width={300}
+/>
 
 ### `StartingCameraPreview`
 
@@ -62,14 +81,26 @@ Component rendered when no camera devices are available.
 
 Component rendered above the BaseVideo until the video is ready (meaning until the play event is emitted).
 
-<img src={StartingCameraPreview} alt="Default component for StartingCameraPreview" width={300}/>
+<img
+  src={StartingCameraPreview}
+  alt="Default component for StartingCameraPreview"
+  width={300}
+/>
 
 ### `VideoErrorPreview`
 
-| Type                           |
-| ------------------------------ |
+| Type                                                   |
+| ------------------------------------------------------ |
 | `ComponentType<VideoErrorPreviewProps>` \| `undefined` |
 
 Component rendered when the video stream could not be retrieved.
 
-<img src={ErrorVideoPreview} alt="Default component for VideoErrorPreview" width={300}/>
+<img
+  src={ErrorVideoPreview}
+  alt="Default component for VideoErrorPreview"
+  width={300}
+/>
+
+## Customization
+
+If the [built-in props](#props) don't provide enough flexibility for you, you can create your own video preview component. You can rely on the state and API provided by the [`MediaDevicesProvider`](../../../guides/camera-and-microphone).

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/avatar.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/avatar.mdx
@@ -50,3 +50,7 @@ The name of the user.
 | `CSSProperties & Record<string, string \| number>` |
 
 Custom CSS to attach to the avatar image/fallback.
+
+## Customization
+
+If you want to build your own avatar component, you'll have to provide your own `ParticipantViewUI` component. For more information, visit the [ParticipantView customizations guide](../../../ui-cookbook/participant-view-customizations).

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/call-stats.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/call-stats.mdx
@@ -10,7 +10,7 @@ The SDK's default component to display statistics about a call is called `CallSt
 - **Call Latency** graph that outlines average round trip time (in ms).
 - **Call Performance** section that displays the below listed call statistics
 
-<img src={CallStats} alt="Panel displaying call statistics" width={300}/>
+<img src={CallStats} alt="Panel displaying call statistics" width={300} />
 
 ### The call statistics displayed:
 
@@ -26,6 +26,7 @@ The SDK's default component to display statistics about a call is called `CallSt
 - **Receiving bitrate** - the rate at which data is transmitted from the server to the app
 
 ## General usage
+
 The default component is just rendered without passing any props:
 
 ```tsx
@@ -40,10 +41,10 @@ const YourComponent = (someProps: SomeProps) => {
 }
 ```
 
-## Customization
-
-The component is not customizable through props, only by applying CSS to elements it renders.
-
 ## Props
 
 None
+
+## Customization
+
+You can create your own call statistics component using the SDK's [call state hooks](../../../guides/call-and-participant-state/#call-state).

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/permission-notification.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/permission-notification.mdx
@@ -8,8 +8,18 @@ import PermissionGrantedNotification from '../../assets/03-ui-components/permiss
 
 The default component used to display permission grant notifications is based on `Notification` component. It is just a popover displaying text. The text displayed is customisable.
 
-<div style={{width: '100%', display: 'flex', justifyContent: 'center', marginBlock: '1rem'}}>
-    <img src={PermissionGrantedNotification} alt="Default UI of PermissionNotification component" />
+<div
+  style={{
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    marginBlock: '1rem',
+  }}
+>
+  <img
+    src={PermissionGrantedNotification}
+    alt="Default UI of PermissionNotification component"
+  />
 </div>
 
 ## General usage
@@ -51,16 +61,12 @@ export const ToggleAudioPublishingButton = (
 };
 ```
 
-## Customization
-
-To learn more about creating custom permission requests listings, have a look at our [permission requests customization guide](../../../ui-cookbook/permission-requests).
-
 ## Props
 
 ### `isAwaitingApproval`
 
 | Type      |
-|-----------|
+| --------- |
 | `boolean` |
 
 Set this to true if there is ongoing request for the permission.
@@ -68,7 +74,7 @@ Set this to true if there is ongoing request for the permission.
 ### `messageApproved`
 
 | Type     |
-|----------|
+| -------- |
 | `string` |
 
 The message to display in the notification once the requested permission is granted.
@@ -76,7 +82,7 @@ The message to display in the notification once the requested permission is gran
 ### `messageRevoked`
 
 | Type     |
-|----------|
+| -------- |
 | `string` |
 
 The message to display in the notification once a permission is revoked.
@@ -84,24 +90,27 @@ The message to display in the notification once a permission is revoked.
 ### `messageAwaitingApproval`
 
 | Type     |
-|----------|
+| -------- |
 | `string` |
 
 The message to display in the notification while the requested permission is awaiting approval.
 
-
 ### `permission`
 
 | Type            |
-|-----------------|
+| --------------- |
 | `OwnCapability` |
 
 The permission for which the notification is displayed.
 
 ### `visibilityTimeout`
 
-| Type                    | Default             |
-| ----------------------- | ------------------- |
-| `number` \| `undefined` | `3500` |
+| Type                    | Default |
+| ----------------------- | ------- |
+| `number` \| `undefined` | `3500`  |
 
 The time in milliseconds to display the notification. Defaults to 3500ms.
+
+## Customization
+
+To learn more about creating custom permission requests listings, have a look at our [permission requests customization guide](../../../ui-cookbook/permission-requests).

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/reaction.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/reaction.mdx
@@ -5,19 +5,11 @@ title: Reaction
 
 Reaction component is used to display emojis in real-time for a specified amount of time. You can utilise this functionality, for example, to notify other participants that you want to speak by "raising hand". Our default sorting algorithm will push participants with raised hand to the top of the list for better visibility. Learn more about reaction events and their customization in the [Reactions & Custom Events guide](../../../guides/reactions-and-custom-events) and see how sorting works in the [Participant Sorting guide](../../../guides/sorting-api).
 
-The SDK comes with the `defaultEmojiReactionMap` which consists of three reactions:
-
-- `:like:` (renders 👍)
-- `:raise-hand:` (renders ✋)
-- `:fireworks:`: (renders 🎉)
-
-You can extend `Reaction` component with your custom map if you need to through `emojiReactionMap` property.
-
 ![Reaction component preview](../../assets/03-ui-components/reaction.png)
 
 ## General usage
 
-Our `DefaultParticipantViewUI` already comes with the `Reaction` component built in but if you're building your custom `ParticipantViewUI` here's how you'd incorporate the `Reaction` component into your UI:
+Our `DefaultParticipantViewUI` already comes with the `Reaction` component built-in but if you're building your custom `ParticipantViewUI` here's how you'd incorporate the `Reaction` component into your UI:
 
 ```tsx
 import {
@@ -46,8 +38,6 @@ export const CustomParticipantViewUI = () => {
 };
 ```
 
-## Final steps
-
 Now we can pass this custom `ParticipantViewUI` component down to our call layout components or directly to `ParticipantView` component in our custom call layout as described in the [ParticipantView customizations guide](../../../ui-cookbook/participant-view-customizations).
 
 ## Props
@@ -67,3 +57,21 @@ The participant whose reaction the component should display.
 | `number` \| `undefined` |
 
 Timeout in miliseconds after which the component resets [participant reaction state](../../../guides/reactions-and-custom-events/#clearing-reactions).
+
+### empjiReactionMap
+
+| Type                     |
+| ------------------------ |
+| `Record<string, string>` |
+
+Mapping of the emoji keys (for example `:like:`) and the associated emoji (for example 👍)
+
+The SDK comes with the following default mapping:
+
+- `:like:` (renders 👍)
+- `:raise-hand:` (renders ✋)
+- `:fireworks:`: (renders 🎉)
+
+## Customization
+
+If you want to build your own reaction component, you'll have to provide your own `ParticipantViewUI` component. For more information visit the [ParticipantView customizations guide](../../../ui-cookbook/participant-view-customizations).

--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/speaking-while-muted-notification.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/utility/speaking-while-muted-notification.mdx
@@ -3,12 +3,23 @@ id: speaking-while-muted-notification
 title: Speaking while muted notification
 ---
 
-import SpeakingWhileMutedNotification from '../../assets/03-ui-components/speaking-while-muted-notification.png'
+import SpeakingWhileMutedNotification from '../../assets/03-ui-components/speaking-while-muted-notification.png';
 
 The `SpeakingWhileMuted` component is based on `Notification` component that is a simple popover. The SDK attaches the component to [`ToggleAudioPublishingButton`](../../call/call-controls). The popover rendering is controlled by sound detection mechanism put in place by `createSoundDetector()` function.
 
-<div style={{width: '100%', display: 'flex', justifyContent: 'center', marginBlock: '1rem'}}>
-    <img src={SpeakingWhileMutedNotification} alt="Default UI of SpeakingWhileMutedNotification component" width={300}/>
+<div
+  style={{
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    marginBlock: '1rem',
+  }}
+>
+  <img
+    src={SpeakingWhileMutedNotification}
+    alt="Default UI of SpeakingWhileMutedNotification component"
+    width={300}
+  />
 </div>
 
 ## General usage
@@ -16,21 +27,21 @@ The `SpeakingWhileMuted` component is based on `Notification` component that is 
 The component is used by wrapping the component to which it will refer:
 
 ```tsx
-    <SpeakingWhileMutedNotification>
-      <ToggleAudioPublishingButton />
-    </SpeakingWhileMutedNotification>
+<SpeakingWhileMutedNotification>
+  <ToggleAudioPublishingButton />
+</SpeakingWhileMutedNotification>
 ```
-
-## Customization
-
-To learn more about creating sound detection functionality, have a look at our [speaking-while-muted tutorial](../../../ui-cookbook/speaking-while-muted).
 
 ## Props
 
 ### `text`
 
-| Type                    | Default |
-| ----------------------- | ------- |
+| Type                    | Default                             |
+| ----------------------- | ----------------------------------- |
 | `string` \| `undefined` | `'You are muted. Unmute to speak.'` |
 
 Text message displayed by the notification.
+
+## Customization
+
+To learn more about creating sound detection functionality, have a look at our [speaking-while-muted tutorial](../../../ui-cookbook/speaking-while-muted).


### PR DESCRIPTION
- [Unify the structure of UI components pages](https://github.com/GetStream/stream-video-js/pull/571#issue-1732498263)
- `Customization` section is moved to end of page (it makes more sense to write about that after `Props`)
- `StreamVideo` page is added