### PR TITLE
feat(react-native): pass participant as prop in FloatingParticipantView

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
@@ -29,11 +29,7 @@ import {
 const App = () => {
   const { useLocalParticipant } = useCallStateHooks();
   const localParticipant = useLocalParticipant();
-  return (
-    localParticipant && (
-      <FloatingParticipantView participant={localParticipant} />
-    )
-  );
+  return <FloatingParticipantView participant={localParticipant} />;
 };
 ```
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
@@ -21,10 +21,19 @@ When the video is muted, the video muted icon is shown in a disabled background.
 In order to use the `FloatingParticipantView` as a standalone component, you should use the following code:
 
 ```tsx {4}
-import { FloatingParticipantView } from '@stream-io/video-react-native-sdk';
+import {
+  FloatingParticipantView,
+  useCallStateHooks,
+} from '@stream-io/video-react-native-sdk';
 
 const App = () => {
-  return <FloatingParticipantView />;
+  const { useLocalParticipant } = useCallStateHooks();
+  const localParticipant = useLocalParticipant();
+  return (
+    localParticipant && (
+      <FloatingParticipantView participant={localParticipant} />
+    )
+  );
 };
 ```
 
@@ -37,6 +46,14 @@ Determines where the floating participant video will be placed initially.
 | Type                                                    | Default value |
 | ------------------------------------------------------- | ------------- |
 | `top-left` \|`top-right`\|`bottom-left`\|`bottom-right` | `top-right`   |
+
+### `participant`
+
+The participant to be renderered in the `FloatingParticipantView`.
+
+| Type                                                                                                            |
+| --------------------------------------------------------------------------------------------------------------- |
+| [`StreamVideoParticipant`](https://github.com/GetStream/stream-video-js/blob/main/packages/client/src/types.ts) |
 
 ### `style`
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
@@ -51,9 +51,9 @@ Determines where the floating participant video will be placed initially.
 
 The participant to be rendered in the `FloatingParticipantView`.
 
-| Type                                                                                                            |
-| --------------------------------------------------------------------------------------------------------------- |
-| [`StreamVideoParticipant`](https://github.com/GetStream/stream-video-js/blob/main/packages/client/src/types.ts) |
+| Type                                                                                                                         |
+| ---------------------------------------------------------------------------------------------------------------------------- |
+| [`StreamVideoParticipant`](https://github.com/GetStream/stream-video-js/blob/main/packages/client/src/types.ts)\|`undefined` |
 
 ### `style`
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
@@ -49,7 +49,7 @@ Determines where the floating participant video will be placed initially.
 
 ### `participant`
 
-The participant to be renderered in the `FloatingParticipantView`.
+The participant to be rendered in the `FloatingParticipantView`.
 
 | Type                                                                                                            |
 | --------------------------------------------------------------------------------------------------------------- |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/participant-view.mdx
@@ -50,10 +50,11 @@ In order to use the `ParticipantView` as a standalone component, you should use 
 ```tsx
 import {
   ParticipantView,
-  useParticipants,
+  useCallStateHooks,
 } from '@stream-io/video-react-native-sdk';
 
 const App = () => {
+  const { useParticipants } = useCallStateHooks();
   const participants = useParticipants();
 
   // Here to show the demo, we pass only first participant. You can pass any of the participant.

--- a/packages/react-native-sdk/jest-setup.ts
+++ b/packages/react-native-sdk/jest-setup.ts
@@ -28,11 +28,6 @@ jest.mock('@notifee/react-native', () =>
   require('@notifee/react-native/jest-mock'),
 );
 
-jest.mock('react-native-reanimated', () => {
-  const RNReanimatedmock = require('react-native-reanimated/mock');
-  return { ...RNReanimatedmock, runOnUI: (fn: any) => fn };
-});
-
 // When mocking we implement only the needed navigator APIs, hence the suppression rule
 // @ts-ignore
 global.navigator = {

--- a/packages/react-native-sdk/jest.config.ts
+++ b/packages/react-native-sdk/jest.config.ts
@@ -2,10 +2,7 @@ import type { Config } from 'jest';
 
 const config: Config = {
   preset: 'react-native',
-  setupFilesAfterEnv: [
-    '<rootDir>/jest-setup.ts',
-    '<rootDir>/node_modules/react-native-gesture-handler/jestSetup.js',
-  ],
+  setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   testPathIgnorePatterns: [
     '<rootDir>/__tests__/mocks/',
     '<rootDir>/__tests__/utils/',

--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -84,9 +84,10 @@ export const CallContent = ({
   } = useTheme();
   const { useHasOngoingScreenShare } = useCallStateHooks();
   const hasScreenShare = useHasOngoingScreenShare();
-  const { useRemoteParticipants } = useCallStateHooks();
+  const { useRemoteParticipants, useLocalParticipant } = useCallStateHooks();
 
   const _remoteParticipants = useRemoteParticipants();
+  const localParticipant = useLocalParticipant();
   const remoteParticipants = useDebouncedValue(_remoteParticipants, 300); // we debounce the remote participants to avoid unnecessary rerenders that happen when participant tracks are all subscribed simultaneously
   const showSpotlightLayout = hasScreenShare || layout === 'spotlight';
 
@@ -143,8 +144,11 @@ export const CallContent = ({
               ParticipantsInfoBadge={ParticipantsInfoBadge}
             />
           )}
-          {showFloatingView && FloatingParticipantView && (
-            <FloatingParticipantView {...participantViewProps} />
+          {showFloatingView && FloatingParticipantView && localParticipant && (
+            <FloatingParticipantView
+              participant={localParticipant}
+              {...participantViewProps}
+            />
           )}
         </View>
         {showSpotlightLayout ? (

--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -144,7 +144,7 @@ export const CallContent = ({
               ParticipantsInfoBadge={ParticipantsInfoBadge}
             />
           )}
-          {showFloatingView && FloatingParticipantView && localParticipant && (
+          {showFloatingView && FloatingParticipantView && (
             <FloatingParticipantView
               participant={localParticipant}
               {...participantViewProps}

--- a/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
+++ b/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
@@ -8,10 +8,10 @@ import { FloatingViewAlignment } from './FloatingView/common';
 import {
   ParticipantView as DefaultParticipantView,
   ParticipantViewComponentProps,
-  ParticipantViewProps,
 } from '../ParticipantView';
 import { useTheme } from '../../../contexts/ThemeContext';
 import AnimatedFloatingView from './FloatingView/AnimatedFloatingView';
+import { StreamVideoParticipant } from '@stream-io/video-client';
 
 export type FloatingParticipantViewAlignment =
   | 'top-left'
@@ -23,12 +23,15 @@ export type FloatingParticipantViewAlignment =
  * Props to be passed for the LocalVideoView component.
  */
 export type FloatingParticipantViewProps = ParticipantViewComponentProps &
-  Pick<CallParticipantsListProps, 'ParticipantView'> &
-  Pick<ParticipantViewProps, 'participant'> & {
+  Pick<CallParticipantsListProps, 'ParticipantView'> & {
     /**
      * Determines where the floating participant video will be placed.
      */
     alignment?: FloatingParticipantViewAlignment;
+    /**
+     * The participant to be rendered in the FloatingParticipantView
+     */
+    participant?: StreamVideoParticipant;
     /**
      * Custom style to be merged with the floating participant view.
      */
@@ -97,6 +100,10 @@ export const FloatingParticipantView = ({
     ParticipantVideoFallback: CustomLocalParticipantViewVideoFallback,
     VideoRenderer,
   };
+
+  if (!participant) {
+    return null;
+  }
 
   return (
     <View

--- a/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
+++ b/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
-import { useCallStateHooks } from '@stream-io/video-react-bindings';
 import { FLOATING_VIDEO_VIEW_STYLE, Z_INDEX } from '../../../constants';
 import { ComponentTestIds } from '../../../constants/TestIds';
 import { VideoSlash } from '../../../icons';
@@ -9,6 +8,7 @@ import { FloatingViewAlignment } from './FloatingView/common';
 import {
   ParticipantView as DefaultParticipantView,
   ParticipantViewComponentProps,
+  ParticipantViewProps,
 } from '../ParticipantView';
 import { useTheme } from '../../../contexts/ThemeContext';
 import AnimatedFloatingView from './FloatingView/AnimatedFloatingView';
@@ -23,7 +23,8 @@ export type FloatingParticipantViewAlignment =
  * Props to be passed for the LocalVideoView component.
  */
 export type FloatingParticipantViewProps = ParticipantViewComponentProps &
-  Pick<CallParticipantsListProps, 'ParticipantView'> & {
+  Pick<CallParticipantsListProps, 'ParticipantView'> &
+  Pick<ParticipantViewProps, 'participant'> & {
     /**
      * Determines where the floating participant video will be placed.
      */
@@ -63,6 +64,7 @@ const CustomLocalParticipantViewVideoFallback = () => {
  */
 export const FloatingParticipantView = ({
   alignment = 'top-right',
+  participant,
   style,
   ParticipantView = DefaultParticipantView,
   ParticipantNetworkQualityIndicator,
@@ -72,8 +74,6 @@ export const FloatingParticipantView = ({
   const {
     theme: { colors, localParticipantsView },
   } = useTheme();
-  const { useLocalParticipant } = useCallStateHooks();
-  const localParticipant = useLocalParticipant();
 
   const floatingAlignmentMap: Record<
     FloatingParticipantViewAlignment,
@@ -89,10 +89,6 @@ export const FloatingParticipantView = ({
     width: number;
     height: number;
   }>();
-
-  if (!localParticipant) {
-    return null;
-  }
 
   const participantViewProps: ParticipantViewComponentProps = {
     ParticipantLabel: null,
@@ -130,7 +126,7 @@ export const FloatingParticipantView = ({
         >
           {ParticipantView && (
             <ParticipantView
-              participant={localParticipant}
+              participant={participant}
               videoMode={'video'}
               style={[
                 styles.participantViewContainer,


### PR DESCRIPTION
This will be useful when we want to change the participant on tap of FloatingParticipantView in 1:1 calls.

Moreover removing localParticipant from FloatingParticipantView makes sense, since its a generic view.