### PR TITLE
feat: stop tracking permission requests in Call state

### DIFF
--- a/packages/client/src/events/__tests__/call-permissions.test.ts
+++ b/packages/client/src/events/__tests__/call-permissions.test.ts
@@ -2,48 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { CallState } from '../../store';
 import {
   watchCallGrantsUpdated,
-  watchCallPermissionRequest,
   watchCallPermissionsUpdated,
 } from '../call-permissions';
 import { OwnCapability } from '../../gen/coordinator';
 import { ConnectionQuality } from '../../gen/video/sfu/models/models';
 
 describe('Call Permission Events', () => {
-  it('call.permission_request ignores own requests', () => {
-    const state = new CallState();
-    // @ts-expect-error
-    state.updateOrAddParticipant('session-id', {
-      userId: 'test',
-      isLocalParticipant: true,
-    });
-    const handler = watchCallPermissionRequest(state);
-    handler({
-      type: 'call.permission_request',
-      permissions: [OwnCapability.SEND_AUDIO, OwnCapability.SEND_VIDEO],
-      // @ts-expect-error
-      user: { id: 'test' },
-    });
-
-    expect(state.callPermissionRequest).toBeUndefined();
-  });
-
-  it('call.permission_request updates the state', () => {
-    const state = new CallState();
-    const handler = watchCallPermissionRequest(state);
-    handler({
-      type: 'call.permission_request',
-      permissions: [OwnCapability.SEND_AUDIO, OwnCapability.SEND_VIDEO],
-      // @ts-expect-error
-      user: { id: 'test' },
-    });
-
-    expect(state.callPermissionRequest).toEqual({
-      type: 'call.permission_request',
-      permissions: [OwnCapability.SEND_AUDIO, OwnCapability.SEND_VIDEO],
-      user: { id: 'test' },
-    });
-  });
-
   it('handles call.permissions_updated', () => {
     const state = new CallState();
     state.setParticipants([

--- a/packages/client/src/events/call-permissions.ts
+++ b/packages/client/src/events/call-permissions.ts
@@ -4,20 +4,6 @@ import { SfuEvent } from '../gen/video/sfu/event/events';
 import { OwnCapability } from '../gen/coordinator';
 
 /**
- * Event handler that watches for `call.permission_request` events
- * Updates the state store using the `callPermissionRequest$` stream
- */
-export const watchCallPermissionRequest = (state: CallState) => {
-  return function onCallPermissionRequest(event: StreamVideoEvent) {
-    if (event.type !== 'call.permission_request') return;
-    const { localParticipant } = state;
-    if (event.user.id !== localParticipant?.userId) {
-      state.setCallPermissionRequest(event);
-    }
-  };
-};
-
-/**
  * Event handler that watches for `call.permissions_updated` events
  */
 export const watchCallPermissionsUpdated = (state: CallState) => {

--- a/packages/client/src/events/callEventHandlers.ts
+++ b/packages/client/src/events/callEventHandlers.ts
@@ -14,7 +14,6 @@ import {
   watchCallMemberRemoved,
   watchCallMemberUpdated,
   watchCallMemberUpdatedPermission,
-  watchCallPermissionRequest,
   watchCallPermissionsUpdated,
   watchCallRecordingStarted,
   watchCallRecordingStopped,
@@ -51,6 +50,7 @@ type AllCallEvents = Exclude<
   | 'call.created' // handled by StreamVideoClient
   | 'call.ring' // handled by StreamVideoClient
   | 'call.notification' // not used currently
+  | 'call.permission_request' // should be handled by the SDK component
   | 'custom' // integrators should handle custom events
   | RingCallEvents // handled by registerRingingCallEventHandlers
 >;
@@ -79,7 +79,6 @@ export const registerEventHandlers = (
     'call.member_removed': watchCallMemberRemoved(state),
     'call.member_updated': watchCallMemberUpdated(state),
     'call.member_updated_permission': watchCallMemberUpdatedPermission(state),
-    'call.permission_request': watchCallPermissionRequest(state),
     'call.permissions_updated': watchCallPermissionsUpdated(state),
     'call.reaction_new': watchNewReactions(state),
     'call.recording_started': watchCallRecordingStarted(state),

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -15,7 +15,6 @@ import {
   CallResponse,
   MemberResponse,
   OwnCapability,
-  PermissionRequestEvent,
 } from '../gen/coordinator';
 import { TrackType } from '../gen/video/sfu/models/models';
 import { Comparator } from '../sorting';
@@ -166,16 +165,6 @@ export class CallState {
    */
   private callRecordingListSubject = new BehaviorSubject<CallRecording[]>([]);
 
-  /**
-   * Emits the latest call permission request sent by any participant of the
-   * current call.
-   *
-   * @internal
-   */
-  private callPermissionRequestSubject = new BehaviorSubject<
-    PermissionRequestEvent | undefined
-  >(undefined);
-
   // Derived state
 
   /**
@@ -250,11 +239,6 @@ export class CallState {
   callRecordingList$: Observable<CallRecording[]>;
 
   /**
-   * Emits the latest call permission request sent by any participant of the current call.
-   */
-  callPermissionRequest$: Observable<PermissionRequestEvent | undefined>;
-
-  /**
    * The raw call metadata object, as defined on the backend.
    */
   metadata$: Observable<CallResponse | undefined>;
@@ -325,8 +309,6 @@ export class CallState {
       this.anonymousParticipantCountSubject.asObservable();
 
     this.callStatsReport$ = this.callStatsReportSubject.asObservable();
-    this.callPermissionRequest$ =
-      this.callPermissionRequestSubject.asObservable();
     this.callRecordingList$ = this.callRecordingListSubject.asObservable();
     this.metadata$ = this.metadataSubject.asObservable();
     this.members$ = this.membersSubject.asObservable();
@@ -506,25 +488,6 @@ export class CallState {
    */
   setCallRecordingsList = (recordings: Patch<CallRecording[]>) => {
     return this.setCurrentValue(this.callRecordingListSubject, recordings);
-  };
-
-  /**
-   * The last call permission request.
-   */
-  get callPermissionRequest() {
-    return this.getCurrentValue(this.callPermissionRequest$);
-  }
-
-  /**
-   * Sets the last call permission request.
-   *
-   * @internal
-   * @param request the last call permission request.
-   */
-  setCallPermissionRequest = (
-    request: Patch<PermissionRequestEvent | undefined>,
-  ) => {
-    return this.setCurrentValue(this.callPermissionRequestSubject, request);
   };
 
   /**

--- a/packages/react-bindings/src/hooks/permissions.ts
+++ b/packages/react-bindings/src/hooks/permissions.ts
@@ -1,4 +1,4 @@
-import { OwnCapability, PermissionRequestEvent } from '@stream-io/video-client';
+import { OwnCapability } from '@stream-io/video-client';
 import { useCallState } from './store';
 import { useObservableValue } from './helpers/useObservableValue';
 
@@ -22,16 +22,4 @@ export const useHasPermissions = (...permissions: OwnCapability[]): boolean => {
 export const useOwnCapabilities = (): OwnCapability[] => {
   const { ownCapabilities$ } = useCallState();
   return useObservableValue(ownCapabilities$);
-};
-
-/**
- * A hook which returns the latest call permission request.
- *
- * @category Call State
- */
-export const useCallPermissionRequest = ():
-  | PermissionRequestEvent
-  | undefined => {
-  const { callPermissionRequest$ } = useCallState();
-  return useObservableValue(callPermissionRequest$);
 };

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
@@ -57,7 +57,6 @@ Here are all the call-related state hooks:
 | `useDominantSpeaker`              | The participant that is the current dominant speaker of the call.                                             |
 | `useOwnCapabilities`              | The capabilities of the local participant.                                                                    |
 | `useHasPermissions`               | Returns `true` if the local participant has all the given permissions.                                        |
-| `useCallPermissionRequest`        | The latest call permission request.                                                                           |
 
 The `CallResponse` object contains the following information:
 

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/08-permission-requests.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/08-permission-requests.mdx
@@ -158,21 +158,32 @@ For readability, the code snippet only contains the `PermissionRequestNotificati
 ```tsx
 const PermissionRequestNotifications = () => {
   const call = useCall();
-  const permissionRequest = useCallPermissionRequest();
+  const localParticipant = useLocalParticipant();
+  const canUpdateCallPermissions = useHasPermissions(
+    OwnCapability.UPDATE_CALL_PERMISSIONS,
+  );
   const [permissionRequests, setPermissionRequests] = useState([]);
 
   useEffect(() => {
-    if (!permissionRequest) {
-      return;
-    }
-    setPermissionRequests((requests) => [...requests, permissionRequest]);
-  }, [permissionRequest]);
+    if (!call || !canUpdateCallPermissions) return;
 
-  if (
-    !call ||
-    permissionRequests.length === 0 ||
-    !call.hasPermission(OwnCapability.UPDATE_CALL_PERMISSIONS)
-  ) {
+    const unsubscribe = call.on(
+      'call.permission_request',
+      (event: StreamVideoEvent) => {
+        // ignore own requests
+        if (event.user.id !== localParticipant?.userId) {
+          setPermissionRequests((requests) =>
+            [...requests, event as PermissionRequestEvent],
+          );
+        }
+      },
+    );
+    return () => {
+      unsubscribe();
+    };
+  }, [call, canUpdateCallPermissions, localParticipant]);
+
+  if (!call || permissionRequests.length === 0) {
     return null;
   }
 
@@ -190,8 +201,8 @@ const PermissionRequestNotifications = () => {
       {permissionRequests.map((request) => (
         <div>
           New request from {request.user.id} to publish {request.permissions}
-          <button onClick={() => answerRequest('accept')}>Accept</button>
-          <button onClick={() => answerRequest('reject')}>Reject</button>
+          <button onClick={() => answerRequest('accept', request)}>Accept</button>
+          <button onClick={() => answerRequest('reject', request)}>Reject</button>
         </div>
       ))}
     </div>
@@ -202,7 +213,7 @@ const PermissionRequestNotifications = () => {
 Let's unpack the above code snippet:
 
 - We only show the permission requests to users that have the necessary capability to accept/reject: `call.hasPermission(OwnCapability.UPDATE_CALL_PERMISSIONS)`
-- We use the `useCallPermissionRequest` hook to be notified about permission requests
+- We subscribe to listen to `'call.permission_request'` WS event to update the list of requests
 - A permission request can be accepted with the `grantPermissions` method of the `Call` instance
 - A permission request can be rejected with the `revokePermissions` method of the `Call` instance. This method can also be used to revoke permissions later in the call.
 
@@ -212,14 +223,16 @@ Here is the full example:
 
 ```tsx
 import {
-  StreamVideo,
-  StreamCall,
-  CallParticipantsView,
-  useCall,
-  StreamTheme,
-  OwnCapability,
-  useCallPermissionRequest,
   CallControls,
+  CallParticipantsView,
+  OwnCapability,
+  PermissionRequestEvent,
+  StreamCall,
+  StreamTheme,
+  StreamVideo,
+  StreamVideoEvent,
+  useCall,
+  useLocalParticipant,
   useHasPermissions,
 } from '@stream-io/video-react-sdk';
 import '@stream-io/video-react-sdk/dist/css/styles.css';
@@ -301,21 +314,32 @@ const PermissionRequests = () => {
 
 const PermissionRequestNotifications = () => {
   const call = useCall();
-  const permissionRequest = useCallPermissionRequest();
+  const localParticipant = useLocalParticipant();
+  const canUpdateCallPermissions = useHasPermissions(
+    OwnCapability.UPDATE_CALL_PERMISSIONS,
+  );
   const [permissionRequests, setPermissionRequests] = useState([]);
 
   useEffect(() => {
-    if (!permissionRequest) {
-      return;
-    }
-    setPermissionRequests((requests) => [...requests, permissionRequest]);
-  }, [permissionRequest]);
+    if (!call || !canUpdateCallPermissions) return;
 
-  if (
-    !call ||
-    permissionRequests.length === 0 ||
-    !call.hasPermission(OwnCapability.UPDATE_CALL_PERMISSIONS)
-  ) {
+    const unsubscribe = call.on(
+      'call.permission_request',
+      (event: StreamVideoEvent) => {
+        // ignore own requests
+        if (event.user.id !== localParticipant?.userId) {
+          setPermissionRequests((requests) =>
+            [...requests, event as PermissionRequestEvent],
+          );
+        }
+      },
+    );
+    return () => {
+      unsubscribe();
+    };
+  }, [call, canUpdateCallPermissions, localParticipant]);
+
+  if (!call || permissionRequests.length === 0) {
     return null;
   }
 
@@ -333,8 +357,8 @@ const PermissionRequestNotifications = () => {
       {permissionRequests.map((request) => (
         <div>
           New request from {request.user.id} to publish {request.permissions}
-          <button onClick={() => answerRequest('accept')}>Accept</button>
-          <button onClick={() => answerRequest('reject')}>Reject</button>
+          <button onClick={() => answerRequest('accept', request)}>Accept</button>
+          <button onClick={() => answerRequest('reject', request)}>Reject</button>
         </div>
       ))}
     </div>

--- a/packages/react-sdk/src/components/Permissions/PermissionRequests.tsx
+++ b/packages/react-sdk/src/components/Permissions/PermissionRequests.tsx
@@ -10,12 +10,13 @@ import {
 import {
   OwnCapability,
   PermissionRequestEvent,
+  StreamVideoEvent,
   UserResponse,
 } from '@stream-io/video-client';
 import {
   useCall,
-  useCallPermissionRequest,
   useHasPermissions,
+  useLocalParticipant,
 } from '@stream-io/video-react-bindings';
 import clsx from 'clsx';
 
@@ -31,23 +32,37 @@ const byNameOrId = (a: UserResponse, b: UserResponse) => {
 
 export const PermissionRequests = () => {
   const call = useCall();
+  const localParticipant = useLocalParticipant();
   const [expanded, setExpanded] = useState(false);
   const [permissionRequests, setPermissionRequests] = useState<
     PermissionRequestEvent[]
   >([]);
-
+  console.log('permissionRequests', permissionRequests);
   const canUpdateCallPermissions = useHasPermissions(
     OwnCapability.UPDATE_CALL_PERMISSIONS,
   );
-  const permissionRequest = useCallPermissionRequest();
+
   useEffect(() => {
-    if (!canUpdateCallPermissions || !permissionRequest) return;
-    setPermissionRequests((requests) =>
-      [...requests, permissionRequest].sort((a, b) =>
-        byNameOrId(a.user, b.user),
-      ),
+    if (!call || !canUpdateCallPermissions) return;
+
+    const unsubscribe = call.on(
+      'call.permission_request',
+      (event: StreamVideoEvent) => {
+        if (event.type !== 'call.permission_request') return;
+
+        if (event.user.id !== localParticipant?.userId) {
+          setPermissionRequests((requests) =>
+            [...requests, event as PermissionRequestEvent].sort((a, b) =>
+              byNameOrId(a.user, b.user),
+            ),
+          );
+        }
+      },
     );
-  }, [canUpdateCallPermissions, permissionRequest]);
+    return () => {
+      unsubscribe();
+    };
+  }, [call, canUpdateCallPermissions, localParticipant]);
 
   const handleUpdatePermission = (
     request: PermissionRequestEvent,


### PR DESCRIPTION
We stop tracking `call.permission_request` events in `Call` state to avoid the `useCallPermissionRequest` hook emitting repeatedly the same event on each re-render. That would lead to duplication of the same event in the component's local state of requests list.