### PR TITLE
fix: do not do any codec preferences when sending dummy sdp

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -867,13 +867,7 @@ export class Call {
         // prepare a generic SDP and send it to the SFU.
         // this is a throw-away SDP that the SFU will use to determine
         // the capabilities of the client (codec support, etc.)
-        .then(() =>
-          getGenericSdp(
-            'recvonly',
-            isRedEnabled,
-            this.streamClient.options.preferredVideoCodec,
-          ),
-        )
+        .then(() => getGenericSdp('recvonly'))
         .then((sdp) => {
           const subscriptions = getCurrentValue(this.trackSubscriptionsSubject);
           const migration: Migration | undefined = isMigrating

--- a/packages/client/src/rtc/codecs.ts
+++ b/packages/client/src/rtc/codecs.ts
@@ -46,47 +46,13 @@ export const getPreferredCodecs = (
   return result;
 };
 
-export const getGenericSdp = async (
-  direction: RTCRtpTransceiverDirection,
-  isRedEnabled: boolean,
-  preferredVideoCodec: string | undefined,
-) => {
+export const getGenericSdp = async (direction: RTCRtpTransceiverDirection) => {
   const tempPc = new RTCPeerConnection();
   tempPc.addTransceiver('video', { direction });
-
-  // if ('setCodecPreferences' in videoTransceiver) {
-  //   const videoCodecPreferences = getPreferredCodecs(
-  //     'audio',
-  //     preferredVideoCodec ?? 'vp8',
-  //   );
-  //   videoTransceiver.setCodecPreferences([...(videoCodecPreferences ?? [])]);
-  // }
-
   tempPc.addTransceiver('audio', { direction });
-  const preferredAudioCodec = isRedEnabled ? 'red' : 'opus';
-  const audioCodecToRemove = !isRedEnabled ? 'red' : undefined;
-
-  // if ('setCodecPreferences' in audioTransceiver) {
-  //   const audioCodecPreferences = getPreferredCodecs(
-  //     'audio',
-  //     preferredAudioCodec,
-  //     // audioCodecToRemove,
-  //   );
-  //   audioTransceiver.setCodecPreferences([...(audioCodecPreferences || [])]);
-  // }
 
   const offer = await tempPc.createOffer();
   let sdp = offer.sdp ?? '';
-
-  if (isReactNative()) {
-    if (preferredVideoCodec) {
-      sdp = setPreferredCodec(sdp, 'video', preferredVideoCodec);
-    }
-    sdp = setPreferredCodec(sdp, 'audio', preferredAudioCodec);
-    if (audioCodecToRemove) {
-      sdp = removeCodec(sdp, 'audio', audioCodecToRemove);
-    }
-  }
 
   tempPc.getTransceivers().forEach((t) => {
     t.stop();


### PR DESCRIPTION
While talking to suchith I realised that we should not do any codec changes to sdp when sending the dummy sdp. 