### PR TITLE
fix: Reliable mid detection

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -535,7 +535,7 @@ export class Publisher {
         return (
           m.type === track.kind &&
           // if `msid` is not present, we assume that the track is the first one
-          (m.msid?.includes(track.id) || true)
+          (m.msid?.includes(track.id) ?? true)
         );
       });
       if (typeof media?.mid === 'undefined') {

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -531,9 +531,18 @@ export class Publisher {
       this.logger('warn', 'No mid found for track. Trying to find it from SDP');
 
       const parsedSdp = SDP.parse(sdp);
-      const media = parsedSdp.media.find((m) => m.type === track.kind);
+      const media = parsedSdp.media.find((m) => {
+        return (
+          m.type === track.kind &&
+          // if `msid` is not present, we assume that the track is the first one
+          (m.msid?.includes(track.id) || true)
+        );
+      });
       if (typeof media?.mid === 'undefined') {
-        this.logger('warn', `No mid found in SDP for track type ${track.kind}`);
+        this.logger(
+          'warn',
+          `No mid found in SDP for track type ${track.kind} and id ${track.id}`,
+        );
         return '';
       }
       return String(media.mid);


### PR DESCRIPTION
### Overview

There is a conflict between video and screen share tracks as both of them have `video` set as a kind. As a consequence, sometimes we were picking up the `mid` identifier of the "other" track. Now, we take the `msid` parameter into consideration when doing the media selection.