### PR TITLE
fix: prevent double publishStream invocation

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -296,7 +296,7 @@ export class Call {
           currentUserId &&
           metadata.blocked_user_ids.includes(currentUserId)
         ) {
-          this.logger('info', 'Leaving call bacause of being blocked');
+          this.logger('info', 'Leaving call because of being blocked');
           await this.leave();
         }
       }),
@@ -1613,7 +1613,7 @@ export class Call {
   /**
    * Sends a custom event to all call participants.
    *
-   * @param event the event to send.
+   * @param payload the payload to send.
    */
   sendCustomEvent = async (payload: { [key: string]: any }) => {
     return this.streamClient.post<SendEventResponse, SendEventRequest>(

--- a/packages/react-sdk/src/core/contexts/MediaDevicesContext.tsx
+++ b/packages/react-sdk/src/core/contexts/MediaDevicesContext.tsx
@@ -319,10 +319,7 @@ export const MediaDevicesProvider = ({
   }, [call, callingState]);
 
   const toggleInitialAudioMuteState = useCallback(
-    () =>
-      setInitialAudioEnabled((prev) => {
-        return !prev;
-      }),
+    () => setInitialAudioEnabled((prev) => !prev),
     [],
   );
   const toggleInitialVideoMuteState = useCallback(

--- a/packages/react-sdk/src/core/hooks/useAudioPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useAudioPublisher.ts
@@ -62,21 +62,19 @@ export const useAudioPublisher = ({
 
   const initialPublishRun = useRef(false);
   useEffect(() => {
-    if (callingState === CallingState.JOINED) {
-      if (
-        (!initialAudioMuted && !initialPublishRun.current) ||
-        isPublishingAudio
-      ) {
-        // automatic publishing should happen only when:
-        // - joining the call from the lobby, and the audio is not muted
-        // - reconnecting to the call with the audio already published
-        publishAudioStream().catch((e) => {
-          console.error('Failed to publish audio stream', e);
-        });
-        initialPublishRun.current = true;
-      }
+    if (
+      callingState === CallingState.JOINED &&
+      !initialPublishRun.current &&
+      !initialAudioMuted
+    ) {
+      // automatic publishing should happen only when joining the call
+      // from the lobby, and the audio is not muted
+      publishAudioStream().catch((e) => {
+        console.error('Failed to publish audio stream', e);
+      });
+      initialPublishRun.current = true;
     }
-  }, [callingState, initialAudioMuted, isPublishingAudio, publishAudioStream]);
+  }, [callingState, initialAudioMuted, publishAudioStream]);
 
   useEffect(() => {
     if (!localParticipant$ || !hasBrowserPermissionAudioInput) return;

--- a/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
+++ b/packages/react-sdk/src/core/hooks/useVideoPublisher.ts
@@ -79,21 +79,19 @@ export const useVideoPublisher = ({
 
   const initialPublishRun = useRef(false);
   useEffect(() => {
-    if (callingState === CallingState.JOINED) {
-      if (
-        (!initialVideoMuted && !initialPublishRun.current) ||
-        isPublishingVideo
-      ) {
-        // automatic publishing should happen only when:
-        // - joining the call from the lobby, and the video is not muted
-        // - reconnecting to the call with the video already published
-        publishVideoStream().catch((e) => {
-          console.error('Failed to publish video stream', e);
-        });
-        initialPublishRun.current = true;
-      }
+    if (
+      callingState === CallingState.JOINED &&
+      !initialPublishRun.current &&
+      !initialVideoMuted
+    ) {
+      // automatic publishing should happen only when joining the call
+      // from the lobby, and the video is not muted
+      publishVideoStream().catch((e) => {
+        console.error('Failed to publish video stream', e);
+      });
+      initialPublishRun.current = true;
     }
-  }, [callingState, initialVideoMuted, isPublishingVideo, publishVideoStream]);
+  }, [callingState, initialVideoMuted, publishVideoStream]);
 
   useEffect(() => {
     if (!localParticipant$ || !hasBrowserPermissionVideoInput) return;


### PR DESCRIPTION
### Overview

Upon reconnection, the effect ran twice and led to race conditions that may mess up the state of the local participant.
Under some circumstances, the local participant would point to an ended video/audio stream while the other one would be normally published to the SFU.