### PR TITLE
feat(egress-composite): add support for external CSS

### DIFF
--- a/sample-apps/react/egress-composite/src/CompositeApp.tsx
+++ b/sample-apps/react/egress-composite/src/CompositeApp.tsx
@@ -10,10 +10,10 @@ import {
 } from '@stream-io/video-react-sdk';
 
 import { useConfigurationContext } from './ConfigurationContext';
-import { EgressReadyNotificationProvider } from './hooks/useNotifyEgress';
+import { EgressReadyNotificationProvider, useExternalCSS } from './hooks';
+import { UIDispatcher, LogoAndTitleOverlay } from './components';
 
 import './CompositeApp.scss';
-import { UIDispatcher, LogoAndTitleOverlay } from './components';
 
 export const CompositeApp = () => {
   const {
@@ -91,6 +91,7 @@ export const CompositeApp = () => {
 
 const StreamThemeWrapper = ({ children }: PropsWithChildren) => {
   // TODO: background style
+  useExternalCSS();
 
   return <StreamTheme>{children}</StreamTheme>;
 };

--- a/sample-apps/react/egress-composite/src/hooks/index.ts
+++ b/sample-apps/react/egress-composite/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useExternalCSS';
+export * from './useNotifyEgress';

--- a/sample-apps/react/egress-composite/src/hooks/useExternalCSS.ts
+++ b/sample-apps/react/egress-composite/src/hooks/useExternalCSS.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+import { useConfigurationContext } from '../ConfigurationContext';
+
+export const useExternalCSS = () => {
+  const { ext_css } = useConfigurationContext();
+
+  useEffect(() => {
+    if (!ext_css) return;
+
+    const linkElement = document.createElement('link');
+
+    linkElement.rel = 'stylesheet';
+    linkElement.href = ext_css;
+    linkElement.type = 'text/css';
+
+    document.head.appendChild(linkElement);
+
+    return () => {
+      linkElement.remove();
+    };
+  }, [ext_css]);
+};

--- a/sample-apps/react/egress-composite/src/main.tsx
+++ b/sample-apps/react/egress-composite/src/main.tsx
@@ -48,7 +48,7 @@ window.setupLayout = (configuration: ConfigurationValue) => {
 //     call_id: "<call_id>",
 //     layout: "grid",
 //     screenshare_layout: "spotlight",
-
+//     ext_css: "https://github.githubassets.com/assets/light-983b05c0927a.css",
 //     options: {
 //       "logo.image_url": "https://theme.zdassets.com/theme_assets/9442057/efc3820e436f9150bc8cf34267fff4df052a1f9c.png",
 //     }


### PR DESCRIPTION
Load external CSS through `ext_css` configuration attribute. 