### PR TITLE
feat: Remove ringing flag from call client

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -483,7 +483,7 @@ export class StreamVideoClient {
   }
 
   /**
-   * A callback that can be used to create ringing calls from push notifications. If the call already existis, it will do nothing.
+   * A callback that can be used to create ringing calls from push notifications. If the call already exists, it will do nothing.
    * @param call_cid
    * @returns
    */


### PR DESCRIPTION
## Problem

 - Having the `ringing` flag in `client.call` can be misleading to integrators, for example they could do: `client.call('default', '123', true),join({ring: false})`
 - The flag also creates API mismatch with iOS and Android

## Solution

`client.onRingingCall` will create a ringing call from a push notification. The naming is based on: https://github.com/GetStream/stream-video-android/blob/develop/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt#L82

@santhoshvai can you please help with the testing?