### PR TITLE
refactor(react-bindings): remove redundant language check

### DIFF
--- a/packages/react-bindings/src/contexts/StreamI18nContext.tsx
+++ b/packages/react-bindings/src/contexts/StreamI18nContext.tsx
@@ -56,11 +56,13 @@ export const useCreateI18n = ({
   );
 
   useEffect(() => {
-    if (i18n.isInitialized && language && i18n?.currentLanguage !== language) {
-      i18n.changeLanguage(language);
-    } else if (!i18n.isInitialized) {
-      if (!language) i18n.changeLanguage();
+    const { isInitialized } = i18n;
+    if (!isInitialized) {
       i18n.init().then((_i18n) => setTranslationFn(() => _i18n.i18nInstance.t));
+    } else {
+      if (language && i18n?.currentLanguage !== language) {
+        i18n.changeLanguage(language);
+      }
     }
   }, [i18n, i18nInstance, language, translationsOverrides]);
 

--- a/packages/react-bindings/src/contexts/StreamI18nContext.tsx
+++ b/packages/react-bindings/src/contexts/StreamI18nContext.tsx
@@ -59,10 +59,10 @@ export const useCreateI18n = ({
     const { isInitialized } = i18n;
     if (!isInitialized) {
       i18n.init().then((_i18n) => setTranslationFn(() => _i18n.i18nInstance.t));
-    } else {
-      if (language && i18n?.currentLanguage !== language) {
-        i18n.changeLanguage(language);
-      }
+      return;
+    }
+    if (language && i18n?.currentLanguage !== language) {
+      i18n.changeLanguage(language);
     }
   }, [i18n, i18nInstance, language, translationsOverrides]);
 

--- a/sample-apps/react-native/dogfood/src/components/VideoWrapper.tsx
+++ b/sample-apps/react-native/dogfood/src/components/VideoWrapper.tsx
@@ -46,12 +46,7 @@ export const VideoWrapper = ({ children }: PropsWithChildren<{}>) => {
   }
 
   return (
-    <StreamVideo
-      client={videoClient}
-      // By default we keep English(en) for now, unless we start supporting switching of language in the application
-      language={'en'}
-      translationsOverrides={translations}
-    >
+    <StreamVideo client={videoClient} translationsOverrides={translations}>
       {children}
     </StreamVideo>
   );


### PR DESCRIPTION
If you check the logic for `changeLanguage`, the first condition in it says https://github.com/GetStream/stream-video-js/blob/main/packages/i18n/src/StreamI18n.ts#L88 which internally throws the warning:
```
I18n instance is not initialized. Call yourStreamI18nInstance.init().
```

This is a yellow box warning for RN SDK.
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-08-13 at 22 28 47](https://github.com/GetStream/stream-video-js/assets/39884168/bf4a2b34-dc53-4b26-8720-3b08119ef039)

-----

Now in StreamI18nContext, we have a redundant condition that seems to `changeLanguage` if there is no `language` passed. But that condition is used when the `i18n.isInitialized` is false/undefined, which will, in turn, call the `this._checkIsInitialized()` from the `changeLanguage` and return the warning.

This PR tries to solve this issue and remove the redundant condition.