### PR TITLE
feat: Allow reusing call instance [WIP]

### DIFF
--- a/packages/client/docusaurus/docs/javascript/02-guides/04-camera-and-microphone.mdx
+++ b/packages/client/docusaurus/docs/javascript/02-guides/04-camera-and-microphone.mdx
@@ -176,16 +176,17 @@ Follow our [Playing Video and Audio guide](../../guides/playing-video-and-audio/
 
 #### Lobby preview
 
-On lobby screens a common UX pattern is to show a visual indicator of the detected audio levels coming from the selected microphone. Here is an example of how you can do that:
+On lobby screens a common UX pattern is to show a visual indicator of the detected audio levels coming from the selected microphone. The client exposes the `createSoundDetector` utility method to help implement this functionality. Here is an example of how you can do that:
 
 ```html
-<progress id="volume" max="100" min="0" value="70"></progress>
+<progress id="volume" max="100" min="0"></progress>
 ```
 
 ```typescript
+import { createSoundDetector } from '@stream-io/video-client';
+
 let cleanup: Function | undefined;
 call.microphone.state.mediaStream$.subscribe(async (mediaStream) => {
-  console.log(mediaStream);
   const progressBar = document.getElementById('volume') as HTMLProgressElement;
   if (mediaStream) {
     cleanup = createSoundDetector(
@@ -211,9 +212,13 @@ This is how you can subscribe to these notifications:
 ```typescript
 call.microphone.state.speakingWhileMuted; // current value
 call.microphone.state.speakingWhileMuted$.subscribe((isSpeaking) => {
-  console.log(`You're muted, unmute yourself to speak`);
+  if (isSpeaking) {
+    console.log(`You're muted, unmute yourself to speak`);
+  }
 }); // Reactive value
 ```
+
+The notification is automatically disabled if the user doesn't have the permission to send audio.
 
 ## Speaker management
 

--- a/packages/client/docusaurus/docs/javascript/02-guides/04-camera-and-microphone.mdx
+++ b/packages/client/docusaurus/docs/javascript/02-guides/04-camera-and-microphone.mdx
@@ -176,16 +176,43 @@ Follow our [Playing Video and Audio guide](../../guides/playing-video-and-audio/
 
 #### Lobby preview
 
-This is how you can show a visual representation about the sound level coming from the user's selected microphone:
+On lobby screens a common UX pattern is to show a visual indicator of the detected audio levels coming from the selected microphone. Here is an example of how you can do that:
+
+```html
+<progress id="volume" max="100" min="0" value="70"></progress>
+```
 
 ```typescript
-// Code example coming soon 🏗️
+let cleanup: Function | undefined;
+call.microphone.state.mediaStream$.subscribe(async (mediaStream) => {
+  console.log(mediaStream);
+  const progressBar = document.getElementById('volume') as HTMLProgressElement;
+  if (mediaStream) {
+    cleanup = createSoundDetector(
+      mediaStream,
+      (event) => {
+        progressBar.value = event.audioLevel;
+      },
+      { detectionFrequencyInMs: 100 },
+    );
+  } else {
+    await cleanup?.();
+    progressBar.value = 0;
+  }
+});
 ```
 
 ### Speaking while muted notification
 
+When the microphone is disabled, the client will automatically start monitoring audio levels, to detect if the user is speaking.
+
+This is how you can subscribe to these notifications:
+
 ```typescript
-// This feature is coming soon 🏗️
+call.microphone.state.speakingWhileMuted; // current value
+call.microphone.state.speakingWhileMuted$.subscribe((isSpeaking) => {
+  console.log(`You're muted, unmute yourself to speak`);
+}); // Reactive value
 ```
 
 ## Speaker management

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -301,9 +301,44 @@ export class Call {
             permission as OwnCapability,
           );
           if (!hasPermission && this.publisher.isPublishing(trackType)) {
-            this.stopPublish(trackType).catch((err) => {
-              this.logger('error', `Error stopping publish ${trackType}`, err);
-            });
+            this.stopPublish(trackType)
+              .catch((err) => {
+                this.logger(
+                  'error',
+                  `Error stopping publish ${trackType}`,
+                  err,
+                );
+              })
+              .then(() => {
+                if (
+                  trackType === TrackType.VIDEO &&
+                  this.camera.state.status === 'enabled'
+                ) {
+                  this.camera
+                    .disable()
+                    .catch((err) =>
+                      this.logger(
+                        'error',
+                        `Error disabling camera after pemission revoked`,
+                        err,
+                      ),
+                    );
+                }
+                if (
+                  trackType === TrackType.AUDIO &&
+                  this.microphone.state.status === 'enabled'
+                ) {
+                  this.microphone
+                    .disable()
+                    .catch((err) =>
+                      this.logger(
+                        'error',
+                        `Error disabling microphone after pemission revoked`,
+                        err,
+                      ),
+                    );
+                }
+              });
           }
         }
       }),

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -269,6 +269,24 @@ export class Call {
 
     this.camera = new CameraManager(this);
     this.microphone = new MicrophoneManager(this);
+
+    this.state.localParticipant$.subscribe(async (p) => {
+      // Soft remote mutes
+      if (
+        !p?.publishedTracks.includes(TrackType.VIDEO) &&
+        this.publisher?.isPublishing(TrackType.VIDEO)
+      ) {
+        await this.camera.disable();
+        this.stopPublish(TrackType.VIDEO);
+      }
+      if (
+        !p?.publishedTracks.includes(TrackType.AUDIO) &&
+        this.publisher?.isPublishing(TrackType.AUDIO)
+      ) {
+        await this.microphone.disable();
+        this.stopPublish(TrackType.AUDIO);
+      }
+    });
   }
 
   private registerEffects() {

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -331,7 +331,11 @@ export class Call {
           const hasPermission = this.permissionsContext.hasPermission(
             permission as OwnCapability,
           );
-          if (!hasPermission && this.publisher.isPublishing(trackType)) {
+          if (
+            !hasPermission &&
+            (this.publisher.isPublishing(trackType) ||
+              this.publisher.isLive(trackType))
+          ) {
             // Stop tracks, then notify device manager
             this.stopPublish(trackType)
               .catch((err) => {
@@ -1176,7 +1180,10 @@ export class Call {
    * @param stopTrack if `true` the track will be stopped, else it will be just disabled
    */
   stopPublish = async (trackType: TrackType, stopTrack: boolean = true) => {
-    this.logger('info', `stopPublish ${TrackType[trackType]}`);
+    this.logger(
+      'info',
+      `stopPublish ${TrackType[trackType]}, stop tracks: ${stopTrack}`,
+    );
     await this.publisher?.unpublishStream(trackType, stopTrack);
   };
 

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -332,7 +332,7 @@ export class Call {
             permission as OwnCapability,
           );
           if (!hasPermission && this.publisher.isPublishing(trackType)) {
-            // Stop tracks, then udate device manager status
+            // Stop tracks, then notify device manager
             this.stopPublish(trackType)
               .catch((err) => {
                 this.logger(

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -396,5 +396,9 @@ const retryable = async <I extends object, O extends SfuResponseWithError>(
     retryAttempt < MAX_RETRIES
   );
 
+  if (rpcCallResult.response.error) {
+    throw rpcCallResult.response.error;
+  }
+
   return rpcCallResult;
 };

--- a/packages/client/src/coordinator/connection/location.ts
+++ b/packages/client/src/coordinator/connection/location.ts
@@ -5,7 +5,7 @@ const HINT_URL = `https://hint.stream-io-video.com/`;
 
 export const getLocationHint = async (
   hintUrl: string = HINT_URL,
-  timeout: number = 1500,
+  timeout: number = 2000,
 ) => {
   const abortController = new AbortController();
   const timeoutId = setTimeout(() => abortController.abort(), timeout);
@@ -18,7 +18,7 @@ export const getLocationHint = async (
     logger('debug', `Location header: ${awsPop}`);
     return awsPop.substring(0, 3); // AMS1-P2 -> AMS
   } catch (e) {
-    logger('error', `Failed to get location hint from ${HINT_URL}`, e);
+    logger('warn', `Failed to get location hint from ${HINT_URL}`, e);
     return 'ERR';
   } finally {
     clearTimeout(timeoutId);

--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -89,12 +89,7 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
     return this.call.stopPublish(TrackType.VIDEO, stopTracks);
   }
 
-  protected muteTracks(): void {
-    this.state.mediaStream
-      ?.getVideoTracks()
-      .forEach((t) => (t.enabled = false));
-  }
-  protected unmuteTracks(): void {
-    this.state.mediaStream?.getVideoTracks().forEach((t) => (t.enabled = true));
+  protected getTrack() {
+    return this.state.mediaStream?.getVideoTracks()[0];
   }
 }

--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -12,7 +12,7 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
   };
 
   constructor(call: Call) {
-    super(call, new CameraManagerState());
+    super(call, new CameraManagerState(), TrackType.VIDEO);
   }
 
   /**
@@ -59,6 +59,10 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
         height !== this.targetResolution.height
       )
         await this.applySettingsToStream();
+      this.logger(
+        'debug',
+        `${width}x${height} target resolution applied to media stream`,
+      );
     }
   }
 

--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -34,7 +34,7 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
    */
   async flip() {
     const newDirection = this.state.direction === 'front' ? 'back' : 'front';
-    this.selectDirection(newDirection);
+    await this.selectDirection(newDirection);
   }
 
   /**

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -50,9 +50,8 @@ export abstract class InputMediaDeviceManager<
     try {
       await this.enablePromise;
       this.state.setStatus('enabled');
-    } catch (error) {
+    } finally {
       this.enablePromise = undefined;
-      throw error;
     }
   }
 
@@ -72,10 +71,8 @@ export abstract class InputMediaDeviceManager<
     try {
       await this.disablePromise;
       this.state.setStatus('disabled');
+    } finally {
       this.disablePromise = undefined;
-    } catch (error) {
-      this.disablePromise = undefined;
-      throw error;
     }
   }
 
@@ -87,7 +84,7 @@ export abstract class InputMediaDeviceManager<
       this.state.prevStatus === 'enabled' &&
       this.state.status === 'disabled'
     ) {
-      this.enable();
+      await this.enable();
     }
   }
 

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -139,6 +139,11 @@ export abstract class InputMediaDeviceManager<
     }
     if (this.call.state.callingState === CallingState.JOINED) {
       await this.stopPublishStream(stopTracks);
+      // This is a noop in most cases because stopPublishStream will dispose the media stream
+      // This handles the rare edge-case when we were joined to a call, but weren't publishing even though the device was enabled
+      if (stopTracks) {
+        disposeOfMediaStream(this.state.mediaStream);
+      }
     } else if (this.state.mediaStream) {
       stopTracks
         ? disposeOfMediaStream(this.state.mediaStream)

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -2,7 +2,6 @@ import { Observable } from 'rxjs';
 import { Call } from '../Call';
 import { CallingState } from '../store';
 import { InputMediaDeviceManagerState } from './InputMediaDeviceManagerState';
-import { disposeOfMediaStream } from './devices';
 import { isReactNative } from '../helpers/platforms';
 import { Logger } from '../coordinator/connection/types';
 import { getLogger } from '../logger';
@@ -140,9 +139,7 @@ export abstract class InputMediaDeviceManager<
 
   protected abstract stopPublishStream(stopTracks: boolean): Promise<void>;
 
-  protected abstract muteTracks(): void;
-
-  protected abstract unmuteTracks(): void;
+  protected abstract getTrack(): undefined | MediaStreamTrack;
 
   private async muteStream(stopTracks: boolean = true) {
     if (!this.state.mediaStream) {
@@ -151,40 +148,59 @@ export abstract class InputMediaDeviceManager<
     this.logger('debug', `${stopTracks ? 'Stopping' : 'Disabling'} stream`);
     if (this.call.state.callingState === CallingState.JOINED) {
       await this.stopPublishStream(stopTracks);
-      if (this.state.mediaStream.active) {
-        this.muteLocalStream(stopTracks);
-      } else if (stopTracks) {
-        // The published won't do this
-        // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the stream
-        if (typeof this.state.mediaStream.release === 'function') {
-          // @ts-expect-error
-          this.state.mediaStream.release();
-        }
-      }
-    } else {
-      this.muteLocalStream(stopTracks);
     }
-    if (stopTracks) {
+    this.muteLocalStream(stopTracks);
+    if (this.getTrack()?.readyState === 'ended') {
+      // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the stream
+      if (typeof this.state.mediaStream.release === 'function') {
+        // @ts-expect-error
+        stream.release();
+      }
       this.state.setMediaStream(undefined);
     }
+  }
+
+  private muteTrack() {
+    const track = this.getTrack();
+    if (!track || !track.enabled) {
+      return;
+    }
+    track.enabled = false;
+  }
+
+  private unmuteTrack() {
+    const track = this.getTrack();
+    if (!track || track.enabled) {
+      return;
+    }
+    track.enabled = true;
+  }
+
+  private stopTrack() {
+    const track = this.getTrack();
+    if (!track || track.readyState === 'ended') {
+      return;
+    }
+    track.stop();
   }
 
   private muteLocalStream(stopTracks: boolean) {
     if (!this.state.mediaStream) {
       return;
     }
-    stopTracks
-      ? disposeOfMediaStream(this.state.mediaStream)
-      : this.muteTracks();
+    stopTracks ? this.stopTrack() : this.muteTrack();
   }
 
   private async unmuteStream() {
     this.logger('debug', 'Starting stream');
     let stream: MediaStream;
-    if (this.state.mediaStream) {
+    if (this.state.mediaStream && this.getTrack()?.readyState === 'live') {
       stream = this.state.mediaStream;
-      this.unmuteTracks();
+      this.unmuteTrack();
     } else {
+      if (this.state.mediaStream) {
+        this.stopTrack();
+      }
       const constraints = { deviceId: this.state.selectedDevice };
       stream = await this.getStream(constraints);
     }

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -139,10 +139,19 @@ export abstract class InputMediaDeviceManager<
     }
     if (this.call.state.callingState === CallingState.JOINED) {
       await this.stopPublishStream(stopTracks);
-      // This is a noop in most cases because stopPublishStream will dispose the media stream
-      // This handles the rare edge-case when we were joined to a call, but weren't publishing even though the device was enabled
       if (stopTracks) {
-        disposeOfMediaStream(this.state.mediaStream);
+        // This is a noop in most cases because stopPublishStream will dispose the media stream
+        // This handles the rare edge-case when we were joined to a call, but weren't publishing even though the device was enabled
+        if (this.state.mediaStream.active) {
+          disposeOfMediaStream(this.state.mediaStream);
+        } else {
+          // The published won't do this
+          // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the stream
+          if (typeof stream.release === 'function') {
+            // @ts-expect-error
+            stream.release();
+          }
+        }
       }
     } else if (this.state.mediaStream) {
       stopTracks

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -147,9 +147,9 @@ export abstract class InputMediaDeviceManager<
         } else {
           // The published won't do this
           // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the stream
-          if (typeof stream.release === 'function') {
+          if (typeof this.state.mediaStream.release === 'function') {
             // @ts-expect-error
-            stream.release();
+            this.state.mediaStream.release();
           }
         }
       }

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -141,7 +141,7 @@ export abstract class InputMediaDeviceManager<
 
   protected abstract getTrack(): undefined | MediaStreamTrack;
 
-  private async muteStream(stopTracks: boolean = true) {
+  protected async muteStream(stopTracks: boolean = true) {
     if (!this.state.mediaStream) {
       return;
     }
@@ -191,7 +191,7 @@ export abstract class InputMediaDeviceManager<
     stopTracks ? this.stopTrack() : this.muteTrack();
   }
 
-  private async unmuteStream() {
+  protected async unmuteStream() {
     this.logger('debug', 'Starting stream');
     let stream: MediaStream;
     if (this.state.mediaStream && this.getTrack()?.readyState === 'live') {

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -207,6 +207,8 @@ export abstract class InputMediaDeviceManager<
     if (this.call.state.callingState === CallingState.JOINED) {
       await this.publishStream(stream);
     }
-    this.state.setMediaStream(stream);
+    if (this.state.mediaStream !== stream) {
+      this.state.setMediaStream(stream);
+    }
   }
 }

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -7,7 +7,7 @@ import { TrackType } from '../gen/video/sfu/models/models';
 
 export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManagerState> {
   constructor(call: Call) {
-    super(call, new MicrophoneManagerState());
+    super(call, new MicrophoneManagerState(), TrackType.AUDIO);
   }
 
   protected getDevices(): Observable<MediaDeviceInfo[]> {

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -4,8 +4,12 @@ import { InputMediaDeviceManager } from './InputMediaDeviceManager';
 import { MicrophoneManagerState } from './MicrophoneManagerState';
 import { getAudioDevices, getAudioStream } from './devices';
 import { TrackType } from '../gen/video/sfu/models/models';
+import { createSoundDetector } from '../helpers/sound-detector';
+import { isReactNative } from '../helpers/platforms';
 
 export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManagerState> {
+  private soundDetectorCleanup?: Function;
+
   constructor(call: Call) {
     super(call, new MicrophoneManagerState(), TrackType.AUDIO);
   }
@@ -27,5 +31,44 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
 
   protected getTrack() {
     return this.state.mediaStream?.getAudioTracks()[0];
+  }
+
+  protected async unmuteStream(): Promise<void> {
+    await super.unmuteStream();
+    if (isReactNative()) {
+      return;
+    }
+    this.state.setSpeakingWhileMuted(false);
+    this.soundDetectorCleanup?.().finally(
+      () => (this.soundDetectorCleanup = undefined),
+    );
+  }
+
+  protected async muteStream(stopTracks?: boolean): Promise<void> {
+    await super.muteStream(stopTracks);
+    if (isReactNative()) {
+      return;
+    }
+    if (
+      this.state.mediaStream &&
+      this.getTrack()?.readyState === 'live' &&
+      !this.getTrack()?.enabled
+    ) {
+      // Need to start a new stream that's not connected to publisher
+      const stream = await this.getStream({
+        deviceId: this.state.selectedDevice,
+      });
+      await this.soundDetectorCleanup?.().finally(
+        () => (this.soundDetectorCleanup = undefined),
+      );
+      this.soundDetectorCleanup = createSoundDetector(stream, (event) => {
+        this.state.setSpeakingWhileMuted(event.isSoundDetected);
+      });
+    } else {
+      this.soundDetectorCleanup?.().finally(
+        () => (this.soundDetectorCleanup = undefined),
+      );
+      this.state.setSpeakingWhileMuted(false);
+    }
   }
 }

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -25,12 +25,7 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
     return this.call.stopPublish(TrackType.AUDIO, stopTracks);
   }
 
-  protected muteTracks(): void {
-    this.state.mediaStream
-      ?.getAudioTracks()
-      .forEach((t) => (t.enabled = false));
-  }
-  protected unmuteTracks(): void {
-    this.state.mediaStream?.getAudioTracks().forEach((t) => (t.enabled = true));
+  protected getTrack() {
+    return this.state.mediaStream?.getAudioTracks()[0];
   }
 }

--- a/packages/client/src/devices/MicrophoneManagerState.ts
+++ b/packages/client/src/devices/MicrophoneManagerState.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Observable, distinctUntilChanged, map } from 'rxjs';
+import { BehaviorSubject, Observable, distinctUntilChanged } from 'rxjs';
 import { InputMediaDeviceManagerState } from './InputMediaDeviceManagerState';
 
 export class MicrophoneManagerState extends InputMediaDeviceManagerState {

--- a/packages/client/src/devices/MicrophoneManagerState.ts
+++ b/packages/client/src/devices/MicrophoneManagerState.ts
@@ -1,5 +1,6 @@
-import { BehaviorSubject, Observable, distinctUntilChanged } from 'rxjs';
+import { BehaviorSubject, Observable, distinctUntilChanged, map } from 'rxjs';
 import { InputMediaDeviceManagerState } from './InputMediaDeviceManagerState';
+import { isReactNative } from '../helpers/platforms';
 
 export class MicrophoneManagerState extends InputMediaDeviceManagerState {
   private speakingWhileMutedSubject = new BehaviorSubject<boolean>(false);
@@ -16,7 +17,16 @@ export class MicrophoneManagerState extends InputMediaDeviceManagerState {
 
     this.speakingWhileMuted$ = this.speakingWhileMutedSubject
       .asObservable()
-      .pipe(distinctUntilChanged());
+      .pipe(
+        map((v) => {
+          if (isReactNative()) {
+            throw new Error('This feature is not supported in React Native');
+          } else {
+            return v;
+          }
+        }),
+        distinctUntilChanged(),
+      );
   }
 
   /**
@@ -25,6 +35,9 @@ export class MicrophoneManagerState extends InputMediaDeviceManagerState {
    * This feature is not available in the React Native SDK.
    */
   get speakingWhileMuted() {
+    if (isReactNative()) {
+      throw new Error('This feature is not supported in React Native');
+    }
     return this.getCurrentValue(this.speakingWhileMuted$);
   }
 

--- a/packages/client/src/devices/MicrophoneManagerState.ts
+++ b/packages/client/src/devices/MicrophoneManagerState.ts
@@ -1,8 +1,38 @@
+import { BehaviorSubject, Observable, distinctUntilChanged } from 'rxjs';
 import { InputMediaDeviceManagerState } from './InputMediaDeviceManagerState';
 
 export class MicrophoneManagerState extends InputMediaDeviceManagerState {
+  private speakingWhileMutedSubject = new BehaviorSubject<boolean>(false);
+
+  /**
+   * An Observable that emits `true` if the user's microphone is muted but they'are speaking.
+   *
+   * This feature is not available in the React Native SDK.
+   */
+  speakingWhileMuted$: Observable<boolean>;
+
   constructor() {
     super('disable-tracks');
+
+    this.speakingWhileMuted$ = this.speakingWhileMutedSubject
+      .asObservable()
+      .pipe(distinctUntilChanged());
+  }
+
+  /**
+   * `true` if the user's microphone is muted but they'are speaking.
+   *
+   * This feature is not available in the React Native SDK.
+   */
+  get speakingWhileMuted() {
+    return this.getCurrentValue(this.speakingWhileMuted$);
+  }
+
+  /**
+   * @internal
+   */
+  setSpeakingWhileMuted(isSpeaking: boolean) {
+    this.setCurrentValue(this.speakingWhileMutedSubject, isSpeaking);
   }
 
   protected getDeviceIdFromStream(stream: MediaStream): string | undefined {

--- a/packages/client/src/devices/MicrophoneManagerState.ts
+++ b/packages/client/src/devices/MicrophoneManagerState.ts
@@ -1,6 +1,5 @@
 import { BehaviorSubject, Observable, distinctUntilChanged, map } from 'rxjs';
 import { InputMediaDeviceManagerState } from './InputMediaDeviceManagerState';
-import { isReactNative } from '../helpers/platforms';
 
 export class MicrophoneManagerState extends InputMediaDeviceManagerState {
   private speakingWhileMutedSubject = new BehaviorSubject<boolean>(false);
@@ -17,16 +16,7 @@ export class MicrophoneManagerState extends InputMediaDeviceManagerState {
 
     this.speakingWhileMuted$ = this.speakingWhileMutedSubject
       .asObservable()
-      .pipe(
-        map((v) => {
-          if (isReactNative()) {
-            throw new Error('This feature is not supported in React Native');
-          } else {
-            return v;
-          }
-        }),
-        distinctUntilChanged(),
-      );
+      .pipe(distinctUntilChanged());
   }
 
   /**
@@ -35,9 +25,6 @@ export class MicrophoneManagerState extends InputMediaDeviceManagerState {
    * This feature is not available in the React Native SDK.
    */
   get speakingWhileMuted() {
-    if (isReactNative()) {
-      throw new Error('This feature is not supported in React Native');
-    }
     return this.getCurrentValue(this.speakingWhileMuted$);
   }
 

--- a/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
+++ b/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
@@ -8,6 +8,7 @@ import { InputMediaDeviceManager } from '../InputMediaDeviceManager';
 import { InputMediaDeviceManagerState } from '../InputMediaDeviceManagerState';
 import { of } from 'rxjs';
 import { disposeOfMediaStream } from '../devices';
+import { TrackType } from '../../gen/video/sfu/models/models';
 
 vi.mock('../devices.ts', () => {
   console.log('MOCKING devices');
@@ -36,7 +37,7 @@ class TestInputMediaDeviceManager extends InputMediaDeviceManager<TestInputMedia
   public unmuteTracks = vi.fn();
 
   constructor(call: Call) {
-    super(call, new TestInputMediaDeviceManagerState());
+    super(call, new TestInputMediaDeviceManagerState(), TrackType.VIDEO);
   }
 }
 

--- a/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
+++ b/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
@@ -7,15 +7,7 @@ import { mockCall, mockVideoDevices, mockVideoStream } from './mocks';
 import { InputMediaDeviceManager } from '../InputMediaDeviceManager';
 import { InputMediaDeviceManagerState } from '../InputMediaDeviceManagerState';
 import { of } from 'rxjs';
-import { disposeOfMediaStream } from '../devices';
 import { TrackType } from '../../gen/video/sfu/models/models';
-
-vi.mock('../devices.ts', () => {
-  console.log('MOCKING devices');
-  return {
-    disposeOfMediaStream: vi.fn(),
-  };
-});
 
 vi.mock('../../Call.ts', () => {
   console.log('MOCKING Call');
@@ -33,8 +25,7 @@ class TestInputMediaDeviceManager extends InputMediaDeviceManager<TestInputMedia
   public getStream = vi.fn(() => Promise.resolve(mockVideoStream()));
   public publishStream = vi.fn();
   public stopPublishStream = vi.fn();
-  public muteTracks = vi.fn();
-  public unmuteTracks = vi.fn();
+  public getTrack = () => this.state.mediaStream!.getVideoTracks()[0];
 
   constructor(call: Call) {
     super(call, new TestInputMediaDeviceManagerState(), TrackType.VIDEO);
@@ -136,11 +127,12 @@ describe('InputMediaDeviceManager.test', () => {
   it('select device when status is enabled', async () => {
     await manager.enable();
     const prevStream = manager.state.mediaStream;
+    vi.spyOn(prevStream!.getVideoTracks()[0], 'stop');
 
     const deviceId = mockVideoDevices[1].deviceId;
     await manager.select(deviceId);
 
-    expect(disposeOfMediaStream).toHaveBeenCalledWith(prevStream);
+    expect(prevStream!.getVideoTracks()[0].stop).toHaveBeenCalledWith();
   });
 
   it('select device when status is enabled and in call', async () => {

--- a/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
@@ -2,12 +2,16 @@ import { Call } from '../../Call';
 import { StreamClient } from '../../coordinator/connection/client';
 import { CallingState, StreamVideoWriteableStateStore } from '../../store';
 
-import { afterEach, beforeEach, describe, vi, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, vi, it, expect, Mock } from 'vitest';
 import { mockCall, mockAudioDevices, mockAudioStream } from './mocks';
 import { getAudioStream } from '../devices';
 import { TrackType } from '../../gen/video/sfu/models/models';
 import { MicrophoneManager } from '../MicrophoneManager';
 import { of } from 'rxjs';
+import {
+  SoundStateChangeHandler,
+  createSoundDetector,
+} from '../../helpers/sound-detector';
 
 vi.mock('../devices.ts', () => {
   console.log('MOCKING devices API');
@@ -17,6 +21,13 @@ vi.mock('../devices.ts', () => {
       return of(mockAudioDevices);
     }),
     getAudioStream: vi.fn(() => Promise.resolve(mockAudioStream())),
+  };
+});
+
+vi.mock('../../helpers/sound-detector.ts', () => {
+  console.log('MOCKING sound detector');
+  return {
+    createSoundDetector: vi.fn(),
   };
 });
 
@@ -95,6 +106,59 @@ describe('MicrophoneManager', () => {
     await manager.disable();
 
     expect(manager.state.mediaStream!.getAudioTracks()[0].enabled).toBe(false);
+  });
+
+  it(`should start sound detection if mic is disabled`, async () => {
+    await manager.enable();
+    await manager.disable();
+
+    expect(createSoundDetector).toHaveBeenCalled();
+  });
+
+  it(`shouldn't start sound detection if mic is stopped`, async () => {
+    // @ts-expect-error
+    manager.state.disableMode = 'stop-tracks';
+    await manager.enable();
+    await manager.disable();
+
+    expect(createSoundDetector).not.toHaveBeenCalled();
+  });
+
+  it(`should stop sound detection if mic is enabled`, async () => {
+    manager.state.setSpeakingWhileMuted(true);
+
+    await manager.enable();
+
+    expect(manager.state.speakingWhileMuted).toBe(false);
+  });
+
+  it(`should stop sound detection if mic is stopped`, async () => {
+    manager.state.setSpeakingWhileMuted(true);
+    // @ts-expect-error
+    manager.state.disableMode = 'stop-tracks';
+    await manager.disable();
+
+    expect(manager.state.speakingWhileMuted).toBe(false);
+  });
+
+  it('should update speaking while muted state', async () => {
+    const mock = createSoundDetector as Mock;
+    let handler: SoundStateChangeHandler;
+    mock.mockImplementation((_: MediaStream, h: SoundStateChangeHandler) => {
+      handler = h;
+    });
+    await manager.enable();
+    await manager.disable();
+
+    expect(manager.state.speakingWhileMuted).toBe(false);
+
+    handler!({ isSoundDetected: true, audioLevel: 2 });
+
+    expect(manager.state.speakingWhileMuted).toBe(true);
+
+    handler!({ isSoundDetected: false, audioLevel: 0 });
+
+    expect(manager.state.speakingWhileMuted).toBe(false);
   });
 
   afterEach(() => {

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -93,6 +93,10 @@ export const mockVideoStream = () => {
       height: 720,
     }),
     enabled: true,
+    readyState: 'live',
+    stop: () => {
+      track.readyState = 'eneded';
+    },
   };
   return {
     getVideoTracks: () => [track],

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -79,6 +79,10 @@ export const mockAudioStream = () => {
       deviceId: mockAudioDevices[0].deviceId,
     }),
     enabled: true,
+    readyState: 'live',
+    stop: () => {
+      track.readyState = 'eneded';
+    },
   };
   return {
     getAudioTracks: () => [track],

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -1,5 +1,7 @@
 import { vi } from 'vitest';
 import { CallingState } from '../../store';
+import { BehaviorSubject } from 'rxjs';
+import { OwnCapability } from '../../gen/coordinator';
 
 export const mockVideoDevices = [
   {
@@ -66,6 +68,11 @@ export const mockCall = () => {
   return {
     state: {
       callingState: CallingState.IDLE,
+      callingState$: new BehaviorSubject(CallingState.JOINED),
+      ownCapabilities$: new BehaviorSubject([
+        OwnCapability.SEND_AUDIO,
+        OwnCapability.SEND_VIDEO,
+      ]),
     },
     publishVideoStream: vi.fn(),
     publishAudioStream: vi.fn(),

--- a/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
+++ b/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
@@ -46,6 +46,7 @@ describe('DynascaleManager', () => {
       call.state.updateOrAddParticipant('session-id', {
         userId: 'user-id',
         sessionId: 'session-id',
+        publishedTracks: [],
       });
 
       const element = document.createElement('div');
@@ -106,6 +107,7 @@ describe('DynascaleManager', () => {
       call.state.updateOrAddParticipant('session-id', {
         userId: 'user-id',
         sessionId: 'session-id',
+        publishedTracks: [],
       });
 
       // @ts-ignore
@@ -113,6 +115,7 @@ describe('DynascaleManager', () => {
         userId: 'user-id-local',
         sessionId: 'session-id-local',
         isLocalParticipant: true,
+        publishedTracks: [],
       });
 
       const cleanup = dynascaleManager.bindAudioElement(

--- a/packages/client/src/helpers/sound-detector.ts
+++ b/packages/client/src/helpers/sound-detector.ts
@@ -82,7 +82,13 @@ export const createSoundDetector = (
         ? 100
         : Math.round((averagedDataValue / audioLevelThreshold) * 100);
 
-    onSoundDetectedStateChanged({ isSoundDetected, audioLevel: percentage });
+    // When the track is disabled, it takes time for the buffer to empty
+    // This check will ensure that we don't send anything if the track is disabled
+    if (audioStream.getAudioTracks()[0]?.enabled) {
+      onSoundDetectedStateChanged({ isSoundDetected, audioLevel: percentage });
+    } else {
+      onSoundDetectedStateChanged({ isSoundDetected: false, audioLevel: 0 });
+    }
   }, detectionFrequencyInMs);
 
   return async function stop() {

--- a/packages/client/src/helpers/sound-detector.ts
+++ b/packages/client/src/helpers/sound-detector.ts
@@ -97,7 +97,9 @@ export const createSoundDetector = (
     // clean-up the AudioContext elements
     microphone.disconnect();
     analyser.disconnect();
-    await audioContext.close();
+    if (audioContext.state !== 'closed') {
+      await audioContext.close();
+    }
 
     // stop the stream
     if (destroyStreamOnStop) {

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -253,6 +253,9 @@ export class Publisher {
       // by an external factor as permission revokes, device disconnected, etc.
       // keep in mind that `track.stop()` doesn't trigger this event.
       track.addEventListener('ended', handleTrackEnded);
+      if (!track.enabled) {
+        track.enabled = true;
+      }
 
       transceiver = this.pc.addTransceiver(track, {
         direction: 'sendonly',

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -352,6 +352,20 @@ export class Publisher {
     return false;
   };
 
+  /**
+   * Returns true if the given track type is currently live
+   *
+   * @param trackType the track type to check.
+   */
+  isLive = (trackType: TrackType): boolean => {
+    const transceiverForTrackType = this.transceiverRegistry[trackType];
+    if (transceiverForTrackType && transceiverForTrackType.sender) {
+      const sender = transceiverForTrackType.sender;
+      return !!sender.track && sender.track.readyState === 'live';
+    }
+    return false;
+  };
+
   private notifyTrackMuteStateChanged = async (
     mediaStream: MediaStream | undefined,
     track: MediaStreamTrack,

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -321,9 +321,7 @@ export class Publisher {
         ? transceiver.sender.track.stop()
         : (transceiver.sender.track.enabled = false);
       // We don't need to notify SFU if unpublishing in response to remote soft mute
-      if (!this.state.localParticipant?.publishedTracks.includes(trackType)) {
-        return;
-      } else {
+      if (this.state.localParticipant?.publishedTracks.includes(trackType)) {
         return this.notifyTrackMuteStateChanged(
           undefined,
           transceiver.sender.track,

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -310,17 +310,24 @@ export class Publisher {
     if (
       transceiver &&
       transceiver.sender.track &&
-      transceiver.sender.track.readyState === 'live'
+      (stopTrack
+        ? transceiver.sender.track.readyState === 'live'
+        : transceiver.sender.track.enabled)
     ) {
       stopTrack
         ? transceiver.sender.track.stop()
         : (transceiver.sender.track.enabled = false);
-      return this.notifyTrackMuteStateChanged(
-        undefined,
-        transceiver.sender.track,
-        trackType,
-        true,
-      );
+      // We don't need to notify SFU if unpublishing in response to remote soft mute
+      if (!this.state.localParticipant?.publishedTracks.includes(trackType)) {
+        return;
+      } else {
+        return this.notifyTrackMuteStateChanged(
+          undefined,
+          transceiver.sender.track,
+          trackType,
+          true,
+        );
+      }
     }
   };
 
@@ -333,7 +340,11 @@ export class Publisher {
     const transceiverForTrackType = this.transceiverRegistry[trackType];
     if (transceiverForTrackType && transceiverForTrackType.sender) {
       const sender = transceiverForTrackType.sender;
-      return !!sender.track && sender.track.readyState === 'live';
+      return (
+        !!sender.track &&
+        sender.track.readyState === 'live' &&
+        sender.track.enabled
+      );
     }
     return false;
   };

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -180,6 +180,7 @@ describe('Publisher', () => {
 
     expect(state.localParticipant?.videoDeviceId).toEqual('test-device-id');
     expect(state.localParticipant?.publishedTracks).toContain(TrackType.VIDEO);
+    expect(track.enabled).toBe(true);
     expect(state.localParticipant?.videoStream).toEqual(mediaStream);
     expect(transceiver.setCodecPreferences).toHaveBeenCalled();
     expect(sfuClient.updateMuteState).toHaveBeenCalledWith(

--- a/packages/client/src/store/rxUtils.ts
+++ b/packages/client/src/store/rxUtils.ts
@@ -40,8 +40,11 @@ export const getCurrentValue = <T>(observable$: Observable<T>) => {
  * @param update the update to apply to the subject.
  * @return the updated value.
  */
-export const setCurrentValue = <T>(subject: Subject<T>, update: Patch<T>) => {
-  const next =
+export const setCurrentValue = <T>(
+  subject: Subject<T>,
+  update: Patch<T>,
+): T => {
+  const next: T =
     // TypeScript needs more context to infer the type of update
     typeof update === 'function' && update instanceof Function
       ? update(getCurrentValue(subject))

--- a/sample-apps/client/ts-quickstart/.env-example
+++ b/sample-apps/client/ts-quickstart/.env-example
@@ -1,3 +1,4 @@
 VITE_STREAM_API_KEY=<your_api_key>
 VITE_STREAM_USER_TOKEN=<user_token>
 VITE_STREAM_CALL_ID=<call_id> # optional
+VITE_STREAM_LOG_LEVEL=warn # optional

--- a/sample-apps/client/ts-quickstart/index.html
+++ b/sample-apps/client/ts-quickstart/index.html
@@ -7,6 +7,7 @@
     <title>Vite + TS</title>
   </head>
   <body>
+    <progress id="volume" max="100" min="0" value="70"></progress>
     <div id="call-controls"></div>
     <div id="participants"></div>
     <script type="module" src="/src/main.ts"></script>

--- a/sample-apps/client/ts-quickstart/index.html
+++ b/sample-apps/client/ts-quickstart/index.html
@@ -7,7 +7,6 @@
     <title>Vite + TS</title>
   </head>
   <body>
-    <progress id="volume" max="100" min="0" value="70"></progress>
     <div id="call-controls"></div>
     <div id="participants"></div>
     <script type="module" src="/src/main.ts"></script>

--- a/sample-apps/client/ts-quickstart/src/controls.ts
+++ b/sample-apps/client/ts-quickstart/src/controls.ts
@@ -45,10 +45,40 @@ const renderFlipButton = (call: Call) => {
   return flipButton;
 };
 
+const renderCallLeaveButton = (call: Call) => {
+  const leaveButton = document.createElement('button');
+
+  leaveButton.addEventListener('click', async () => {
+    try {
+      await call.leave();
+    } catch (err) {
+      console.error(`Leave failed`, err);
+    }
+  });
+
+  leaveButton.innerText = 'Leave call';
+
+  return leaveButton;
+};
+
+const renderCallJoinButton = (call: Call) => {
+  const joinButton = document.createElement('button');
+
+  joinButton.addEventListener('click', async () => {
+    await call.join();
+  });
+
+  joinButton.innerText = 'Join call';
+
+  return joinButton;
+};
+
 export const renderControls = (call: Call) => {
   return {
     audioButton: renderAudioButton(call),
     videoButton: renderVideoButton(call),
     flipButton: renderFlipButton(call),
+    leaveButton: renderCallLeaveButton(call),
+    joinButton: renderCallJoinButton(call),
   };
 };

--- a/sample-apps/client/ts-quickstart/src/main.ts
+++ b/sample-apps/client/ts-quickstart/src/main.ts
@@ -36,12 +36,17 @@ const client = new StreamVideoClient({
   options: { logLevel: import.meta.env.VITE_STREAM_LOG_LEVEL },
 });
 const call = client.call('default', callId);
+// @ts-expect-error exposed for debug purposes
+window.call = call;
+
 call.join({ create: true }).then(async () => {
   // render mic and camera controls
   const controls = renderControls(call);
   const container = document.getElementById('call-controls')!;
   container.appendChild(controls.audioButton);
   container.appendChild(controls.videoButton);
+  container.appendChild(controls.joinButton);
+  container.appendChild(controls.leaveButton);
 
   container.appendChild(renderAudioDeviceSelector(call));
 

--- a/sample-apps/client/ts-quickstart/src/main.ts
+++ b/sample-apps/client/ts-quickstart/src/main.ts
@@ -78,29 +78,3 @@ call.state.participants$.subscribe((participants) => {
       }
     });
 });
-
-call.microphone.state.speakingWhileMuted$.subscribe((isSpeaking) => {
-  if (isSpeaking) {
-    console.log(`You're muted, unmute yourself to speak`);
-  } else {
-    console.log(`There you go`);
-  }
-});
-
-let cleanup: Function | undefined;
-call.microphone.state.mediaStream$.subscribe(async (mediaStream) => {
-  console.log(mediaStream);
-  const progressBar = document.getElementById('volume') as HTMLProgressElement;
-  if (mediaStream) {
-    cleanup = createSoundDetector(
-      mediaStream,
-      (event) => {
-        progressBar.value = event.audioLevel;
-      },
-      { detectionFrequencyInMs: 100 },
-    );
-  } else {
-    await cleanup?.();
-    progressBar.value = 0;
-  }
-});

--- a/sample-apps/client/ts-quickstart/src/main.ts
+++ b/sample-apps/client/ts-quickstart/src/main.ts
@@ -29,7 +29,12 @@ const callId =
   import.meta.env.VITE_STREAM_CALL_ID ||
   (new Date().getTime() + Math.round(Math.random() * 100)).toString();
 
-const client = new StreamVideoClient({ apiKey, token, user });
+const client = new StreamVideoClient({
+  apiKey,
+  token,
+  user,
+  options: { logLevel: import.meta.env.VITE_STREAM_LOG_LEVEL },
+});
 const call = client.call('default', callId);
 call.join({ create: true }).then(async () => {
   // render mic and camera controls

--- a/sample-apps/client/ts-quickstart/src/main.ts
+++ b/sample-apps/client/ts-quickstart/src/main.ts
@@ -78,3 +78,29 @@ call.state.participants$.subscribe((participants) => {
       }
     });
 });
+
+call.microphone.state.speakingWhileMuted$.subscribe((isSpeaking) => {
+  if (isSpeaking) {
+    console.log(`You're muted, unmute yourself to speak`);
+  } else {
+    console.log(`There you go`);
+  }
+});
+
+let cleanup: Function | undefined;
+call.microphone.state.mediaStream$.subscribe(async (mediaStream) => {
+  console.log(mediaStream);
+  const progressBar = document.getElementById('volume') as HTMLProgressElement;
+  if (mediaStream) {
+    cleanup = createSoundDetector(
+      mediaStream,
+      (event) => {
+        progressBar.value = event.audioLevel;
+      },
+      { detectionFrequencyInMs: 100 },
+    );
+  } else {
+    await cleanup?.();
+    progressBar.value = 0;
+  }
+});

--- a/sample-apps/react/messenger-clone/.env-example
+++ b/sample-apps/react/messenger-clone/.env-example
@@ -1,2 +1,2 @@
-VITE_STREAM_API_KEY=<your_api_key>
+VITE_STREAM_KEY=<your_api_key>
 VITE_TOKEN_PROVIDER_URL=<your_token_provider_url>

--- a/sample-apps/react/messenger-clone/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/sample-apps/react/messenger-clone/src/components/ChannelPreview/ChannelPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import { MouseEvent, useMemo } from 'react';
 import clsx from 'clsx';
 import {
   Avatar as DefaultAvatar,
@@ -21,7 +21,6 @@ const UnMemoizedChannelPreview = (props: ChannelPreviewUIComponentProps) => {
     unread,
     watchers,
   } = props;
-  const channelPreviewButton = useRef<HTMLButtonElement | null>(null);
   const calls = useCalls();
   const callToChannel = useMemo(() => {
     return calls.find((call) => call.state.custom.channelCid === channel.cid);
@@ -31,19 +30,16 @@ const UnMemoizedChannelPreview = (props: ChannelPreviewUIComponentProps) => {
     displayTitle ||
     channel.state.messages[channel.state.messages.length - 1]?.user?.id;
 
-  const onSelectChannel = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const onSelectChannel = (e: MouseEvent<HTMLElement>) => {
     if (customOnSelectChannel) {
       customOnSelectChannel(e);
     } else if (setActiveChannel) {
       setActiveChannel(channel, watchers);
     }
-    if (channelPreviewButton?.current) {
-      channelPreviewButton.current.blur();
-    }
   };
 
   return (
-    <button
+    <div
       aria-label={`Select Channel: ${displayTitle || ''}`}
       aria-selected={active}
       className={clsx(
@@ -54,8 +50,6 @@ const UnMemoizedChannelPreview = (props: ChannelPreviewUIComponentProps) => {
       )}
       data-testid="channel-preview-button"
       onClick={onSelectChannel}
-      ref={channelPreviewButton}
-      role="option"
     >
       <div className="str-chat__channel-preview-messenger--left">
         <Avatar image={displayImage} name={avatarName} size={40} />
@@ -83,7 +77,7 @@ const UnMemoizedChannelPreview = (props: ChannelPreviewUIComponentProps) => {
           {latestMessage}
         </div>
       </div>
-    </button>
+    </div>
   );
 };
 
@@ -91,6 +85,4 @@ const UnMemoizedChannelPreview = (props: ChannelPreviewUIComponentProps) => {
  * Used as preview component for channel item in [ChannelList](#channellist) component.
  * Its best suited for messenger type chat.
  */
-export const ChannelPreview = React.memo(
-  UnMemoizedChannelPreview,
-) as typeof UnMemoizedChannelPreview;
+export const ChannelPreview = UnMemoizedChannelPreview;

--- a/sample-apps/react/messenger-clone/src/contexts/ClientProviders.tsx
+++ b/sample-apps/react/messenger-clone/src/contexts/ClientProviders.tsx
@@ -24,6 +24,9 @@ export const ClientProviders = ({
       user,
       token,
       tokenProvider,
+      options: {
+        logLevel: 'debug',
+      },
     });
     setVideoClient(client);
 


### PR DESCRIPTION
### Overview

Allows a `call` instance to be reused for multiple `.join() -> .leave() -> .join()` cycles.

Based on #1011 - I'll update the base once #1011 is tested and merged.