### PR TITLE
feat: apply target resolution to video feed, sync camera/mic init

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1718,6 +1718,10 @@ export class Call {
   };
 
   private async initCamera() {
+    // Wait for any in progress camera operation
+    this.camera.enablePromise ? await this.camera.enablePromise : null;
+    this.camera.disablePromise ? await this.camera.disablePromise : null;
+
     if (
       this.state.localParticipant?.videoStream ||
       !this.permissionsContext.hasPermission('send-video')
@@ -1726,27 +1730,31 @@ export class Call {
     }
 
     // Set camera direction if it's not yet set
-    // This will also start publishing if camera is enabled
     if (!this.camera.state.direction && !this.camera.state.selectedDevice) {
       let defaultDirection: CameraDirection = 'front';
       const backendSetting = this.state.settings?.video.camera_facing;
       if (backendSetting) {
         defaultDirection = backendSetting === 'front' ? 'front' : 'back';
       }
-      this.camera.selectDirection(defaultDirection);
-    } else if (this.camera.state.status === 'enabled') {
-      // Publish already started media streams (this is the case if there is a lobby screen before join)
-      // Wait for media stream
-      this.camera.state.mediaStream$
-        .pipe(takeWhile((s) => s === undefined, true))
-        .subscribe((stream) => {
-          if (!this.state.localParticipant?.videoStream) {
-            this.publishVideoStream(stream!);
-          }
-        });
+      this.camera.state.setDirection(defaultDirection);
     }
 
-    // Apply backend config (this is the case if there is no lobby screen before join)
+    // Set target resolution
+    const targetResolution = this.state.settings?.video.target_resolution;
+    if (targetResolution) {
+      await this.camera.selectTargetResolution(targetResolution);
+    }
+
+    // Publish already that was set before we joined
+    if (
+      this.camera.state.status === 'enabled' &&
+      this.camera.state.mediaStream &&
+      !this.publisher?.isPublishing(TrackType.VIDEO)
+    ) {
+      await this.publishVideoStream(this.camera.state.mediaStream);
+    }
+
+    // Start camera if backend config speicifies, and there is no local setting
     if (
       this.camera.state.status === undefined &&
       this.state.settings?.video.camera_default_on
@@ -1756,6 +1764,12 @@ export class Call {
   }
 
   private async initMic() {
+    // Wait for any in progress mic operation
+    this.microphone.enablePromise ? await this.microphone.enablePromise : null;
+    this.microphone.disablePromise
+      ? await this.microphone.disablePromise
+      : null;
+
     if (
       this.state.localParticipant?.audioStream ||
       !this.permissionsContext.hasPermission('send-audio')
@@ -1763,19 +1777,16 @@ export class Call {
       return;
     }
 
-    // Publish already started media streams (this is the case if there is a lobby screen before join)
-    if (this.microphone.state.status === 'enabled') {
-      // Wait for media stream
-      this.microphone.state.mediaStream$
-        .pipe(takeWhile((s) => s === undefined, true))
-        .subscribe((stream) => {
-          if (!this.state.localParticipant?.audioStream) {
-            this.publishAudioStream(stream!);
-          }
-        });
+    // Publish media stream that was set before we joined
+    if (
+      this.microphone.state.status === 'enabled' &&
+      this.microphone.state.mediaStream &&
+      !this.publisher?.isPublishing(TrackType.AUDIO)
+    ) {
+      this.publishAudioStream(this.microphone.state.mediaStream);
     }
 
-    // Apply backend config (this is the case if there is no lobby screen before join)
+    // Start mic if backend config speicifies, and there is no local setting
     if (
       this.microphone.state.status === undefined &&
       this.state.settings?.audio.mic_default_on

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1719,8 +1719,12 @@ export class Call {
 
   private async initCamera() {
     // Wait for any in progress camera operation
-    this.camera.enablePromise ? await this.camera.enablePromise : null;
-    this.camera.disablePromise ? await this.camera.disablePromise : null;
+    if (this.camera.enablePromise) {
+      await this.camera.enablePromise;
+    }
+    if (this.camera.disablePromise) {
+      await this.camera.disablePromise;
+    }
 
     if (
       this.state.localParticipant?.videoStream ||
@@ -1765,10 +1769,12 @@ export class Call {
 
   private async initMic() {
     // Wait for any in progress mic operation
-    this.microphone.enablePromise ? await this.microphone.enablePromise : null;
-    this.microphone.disablePromise
-      ? await this.microphone.disablePromise
-      : null;
+    if (this.microphone.enablePromise) {
+      await this.microphone.enablePromise;
+    }
+    if (this.microphone.disablePromise) {
+      await this.microphone.disablePromise;
+    }
 
     if (
       this.state.localParticipant?.audioStream ||

--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -6,6 +6,11 @@ import { getVideoDevices, getVideoStream } from './devices';
 import { TrackType } from '../gen/video/sfu/models/models';
 
 export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
+  private targetResolution = {
+    width: 1280,
+    height: 720,
+  };
+
   constructor(call: Call) {
     super(call, new CameraManagerState());
   }
@@ -32,12 +37,39 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
     this.selectDirection(newDirection);
   }
 
+  /**
+   * @internal
+   */
+  async selectTargetResolution(resolution: { width: number; height: number }) {
+    this.targetResolution.height = resolution.height;
+    this.targetResolution.width = resolution.width;
+    if (this.enablePromise) {
+      try {
+        await this.enablePromise;
+      } catch (error) {
+        // couldn't enable device, target resolution will be applied the next time user attempts to start the device
+      }
+    }
+    if (this.state.status === 'enabled') {
+      const { width, height } = this.state
+        .mediaStream!.getVideoTracks()[0]
+        ?.getSettings();
+      if (
+        width !== this.targetResolution.width ||
+        height !== this.targetResolution.height
+      )
+        await this.applySettingsToStream();
+    }
+  }
+
   protected getDevices(): Observable<MediaDeviceInfo[]> {
     return getVideoDevices();
   }
   protected getStream(
     constraints: MediaTrackConstraints,
   ): Promise<MediaStream> {
+    constraints.width = this.targetResolution.width;
+    constraints.height = this.targetResolution.height;
     // We can't set both device id and facing mode
     // Device id has higher priority
     if (!constraints.deviceId && this.state.direction) {

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -89,6 +89,8 @@ export const mockVideoStream = () => {
   const track = {
     getSettings: () => ({
       deviceId: mockVideoDevices[0].deviceId,
+      width: 1280,
+      height: 720,
     }),
     enabled: true,
   };


### PR DESCRIPTION
- Backend sends us the target resolution for the video stream -> the new device API now applies these settings
- Additional safeguards to make sure we don't accidentally start two media streams / publish twice when we init the camera/mic in the join method

@khushal87, @vishalnarkhede  can you please test that everything works with RN as expected?