### PR TITLE
fix: shorter thresholds for ICE restarts

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -124,7 +124,7 @@ export class Publisher {
     isDtxEnabled,
     isRedEnabled,
     preferredVideoCodec,
-    iceRestartDelay = 5000,
+    iceRestartDelay = 2500,
   }: PublisherOpts) {
     this.pc = this.createPeerConnection(connectionConfig);
     this.sfuClient = sfuClient;

--- a/packages/client/src/rtc/Subscriber.ts
+++ b/packages/client/src/rtc/Subscriber.ts
@@ -46,7 +46,7 @@ export class Subscriber {
     dispatcher,
     state,
     connectionConfig,
-    iceRestartDelay = 5000,
+    iceRestartDelay = 2500,
   }: SubscriberOpts) {
     this.sfuClient = sfuClient;
     this.dispatcher = dispatcher;


### PR DESCRIPTION
### Overview

This is a follow-up to #814. We are reducing the delay to 2.5 seconds until we perform an ICE restart.