### PR TITLE
fix: guest auth didn't wait for some API calls

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -152,16 +152,7 @@ export class StreamVideoClient {
     };
     if (user.type === 'guest') {
       connectUser = async () => {
-        const response = await this.createGuestUser({
-          user: {
-            ...user,
-            role: 'guest',
-          },
-        });
-        return this.streamClient.connectUser(
-          response.user,
-          response.access_token,
-        );
+        return this.streamClient.connectGuestUser(user);
       };
     }
     this.connectionPromise = this.disconnectionPromise

--- a/packages/client/src/__tests__/StreamVideoClient.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.test.ts
@@ -3,6 +3,7 @@ import { StreamVideoClient } from '../StreamVideoClient';
 import 'dotenv/config';
 import { generateUUIDv4 } from '../coordinator/connection/utils';
 import { StreamVideoServerClient } from '../StreamVideoServerClient';
+import { User } from '../coordinator/connection/types';
 
 const apiKey = process.env.STREAM_API_KEY!;
 const secret = process.env.STREAM_SECRET!;
@@ -85,6 +86,18 @@ describe('StreamVideoClient', () => {
     expect(params['connection_id']).toBe(
       client.streamClient._getConnectionID(),
     );
+  });
+
+  it('API calls should be hold until auth is done - guest user', async () => {
+    const user: User = {
+      id: 'jane-guest',
+      type: 'guest',
+    };
+
+    client.connectUser(user);
+    const response = await client.queryCalls({});
+
+    expect(response.calls).toBeDefined();
   });
 
   afterEach(() => {


### PR DESCRIPTION
I ran into this problem while creating the livestream viewer sample app, where I'll use guest users