### PR TITLE
feat(react-native): add plugin to update the setup method to MainApplication.java

### DIFF
--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withAppDelegate.test.tsx
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withAppDelegate.test.tsx
@@ -76,19 +76,4 @@ describe('withStreamVideoReactNativeSDKAppDelegate', () => {
       'Cannot setup StreamVideoReactNativeSDK because the AppDelegate is not Objective C',
     );
   });
-
-  it(`fails to add to a malformed app delegate`, () => {
-    // Prepare a mock config
-    const config: CustomExpoConfig = {
-      name: 'test-app',
-      slug: 'test-app',
-      modResults: {
-        language: 'objc',
-        contents: `foobar`,
-      },
-    };
-    expect(() => withStreamVideoReactNativeSDKAppDelegate(config)).toThrow(
-      "Cannot add StreamVideoReactNativeSDK to the project's AppDelegate because it's malformed.",
-    );
-  });
 });

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withMainApplication.test.tsx
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withMainApplication.test.tsx
@@ -1,6 +1,6 @@
-import { withAppDelegate } from '@expo/config-plugins';
+import { withMainApplication } from '@expo/config-plugins';
 import { getFixture } from '../fixtures/index';
-import withStreamVideoReactNativeSDKAppDelegate from '../src/withAppDelegate';
+import withStreamVideoReactNativeSDKMainApplication from '../src/withMainApplication';
 import { ExpoConfig } from '@expo/config-types';
 
 // Define a custom type that extends ExpoConfig
@@ -15,16 +15,16 @@ jest.mock('@expo/config-plugins', () => {
   const originalModule = jest.requireActual('@expo/config-plugins');
   return {
     ...originalModule,
-    withAppDelegate: jest.fn(),
+    withMainApplication: jest.fn(),
   };
 });
 
-const ExpoModulesAppDelegate = getFixture('AppDelegate.mm');
+const ExpoModulesMainApplication = getFixture('MainApplication.java');
 
-describe('withStreamVideoReactNativeSDKAppDelegate', () => {
+describe('withStreamVideoReactNativeSDKMainApplication', () => {
   beforeEach(() => {
     // Mock the behavior of withAppDelegate
-    (withAppDelegate as jest.Mock).mockImplementationOnce(
+    (withMainApplication as jest.Mock).mockImplementationOnce(
       (config, callback) => {
         const updatedConfig: CustomExpoConfig = callback(
           config as CustomExpoConfig,
@@ -33,62 +33,66 @@ describe('withStreamVideoReactNativeSDKAppDelegate', () => {
       },
     );
   });
-  it('should modify config for Objective-C AppDelegate', () => {
-    // Prepare a mock config
-    const config: CustomExpoConfig = {
-      name: 'test-app',
-      slug: 'test-app',
-      modResults: {
-        language: 'objc',
-        contents: ExpoModulesAppDelegate,
-      },
-    };
 
-    const updatedConfig = withStreamVideoReactNativeSDKAppDelegate(
-      config,
-    ) as CustomExpoConfig;
-
-    // Assert that withAppDelegate was called with the correct arguments
-    expect(withAppDelegate).toHaveBeenCalledWith(config, expect.any(Function));
-
-    expect(updatedConfig.modResults.contents).toMatch(
-      /#import "StreamVideoReactNative.h"/,
-    );
-
-    // Assert that the updated config contains the expected changes
-    expect(updatedConfig.modResults.contents).toContain(
-      '[StreamVideoReactNative setup]',
-    );
-  });
-
-  it('should throw error for different language AppDelegate', () => {
+  it('should modify config for Java MainApplication', () => {
     // Prepare a mock config
     const config: CustomExpoConfig = {
       name: 'test-app',
       slug: 'test-app',
       modResults: {
         language: 'java',
-        contents: ExpoModulesAppDelegate,
+        contents: ExpoModulesMainApplication,
       },
     };
 
-    expect(() => withStreamVideoReactNativeSDKAppDelegate(config)).toThrow(
-      'Cannot setup StreamVideoReactNativeSDK because the AppDelegate is not Objective C',
+    const updatedConfig = withStreamVideoReactNativeSDKMainApplication(
+      config,
+    ) as CustomExpoConfig;
+
+    // Assert that withAppDelegate was called with the correct arguments
+    expect(withMainApplication).toHaveBeenCalledWith(
+      config,
+      expect.any(Function),
+    );
+
+    expect(updatedConfig.modResults.contents).toMatch(
+      'com.streamvideo.reactnative.StreamVideoReactNative',
+    );
+
+    // Assert that the updated config contains the expected changes
+    expect(updatedConfig.modResults.contents).toContain(
+      'StreamVideoReactNative.setup();',
     );
   });
 
-  it(`fails to add to a malformed app delegate`, () => {
+  it('should throw error for different language MainApplication', () => {
     // Prepare a mock config
     const config: CustomExpoConfig = {
       name: 'test-app',
       slug: 'test-app',
       modResults: {
         language: 'objc',
+        contents: ExpoModulesMainApplication,
+      },
+    };
+
+    expect(() => withStreamVideoReactNativeSDKMainApplication(config)).toThrow(
+      'Cannot setup StreamVideoReactNativeSDK because the MainApplication is not in Java/Kotlin',
+    );
+  });
+
+  it(`fails to add to a malformed MainApplication`, () => {
+    // Prepare a mock config
+    const config: CustomExpoConfig = {
+      name: 'test-app',
+      slug: 'test-app',
+      modResults: {
+        language: 'java',
         contents: `foobar`,
       },
     };
-    expect(() => withStreamVideoReactNativeSDKAppDelegate(config)).toThrow(
-      "Cannot add StreamVideoReactNativeSDK to the project's AppDelegate because it's malformed.",
+    expect(() => withStreamVideoReactNativeSDKMainApplication(config)).toThrow(
+      "Cannot add StreamVideoReactNativeSDK to the project's MainApplication because it's malformed.",
     );
   });
 });

--- a/packages/react-native-sdk/expo-config-plugin/fixtures/MainApplication.java
+++ b/packages/react-native-sdk/expo-config-plugin/fixtures/MainApplication.java
@@ -1,5 +1,4 @@
 package io.getstream.expovideosample;
-import com.streamvideo.reactnative.StreamVideoReactNative;
 
 import android.app.Application;
 import android.content.res.Configuration;
@@ -67,7 +66,6 @@ public class MainApplication extends Application implements ReactApplication {
     }
     ReactNativeFlipper.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
     ApplicationLifecycleDispatcher.onApplicationCreate(this);
-  StreamVideoReactNative.setup();
 }
 
   @Override

--- a/packages/react-native-sdk/expo-config-plugin/fixtures/index.ts
+++ b/packages/react-native-sdk/expo-config-plugin/fixtures/index.ts
@@ -1,7 +1,9 @@
 import path from 'path';
 import fs from 'fs';
 
-export function getFixture(name: 'AppDelegate.mm'): string {
+export function getFixture(
+  name: 'AppDelegate.mm' | 'MainApplication.java',
+): string {
   const filepath = path.join(__dirname, name);
   return fs.readFileSync(filepath, 'utf8');
 }

--- a/packages/react-native-sdk/expo-config-plugin/src/index.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/index.ts
@@ -1,8 +1,12 @@
 import { ConfigPlugin, withPlugins } from '@expo/config-plugins';
 import withStreamVideoReactNativeSDKAppDelegate from './withAppDelegate';
+import withStreamVideoReactNativeSDKMainApplication from './withMainApplication';
 
 const withStreamVideoReactNativeSDK: ConfigPlugin = (config) => {
-  return withPlugins(config, [withStreamVideoReactNativeSDKAppDelegate]);
+  return withPlugins(config, [
+    withStreamVideoReactNativeSDKAppDelegate,
+    withStreamVideoReactNativeSDKMainApplication,
+  ]);
 };
 
 export default withStreamVideoReactNativeSDK;

--- a/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
@@ -4,19 +4,6 @@ import {
   insertContentsInsideObjcFunctionBlock,
 } from '@expo/config-plugins/build/ios/codeMod';
 
-export const addStreamVideoReactNativeSDKAppDelegateSetup = (
-  contents: string,
-): string => {
-  const setupMethod = '[StreamVideoReactNative setup];';
-
-  return insertContentsInsideObjcFunctionBlock(
-    contents,
-    'application:didFinishLaunchingWithOptions:',
-    setupMethod,
-    { position: 'head' },
-  );
-};
-
 const withStreamVideoReactNativeSDKAppDelegate: ConfigPlugin = (
   configuration,
 ) => {
@@ -25,8 +12,12 @@ const withStreamVideoReactNativeSDKAppDelegate: ConfigPlugin = (
       config.modResults.contents = addObjcImports(config.modResults.contents, [
         '"StreamVideoReactNative.h"',
       ]);
-      config.modResults.contents = addStreamVideoReactNativeSDKAppDelegateSetup(
+      const setupMethod = '[StreamVideoReactNative setup];';
+      config.modResults.contents = insertContentsInsideObjcFunctionBlock(
         config.modResults.contents,
+        'application:didFinishLaunchingWithOptions:',
+        setupMethod,
+        { position: 'head' },
       );
     } else {
       throw new Error(

--- a/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
@@ -23,8 +23,10 @@ export const addStreamVideoReactNativeSDKAppDelegateSetup = (
   });
 };
 
-const withStreamVideoReactNativeSDKAppDelegate: ConfigPlugin = (config) => {
-  return withAppDelegate(config, (config) => {
+const withStreamVideoReactNativeSDKAppDelegate: ConfigPlugin = (
+  configuration,
+) => {
+  return withAppDelegate(configuration, (config) => {
     if (['objc', 'objcpp'].includes(config.modResults.language)) {
       try {
         config.modResults.contents = addObjcImports(

--- a/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
@@ -3,24 +3,9 @@ import {
   MergeResults,
   mergeContents,
 } from '@expo/config-plugins/build/utils/generateCode';
+import { addObjcImports } from '@expo/config-plugins/build/ios/codeMod';
 
 const commentFormat = '//';
-
-export const addStreamVideoReactNativeSDKAppDelegateImport = (
-  src: string,
-): MergeResults => {
-  const newSrc = '#import "StreamVideoReactNative.h"';
-  const StreamVideoReactNativeSDKAppDelegateImportRegex =
-    /#import "AppDelegate.h"/;
-  return mergeContents({
-    tag: 'video-react-native-sdk-app-delegate-import',
-    src,
-    newSrc,
-    anchor: StreamVideoReactNativeSDKAppDelegateImportRegex,
-    offset: 1,
-    comment: commentFormat,
-  });
-};
 
 export const addStreamVideoReactNativeSDKAppDelegateSetup = (
   src: string,
@@ -42,10 +27,10 @@ const withStreamVideoReactNativeSDKAppDelegate: ConfigPlugin = (config) => {
   return withAppDelegate(config, (config) => {
     if (['objc', 'objcpp'].includes(config.modResults.language)) {
       try {
-        config.modResults.contents =
-          addStreamVideoReactNativeSDKAppDelegateImport(
-            config.modResults.contents,
-          ).contents;
+        config.modResults.contents = addObjcImports(
+          config.modResults.contents,
+          ['"StreamVideoReactNative.h"'],
+        );
         config.modResults.contents =
           addStreamVideoReactNativeSDKAppDelegateSetup(
             config.modResults.contents,

--- a/packages/react-native-sdk/expo-config-plugin/src/withMainApplication.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withMainApplication.ts
@@ -1,0 +1,35 @@
+import { ConfigPlugin, withMainApplication } from '@expo/config-plugins';
+import {
+  addImports,
+  appendContentsInsideDeclarationBlock,
+} from '@expo/config-plugins/build/android/codeMod';
+
+const withStreamVideoReactNativeSDKMainApplication: ConfigPlugin = (config) => {
+  return withMainApplication(config, (config) => {
+    if (['java', 'kt'].includes(config.modResults.language)) {
+      try {
+        config.modResults.contents = addImports(
+          config.modResults.contents,
+          ['com.streamvideo.reactnative.StreamVideoReactNative'],
+          config.modResults.language === 'java',
+        );
+        config.modResults.contents = appendContentsInsideDeclarationBlock(
+          config.modResults.contents,
+          'onCreate',
+          'StreamVideoReactNative.setup();\n',
+        );
+      } catch (error: any) {
+        throw new Error(
+          "Cannot add StreamVideoReactNativeSDK to the project's MainApplication because it's malformed.",
+        );
+      }
+    } else {
+      throw new Error(
+        'Cannot setup StreamVideoReactNativeSDK because the MainApplication is not in Java/Kotlin',
+      );
+    }
+    return config;
+  });
+};
+
+export default withStreamVideoReactNativeSDKMainApplication;

--- a/packages/react-native-sdk/expo-config-plugin/src/withMainApplication.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withMainApplication.ts
@@ -4,8 +4,10 @@ import {
   appendContentsInsideDeclarationBlock,
 } from '@expo/config-plugins/build/android/codeMod';
 
-const withStreamVideoReactNativeSDKMainApplication: ConfigPlugin = (config) => {
-  return withMainApplication(config, (config) => {
+const withStreamVideoReactNativeSDKMainApplication: ConfigPlugin = (
+  configuration,
+) => {
+  return withMainApplication(configuration, (config) => {
     if (['java', 'kt'].includes(config.modResults.language)) {
       try {
         config.modResults.contents = addImports(

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -14,7 +14,7 @@
     "start": "yarn copy-version && tsc --project tsconfig.json --watch",
     "build:expo-plugin": "rimraf plugin/build && tsc --build expo-config-plugin",
     "build": "yarn clean && yarn copy-version && tsc --project tsconfig.json && yarn build:expo-plugin",
-    "test:expo-plugin": "jest expo-config-plugin",
+    "test:expo-plugin": "jest expo-config-plugin --coverage",
     "test": "jest --coverage && yarn test:expo-plugin",
     "copy-version": "echo \"export const version = '$npm_package_version';\" > ./version.ts"
   },

--- a/sample-apps/react-native/expo-video-sample/android/gradle.properties
+++ b/sample-apps/react-native/expo-video-sample/android/gradle.properties
@@ -52,6 +52,7 @@ expo.webp.enabled=true
 # Disabled by default because iOS doesn't support animated webp
 expo.webp.animated=false
 
+android.enableDexingArtifactTransform.desugaring=false
 android.minSdkVersion=24
 EX_DEV_CLIENT_NETWORK_INSPECTOR=true
 # disables the check for multiple instances for gesture handler

--- a/sample-apps/react-native/expo-video-sample/ios/expovideosample.xcodeproj/project.pbxproj
+++ b/sample-apps/react-native/expo-video-sample/ios/expovideosample.xcodeproj/project.pbxproj
@@ -11,15 +11,14 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		4E3966BC27484EDA8FB87C02 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9FF87926924698B43B10B2 /* noop-file.swift */; };
 		96905EF65AED1B983A6B3ABC /* libPods-expovideosample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-expovideosample.a */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
+		B25C8EADCB434521A1E40315 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D02BD337F147D496056246 /* noop-file.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
-		0E9FF87926924698B43B10B2 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "expovideosample/noop-file.swift"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* expovideosample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = expovideosample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = expovideosample/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = expovideosample/AppDelegate.mm; sourceTree = "<group>"; };
@@ -30,6 +29,7 @@
 		6C2E3173556A471DD304B334 /* Pods-expovideosample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expovideosample.debug.xcconfig"; path = "Target Support Files/Pods-expovideosample/Pods-expovideosample.debug.xcconfig"; sourceTree = "<group>"; };
 		7A4D352CD337FB3A3BF06240 /* Pods-expovideosample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expovideosample.release.xcconfig"; path = "Target Support Files/Pods-expovideosample/Pods-expovideosample.release.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = expovideosample/SplashScreen.storyboard; sourceTree = "<group>"; };
+		B8D02BD337F147D496056246 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "expovideosample/noop-file.swift"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-expovideosample/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
@@ -58,7 +58,7 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				0E9FF87926924698B43B10B2 /* noop-file.swift */,
+				B8D02BD337F147D496056246 /* noop-file.swift */,
 			);
 			name = expovideosample;
 			sourceTree = "<group>";
@@ -150,7 +150,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				D94EA2D6B4C564DE7B88A179 /* [CP] Embed Pods Frameworks */,
+				9FD8F9FF19755599E3DC81F4 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -262,7 +262,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-expovideosample/Pods-expovideosample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D94EA2D6B4C564DE7B88A179 /* [CP] Embed Pods Frameworks */ = {
+		9FD8F9FF19755599E3DC81F4 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -311,7 +311,7 @@
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */,
-				4E3966BC27484EDA8FB87C02 /* noop-file.swift in Sources */,
+				B25C8EADCB434521A1E40315 /* noop-file.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sample-apps/react-native/expo-video-sample/ios/expovideosample/AppDelegate.mm
+++ b/sample-apps/react-native/expo-video-sample/ios/expovideosample/AppDelegate.mm
@@ -1,7 +1,5 @@
 #import "AppDelegate.h"
-// @generated begin video-react-native-sdk-app-delegate-import - expo prebuild (DO NOT MODIFY) sync-02f2447ac3ad7e976045c452f81168c758d0c2b7
 #import "StreamVideoReactNative.h"
-// @generated end video-react-native-sdk-app-delegate-import
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTLinkingManager.h>


### PR DESCRIPTION
Changes - 
- Add MainApplication.java setup methods using the plugin
- Improve the import method for AppDelegate.mm
- Improve test coverage to:
```
-------------------------|---------|----------|---------|---------|-------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------------|---------|----------|---------|---------|-------------------
All files                |   96.29 |    83.33 |     100 |   96.29 |
 fixtures                |     100 |      100 |     100 |     100 |
  index.ts               |     100 |      100 |     100 |     100 |
 src                     |      96 |    83.33 |     100 |      96 |
  withAppDelegate.ts     |   93.75 |       75 |     100 |   93.75 | 44
  withMainApplication.ts |     100 |      100 |     100 |     100 |
-------------------------|---------|----------|---------|---------|-------------------
```