### PR TITLE
fix(react-native-sdk): handle media device initial state when media status is undefined

### DIFF
--- a/packages/react-native-sdk/src/providers/MediaStreamManagement.tsx
+++ b/packages/react-native-sdk/src/providers/MediaStreamManagement.tsx
@@ -79,7 +79,11 @@ export const MediaStreamManagement = ({
       typeof initialAudioEnabled !== 'undefined' &&
       isMicPermissionGranted$.getValue()
     ) {
-      if (initialAudioEnabled && call?.microphone.state.status === 'disabled') {
+      if (
+        initialAudioEnabled &&
+        (call?.microphone.state.status === undefined ||
+          call?.microphone.state.status === 'disabled')
+      ) {
         call?.microphone.enable();
       } else {
         call?.microphone.disable();
@@ -89,7 +93,11 @@ export const MediaStreamManagement = ({
       typeof initialVideoEnabled !== 'undefined' &&
       isCameraPermissionGranted$.getValue()
     ) {
-      if (initialVideoEnabled && call?.camera.state.status === 'disabled') {
+      if (
+        initialVideoEnabled &&
+        (call?.camera.state.status === undefined ||
+          call?.camera.state.status === 'disabled')
+      ) {
         call?.camera.enable();
       } else {
         call?.camera.disable();


### PR DESCRIPTION
If we pass:
```
mediaDeviceInitialState={{
        initialAudioEnabled: true,
        initialVideoEnabled: true,
      }}
```
to `StreamCall` it is expected that the initial states in the lobby/call will be unmute for the camera and microphone.

However, the mic and camera still remain muted in the Lobby. Which I don't think should happen. The culprit here is `call?.microphone.state.status` which is `undefined` and `initialAudioEnabled` if `true`, `initialAudioEnabled && call?.microphone.state.status === 'disabled'` will always result in `false`, no matter what.

The PR tends to fix this issue.