### PR TITLE
docs: add backlinks to the main marketing pages

### DIFF
--- a/packages/react-sdk/docusaurus/docs/React/02-tutorials/01-video-calling.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-tutorials/01-video-calling.mdx
@@ -3,8 +3,6 @@ title: Video Call Tutorial
 description: How to build a video call similar to Zoom or facebook messenger
 ---
 
-import ImageShowcase from '@site/src/components/ImageShowcase';
-
 import FinishedTutorial from '../assets/01-basics/01-tutorial/finished-tutorial.png';
 import TutorialInProgress from '../assets/01-basics/01-tutorial/tutorial-in-progress.png';
 import { TokenSnippet } from '../../../shared/_tokenSnippet.jsx';
@@ -455,12 +453,15 @@ Please do let us know if you ran into any issues while building an video calling
 
 To recap what we've learned about Stream video calling:
 
-- You set up a call: (`const call = client.call("default", "123")`)
+- You set up a call: `const call = client.call("default", "123")`
 - The call type ("default" in the above case) controls which features are enabled and how permissions are setup
-- When you join a call, real-time communication is set up for audio & video calling: (`call.join()`)
+- When you join a call, real-time communication is set up for audio & video calling: `call.join()`
 - State-related hooks such as `useLocalParticipant` make it easy to build your own UI
 - `ParticipantView` is the low-level component that renders audio and video
 
-We've used [Stream's Video Calling API](https://getstream.io/video/), which means calls run on a global edge network of video servers. By being closer to your users the latency and reliability of calls are better. The React SDK enables you to build in-app video calling, audio rooms and livestreaming in days.
+We've used [Stream's Video Calling API](https://getstream.io/video/video-calling/),
+which means calls run on a global edge network of video servers.
+By being closer to your users the latency and reliability of calls are better.
+The React SDK enables you to build in-app [video calling, audio rooms and livestreaming](https://getstream.io/video/) in days.
 
 We hope you've enjoyed this tutorial and please do feel free to reach out if you have any suggestions or questions.

--- a/packages/react-sdk/docusaurus/docs/React/02-tutorials/02-audio-room.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-tutorials/02-audio-room.mdx
@@ -599,11 +599,14 @@ To recap what we've learned:
 - You set up a call with `const call = client.call('audio_room', '123')`
 - The call type `audio_room` controls which features are enabled and how permissions are set up
 - The `audio_room` by default enables `backstage` mode, and only allows admins and the creator of the call to join before the call goes live
-- When you join a call, realtime communication is set up for audio & video calling: `await call.join()`
+- When you join a call, realtime communication is set up for audio: `await call.join()`
 - Call state `call.state` and helper state access hooks make it easy to build your own UI
-- Calls run on Stream's global edge network of video servers. Being closer to your users improves the latency and reliability of calls. For audio rooms we use Opus RED and Opus DTX for optimal audio quality.
+- For audio rooms we use Opus RED and Opus DTX for optimal audio quality.
 
-The SDKs enable you to build audio rooms, video calling and livestreaming in days.
+We've used [Stream's Audio Rooms API](https://getstream.io/video/audio-rooms/),
+which means calls run on a global edge network of video servers.
+By being closer to your users the latency and reliability of calls are better.
+The React SDK enables you to build in-app [video calling, audio rooms and livestreaming](https://getstream.io/video/) in days.
 
 We hope you've enjoyed this tutorial and please do feel free to reach out if you have any suggestions or questions.
 You can find the code and the stylesheet for this tutorial in [this CodeSandbox](https://codesandbox.io/s/audio-rooms-tutorial-glhgrg).

--- a/packages/react-sdk/docusaurus/docs/React/02-tutorials/03-livestream.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-tutorials/03-livestream.mdx
@@ -375,3 +375,24 @@ check this Livestreaming sample app:
 - [Livestream App live preview](https://video-react-livestream-app.vercel.app/)
 
 :::
+
+## Recap
+
+It was fun to see just how quickly you can build a live-stream app for your hosts and viewers.
+Please do let us know if you ran into any issues.
+Our team is also happy to review your UI designs and offer recommendations on how to achieve it with Stream.
+
+To recap what we've learned:
+
+- You set up a call with `const call = client.call('livestream', '123')`
+- The call type `livestream` controls which features are enabled and how permissions are set up
+- The `livestream` by default enables `backstage` mode, and only allows admins and the creator of the call to join before the call goes live
+- When you join a call, realtime communication is set up for audio & video streaming: `await call.join()`
+- Call state `call.state` and helper state access hooks make it easy to build your own UI
+
+We've used [Stream's Livestreaming API](https://getstream.io/video/livestreaming/),
+which means calls run on a global edge network of video servers.
+By being closer to your users the latency and reliability of calls are better.
+The React SDK enables you to build in-app [video calling, audio rooms and livestreaming](https://getstream.io/video/) in days.
+
+We hope you've enjoyed this tutorial and please do feel free to reach out if you have any suggestions or questions.


### PR DESCRIPTION
### Overview

Adds backlinks to the main marketing pages in all of our tutorials.
Context: https://getstream.slack.com/archives/C022N8JNQGZ/p1689185200690119