### PR TITLE
fix: provide app-argument for iOS smart banners

### DIFF
--- a/sample-apps/react/react-video-demo/src/App.tsx
+++ b/sample-apps/react/react-video-demo/src/App.tsx
@@ -106,6 +106,18 @@ const Init = () => {
   }, [client]);
 
   useEffect(() => {
+    const appleItunesAppMeta = document
+      .getElementsByTagName('meta')
+      .namedItem('apple-itunes-app');
+    if (appleItunesAppMeta) {
+      appleItunesAppMeta.setAttribute(
+        'content',
+        `app-id=1644313060, app-argument=${window.location.href}`,
+      );
+    }
+  }, []);
+
+  useEffect(() => {
     setSteps(tour);
   }, []);
 


### PR DESCRIPTION
### Overview

Provides the current URL that includes the call ID as an argument to iOS Safari smart app banner.