### PR TITLE
feat(react-dogfood): add useWakeLock hook

### DIFF
--- a/sample-apps/react/react-dogfood/components/MeetingUI.tsx
+++ b/sample-apps/react/react-dogfood/components/MeetingUI.tsx
@@ -33,7 +33,7 @@ import {
   UnreadCountBadge,
 } from '.';
 import { ActiveCallHeader } from './ActiveCallHeader';
-import { useKeyboardShortcuts, useWatchChannel } from '../hooks';
+import { useKeyboardShortcuts, useWakeLock, useWatchChannel } from '../hooks';
 import { DEFAULT_LAYOUT, getLayoutSettings, LayoutMap } from './LayoutSelector';
 import { Stage } from './Stage';
 import { ToggleParticipantListButton } from './ToggleParticipantListButton';
@@ -140,6 +140,7 @@ export const MeetingUI = ({ chatClient, enablePreview }: MeetingUIProps) => {
   }, [activeCall, isSortingDisabled]);
 
   useKeyboardShortcuts();
+  useWakeLock();
 
   let ComponentToRender: JSX.Element | null = null;
   if (show === 'error-join' || show === 'error-leave') {

--- a/sample-apps/react/react-dogfood/hooks/index.ts
+++ b/sample-apps/react/react-dogfood/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useChatClient';
 export * from './useWatchChannel';
 export * from './useKeyboardShortcuts';
+export * from './useWakeLock';

--- a/sample-apps/react/react-dogfood/hooks/useWakeLock.ts
+++ b/sample-apps/react/react-dogfood/hooks/useWakeLock.ts
@@ -1,0 +1,32 @@
+import { CallingState, useCallCallingState } from '@stream-io/video-react-sdk';
+import { useEffect } from 'react';
+
+interface WakeLockSentinel {
+  release(): Promise<void>;
+}
+
+export const useWakeLock = () => {
+  const callState = useCallCallingState();
+
+  useEffect(() => {
+    if (callState !== CallingState.JOINED || !('wakeLock' in navigator)) return;
+
+    let interrupted = false;
+    let wakeLockSentinel: null | WakeLockSentinel = null;
+    // @ts-expect-error
+    navigator.wakeLock
+      .request('screen')
+      .then((wls: WakeLockSentinel) => {
+        if (interrupted) return wls.release();
+        wakeLockSentinel = wls;
+      })
+      .catch((error: unknown) =>
+        console.log(`Couldn't setup WakeLock due to: ${error}`),
+      );
+
+    return () => {
+      interrupted = true;
+      wakeLockSentinel?.release();
+    };
+  }, [callState]);
+};


### PR DESCRIPTION
This hook prevents your screen from dimming while in a long noninteractive call.

[Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) has not been yet implemented to the FF so this feature only works on other major browsers (apparently on Safari too 🤯). 