### PR TITLE
feat: Add call.create

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -504,6 +504,15 @@ export class Call {
   };
 
   /**
+   * Creates a call
+   *
+   * @param data the data to create the call with.
+   */
+  create = async (data?: GetOrCreateCallRequest) => {
+    return this.getOrCreate(data);
+  };
+
+  /**
    * A shortcut for {@link Call.get} with `ring` parameter set to `true`.
    * Will send a `call.ring` event to the call members.
    */

--- a/packages/client/src/__tests__/server-side/call-types.test.ts
+++ b/packages/client/src/__tests__/server-side/call-types.test.ts
@@ -71,7 +71,17 @@ describe('call types CRUD API', () => {
   });
 
   it('delete', async () => {
-    await client.deleteCallType(callTypeName);
+    try {
+      await client.deleteCallType(callTypeName);
+    } catch (e) {
+      // the first request fails on backend sometimes
+      // retry it
+      await new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), 2000);
+      });
+
+      await client.deleteCallType(callTypeName);
+    }
 
     await expect(() => client.getCallType(callTypeName)).rejects.toThrowError();
   });

--- a/packages/client/src/__tests__/server-side/call.test.ts
+++ b/packages/client/src/__tests__/server-side/call.test.ts
@@ -26,7 +26,7 @@ describe('call API', () => {
   });
 
   it('create', async () => {
-    const response = await call.getOrCreate({
+    const response = await call.create({
       data: { created_by_id: 'john' },
     });
 


### PR DESCRIPTION
- `call.create` added: https://getstream.slack.com/archives/C05FT65AVT8/p1690189296241139
- the delete call type test fails from time to time, I checked it a number of times, [it has to be a backend issue](https://getstream.slack.com/archives/C040262MY9K/p1690198559995009), but I don't think it's being fixed. I added a retry logic for the test to hopefully avoid flakiness. 