### PR TITLE
fix: disable app-clips, show banner for iOS as well

### DIFF
--- a/sample-apps/react/react-video-demo/index.html
+++ b/sample-apps/react/react-video-demo/index.html
@@ -4,11 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <meta
-      name="apple-itunes-app"
-      content="app-id=1644313060, app-clip-bundle-id=io.getstream.iOS.VideoDemoApp.Clip, app-clip-display=card"
-    />
-
     <link
       rel="icon"
       type="image/png"

--- a/sample-apps/react/react-video-demo/src/components/Header/MobileAppBanner.tsx
+++ b/sample-apps/react/react-video-demo/src/components/Header/MobileAppBanner.tsx
@@ -4,12 +4,40 @@ import { useState } from 'react';
 import { useCall } from '@stream-io/video-react-sdk';
 
 export const MobileAppBanner = (props: {
+  platform: 'android' | 'ios';
   className?: string;
   onDismiss?: () => void;
 }) => {
   const call = useCall();
   const [isVisible, setIsVisible] = useState(true);
   if (!isVisible) return null;
+
+  const platformLinks: Record<
+    'android' | 'ios',
+    { label: string; url: string; active: boolean }[]
+  > = {
+    android: [
+      {
+        label: 'Android',
+        url: `https://play.google.com/store/apps/details?id=io.getstream.video.android&referrer=${encodeURIComponent(
+          `call_id=${call?.id}`,
+        )}`,
+        active: true,
+      },
+      { label: 'React Native', url: '#', active: false },
+      { label: 'Flutter', url: '#', active: false },
+    ],
+    ios: [
+      {
+        label: 'iOS',
+        url: 'https://apps.apple.com/us/app/stream-video-calls/id1644313060',
+        active: true,
+      },
+      { label: 'React Native', url: '#', active: false },
+      { label: 'Flutter', url: '#', active: false },
+    ],
+  };
+
   return (
     <div className={classNames(styles.mobileBanner, props.className)}>
       <h2 className={styles.tryNativeHeading}>Try Native!</h2>
@@ -19,30 +47,19 @@ export const MobileAppBanner = (props: {
         Why don't you give it a try to one of our native mobile apps:
       </p>
       <div className="flex flex-wrap flex-col xs:flex-row justify-center gap-2 w-full">
-        <a
-          className={styles.nativeAppLink + ' flex-1'}
-          href={`https://play.google.com/store/apps/details?id=io.getstream.video.android&referrer=${encodeURIComponent(
-            `call_id=${call?.id}`,
-          )}`}
-          target="_blank"
-          rel="noreferrer"
-        >
-          Android
-        </a>
-        <a
-          className={styles.nativeAppLink + ' flex-1 hidden'}
-          href="#"
-          target="_blank"
-        >
-          React Native
-        </a>
-        <a
-          className={styles.nativeAppLink + ' flex-1 hidden'}
-          href="#"
-          target="_blank"
-        >
-          Flutter
-        </a>
+        {(platformLinks[props.platform] || [])
+          .filter((app) => app.active)
+          .map((link) => (
+            <a
+              key={link.label}
+              className={classNames(styles.nativeAppLink, 'flex-1')}
+              href={link.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {link.label}
+            </a>
+          ))}
       </div>
       <p className={styles.infoText}>
         Of course, you can always continue in your browser

--- a/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.tsx
+++ b/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode, useState } from 'react';
 import classnames from 'classnames';
-import { isAndroid, isIOS, isSafari } from 'mobile-device-detect';
+import { isAndroid, isIOS } from 'mobile-device-detect';
 import { FeatureCollection, Geometry } from 'geojson';
 
 import LatencyMap from '../../LatencyMap';
@@ -23,7 +23,7 @@ export const LobbyLayout: FC<Props> = ({
   edges,
 }) => {
   const { qr } = useUserContext();
-  const shouldRenderMobileAppBanner = qr && (isAndroid || (isIOS && !isSafari));
+  const shouldRenderMobileAppBanner = qr && (isAndroid || isIOS);
   const [isNativeAppsBannerDismissed, setIsNativeAppsBannerDismissed] =
     useState(!shouldRenderMobileAppBanner);
   const rootClassName = classnames(

--- a/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.tsx
+++ b/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode, useState } from 'react';
 import classnames from 'classnames';
-import { isAndroid } from 'mobile-device-detect';
+import { isAndroid, isIOS, isSafari } from 'mobile-device-detect';
 import { FeatureCollection, Geometry } from 'geojson';
 
 import LatencyMap from '../../LatencyMap';
@@ -23,7 +23,7 @@ export const LobbyLayout: FC<Props> = ({
   edges,
 }) => {
   const { qr } = useUserContext();
-  const shouldRenderMobileAppBanner = isAndroid && qr;
+  const shouldRenderMobileAppBanner = qr && (isAndroid || (isIOS && !isSafari));
   const [isNativeAppsBannerDismissed, setIsNativeAppsBannerDismissed] =
     useState(!shouldRenderMobileAppBanner);
   const rootClassName = classnames(
@@ -36,6 +36,7 @@ export const LobbyLayout: FC<Props> = ({
       <LatencyMap className={styles.latencyMap} sourceData={edges} />
       {shouldRenderMobileAppBanner && (
         <MobileAppBanner
+          platform={isAndroid ? 'android' : 'ios'}
           className={styles.mobileBanner}
           onDismiss={() => {
             setIsNativeAppsBannerDismissed(true);

--- a/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.tsx
+++ b/sample-apps/react/react-video-demo/src/components/Layout/LobbyLayout/LobbyLayout.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode, useState } from 'react';
 import classnames from 'classnames';
-import { isAndroid, isIOS } from 'mobile-device-detect';
+import { isAndroid, isIOS, isSafari } from 'mobile-device-detect';
 import { FeatureCollection, Geometry } from 'geojson';
 
 import LatencyMap from '../../LatencyMap';
@@ -23,7 +23,7 @@ export const LobbyLayout: FC<Props> = ({
   edges,
 }) => {
   const { qr } = useUserContext();
-  const shouldRenderMobileAppBanner = qr && (isAndroid || isIOS);
+  const shouldRenderMobileAppBanner = qr && (isAndroid || (isIOS && !isSafari));
   const [isNativeAppsBannerDismissed, setIsNativeAppsBannerDismissed] =
     useState(!shouldRenderMobileAppBanner);
   const rootClassName = classnames(

--- a/sample-apps/react/react-video-demo/src/components/Views/LobbyView/LobbyView.tsx
+++ b/sample-apps/react/react-video-demo/src/components/Views/LobbyView/LobbyView.tsx
@@ -6,7 +6,7 @@ import { User } from '@stream-io/video-react-sdk';
 import LobbyPanel from '../../LobbyPanel';
 import Header from '../../Header';
 
-import { requestMediaPermissions, MediaPermissionsError } from 'mic-check';
+import { MediaPermissionsError, requestMediaPermissions } from 'mic-check';
 
 import LobbyLayout from '../../Layout/LobbyLayout';
 
@@ -60,15 +60,15 @@ export const LobbyView: FC<Props & Lobby> = ({
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const nextSentence =
-        loadingSentences[
-          (loadingSentences.indexOf(loadingSentence) + 1) %
-            loadingSentences.length
-        ];
-      setLoadingSentence(nextSentence);
+      setLoadingSentence((currentSentence) => {
+        const nextIndex =
+          (loadingSentences.indexOf(currentSentence) + 1) %
+          loadingSentences.length;
+        return loadingSentences[nextIndex];
+      });
     }, 1000);
     return () => clearInterval(interval);
-  }, [loadingSentence]);
+  }, []);
 
   return (
     <LobbyLayout


### PR DESCRIPTION
### Overview

Disables the App-Clips integration for iOS. Show a custom banner when opening the demo app from an iOS device and a non-Safari browser.

Related: #832 

<img width="389" alt="Screenshot 2023-08-08 at 16 48 50" src="https://github.com/GetStream/stream-video-js/assets/843172/f1613c39-22e5-4164-bb2d-c179c3250a34">
