### PR TITLE
feat: reconnection flow support for RN

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -103,7 +103,6 @@ import {
   StreamCallEvent,
 } from './coordinator/connection/types';
 import { getClientDetails } from './client-details';
-import { isReactNative } from './helpers/platforms';
 import { getLogger } from './logger';
 
 /**
@@ -134,16 +133,6 @@ export class Call {
    * The state of this call.
    */
   readonly state = new CallState();
-
-  private rejoinPromise: (() => Promise<void>) | undefined;
-
-  /**
-   * A promise that exposes the reconnection logic
-   * The use-case is for the react-native platform where online/offline events are not available in the window
-   */
-  get rejoin(): (() => Promise<void>) | undefined {
-    return this.rejoinPromise;
-  }
 
   /**
    * Flag indicating whether this call is "watched" and receives
@@ -387,7 +376,6 @@ export class Call {
     if (callingState === CallingState.LEFT) {
       throw new Error('Cannot leave call that has already been left.');
     }
-    this.rejoinPromise = undefined;
 
     if (this.ringing) {
       // I'm the one who started the call, so I should cancel it.
@@ -685,7 +673,7 @@ export class Call {
       // we shouldn't be republishing the streams if we're migrating
       // as the underlying peer connection will take care of it as part
       // of the ice-restart process
-      if (localParticipant && !isReactNative() && !migrate) {
+      if (localParticipant && !migrate) {
         const {
           audioStream,
           videoStream,
@@ -702,8 +690,6 @@ export class Call {
         `[Rejoin]: State restored. Attempt: ${this.reconnectAttempts}`,
       );
     };
-
-    this.rejoinPromise = rejoin;
 
     // reconnect if the connection was closed unexpectedly. example:
     // - SFU crash or restart
@@ -744,8 +730,6 @@ export class Call {
           sfuClient.isMigratingAway
         )
           return;
-        // do nothing for react-native as it is handled by SDK
-        if (isReactNative()) return;
         if (this.reconnectAttempts < this.maxReconnectAttempts) {
           rejoin().catch((err) => {
             this.logger(
@@ -766,38 +750,44 @@ export class Call {
     });
 
     // handlers for connection online/offline events
-    // Note: window.addEventListener is not available in React Native, hence the check
-    if (typeof window !== 'undefined' && window.addEventListener) {
-      const handleOnOffline = () => {
-        window.removeEventListener('offline', handleOnOffline);
-        this.logger('warn', '[Rejoin]: Going offline...');
-        this.state.setCallingState(CallingState.OFFLINE);
-      };
-
-      const handleOnOnline = () => {
-        window.removeEventListener('online', handleOnOnline);
-        if (this.state.callingState === CallingState.OFFLINE) {
-          this.logger('info', '[Rejoin]: Going online...');
-          rejoin().catch((err) => {
-            this.logger(
-              'error',
-              `[Rejoin]: Rejoin failed for ${this.reconnectAttempts} times. Giving up.`,
-              err,
-            );
-            this.state.setCallingState(CallingState.RECONNECTING_FAILED);
-          });
+    const unsubscribeOnlineEvent = this.streamClient.on(
+      'connection.changed',
+      (e) => {
+        if (e.type !== 'connection.changed') return;
+        if (!e.online) return;
+        unsubscribeOnlineEvent();
+        if (
+          [CallingState.JOINED, CallingState.JOINING].includes(
+            this.state.callingState,
+          )
+        ) {
+          return;
         }
-      };
+        this.logger('info', '[Rejoin]: Going online...');
+        rejoin().catch((err) => {
+          this.logger(
+            'error',
+            `[Rejoin]: Rejoin failed for ${this.reconnectAttempts} times. Giving up.`,
+            err,
+          );
+          this.state.setCallingState(CallingState.RECONNECTING_FAILED);
+        });
+      },
+    );
+    const unsubscribeOfflineEvent = this.streamClient.on(
+      'connection.changed',
+      (e) => {
+        if (e.type !== 'connection.changed') return;
+        if (e.online) return;
+        unsubscribeOfflineEvent();
+        this.state.setCallingState(CallingState.OFFLINE);
+      },
+    );
 
-      window.addEventListener('offline', handleOnOffline);
-      window.addEventListener('online', handleOnOnline);
-
-      // register cleanup hooks
-      this.leaveCallHooks.push(
-        () => window.removeEventListener('offline', handleOnOffline),
-        () => window.removeEventListener('online', handleOnOnline),
-      );
-    }
+    this.leaveCallHooks.push(() => {
+      unsubscribeOnlineEvent();
+      unsubscribeOfflineEvent();
+    });
 
     if (!this.subscriber) {
       this.subscriber = new Subscriber({

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -610,7 +610,7 @@ export class Call {
     }
 
     // FIXME OL: remove once cascading is implemented
-    if (typeof window !== 'undefined' && window.location.search) {
+    if (typeof window !== 'undefined' && window.location?.search) {
       const params = new URLSearchParams(window.location.search);
       sfuServer.url = params.get('sfuUrl') || sfuServer.url;
       sfuServer.ws_endpoint = params.get('sfuWsUrl') || sfuServer.ws_endpoint;

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -106,7 +106,7 @@ export class StreamSfuClient {
   private readonly rpc: SignalServerClient;
   private keepAliveInterval?: NodeJS.Timeout;
   private connectionCheckTimeout?: NodeJS.Timeout;
-  private pingIntervalInMs = 25 * 1000;
+  private pingIntervalInMs = 10 * 1000;
   private unhealthyTimeoutInMs = this.pingIntervalInMs + 5 * 1000;
   private lastMessageTimestamp?: Date;
   private readonly unsubscribeIceTrickle: () => void;

--- a/packages/client/src/coordinator/connection/connection.ts
+++ b/packages/client/src/coordinator/connection/connection.ts
@@ -475,7 +475,8 @@ export class StableWSConnection {
     if (event.type === 'offline') {
       // mark the connection as down
       this._log('onlineStatusChanged() - Status changing to offline');
-      this._setHealth(false);
+      // we know that the app is offline so dispatch the unhealthy connection event immediately
+      this._setHealth(false, true);
     } else if (event.type === 'online') {
       // retry right now...
       // We check this.isHealthy, not sure if it's always
@@ -628,14 +629,15 @@ export class StableWSConnection {
    * Broadcasts an event in case the connection status changed.
    *
    * @param {boolean} healthy boolean indicating if the connection is healthy or not
+   * @param {boolean} dispatchImmediately boolean indicating to dispatch event immediately even if the connection is unhealthy
    *
    */
-  _setHealth = (healthy: boolean) => {
+  _setHealth = (healthy: boolean, dispatchImmediately = false) => {
     if (healthy === this.isHealthy) return;
 
     this.isHealthy = healthy;
 
-    if (this.isHealthy) {
+    if (this.isHealthy || dispatchImmediately) {
       this.client.dispatchEvent({
         type: 'connection.changed',
         online: this.isHealthy,

--- a/packages/client/src/rtc/flows/join.ts
+++ b/packages/client/src/rtc/flows/join.ts
@@ -112,7 +112,7 @@ const toRtcConfiguration = (config?: ICEServer[]) => {
 
 const getCascadingModeParams = () => {
   if (typeof window === 'undefined') return null;
-  const params = new URLSearchParams(window.location.search);
+  const params = new URLSearchParams(window.location?.search);
   const cascadingEnabled = params.get('cascading') !== null;
   if (cascadingEnabled) {
     const rawParams: Record<string, string> = {};

--- a/packages/react-native-sdk/src/hooks/useCallControls.tsx
+++ b/packages/react-native-sdk/src/hooks/useCallControls.tsx
@@ -1,8 +1,7 @@
-import { Call, CallingState, SfuModels } from '@stream-io/video-client';
+import { SfuModels } from '@stream-io/video-client';
 import { useCall, useLocalParticipant } from '@stream-io/video-react-bindings';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { useAppStateListener } from '../utils/hooks/useAppStateListener';
-import NetInfo from '@react-native-community/netinfo';
 import { useMediaStreamManagement } from '../providers/MediaStreamManagement';
 
 /**
@@ -17,7 +16,6 @@ export const useCallControls = () => {
   /** Refs to keep track of the current call and whether the user is online or not */
   const callRef = useRef(call);
   callRef.current = call;
-  const isOnlineRef = useRef(true);
 
   const {
     publishAudioStream,
@@ -49,31 +47,6 @@ export const useCallControls = () => {
     isVideoPublishedRef.current ? publishVideoStream : undefined,
   );
 
-  /**
-   * Effect to re-join to an existing call happens in case the user comes back online
-   */
-  useEffect(() => {
-    const unsubscribe = NetInfo.addEventListener(async (state) => {
-      const { isConnected, isInternetReachable } = state;
-      const isOnline = isConnected !== false && isInternetReachable !== false;
-      isOnlineRef.current = isOnline;
-      if (!callRef.current) {
-        return;
-      }
-      const callToJoin = callRef.current;
-      await rejoinCall(
-        callToJoin,
-        isOnline,
-        isAudioPublishedRef.current,
-        isVideoPublishedRef.current,
-        publishAudioStreamRef.current,
-        publishVideoStreamRef.current,
-      );
-    });
-
-    return unsubscribe;
-  }, []);
-
   const toggleVideoMuted = useCallback(async () => {
     if (!isVideoPublished) {
       publishVideoStream();
@@ -97,34 +70,3 @@ export const useCallControls = () => {
     toggleVideoMuted,
   };
 };
-
-/**
- * Helper function to rejoin a call and then publish the streams
- */
-async function rejoinCall(
-  callToJoin: Call,
-  isOnline: boolean,
-  isAudioPublished: boolean,
-  isVideoPublished: boolean,
-  publishAudioStream: () => Promise<void>,
-  publishVideoStream: () => Promise<void>,
-) {
-  const isCurrentStateOffline =
-    callToJoin.state.callingState === CallingState.OFFLINE;
-  if (!isOnline && !isCurrentStateOffline) {
-    callToJoin.state.setCallingState(CallingState.OFFLINE);
-  } else if (isOnline && isCurrentStateOffline && callToJoin.rejoin) {
-    try {
-      await callToJoin.rejoin();
-      if (isAudioPublished) {
-        await publishAudioStream();
-      }
-      if (isVideoPublished) {
-        await publishVideoStream();
-      }
-    } catch (e) {
-      console.error('Failed to rejoin', e);
-      callToJoin.state.setCallingState(CallingState.RECONNECTING_FAILED);
-    }
-  }
-}

--- a/packages/react-native-sdk/src/providers/StreamVideo.tsx
+++ b/packages/react-native-sdk/src/providers/StreamVideo.tsx
@@ -23,9 +23,14 @@ export const StreamVideo = (props: PropsWithChildren<StreamVideoProps>) => {
    * Effect to inform the coordinator about the online status of the app
    */
   useEffect(() => {
+    let prevIsOnline = true;
     const unsubscribe = NetInfo.addEventListener((state) => {
       const { isConnected, isInternetReachable } = state;
-      const isOnline = isConnected !== false && isInternetReachable !== false;
+      const isOnline = isConnected === true && isInternetReachable === true;
+      if (isOnline === prevIsOnline) {
+        return;
+      }
+      prevIsOnline = isOnline;
       // @ts-expect-error - due to being incompatible with DOM event type
       client.streamClient.wsConnection?.onlineStatusChanged({
         type: isOnline ? 'online' : 'offline',

--- a/sample-apps/react-native/dogfood/App.tsx
+++ b/sample-apps/react-native/dogfood/App.tsx
@@ -26,9 +26,12 @@ import { ChatWrapper } from './src/components/ChatWrapper';
 import { AppMode } from './src/navigators/AppMode';
 import { setPushConfig } from './src/utils/setPushConfig';
 import { useSyncPermissions } from './src/hooks/useSyncPermissions';
+import { LogBox } from 'react-native';
 
 // @ts-expect-error
 Logger.enable(false);
+
+LogBox.ignoreAllLogs();
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 


### PR DESCRIPTION
## The main change

In `call.ts`, changed the window.eventlistener mechanism to detect online/offline to use the videoclient's connection change event. So that it works across RN and web

## Tested on

* ios device, android emulator, react web dogfood in desktop