### PR TITLE
feat(client): prefer vp8 for android on react-native

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -108,8 +108,9 @@ import {
   Logger,
   StreamCallEvent,
 } from './coordinator/connection/types';
-import { getClientDetails } from './client-details';
+import { getClientDetails, getOSInfo } from './client-details';
 import { getLogger } from './logger';
+import { isReactNative } from './helpers/platforms';
 
 /**
  * An object representation of a `Call`.
@@ -819,6 +820,12 @@ export class Call {
     const isDtxEnabled = !!audioSettings?.opus_dtx_enabled;
     const isRedEnabled = !!audioSettings?.redundant_coding_enabled;
 
+    let preferredVideoCodec = this.streamClient.options.preferredVideoCodec;
+    if (isReactNative()) {
+      const isIOS = getOSInfo()?.name.toLowerCase() === 'ios';
+      preferredVideoCodec = isIOS ? undefined : 'VP8';
+    }
+
     if (!this.publisher) {
       this.publisher = new Publisher({
         sfuClient,
@@ -827,7 +834,7 @@ export class Call {
         connectionConfig,
         isDtxEnabled,
         isRedEnabled,
-        preferredVideoCodec: this.streamClient.options.preferredVideoCodec,
+        preferredVideoCodec,
       });
     }
 

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -854,11 +854,7 @@ export class Call {
         // this is a throw-away SDP that the SFU will use to determine
         // the capabilities of the client (codec support, etc.)
         .then(() =>
-          getGenericSdp(
-            'recvonly',
-            isRedEnabled,
-            this.streamClient.options.preferredVideoCodec,
-          ),
+          getGenericSdp('recvonly', isRedEnabled, preferredVideoCodec),
         )
         .then((sdp) => {
           const subscriptions = getCurrentValue(this.trackSubscriptionsSubject);


### PR DESCRIPTION
This PR adds support for:

* Always prioritising VP8 on Android -- aligns with flutter
* Adds support to remove video codecs as well with check for `rtcp-fb` -- currently we don't remove video codecs though