### PR TITLE
fix: override default handler with onPressHandler prop for ToggleCameraButton

### DIFF
--- a/packages/react-native-sdk/src/components/Call/CallControls/ToggleCameraFaceButton.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallControls/ToggleCameraFaceButton.tsx
@@ -34,7 +34,11 @@ export const ToggleCameraFaceButton = ({
     theme: { colors, toggleCameraFaceButton },
   } = useTheme();
   const onPress = async () => {
-    onPressHandler?.();
+    if (onPressHandler) {
+      onPressHandler();
+      return;
+    }
+
     await call?.camera.flip();
   };
 


### PR DESCRIPTION
To keep the behaviour of onPressHandler consistent with other control buttons.