### PR TITLE
fix: promise rejection on call leave

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -146,6 +146,7 @@ export class Publisher {
       });
     }
 
+    this.pc.removeEventListener('negotiationneeded', this.onNegotiationNeeded);
     this.pc.close();
   };
 


### PR DESCRIPTION
without this,

when pc.close is done, negotiate is called immediately on RN and maybe also non chromium browsers?! and results in the following error 

```
Possible Unhandled Promise Rejection (id: 1):
Error: CreateOffer called when PeerConnection is closed.
```