### PR TITLE
fix: deploy sample apps whenever there are changes within the SDKs

### DIFF
--- a/.github/workflows/deploy-react-sample-apps.yml
+++ b/.github/workflows/deploy-react-sample-apps.yml
@@ -63,12 +63,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v2.11.1
-        id: changes
-        with:
-          filters: |
-            sample-apps:
-              - 'sample-apps/react/${{ matrix.application.folder || matrix.application.name }}/**/*'
+#      - uses: dorny/paths-filter@v2.11.1
+#        id: changes
+#        with:
+#          filters: |
+#            sample-apps:
+#              - 'sample-apps/react/${{ matrix.application.folder || matrix.application.name }}/**/*'
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -98,7 +98,7 @@ jobs:
 
       ### Vercel deployment (Production) ###
       - name: Vercel Pull/Build/Deploy (Production)
-        if: ${{ github.ref_name == 'main' && steps.changes.outputs.sample-apps == 'true' }}
+        if: ${{ github.ref_name == 'main' }}
         run: >
           yarn vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }} &&
           yarn vercel build --prod --token=${{ secrets.VERCEL_TOKEN }} &&


### PR DESCRIPTION
### Overview

Reverts #989 

Sample Apps need to get new production deployments whenever the SDKs get an update. That's how we ensure they run well with the latest SDK version.