### PR TITLE
fix: restore CallUserMuted event

### DIFF
--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -1543,6 +1543,43 @@ export interface CallUpdatedEvent {
   type: string;
 }
 /**
+ * This event is sent when a call member is muted
+ * @export
+ * @interface CallUserMuted
+ */
+export interface CallUserMuted {
+  /**
+   *
+   * @type {string}
+   * @memberof CallUserMuted
+   */
+  call_cid: string;
+  /**
+   *
+   * @type {string}
+   * @memberof CallUserMuted
+   */
+  created_at: string;
+  /**
+   *
+   * @type {string}
+   * @memberof CallUserMuted
+   */
+  from_user_id: string;
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof CallUserMuted
+   */
+  muted_user_ids: Array<string>;
+  /**
+   * The type of event: "call.user_muted" in this case
+   * @type {string}
+   * @memberof CallUserMuted
+   */
+  type: string;
+}
+/**
  *
  * @export
  * @interface ConnectUserDetailsRequest
@@ -4119,6 +4156,7 @@ export type VideoEvent =
   | ({ type: 'call.session_started' } & CallSessionStartedEvent)
   | ({ type: 'call.unblocked_user' } & UnblockedUserEvent)
   | ({ type: 'call.updated' } & CallUpdatedEvent)
+  | ({ type: 'call.user_muted' } & CallUserMuted)
   | ({ type: 'connection.error' } & ConnectionErrorEvent)
   | ({ type: 'connection.ok' } & ConnectedEvent)
   | ({ type: 'custom' } & CustomVideoEvent)


### PR DESCRIPTION
### Overview

https://github.com/GetStream/stream-video-js/commit/739602e6ddb9e56502c1dfb228b44760c88e4cdb accidentally removes the `CallUserMuted` event which causes compilation errors.

This PR restores it back.