### PR TITLE
fix(react-native): participant label should check for sfu mute state

### DIFF
--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantLabel.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantLabel.tsx
@@ -2,14 +2,11 @@ import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { MicOff, PinVertical, ScreenShare, VideoSlash } from '../../../icons';
 import { theme } from '../../../theme';
-import {
-  useCall,
-  useCallStateHooks,
-  useI18n,
-} from '@stream-io/video-react-bindings';
+import { useCall, useI18n } from '@stream-io/video-react-bindings';
 import { ComponentTestIds } from '../../../constants/TestIds';
 import { ParticipantViewProps } from './ParticipantView';
 import { Z_INDEX } from '../../../constants';
+import { SfuModels } from '@stream-io/video-client';
 
 /**
  * Props for the ParticipantLabel component.
@@ -26,17 +23,15 @@ export const ParticipantLabel = ({
   participant,
   videoMode,
 }: ParticipantLabelProps) => {
-  const { name, userId, pin, sessionId, isLocalParticipant } = participant;
+  const { name, userId, pin, publishedTracks, sessionId, isLocalParticipant } =
+    participant;
   const call = useCall();
-  const { useCameraState, useMicrophoneState } = useCallStateHooks();
-  const { status: micStatus } = useMicrophoneState();
-  const { status: cameraStatus } = useCameraState();
   const { t } = useI18n();
   const participantName = name ?? userId;
   const participantLabel = isLocalParticipant ? t('You') : participantName;
   const isPinningEnabled = pin?.isLocalPin;
-  const isAudioMuted = micStatus === 'disabled';
-  const isVideoMuted = cameraStatus === 'disabled';
+  const isAudioMuted = !publishedTracks.includes(SfuModels.TrackType.AUDIO);
+  const isVideoMuted = !publishedTracks.includes(SfuModels.TrackType.VIDEO);
 
   const unPinParticipantHandler = () => {
     call?.unpin(sessionId);


### PR DESCRIPTION
currently it checks for local camera's mute