### PR TITLE
fix: wait for connection ok for all API requests

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -333,7 +333,6 @@ export class StreamVideoClient {
    * @param data the query data.
    */
   queryCalls = async (data: QueryCallsRequest) => {
-    if (data.watch) await this.streamClient.connectionIdPromise;
     const response = await this.streamClient.post<
       QueryCallsResponse,
       QueryCallsRequest

--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -509,7 +509,10 @@ export class StreamClient {
       if (this.waitForConnectPromise) {
         await this.waitForConnectPromise;
       }
-      await this.tokenManager.tokenReady();
+      await Promise.all([
+        this.tokenManager.tokenReady(),
+        this.connectionIdPromise,
+      ]);
     }
     const requestConfig = this._enrichAxiosOptions(options);
     try {

--- a/packages/client/src/rtc/flows/join.ts
+++ b/packages/client/src/rtc/flows/join.ts
@@ -27,8 +27,6 @@ export const join = async (
   id: string,
   data?: JoinCallData,
 ) => {
-  await httpClient.connectionIdPromise;
-
   const joinCallResponse = await doJoin(httpClient, type, id, data);
   const { call, credentials, members, own_capabilities } = joinCallResponse;
   return {


### PR DESCRIPTION
If the fix works, I'll rename the `connectionIdPromise` to a better name