### PR TITLE
fix: hide participant actions menu in Composite App

### DIFF
--- a/sample-apps/react/egress-composite/src/layouts/grid/GridView.tsx
+++ b/sample-apps/react/egress-composite/src/layouts/grid/GridView.tsx
@@ -1,19 +1,21 @@
 import {
-  PaginatedGridLayout,
   DefaultParticipantViewUI,
+  PaginatedGridLayout,
 } from '@stream-io/video-react-sdk';
 import { useAppConfig } from '../../hooks/useAppConfig';
 
 import './GridView.scss';
 
 export const GridView = () => {
-  // const setParticipantVideoRef = useEgressReadyWhenAnyParticipantMounts();
   const { gridSize } = useAppConfig();
   return (
     <div className="grid-view">
       <PaginatedGridLayout
         ParticipantViewUI={
-          <DefaultParticipantViewUI indicatorsVisible={false} />
+          <DefaultParticipantViewUI
+            indicatorsVisible={false}
+            showMenuButton={false}
+          />
         }
         excludeLocalParticipant
         groupSize={gridSize || 25}


### PR DESCRIPTION
### Overview

Hides the "Participant Actions" menu in the Grid layout.