### PR TITLE
refactor(react-native): e2e tests local commands and improved guide to run the e2e tests

### DIFF
--- a/sample-apps/react-native/dogfood/.gitignore
+++ b/sample-apps/react-native/dogfood/.gitignore
@@ -51,6 +51,7 @@ yarn-error.log
 **/fastlane/Preview.html
 **/fastlane/screenshots
 **/fastlane/test_output
+**/fastlane/hierarchy.json
 /dist
 
 # Bundle artifact

--- a/sample-apps/react-native/dogfood/Gemfile.lock
+++ b/sample-apps/react-native/dogfood/Gemfile.lock
@@ -3,11 +3,12 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.0.6)
+    activesupport (6.1.7.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
@@ -256,7 +257,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
-    rubocop-performance (1.18.0)
+    rubocop-performance (1.17.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     rubocop-require_tools (0.1.2)
@@ -304,6 +305,7 @@ GEM
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
     xctest_list (1.2.1)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby
@@ -325,4 +327,4 @@ RUBY VERSION
    ruby 3.1.1p18
 
 BUNDLED WITH
-   2.3.14
+   2.3.21

--- a/sample-apps/react-native/dogfood/README.md
+++ b/sample-apps/react-native/dogfood/README.md
@@ -28,6 +28,6 @@ The following are the steps to run the E2E tests:
 - Install [maestro](https://github.com/mobile-dev-inc/maestro) CLI tool.
 - Install [stream-video-buddy](https://github.com/GetStream/stream-video-buddy) CLI tool.
 - Launch the simulator and install the test app by following the instructions above.
-- Start the test flow by running `yarn test-e2e:ios or yarn test-e2e-android` from the root of this project(`/sample-apps/react-native/dogfood`) to run the tests for iOS and Android, respectively. This will run the tests on a device of your choice.
+- Start the test flow by running `yarn test-e2e:ios or yarn test-e2e:android` from the root of this project(`/sample-apps/react-native/dogfood`) to run the tests for iOS and Android, respectively. This will run the tests on a device of your choice.
 
 > Note: If you get this error: `[11:32:00]: Exit status of command 'scripts/create-sentry-properties.sh' was 1 instead of 0. Must provide SENTRY_RN_AUTH_TOKEN in environment`, please add `SENTRY_RN_AUTH_TOKEN` to your `.env` file of the project. The value for the same, can be found [here](https://www.notion.so/stream-wiki/Video-dogfood-app-8fd4b72b2ac9495eb55872f5a70b5f6d).

--- a/sample-apps/react-native/dogfood/README.md
+++ b/sample-apps/react-native/dogfood/README.md
@@ -12,8 +12,8 @@
 7. Run `npx pod-install` to install pods (ios only)
 8. Follow [this guide](https://www.notion.so/stream-wiki/Video-dogfood-app-8fd4b72b2ac9495eb55872f5a70b5f6d) and setup
    Sentry error tracking (or: `SENTRY_RN_AUTH_TOKEN=<your-token> ./scripts/create-sentry-properties.sh`)
-9. Run the app 
-   - On simulator: Run `yarn ios` and/or `yarn android` to run the app 
+9. Run the app
+   - On simulator: Run `yarn ios` and/or `yarn android` to run the app
    - On device: Run `npm install -g ios-deploy` then `yarn ios --device`
 
 ## Invite links to install app on devices
@@ -25,7 +25,9 @@
 
 The following are the steps to run the E2E tests:
 
-- Install [maestro](https://github.com/mobile-dev-inc/maestro) CLI tool
-- Install [stream-video-buddy](https://github.com/GetStream/stream-video-buddy) CLI tool
-- Launch the simulator and install the test app by following the instructions above
-- Start the test flow by running `yarn test-e2e` from the root of this project. This will run the tests either on a device of choice
+- Install [maestro](https://github.com/mobile-dev-inc/maestro) CLI tool.
+- Install [stream-video-buddy](https://github.com/GetStream/stream-video-buddy) CLI tool.
+- Launch the simulator and install the test app by following the instructions above.
+- Start the test flow by running `yarn test-e2e:ios or yarn test-e2e-android` from the root of this project(`/sample-apps/react-native/dogfood`) to run the tests for iOS and Android, respectively. This will run the tests on a device of your choice.
+
+> Note: If you get this error: `[11:32:00]: Exit status of command 'scripts/create-sentry-properties.sh' was 1 instead of 0. Must provide SENTRY_RN_AUTH_TOKEN in environment`, please add `SENTRY_RN_AUTH_TOKEN` to your `.env` file of the project. The value for the same, can be found [here](https://www.notion.so/stream-wiki/Video-dogfood-app-8fd4b72b2ac9495eb55872f5a70b5f6d).

--- a/sample-apps/react-native/dogfood/fastlane/Fastfile
+++ b/sample-apps/react-native/dogfood/fastlane/Fastfile
@@ -63,18 +63,7 @@ lane :pod_install do
   end
 end
 
-lane :build_ios do
-  create_sentry_properties
-
-  app_store_connect_api_key
-
-  match_appstore
-
-  settings_to_override = {
-    BUNDLE_IDENTIFIER: 'io.getstream.rnvideosample',
-    PROVISIONING_PROFILE_SPECIFIER: 'match AppStore io.getstream.rnvideosample'
-  }
-
+lane :bump_ios_version_number do
   increment_version_number(
     version_number: load_package['version'],
     xcodeproj: 'ios/StreamReactNativeVideoSDKSample.xcodeproj'
@@ -89,6 +78,21 @@ lane :build_ios do
     build_number: current_build_number + 1,
     xcodeproj: 'ios/StreamReactNativeVideoSDKSample.xcodeproj'
   )
+end
+
+lane :build_ios do
+  bump_ios_version_number if is_ci
+
+  create_sentry_properties
+
+  app_store_connect_api_key
+
+  match_appstore
+
+  settings_to_override = {
+    BUNDLE_IDENTIFIER: 'io.getstream.rnvideosample',
+    PROVISIONING_PROFILE_SPECIFIER: 'match AppStore io.getstream.rnvideosample'
+  }
 
   gym(
     workspace: 'ios/StreamReactNativeVideoSDKSample.xcworkspace',
@@ -168,9 +172,7 @@ rescue StandardError => e
   UI.important('Another build is already in beta review. Skipping beta review submission')
 end
 
-lane :build_android do
-  create_sentry_properties
-
+lane :bump_android_version_number do
   ENV['ENVFILE'] = '.env.production'
 
   latest_app_distribution_version_code = firebase_app_distribution_get_latest_release(
@@ -186,6 +188,12 @@ lane :build_android do
     gradle_file_path: 'android/app/build.gradle',
     version_name: load_package['version']
   )
+end
+
+lane :build_android do
+  bump_android_version_number if is_ci
+
+  create_sentry_properties
 
   gradle(
     project_dir: 'android',
@@ -198,6 +206,8 @@ lane :build_android do
 end
 
 lane :test_android do |options|
+  build_android unless is_ci && options[:skip_install]
+
   start_video_buddy
 
   wait_android_emu_idle if is_ci

--- a/sample-apps/react-native/dogfood/package.json
+++ b/sample-apps/react-native/dogfood/package.json
@@ -11,6 +11,8 @@
     "clean-install": "rm -rf node_modules && yarn cache clean && yarn install",
     "setup": "yarn && yarn build:react-native:deps && npx pod-install",
     "test-e2e": "bundle exec fastlane test_e2e",
+    "test-e2e:android": "bundle exec fastlane test_android",
+    "test-e2e:ios": "bundle exec fastlane test_ios",
     "test": "jest",
     "lint": "eslint --cache --fix 'src/**/*.{ts,tsx}'",
     "lint:ci": "eslint --cache 'src/**/*.{ts,tsx}'"


### PR DESCRIPTION
The guide for the sentry token is added because of the failing tests on my local environment even though I have the token on my ~/.zshrc. It seems like it needs to be in the `.env` of the project to run the tests.