### PR TITLE
feat: take the location-hint on SDK init

### DIFF
--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -105,7 +105,10 @@ export class StreamClient {
     this.node = !this.browser;
 
     if (this.browser) {
-      this.locationHint = getLocationHint(options?.locationHintTimeout);
+      this.locationHint = getLocationHint(
+        options?.locationHintUrl,
+        options?.locationHintTimeout,
+      );
     }
 
     this.options = {
@@ -185,10 +188,14 @@ export class StreamClient {
       .replace(':3030', ':8800');
   };
 
-  getLocationHint = async (timeout?: number): Promise<string> => {
+  getLocationHint = async (
+    hintUrl?: string,
+    timeout?: number,
+  ): Promise<string> => {
     const hint = await this.locationHint;
     if (!hint || hint === 'ERR') {
       this.locationHint = getLocationHint(
+        hintUrl ?? this.options.locationHintUrl,
         timeout ?? this.options.locationHintTimeout,
       );
       return this.locationHint;

--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -34,6 +34,7 @@ import {
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 import { version } from '../../../version';
+import { getLocationHint } from './location';
 
 export class StreamClient {
   _user?: UserWithId;
@@ -47,6 +48,8 @@ export class StreamClient {
   key: string;
   listeners: Record<string, Array<(event: StreamVideoEvent) => void>>;
   logger: Logger;
+
+  private locationHint: Promise<string> | undefined;
 
   node: boolean;
   options: StreamClientOptions;
@@ -100,6 +103,10 @@ export class StreamClient {
 
     this.browser = inputOptions.browser || typeof window !== 'undefined';
     this.node = !this.browser;
+
+    if (this.browser) {
+      this.locationHint = getLocationHint(options?.locationHintTimeout);
+    }
 
     this.options = {
       timeout: 5000,
@@ -176,6 +183,17 @@ export class StreamClient {
     this.wsBaseURL = this.baseURL
       .replace('http', 'ws')
       .replace(':3030', ':8800');
+  };
+
+  getLocationHint = async (timeout?: number): Promise<string> => {
+    const hint = await this.locationHint;
+    if (!hint || hint === 'ERR') {
+      this.locationHint = getLocationHint(
+        timeout ?? this.options.locationHintTimeout,
+      );
+      return this.locationHint;
+    }
+    return hint;
   };
 
   _getConnectionID = () =>

--- a/packages/client/src/coordinator/connection/location.ts
+++ b/packages/client/src/coordinator/connection/location.ts
@@ -1,13 +1,16 @@
 import { getLogger } from '../../logger';
 
 const logger = getLogger(['location']);
-const hintURL = `https://hint.stream-io-video.com/`;
+const HINT_URL = `https://hint.stream-io-video.com/`;
 
-export const getLocationHint = async (timeout: number = 1500) => {
+export const getLocationHint = async (
+  hintUrl: string = HINT_URL,
+  timeout: number = 1500,
+) => {
   const abortController = new AbortController();
   const timeoutId = setTimeout(() => abortController.abort(), timeout);
   try {
-    const response = await fetch(hintURL, {
+    const response = await fetch(HINT_URL, {
       method: 'HEAD',
       signal: abortController.signal,
     });
@@ -15,7 +18,7 @@ export const getLocationHint = async (timeout: number = 1500) => {
     logger('debug', `Location header: ${awsPop}`);
     return awsPop.substring(0, 3); // AMS1-P2 -> AMS
   } catch (e) {
-    logger('error', `Failed to get location hint from ${hintURL}`, e);
+    logger('error', `Failed to get location hint from ${HINT_URL}`, e);
     return 'ERR';
   } finally {
     clearTimeout(timeoutId);

--- a/packages/client/src/coordinator/connection/location.ts
+++ b/packages/client/src/coordinator/connection/location.ts
@@ -1,0 +1,23 @@
+import { getLogger } from '../../logger';
+
+const logger = getLogger(['location']);
+const hintURL = `https://hint.stream-io-video.com/`;
+
+export const getLocationHint = async (timeout: number = 1500) => {
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), timeout);
+  try {
+    const response = await fetch(hintURL, {
+      method: 'HEAD',
+      signal: abortController.signal,
+    });
+    const awsPop = response.headers.get('x-amz-cf-pop') || 'ERR';
+    logger('debug', `Location header: ${awsPop}`);
+    return awsPop.substring(0, 3); // AMS1-P2 -> AMS
+  } catch (e) {
+    logger('error', `Failed to get location hint from ${hintURL}`, e);
+    return 'ERR';
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -103,6 +103,10 @@ export type StreamClientOptions = Partial<AxiosRequestConfig> & {
   logger?: Logger;
   logLevel?: LogLevel;
   /**
+   * The URL to use for the location hint.
+   */
+  locationHintUrl?: string;
+  /**
    * The default timeout for requesting a location hint.
    */
   locationHintTimeout?: number;

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -103,6 +103,10 @@ export type StreamClientOptions = Partial<AxiosRequestConfig> & {
   logger?: Logger;
   logLevel?: LogLevel;
   /**
+   * The default timeout for requesting a location hint.
+   */
+  locationHintTimeout?: number;
+  /**
    * When true, user will be persisted on client. Otherwise if `connectUser` call fails, then you need to
    * call `connectUser` again to retry.
    * This is mainly useful for chat application working in offline mode, where you will need client.user to

--- a/packages/client/src/rtc/flows/join.ts
+++ b/packages/client/src/rtc/flows/join.ts
@@ -10,7 +10,6 @@ import {
   StreamVideoParticipant,
 } from '../../types';
 import { StreamClient } from '../../coordinator/connection/client';
-import { getLogger } from '../../logger';
 
 /**
  * Collects all necessary information to join a call, talks to the coordinator
@@ -45,7 +44,7 @@ const doJoin = async (
   id: string,
   data?: JoinCallData,
 ) => {
-  const location = await getLocationHint();
+  const location = await httpClient.getLocationHint();
   const request: JoinCallRequest = {
     ...data,
     location,
@@ -73,27 +72,6 @@ const doJoin = async (
     `/call/${type}/${id}/join`,
     request,
   );
-};
-
-const getLocationHint = async () => {
-  const hintURL = `https://hint.stream-io-video.com/`;
-  const abortController = new AbortController();
-  const timeoutId = setTimeout(() => abortController.abort(), 1000);
-  const logger = getLogger(['call']);
-  try {
-    const response = await fetch(hintURL, {
-      method: 'HEAD',
-      signal: abortController.signal,
-    });
-    const awsPop = response.headers.get('x-amz-cf-pop') || 'ERR';
-    logger?.('info', `Location header: ${awsPop}`);
-    return awsPop.substring(0, 3); // AMS1-P2 -> AMS
-  } catch (e) {
-    logger?.('error', `Failed to get location hint from ${hintURL}`, e);
-    return 'ERR';
-  } finally {
-    clearTimeout(timeoutId);
-  }
 };
 
 const toRtcConfiguration = (config?: ICEServer[]) => {


### PR DESCRIPTION
### Overview

In order to speed up the join flow, the location hint parameter is now determined and cached at SDK initialization (i.e. at the time when the `StreamVideoClient` instance is constructed). This should save us ~0.5 seconds during the join phase.
