### PR TITLE
fix: [RN] Reduce bootstrap timeout

### DIFF
--- a/.github/workflows/react-native-workflow.yml
+++ b/.github/workflows/react-native-workflow.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/rn-bootstrap
+        timeout-minutes: 15
         env:
           INSTALL_NODE: true
           INSTALL_RN_DEPENDENCIES: true
@@ -60,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/rn-bootstrap
-        timeout-minutes: 30
+        timeout-minutes: 15
         env:
           INSTALL_NODE: true
           INSTALL_PODS: true
@@ -91,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/rn-bootstrap
-        timeout-minutes: 30
+        timeout-minutes: 15
         env:
           INSTALL_NODE: true
           INSTALL_PODS: true
@@ -124,7 +125,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/rn-bootstrap
-        timeout-minutes: 30
+        timeout-minutes: 15
 
       - name: Download .ipa
         uses: actions/download-artifact@v3
@@ -143,7 +144,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/rn-bootstrap
-        timeout-minutes: 30
+        timeout-minutes: 15
         env:
           INSTALL_NODE: true
           INSTALL_JAVA: true
@@ -171,7 +172,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/rn-bootstrap
-        timeout-minutes: 30
+        timeout-minutes: 15
         env:
           INSTALL_NODE: true
           INSTALL_FFMPEG: true
@@ -219,7 +220,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/rn-bootstrap
-        timeout-minutes: 30
+        timeout-minutes: 15
 
       - name: Download .apk
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Usually, it takes 4-7 minutes for bootstrap to complete. If it takes longer, it will be stuck and fail by timeout. For now, reducing the timeout to get the failed job faster.