### PR TITLE
feat: extra config params in goLive() API

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -28,6 +28,7 @@ import {
   GetCallResponse,
   GetOrCreateCallRequest,
   GetOrCreateCallResponse,
+  GoLiveRequest,
   GoLiveResponse,
   ListRecordingsResponse,
   MuteUsersRequest,
@@ -1461,11 +1462,14 @@ export class Call {
 
   /**
    * Starts the livestreaming of the call.
+   *
+   * @param data the request data.
+   * @param params the request params.
    */
-  goLive = async (params?: { notify?: boolean }) => {
-    return this.streamClient.post<GoLiveResponse>(
+  goLive = async (data: GoLiveRequest, params?: { notify?: boolean }) => {
+    return this.streamClient.post<GoLiveResponse, GoLiveRequest>(
       `${this.streamClientBasePath}/go_live`,
-      {},
+      data,
       params,
     );
   };

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1466,7 +1466,7 @@ export class Call {
    * @param data the request data.
    * @param params the request params.
    */
-  goLive = async (data: GoLiveRequest, params?: { notify?: boolean }) => {
+  goLive = async (data: GoLiveRequest = {}, params?: { notify?: boolean }) => {
     return this.streamClient.post<GoLiveResponse, GoLiveRequest>(
       `${this.streamClientBasePath}/go_live`,
       data,

--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -2415,6 +2415,31 @@ export interface GetOrCreateCallResponse {
 /**
  *
  * @export
+ * @interface GoLiveRequest
+ */
+export interface GoLiveRequest {
+  /**
+   *
+   * @type {boolean}
+   * @memberof GoLiveRequest
+   */
+  start_hls?: boolean;
+  /**
+   *
+   * @type {boolean}
+   * @memberof GoLiveRequest
+   */
+  start_recording?: boolean;
+  /**
+   *
+   * @type {boolean}
+   * @memberof GoLiveRequest
+   */
+  start_transcription?: boolean;
+}
+/**
+ *
+ * @export
  * @interface GoLiveResponse
  */
 export interface GoLiveResponse {

--- a/packages/react-sdk/docusaurus/docs/React/02-tutorials/03-livestream.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-tutorials/03-livestream.mdx
@@ -286,6 +286,17 @@ Only after you call `call.goLive()` will regular users be allowed to join the li
 This is convenient for many livestreaming and audio-room use cases. If you want calls to start immediately when you join them that's also possible.
 Simply go the Stream dashboard, click the livestream call type and disable the backstage mode.
 
+The `call.goLive` method can also automatically start HLS livestreaming, recording or transcribing.
+In order to do that, you need to pass the corresponding optional parameter:
+
+```ts
+await call.goLive({
+  start_hls: true,
+  start_recording: true,
+  start_transcription: true,
+});
+```
+
 ### Step 4 - (Optional) Publishing RTMP using OBS
 
 The example above showed how to publish your device camera to the livestream.
@@ -333,7 +344,8 @@ So HLS can be a good option when:
 - A 10-20 second delay is acceptable
 - Your users want to watch the Stream in poor network conditions
 
-Let's show how to broadcast your call to HLS:
+One option to start HLS is to set the `start_hls` parameter to `true` in the `call.goLive()` method, as described above.
+If you want to explicitly start it, when you are live, you can use the following method:
 
 ```ts
 import { useCall, useCallMetadata } from '@stream-io/video-react-sdk';


### PR DESCRIPTION
### Overview

Add additional configuration parameters for the `call.goLive()` endpoint.