### PR TITLE
fix(ParticipantView): remove audio element while muted

### DIFF
--- a/packages/react-sdk/src/core/components/ParticipantView/ParticipantView.tsx
+++ b/packages/react-sdk/src/core/components/ParticipantView/ParticipantView.tsx
@@ -160,12 +160,13 @@ export const ParticipantView = forwardRef<HTMLDivElement, ParticipantViewProps>(
         )}
       >
         <ParticipantViewContext.Provider value={participantViewContextValue}>
-          <Audio
-            // mute the local participant, as we don't want to hear ourselves
-            muted={isLocalParticipant || muteAudio}
-            sinkId={localParticipant?.audioOutputDeviceId}
-            audioStream={audioStream}
-          />
+          {/* mute the local participant, as we don't want to hear ourselves */}
+          {!isLocalParticipant && !muteAudio && (
+            <Audio
+              sinkId={localParticipant?.audioOutputDeviceId}
+              audioStream={audioStream}
+            />
+          )}
           <Video
             VideoPlaceholder={VideoPlaceholder}
             participant={participant}


### PR DESCRIPTION
The `audio` element essentially does nothing when muted so to reduce amount of rendered elements we can safely remove it.