### PR TITLE
feat(react-sdk): extract toggle functions to hooks + permissions

### DIFF
--- a/packages/i18n/src/translations/de.json
+++ b/packages/i18n/src/translations/de.json
@@ -10,5 +10,29 @@
   "Select Speakers": "Wähle den Lautsprecher",
   "Speakers": "Lautsprecher",
   "Video": "Video",
-  "You are muted. Unmute to speak.": "Du bist stummgeschaltet. Schalte den Ton an, um zu sprechen."
+  "You are muted. Unmute to speak.": "Du bist stummgeschaltet. Schalte den Ton an, um zu sprechen.",
+
+  "You can now speak.": "<missing-translation>",
+  "Awaiting for an approval to speak.": "<missing-translation>",
+  "You can no longer speak.": "<missing-translation>",
+  "You can now share your video.": "<missing-translation>",
+  "Awaiting for an approval to share your video.": "<missing-translation>",
+  "You can no longer share your video.": "<missing-translation>",
+  "Waiting for recording to stop...": "<missing-translation>",
+  "Waiting for recording to start...": "<missing-translation>",
+  "Record call": "<missing-translation>",
+  "Reactions": "<missing-translation>",
+  "You can now share your screen.": "<missing-translation>",
+  "Awaiting for an approval to share screen.": "<missing-translation>",
+  "You can no longer share your screen.": "<missing-translation>",
+  "Share screen": "<missing-translation>",
+
+  "Allow": "<missing-translation>",
+  "Revoke": "<missing-translation>",
+  "Dismiss": "<missing-translation>",
+
+  "{{ userName }} is requesting to speak": "<missing-translation>",
+  "{{ userName }} is requesting to share their camera": "<missing-translation>",
+  "{{ userName }} is requesting to present their screen": "<missing-translation>",
+  "{{ userName }} is requesting permission: {{ permission }}": "<missing-translation>"
 }

--- a/packages/i18n/src/translations/en.json
+++ b/packages/i18n/src/translations/en.json
@@ -10,5 +10,29 @@
   "Select Speakers": "Select Speakers",
   "Speakers": "Speakers",
   "Video": "Video",
-  "You are muted. Unmute to speak.": "You are muted. Unmute to speak."
+  "You are muted. Unmute to speak.": "You are muted. Unmute to speak.",
+
+  "You can now speak.": "You can now speak.",
+  "Awaiting for an approval to speak.": "Awaiting for an approval to speak.",
+  "You can no longer speak.": "You can no longer speak.",
+  "You can now share your video.": "You can now share your video.",
+  "Awaiting for an approval to share your video.": "Awaiting for an approval to share your video.",
+  "You can no longer share your video.": "You can no longer share your video.",
+  "Waiting for recording to stop...": "Waiting for recording to stop...",
+  "Waiting for recording to start...": "Waiting for recording to start...",
+  "Record call": "Record call",
+  "Reactions": "Reactions",
+  "You can now share your screen.": "You can now share your screen.",
+  "Awaiting for an approval to share screen.": "Awaiting for an approval to share screen.",
+  "You can no longer share your screen.": "You can no longer share your screen.",
+  "Share screen": "Share screen",
+
+  "Allow": "Allow",
+  "Revoke": "Revoke",
+  "Dismiss": "Dismiss",
+
+  "{{ userName }} is requesting to speak": "{{ userName }} is requesting to speak",
+  "{{ userName }} is requesting to share their camera": "{{ userName }} is requesting to share their camera",
+  "{{ userName }} is requesting to present their screen": "{{ userName }} is requesting to present their screen",
+  "{{ userName }} is requesting permission: {{ permission }}": "{{ userName }} is requesting permission: {{ permission }}"
 }

--- a/packages/i18n/src/translations/es.json
+++ b/packages/i18n/src/translations/es.json
@@ -10,5 +10,29 @@
   "Select Speakers": "Elige los Altavoces",
   "Speakers": "Altavoces",
   "Video": "Vídeo",
-  "You are muted. Unmute to speak.": "Estás silenciado. Activa el sonido para hablar."
+  "You are muted. Unmute to speak.": "Estás silenciado. Activa el sonido para hablar.",
+
+  "You can now speak.": "<missing-translation>",
+  "Awaiting for an approval to speak.": "<missing-translation>",
+  "You can no longer speak.": "<missing-translation>",
+  "You can now share your video.": "<missing-translation>",
+  "Awaiting for an approval to share your video.": "<missing-translation>",
+  "You can no longer share your video.": "<missing-translation>",
+  "Waiting for recording to stop...": "<missing-translation>",
+  "Waiting for recording to start...": "<missing-translation>",
+  "Record call": "<missing-translation>",
+  "Reactions": "<missing-translation>",
+  "You can now share your screen.": "<missing-translation>",
+  "Awaiting for an approval to share screen.": "<missing-translation>",
+  "You can no longer share your screen.": "<missing-translation>",
+  "Share screen": "<missing-translation>",
+
+  "Allow": "<missing-translation>",
+  "Revoke": "<missing-translation>",
+  "Dismiss": "<missing-translation>",
+
+  "{{ userName }} is requesting to speak": "<missing-translation>",
+  "{{ userName }} is requesting to share their camera": "<missing-translation>",
+  "{{ userName }} is requesting to present their screen": "<missing-translation>",
+  "{{ userName }} is requesting permission: {{ permission }}": "<missing-translation>"
 }

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -17,4 +17,7 @@ export type TranslationsRegistry = Record<
   TranslationsForLanguage
 >;
 
-export type TranslatorFunction = (key: string) => string;
+export type TranslatorFunction = (
+  key: string,
+  options?: Record<string, unknown>,
+) => string;

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/08-permission-requests.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/08-permission-requests.mdx
@@ -90,11 +90,30 @@ call.goLive();
 
 ## Request permission
 
-In this step we will implement the `PermissionRequests` component to send permission requests.
+In this step we will implement the `PermissionRequests` and the `PermissionRequestButton` components to send permission requests.
 
-For readability the code snippet only contains the `PermissionRequests` implementation, the [full example](#finished-example) is available at the end of the guide.
+For readability the code snippet only contains the `PermissionRequests` and the `PermissionRequestButton` implementation, the [full example](#finished-example) is available at the end of the guide.
 
 ```tsx
+import { useRequestPermission } from '@stream-io/video-react-sdk';
+
+const PermissionRequestButton = ({ children, capability }) => {
+  const {
+    requestPermission,
+    hasPermission,
+    canRequestPermission,
+    isAwaitingPermission,
+  } = useRequestPermission(capability);
+
+  if (hasPermission || !canRequestPermission) return null;
+
+  return (
+    <button disabled={isAwaitingPermission} onClick={() => requestPermission()}>
+      {children}
+    </button>
+  );
+};
+
 const PermissionRequests = () => {
   const call = useCall();
   const canSendAudio = useHasPermissions(OwnCapability.SEND_AUDIO);
@@ -105,34 +124,17 @@ const PermissionRequests = () => {
     return null;
   }
 
-  const shouldDisplayButton = (capability) => {
-    return (
-      call.permissionsContext.canRequest(capability) &&
-      !call.permissionsContext.hasPermission(capability)
-    );
-  };
-
-  const requestPermission = (capability) => {
-    call.requestPermissions({ permissions: [capability] });
-  };
-
   return (
     <div>
-      {shouldDisplayButton(OwnCapability.SEND_AUDIO) && (
-        <button onClick={() => requestPermission(OwnCapability.SEND_AUDIO)}>
-          Request audio permission
-        </button>
-      )}
-      {shouldDisplayButton(OwnCapability.SEND_VIDEO) && (
-        <button onClick={() => requestPermission(OwnCapability.SEND_VIDEO)}>
-          Request video permission
-        </button>
-      )}
-      {shouldDisplayButton(OwnCapability.SCREENSHARE) && (
-        <button onClick={() => requestPermission(OwnCapability.SCREENSHARE)}>
-          Request screen share permission
-        </button>
-      )}
+      <PermissionRequestButton capability={OwnCapability.SEND_AUDIO}>
+        Request audio permission
+      </PermissionRequestButton>
+      <PermissionRequestButton capability={OwnCapability.SEND_VIDEO}>
+        Request video permission
+      </PermissionRequestButton>
+      <PermissionRequestButton capability={OwnCapability.SCREENSHARE}>
+        Request screen share permission
+      </PermissionRequestButton>
       {canSendAudio ? 'Allowed to send audio' : 'Not allowed to send audio'}
       {canSendVideo ? 'Allowed to send video' : 'Not allowed to send video'}
       {canShareScreen
@@ -146,7 +148,7 @@ const PermissionRequests = () => {
 Let's unpack the above code snippet:
 
 - We only display the request button if the user is allowed to request the specific capability and doesn't already have that permission. For more information, check out the [permissions guide](../../guides/permissions-and-moderation).
-- To send the request we are using the `requestPermissions` method of the `Call` instance.
+- To send the request we are using the `requestPermission` function (wrapper around `requestPermissions` method of the `Call` instance) which comes from the `useRequestPermission` hook.
 - We use the `useHasPermissions` hook to be notified when the request was approved. Alternatively you can subscribe to the [`call.permissions_updated` event](../../advanced/events/).
 
 ## Receive permission requests
@@ -172,9 +174,10 @@ const PermissionRequestNotifications = () => {
       (event: StreamVideoEvent) => {
         // ignore own requests
         if (event.user.id !== localParticipant?.userId) {
-          setPermissionRequests((requests) =>
-            [...requests, event as PermissionRequestEvent],
-          );
+          setPermissionRequests((requests) => [
+            ...requests,
+            event as PermissionRequestEvent,
+          ]);
         }
       },
     );
@@ -201,8 +204,12 @@ const PermissionRequestNotifications = () => {
       {permissionRequests.map((request) => (
         <div>
           New request from {request.user.id} to publish {request.permissions}
-          <button onClick={() => answerRequest('accept', request)}>Accept</button>
-          <button onClick={() => answerRequest('reject', request)}>Reject</button>
+          <button onClick={() => answerRequest('accept', request)}>
+            Accept
+          </button>
+          <button onClick={() => answerRequest('reject', request)}>
+            Reject
+          </button>
         </div>
       ))}
     </div>
@@ -265,6 +272,23 @@ const CallUI = () => {
   );
 };
 
+const PermissionRequestButton = ({ children, capability }) => {
+  const {
+    requestPermission,
+    hasPermission,
+    canRequestPermission,
+    isAwaitingPermission,
+  } = useRequestPermission(capability);
+
+  if (hasPermission || !canRequestPermission) return null;
+
+  return (
+    <button disabled={isAwaitingPermission} onClick={() => requestPermission()}>
+      {children}
+    </button>
+  );
+};
+
 const PermissionRequests = () => {
   const call = useCall();
   const canSendAudio = useHasPermissions(OwnCapability.SEND_AUDIO);
@@ -275,34 +299,17 @@ const PermissionRequests = () => {
     return null;
   }
 
-  const shouldDisplayButton = (capability) => {
-    return (
-      call.permissionsContext.canRequest(capability) &&
-      !call.permissionsContext.hasPermission(capability)
-    );
-  };
-
-  const requestPermission = (capability) => {
-    call.requestPermissions({ permissions: [capability] });
-  };
-
   return (
     <div>
-      {shouldDisplayButton(OwnCapability.SEND_AUDIO) && (
-        <button onClick={() => requestPermission(OwnCapability.SEND_AUDIO)}>
-          Request audio permission
-        </button>
-      )}
-      {shouldDisplayButton(OwnCapability.SEND_VIDEO) && (
-        <button onClick={() => requestPermission(OwnCapability.SEND_VIDEO)}>
-          Request video permission
-        </button>
-      )}
-      {shouldDisplayButton(OwnCapability.SCREENSHARE) && (
-        <button onClick={() => requestPermission(OwnCapability.SCREENSHARE)}>
-          Request screen share permission
-        </button>
-      )}
+      <PermissionRequestButton capability={OwnCapability.SEND_AUDIO}>
+        Request audio permission
+      </PermissionRequestButton>
+      <PermissionRequestButton capability={OwnCapability.SEND_VIDEO}>
+        Request video permission
+      </PermissionRequestButton>
+      <PermissionRequestButton capability={OwnCapability.SCREENSHARE}>
+        Request screen share permission
+      </PermissionRequestButton>
       {canSendAudio ? 'Allowed to send audio' : 'Not allowed to send audio'}
       {canSendVideo ? 'Allowed to send video' : 'Not allowed to send video'}
       {canShareScreen
@@ -328,9 +335,10 @@ const PermissionRequestNotifications = () => {
       (event: StreamVideoEvent) => {
         // ignore own requests
         if (event.user.id !== localParticipant?.userId) {
-          setPermissionRequests((requests) =>
-            [...requests, event as PermissionRequestEvent],
-          );
+          setPermissionRequests((requests) => [
+            ...requests,
+            event as PermissionRequestEvent,
+          ]);
         }
       },
     );
@@ -357,8 +365,12 @@ const PermissionRequestNotifications = () => {
       {permissionRequests.map((request) => (
         <div>
           New request from {request.user.id} to publish {request.permissions}
-          <button onClick={() => answerRequest('accept', request)}>Accept</button>
-          <button onClick={() => answerRequest('reject', request)}>Reject</button>
+          <button onClick={() => answerRequest('accept', request)}>
+            Accept
+          </button>
+          <button onClick={() => answerRequest('reject', request)}>
+            Reject
+          </button>
         </div>
       ))}
     </div>

--- a/packages/react-sdk/src/components/CallControls/ReactionsButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ReactionsButton.tsx
@@ -1,5 +1,5 @@
 import { OwnCapability, StreamReaction } from '@stream-io/video-client';
-import { Restricted, useCall } from '@stream-io/video-react-bindings';
+import { Restricted, useCall, useI18n } from '@stream-io/video-react-bindings';
 
 import { CompositeButton, IconButton } from '../Button';
 import { defaultEmojiReactionMap } from '../Reaction';
@@ -27,17 +27,19 @@ export interface ReactionsButtonProps {
 export const ReactionsButton = ({
   reactions = defaultReactions,
 }: ReactionsButtonProps) => {
+  const { t } = useI18n();
+
   return (
     <Restricted requiredGrants={[OwnCapability.CREATE_REACTION]}>
       <CompositeButton
         active={false}
-        caption="Reactions"
+        caption={t('Reactions')}
         menuPlacement="top-start"
         Menu={<DefaultReactionsMenu reactions={reactions} />}
       >
         <IconButton
           icon="reactions"
-          title="Reactions"
+          title={t('Reactions')}
           onClick={() => {
             console.log('Reactions');
           }}

--- a/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
@@ -1,5 +1,5 @@
 import { OwnCapability } from '@stream-io/video-client';
-import { Restricted, useCall } from '@stream-io/video-react-bindings';
+import { Restricted, useCall, useI18n } from '@stream-io/video-react-bindings';
 import { CompositeButton, IconButton } from '../Button/';
 import { LoadingIndicator } from '../LoadingIndicator';
 import { useToggleCallRecording } from '../../hooks/useToggleCallRecording';
@@ -13,6 +13,7 @@ export const RecordCallButton = ({
 }: RecordCallButtonProps) => {
   const call = useCall();
 
+  const { t } = useI18n();
   const { toggleCallRecording, isAwaitingResponse, isCallRecordingInProgress } =
     useToggleCallRecording();
 
@@ -28,8 +29,8 @@ export const RecordCallButton = ({
           <LoadingIndicator
             tooltip={
               isCallRecordingInProgress
-                ? 'Waiting for recording to stop... '
-                : 'Waiting for recording to start...'
+                ? t('Waiting for recording to stop...')
+                : t('Waiting for recording to start...')
             }
           />
         ) : (
@@ -38,7 +39,7 @@ export const RecordCallButton = ({
             enabled={!!call}
             disabled={!call}
             icon={isCallRecordingInProgress ? 'recording-on' : 'recording-off'}
-            title="Record call"
+            title={t('Record call')}
             onClick={toggleCallRecording}
           />
         )}

--- a/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
@@ -1,12 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
 import { OwnCapability } from '@stream-io/video-client';
-import {
-  Restricted,
-  useCall,
-  useIsCallRecordingInProgress,
-} from '@stream-io/video-react-bindings';
+import { Restricted, useCall } from '@stream-io/video-react-bindings';
 import { CompositeButton, IconButton } from '../Button/';
 import { LoadingIndicator } from '../LoadingIndicator';
+import { useToggleCallRecording } from '../../hooks/useToggleCallRecording';
 
 export type RecordCallButtonProps = {
   caption?: string;
@@ -16,30 +12,9 @@ export const RecordCallButton = ({
   caption = 'Record',
 }: RecordCallButtonProps) => {
   const call = useCall();
-  const isCallRecordingInProgress = useIsCallRecordingInProgress();
-  const [isAwaitingResponse, setIsAwaitingResponse] = useState(false);
-  useEffect(() => {
-    // we wait until call.recording_started/stopped event to flips the
-    // `isCallRecordingInProgress` state variable.
-    // Once the flip happens, we remove the loading indicator
-    setIsAwaitingResponse((isAwaiting) => {
-      if (isAwaiting) return false;
-      return isAwaiting;
-    });
-  }, [isCallRecordingInProgress]);
 
-  const toggleRecording = useCallback(async () => {
-    try {
-      setIsAwaitingResponse(true);
-      if (isCallRecordingInProgress) {
-        await call?.stopRecording();
-      } else {
-        await call?.startRecording();
-      }
-    } catch (e) {
-      console.error(`Failed start recording`, e);
-    }
-  }, [call, isCallRecordingInProgress]);
+  const { toggleCallRecording, isAwaitingResponse, isCallRecordingInProgress } =
+    useToggleCallRecording();
 
   return (
     <Restricted
@@ -64,7 +39,7 @@ export const RecordCallButton = ({
             disabled={!call}
             icon={isCallRecordingInProgress ? 'recording-on' : 'recording-off'}
             title="Record call"
-            onClick={toggleRecording}
+            onClick={toggleCallRecording}
           />
         )}
       </CompositeButton>

--- a/packages/react-sdk/src/components/CallControls/ScreenShareButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ScreenShareButton.tsx
@@ -3,6 +3,7 @@ import {
   Restricted,
   useCall,
   useHasOngoingScreenShare,
+  useI18n,
 } from '@stream-io/video-react-bindings';
 import { CompositeButton, IconButton } from '../Button/';
 import { PermissionNotification } from '../Notification';
@@ -18,6 +19,7 @@ export const ScreenShareButton = ({
   const call = useCall();
   const isSomeoneScreenSharing = useHasOngoingScreenShare();
 
+  const { t } = useI18n();
   const { toggleScreenShare, isAwaitingPermission, isScreenSharing } =
     useToggleScreenShare();
 
@@ -26,14 +28,14 @@ export const ScreenShareButton = ({
       <PermissionNotification
         permission={OwnCapability.SCREENSHARE}
         isAwaitingApproval={isAwaitingPermission}
-        messageApproved="You can now share your screen."
-        messageAwaitingApproval="Awaiting for an approval to share screen."
-        messageRevoked="You can no longer share your screen."
+        messageApproved={t('You can now share your screen.')}
+        messageAwaitingApproval={t('Awaiting for an approval to share screen.')}
+        messageRevoked={t('You can no longer share your screen.')}
       >
         <CompositeButton active={isSomeoneScreenSharing} caption={caption}>
           <IconButton
             icon={isScreenSharing ? 'screen-share-on' : 'screen-share-off'}
-            title="Share screen"
+            title={t('Share screen')}
             disabled={(!isScreenSharing && isSomeoneScreenSharing) || !call}
             onClick={toggleScreenShare}
           />

--- a/packages/react-sdk/src/components/CallControls/ScreenShareButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ScreenShareButton.tsx
@@ -1,18 +1,12 @@
-import { useEffect, useState } from 'react';
-import {
-  getScreenShareStream,
-  OwnCapability,
-  SfuModels,
-} from '@stream-io/video-client';
+import { OwnCapability } from '@stream-io/video-client';
 import {
   Restricted,
   useCall,
   useHasOngoingScreenShare,
-  useHasPermissions,
-  useLocalParticipant,
 } from '@stream-io/video-react-bindings';
 import { CompositeButton, IconButton } from '../Button/';
 import { PermissionNotification } from '../Notification';
+import { useToggleScreenShare } from '../../hooks';
 
 export type ScreenShareButtonProps = {
   caption?: string;
@@ -22,24 +16,16 @@ export const ScreenShareButton = ({
   caption = 'Screen Share',
 }: ScreenShareButtonProps) => {
   const call = useCall();
-  const localParticipant = useLocalParticipant();
   const isSomeoneScreenSharing = useHasOngoingScreenShare();
-  const isScreenSharing = localParticipant?.publishedTracks.includes(
-    SfuModels.TrackType.SCREEN_SHARE,
-  );
 
-  const [isAwaitingApproval, setIsAwaitingApproval] = useState(false);
-  const hasPermission = useHasPermissions(OwnCapability.SCREENSHARE);
-  useEffect(() => {
-    if (hasPermission) {
-      setIsAwaitingApproval(false);
-    }
-  }, [hasPermission]);
+  const { toggleScreenShare, isAwaitingPermission, isScreenSharing } =
+    useToggleScreenShare();
+
   return (
     <Restricted requiredGrants={[OwnCapability.SCREENSHARE]}>
       <PermissionNotification
         permission={OwnCapability.SCREENSHARE}
-        isAwaitingApproval={isAwaitingApproval}
+        isAwaitingApproval={isAwaitingPermission}
         messageApproved="You can now share your screen."
         messageAwaitingApproval="Awaiting for an approval to share screen."
         messageRevoked="You can no longer share your screen."
@@ -49,33 +35,7 @@ export const ScreenShareButton = ({
             icon={isScreenSharing ? 'screen-share-on' : 'screen-share-off'}
             title="Share screen"
             disabled={(!isScreenSharing && isSomeoneScreenSharing) || !call}
-            onClick={async () => {
-              if (
-                !hasPermission &&
-                call?.permissionsContext.canRequest(OwnCapability.SCREENSHARE)
-              ) {
-                setIsAwaitingApproval(true);
-                await call
-                  .requestPermissions({
-                    permissions: [OwnCapability.SCREENSHARE],
-                  })
-                  .catch((reason) => {
-                    console.log('RequestPermissions failed', reason);
-                  });
-                return;
-              }
-
-              if (!isScreenSharing && hasPermission) {
-                const stream = await getScreenShareStream().catch((e) => {
-                  console.log(`Can't share screen: ${e}`);
-                });
-                if (stream) {
-                  await call?.publishScreenShareStream(stream);
-                }
-              } else {
-                await call?.stopPublish(SfuModels.TrackType.SCREEN_SHARE);
-              }
-            }}
+            onClick={toggleScreenShare}
           />
         </CompositeButton>
       </PermissionNotification>

--- a/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
@@ -64,9 +64,9 @@ export const ToggleAudioPublishingButton = (
       <PermissionNotification
         permission={OwnCapability.SEND_AUDIO}
         isAwaitingApproval={isAwaitingPermission}
-        messageApproved="You can now speak."
-        messageAwaitingApproval="Awaiting for an approval to speak."
-        messageRevoked="You can no longer speak."
+        messageApproved={t('You can now speak.')}
+        messageAwaitingApproval={t('Awaiting for an approval to speak.')}
+        messageRevoked={t('You can no longer speak.')}
       >
         <CompositeButton Menu={Menu} active={isAudioMute} caption={caption}>
           <IconButton

--- a/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
@@ -56,14 +56,14 @@ export const ToggleAudioPublishingButton = (
     SfuModels.TrackType.AUDIO,
   );
 
-  const { toggleAudioMuteState: handleClick, isAwaitingApproval } =
+  const { toggleAudioMuteState: handleClick, isAwaitingPermission } =
     useToggleAudioMuteState();
 
   return (
     <Restricted requiredGrants={[OwnCapability.SEND_AUDIO]}>
       <PermissionNotification
         permission={OwnCapability.SEND_AUDIO}
-        isAwaitingApproval={isAwaitingApproval}
+        isAwaitingApproval={isAwaitingPermission}
         messageApproved="You can now speak."
         messageAwaitingApproval="Awaiting for an approval to speak."
         messageRevoked="You can no longer speak."

--- a/packages/react-sdk/src/components/CallControls/ToggleVideoButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleVideoButton.tsx
@@ -55,14 +55,14 @@ export const ToggleVideoPublishingButton = (
     SfuModels.TrackType.VIDEO,
   );
 
-  const { toggleVideoMuteState: handleClick, isAwaitingApproval } =
+  const { toggleVideoMuteState: handleClick, isAwaitingPermission } =
     useToggleVideoMuteState();
 
   return (
     <Restricted requiredGrants={[OwnCapability.SEND_VIDEO]}>
       <PermissionNotification
         permission={OwnCapability.SEND_VIDEO}
-        isAwaitingApproval={isAwaitingApproval}
+        isAwaitingApproval={isAwaitingPermission}
         messageApproved="You can now share your video."
         messageAwaitingApproval="Awaiting for an approval to share your video."
         messageRevoked="You can no longer share your video."

--- a/packages/react-sdk/src/components/CallControls/ToggleVideoButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleVideoButton.tsx
@@ -63,9 +63,11 @@ export const ToggleVideoPublishingButton = (
       <PermissionNotification
         permission={OwnCapability.SEND_VIDEO}
         isAwaitingApproval={isAwaitingPermission}
-        messageApproved="You can now share your video."
-        messageAwaitingApproval="Awaiting for an approval to share your video."
-        messageRevoked="You can no longer share your video."
+        messageApproved={t('You can now share your video.')}
+        messageAwaitingApproval={t(
+          'Awaiting for an approval to share your video.',
+        )}
+        messageRevoked={t('You can no longer share your video.')}
       >
         <CompositeButton Menu={Menu} active={isVideoMute} caption={caption}>
           <IconButton

--- a/packages/react-sdk/src/hooks/index.ts
+++ b/packages/react-sdk/src/hooks/index.ts
@@ -2,3 +2,6 @@ export * from './useFloatingUIPreset';
 export * from './useScrollPosition';
 export * from './useToggleAudioMuteState';
 export * from './useToggleVideoMuteState';
+export * from './useToggleScreenShare';
+export * from './useToggleCallRecording';
+export * from './useRequestPermission';

--- a/packages/react-sdk/src/hooks/useRequestPermission.ts
+++ b/packages/react-sdk/src/hooks/useRequestPermission.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+import { OwnCapability } from '@stream-io/video-client';
+import { useCall, useHasPermissions } from '@stream-io/video-react-bindings';
+
+export const useRequestPermission = (permission: OwnCapability) => {
+  const call = useCall();
+  const hasPermission = useHasPermissions(permission);
+  const canRequestPermission =
+    !!call?.permissionsContext.canRequest(permission);
+  const [isAwaitingPermission, setIsAwaitingPermission] = useState(false); // TODO: load with possibly pending state
+
+  useEffect(() => {
+    const reset = () => setIsAwaitingPermission(false);
+
+    if (hasPermission) reset();
+  }, [hasPermission]);
+
+  const requestPermission = useCallback(async () => {
+    if (isAwaitingPermission || !canRequestPermission) return false;
+    if (hasPermission) return true;
+
+    setIsAwaitingPermission(true);
+
+    try {
+      await call?.requestPermissions({
+        permissions: [permission],
+      });
+    } catch (error) {
+      setIsAwaitingPermission(false);
+      throw new Error(`requestPermission failed: ${error}`);
+    }
+
+    return false;
+  }, [
+    call,
+    canRequestPermission,
+    hasPermission,
+    isAwaitingPermission,
+    permission,
+  ]);
+
+  return {
+    requestPermission,
+    hasPermission,
+    canRequestPermission,
+    isAwaitingPermission,
+  };
+};

--- a/packages/react-sdk/src/hooks/useToggleAudioMuteState.ts
+++ b/packages/react-sdk/src/hooks/useToggleAudioMuteState.ts
@@ -1,62 +1,33 @@
-import { useCallback, useEffect, useState } from 'react';
-import {
-  useCall,
-  useHasPermissions,
-  useLocalParticipant,
-} from '@stream-io/video-react-bindings';
+import { useCallback, useRef } from 'react';
+import { useLocalParticipant } from '@stream-io/video-react-bindings';
 import { OwnCapability, SfuModels } from '@stream-io/video-client';
 
 import { useMediaDevices } from '../core';
+import { useRequestPermission } from './useRequestPermission';
 
 export const useToggleAudioMuteState = () => {
   const { publishAudioStream, stopPublishingAudio } = useMediaDevices();
   const localParticipant = useLocalParticipant();
-  const call = useCall();
-  const hasPermission = useHasPermissions(OwnCapability.SEND_AUDIO);
-  const [isAwaitingApproval, setIsAwaitingApproval] = useState(false);
 
-  const isAudioMute = !localParticipant?.publishedTracks.includes(
+  const { isAwaitingPermission, requestPermission } = useRequestPermission(
+    OwnCapability.SEND_AUDIO,
+  );
+
+  // to keep the toggle function as stable as possible
+  const isAudioMutedReference = useRef(false);
+
+  isAudioMutedReference.current = !localParticipant?.publishedTracks.includes(
     SfuModels.TrackType.AUDIO,
   );
 
-  useEffect(() => {
-    if (hasPermission) {
-      setIsAwaitingApproval(false);
-    }
-  }, [hasPermission]);
-
   const toggleAudioMuteState = useCallback(async () => {
-    if (
-      !hasPermission &&
-      call &&
-      call.permissionsContext.canRequest(OwnCapability.SEND_AUDIO)
-    ) {
-      setIsAwaitingApproval(true);
-      await call
-        .requestPermissions({
-          permissions: [OwnCapability.SEND_AUDIO],
-        })
-        .catch((reason) => {
-          console.log('RequestPermissions failed', reason);
-        });
-      return;
+    if (isAudioMutedReference.current) {
+      const canPublish = await requestPermission();
+      if (canPublish) return publishAudioStream();
     }
-    if (isAudioMute) {
-      if (hasPermission) {
-        await publishAudioStream();
-      } else {
-        console.log('Cannot publish audio stream. Insufficient permissions.');
-      }
-    } else {
-      stopPublishingAudio();
-    }
-  }, [
-    call,
-    hasPermission,
-    isAudioMute,
-    publishAudioStream,
-    stopPublishingAudio,
-  ]);
 
-  return { toggleAudioMuteState, isAwaitingApproval };
+    if (!isAudioMutedReference.current) stopPublishingAudio();
+  }, [publishAudioStream, requestPermission, stopPublishingAudio]);
+
+  return { toggleAudioMuteState, isAwaitingPermission };
 };

--- a/packages/react-sdk/src/hooks/useToggleCallRecording.ts
+++ b/packages/react-sdk/src/hooks/useToggleCallRecording.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  useCall,
+  useIsCallRecordingInProgress,
+} from '@stream-io/video-react-bindings';
+
+export const useToggleCallRecording = () => {
+  const call = useCall();
+  const isCallRecordingInProgress = useIsCallRecordingInProgress();
+  const [isAwaitingResponse, setIsAwaitingResponse] = useState(false);
+
+  // TODO: add permissions
+
+  useEffect(() => {
+    // we wait until call.recording_started/stopped event to flips the
+    // `isCallRecordingInProgress` state variable.
+    // Once the flip happens, we remove the loading indicator
+    setIsAwaitingResponse((isAwaiting) => {
+      if (isAwaiting) return false;
+      return isAwaiting;
+    });
+  }, [isCallRecordingInProgress]);
+
+  const toggleCallRecording = useCallback(async () => {
+    try {
+      setIsAwaitingResponse(true);
+      if (isCallRecordingInProgress) {
+        await call?.stopRecording();
+      } else {
+        await call?.startRecording();
+      }
+    } catch (e) {
+      console.error(`Failed start recording`, e);
+    }
+  }, [call, isCallRecordingInProgress]);
+
+  return { toggleCallRecording, isAwaitingResponse, isCallRecordingInProgress };
+};

--- a/packages/react-sdk/src/hooks/useToggleScreenShare.ts
+++ b/packages/react-sdk/src/hooks/useToggleScreenShare.ts
@@ -1,0 +1,42 @@
+import { useCallback, useRef } from 'react';
+import { useCall, useLocalParticipant } from '@stream-io/video-react-bindings';
+import {
+  OwnCapability,
+  SfuModels,
+  getScreenShareStream,
+} from '@stream-io/video-client';
+import { useRequestPermission } from './useRequestPermission';
+
+export const useToggleScreenShare = () => {
+  const localParticipant = useLocalParticipant();
+  const call = useCall();
+  const isScreenSharingReference = useRef(false);
+  const { isAwaitingPermission, requestPermission } = useRequestPermission(
+    OwnCapability.SCREENSHARE,
+  );
+
+  const isScreenSharing = !!localParticipant?.publishedTracks.includes(
+    SfuModels.TrackType.SCREEN_SHARE,
+  );
+
+  isScreenSharingReference.current = isScreenSharing;
+
+  const toggleScreenShare = useCallback(async () => {
+    if (!isScreenSharingReference.current) {
+      const canPublish = await requestPermission();
+      if (!canPublish) return;
+
+      const stream = await getScreenShareStream().catch((e) => {
+        console.log(`Can't share screen: ${e}`);
+      });
+
+      if (stream) {
+        return call?.publishScreenShareStream(stream);
+      }
+    }
+
+    call?.stopPublish(SfuModels.TrackType.SCREEN_SHARE);
+  }, [call, requestPermission]);
+
+  return { toggleScreenShare, isAwaitingPermission, isScreenSharing };
+};


### PR DESCRIPTION
### Known bugs for permissions

1. permission states not persisted/properly propagated
   - disable audio and video by clicking the context buttons - whatever comes first (in this case audio) is overriden and can be published by the user
   - after reload (user which had their audio/video disabled) can seemingly publish tracks but other users won't see/hear anything - works only after explicitly allowing it (sometimes)

2. missing dismiss events (do nothing)
   - currently "dismissing" permission requests leads to revoking (user A and user B receive request from user C, user A allows, user B "dismisses", user C still cannot publish)
   - dismissing permission request from the requestor side won't remove dismissed requests from the list of the target users

TODO:
- [x] add dismiss button to the `PermissionRequestList` element
- [x] finish adjusting documentation
- [x] add new translations