### PR TITLE
feat: respect user_session_id in call.session events

### DIFF
--- a/packages/client/src/events/__tests__/sessions.test.ts
+++ b/packages/client/src/events/__tests__/sessions.test.ts
@@ -68,6 +68,7 @@ describe('call.session events', () => {
         id: 'user-id',
         role: 'user',
       },
+      user_session_id: '123',
     });
     expect(state.metadata).toEqual({
       session: {
@@ -78,6 +79,8 @@ describe('call.session events', () => {
               id: 'user-id',
               role: 'user',
             },
+            user_session_id: '123',
+            role: 'user',
           },
         ],
         participants_count_by_role: {
@@ -100,6 +103,7 @@ describe('call.session events', () => {
               id: 'user-id',
               role: 'user',
             },
+            user_session_id: '123',
           },
         ],
         participants_count_by_role: {
@@ -115,6 +119,7 @@ describe('call.session events', () => {
         id: 'user-id',
         role: 'user',
       },
+      user_session_id: '123',
     });
     expect(state.metadata).toEqual({
       session: {

--- a/packages/client/src/events/sessions.ts
+++ b/packages/client/src/events/sessions.ts
@@ -33,7 +33,7 @@ export const watchCallSessionEnded = (state: CallState) => {
 export const watchCallSessionParticipantJoined = (state: CallState) => {
   return function onCallParticipantJoined(event: StreamVideoEvent) {
     if (event.type !== 'call.session_participant_joined') return;
-    const { user } = event;
+    const { user, user_session_id } = event;
     state.setMetadata((metadata) => {
       if (!metadata || !metadata.session) {
         state.logger(
@@ -55,6 +55,8 @@ export const watchCallSessionParticipantJoined = (state: CallState) => {
               // FIXME OL: ideally, this comes from the backend
               joined_at: new Date().toISOString(),
               user,
+              role: user.role,
+              user_session_id,
             },
           ],
           participants_count_by_role: {
@@ -75,7 +77,7 @@ export const watchCallSessionParticipantJoined = (state: CallState) => {
 export const watchCallSessionParticipantLeft = (state: CallState) => {
   return function onCallParticipantLeft(event: StreamVideoEvent) {
     if (event.type !== 'call.session_participant_left') return;
-    const { user } = event;
+    const { user, user_session_id } = event;
     state.setMetadata((metadata) => {
       if (!metadata || !metadata.session) {
         state.logger(
@@ -91,7 +93,9 @@ export const watchCallSessionParticipantLeft = (state: CallState) => {
         ...metadata,
         session: {
           ...session,
-          participants: participants.filter((p) => p.user.id !== user.id),
+          participants: participants.filter(
+            (p) => p.user_session_id !== user_session_id,
+          ),
           participants_count_by_role: {
             ...participants_count_by_role,
             [user.role]: Math.max(

--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -149,6 +149,7 @@ export interface AudioSettings {
  */
 export const AudioSettingsDefaultDeviceEnum = {
   SPEAKER: 'speaker',
+  EARPIECE: 'earpiece',
 } as const;
 export type AudioSettingsDefaultDeviceEnum =
   (typeof AudioSettingsDefaultDeviceEnum)[keyof typeof AudioSettingsDefaultDeviceEnum];
@@ -202,6 +203,7 @@ export interface AudioSettingsRequest {
  */
 export const AudioSettingsRequestDefaultDeviceEnum = {
   SPEAKER: 'speaker',
+  EARPIECE: 'earpiece',
 } as const;
 export type AudioSettingsRequestDefaultDeviceEnum =
   (typeof AudioSettingsRequestDefaultDeviceEnum)[keyof typeof AudioSettingsRequestDefaultDeviceEnum];
@@ -738,10 +740,22 @@ export interface CallParticipantResponse {
   joined_at: string;
   /**
    *
+   * @type {string}
+   * @memberof CallParticipantResponse
+   */
+  role: string;
+  /**
+   *
    * @type {UserResponse}
    * @memberof CallParticipantResponse
    */
   user: UserResponse;
+  /**
+   *
+   * @type {string}
+   * @memberof CallParticipantResponse
+   */
+  user_session_id: string;
 }
 /**
  * This event is sent when a reaction is sent in a call, clients should use this to show the reaction in the call screen
@@ -1184,6 +1198,12 @@ export interface CallSessionParticipantJoinedEvent {
    * @memberof CallSessionParticipantJoinedEvent
    */
   user: UserResponse;
+  /**
+   * The user session ID of the user that joined the call session
+   * @type {string}
+   * @memberof CallSessionParticipantJoinedEvent
+   */
+  user_session_id: string;
 }
 /**
  * This event is sent when a participant leaves a call session
@@ -1221,6 +1241,12 @@ export interface CallSessionParticipantLeftEvent {
    * @memberof CallSessionParticipantLeftEvent
    */
   user: UserResponse;
+  /**
+   * The user session ID of the user that left the call session
+   * @type {string}
+   * @memberof CallSessionParticipantLeftEvent
+   */
+  user_session_id: string;
 }
 /**
  *

--- a/packages/react-dogfood/components/Lobby.tsx
+++ b/packages/react-dogfood/components/Lobby.tsx
@@ -58,19 +58,13 @@ export const Lobby = ({ onJoin, callId, enablePreview = true }: LobbyProps) => {
     <Stack height={1}>
       <LobbyHeader />
       <Stack
-        direction="row"
+        direction="column"
         justifyContent="center"
         alignItems="center"
         spacing={2}
         flexGrow={1}
       >
-        <Box
-          sx={{
-            position: 'fixed',
-            left: '1rem',
-            top: '80px',
-          }}
-        >
+        <Box>
           <ParticipantsPreview />
         </Box>
         <Stack spacing={2} alignItems="center">

--- a/packages/react-dogfood/components/ParticipantsPreview.tsx
+++ b/packages/react-dogfood/components/ParticipantsPreview.tsx
@@ -13,26 +13,26 @@ export const ParticipantsPreview = () => {
     return null;
   return (
     <Stack sx={{ gap: '0.75rem', margin: 0 }}>
-      <Typography sx={{ fontSize: '1.125rem', fontWeight: '700' }}>
-        Already in call ({callMetadata.session.participants.length}):
+      <Typography variant="body1">
+        Already in this call ({callMetadata.session.participants.length}):
       </Typography>
       <Stack
         direction="row"
+        gap="0.5rem"
+        flexWrap="wrap"
         sx={{
-          flexWrap: 'wrap',
           overflowY: 'auto',
-          maxHeight: '300px',
-          maxWidth: '200px',
-          gap: '0.5rem',
         }}
       >
         {callMetadata.session.participants.map((participant) => (
-          <Stack alignItems="center" key={participant.user.id}>
+          <Stack alignItems="center" key={participant.user_session_id}>
             <Avatar
               name={participant.user.name}
               imageSrc={participant.user.image}
             />
-            {participant.user.name && <div>{participant.user.name}</div>}
+            {participant.user.name && (
+              <Typography variant="caption">{participant.user.name}</Typography>
+            )}
           </Stack>
         ))}
       </Stack>


### PR DESCRIPTION
### Overview

Updates to the newest OpenAPI schema and now we respect the `user_session_id` parameter.
Without this field, we were filtering out participants based on their `user_id` which is problematic in scenarios where the same user enters the same call multiple times.