### PR TITLE
fix: scrolling when mobile banner is visible

### DIFF
--- a/sample-apps/react/react-video-demo/src/App.tsx
+++ b/sample-apps/react/react-video-demo/src/App.tsx
@@ -126,26 +126,15 @@ const Init = () => {
   }, []);
 
   useEffect(() => {
-    let markerTimer: ReturnType<typeof setTimeout>;
-
     async function fetchEdges() {
-      if (!client) {
-        return;
-      }
+      if (!client) return;
       const response: GetEdgesResponse = await client.edges();
-
-      if (!edges) {
-        const features = createGeoJsonFeatures(response.edges);
-        setEdges(features);
-      }
+      const features = createGeoJsonFeatures(response.edges);
+      setEdges(features);
     }
 
     fetchEdges();
-
-    return () => {
-      clearTimeout(markerTimer);
-    };
-  }, [edges, isCallActive, client]);
+  }, [client]);
 
   const joinMeeting = useCallback(async () => {
     setIsJoiningCall(true);

--- a/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.module.css
+++ b/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.module.css
@@ -11,6 +11,10 @@
   grid-template-areas: 'body';
 }
 
+.mobileBannerVisible {
+  height: calc(100vh - 80px);
+}
+
 @media screen(md) {
   .layoutContainer {
     @apply grid relative z-10 w-full;

--- a/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.tsx
+++ b/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.tsx
@@ -24,10 +24,13 @@ export const LobbyLayout: FC<Props> = ({
 }) => {
   const { qr } = useUserContext();
   const shouldRenderMobileAppBanner = isAndroid && qr;
-  const [shouldCenterBody, setShouldCenterBody] = useState(
-    !shouldRenderMobileAppBanner,
+  const [isNativeAppsBannerDismissed, setIsNativeAppsBannerDismissed] =
+    useState(!shouldRenderMobileAppBanner);
+  const rootClassName = classnames(
+    styles.root,
+    className,
+    !isNativeAppsBannerDismissed && 'h-auto overflow-y-scroll',
   );
-  const rootClassName = classnames(styles.root, className);
   return (
     <section className={rootClassName}>
       <LatencyMap className={styles.latencyMap} sourceData={edges} />
@@ -35,15 +38,20 @@ export const LobbyLayout: FC<Props> = ({
         <MobileAppBanner
           className={styles.mobileBanner}
           onDismiss={() => {
-            setShouldCenterBody(true);
+            setIsNativeAppsBannerDismissed(true);
           }}
         />
       )}
-      <section className={styles.layoutContainer}>
+      <section
+        className={classnames(
+          styles.layoutContainer,
+          !isNativeAppsBannerDismissed && styles.mobileBannerVisible,
+        )}
+      >
         <div className={styles.header}>{header}</div>
         <div
           className={classnames(styles.body, {
-            'items-center': shouldCenterBody,
+            'items-center': isNativeAppsBannerDismissed,
           })}
         >
           {children}


### PR DESCRIPTION
### Overview

Enables scrolling in the lobby when the "native apps banner" is shown. See: #832 
Also, fixes the duplicated `GET /edges` request.