### PR TITLE
fix: correctly report `live` state of the call

### DIFF
--- a/packages/react-bindings/src/hooks/callStateHooks.ts
+++ b/packages/react-bindings/src/hooks/callStateHooks.ts
@@ -62,7 +62,8 @@ export const useIsCallBroadcastingInProgress = (): boolean => {
  */
 export const useIsCallLive = (): boolean => {
   const { backstage$ } = useCallState();
-  return useObservableValue(backstage$);
+  const isBackstageOn = useObservableValue(backstage$);
+  return !isBackstageOn;
 };
 
 /**


### PR DESCRIPTION
### Overview

Fixes a regression introduced with #931