### PR TITLE
fix: provide apple-itunes-app meta tag for the demo app

### DIFF
--- a/sample-apps/react/react-video-demo/index.html
+++ b/sample-apps/react/react-video-demo/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="apple-itunes-app" content="app-id=1644313060" />
 
     <link
       rel="icon"


### PR DESCRIPTION
### Overview

Provides a `meta` tag pointing to the corresponding app in App Store.