### PR TITLE
docs(react-native): remove unused docs import

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/08-native-permissions.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/08-native-permissions.mdx
@@ -46,7 +46,7 @@ In this step, we create a function called `requestAndUpdatePermissions`. This fu
 ```ts title=src/utils/requestAndUpdatePermissions.ts
 import { Platform } from 'react-native';
 import { PERMISSIONS, requestMultiple } from 'react-native-permissions';
-import { androidProcessPermissions, iosProcessPermissions } from 'src/utils/updatePermissions';
+
 
 export const requestAndUpdatePermissions = async () => {
   if (Platform.OS === 'ios') {


### PR DESCRIPTION
Think this is a leftover from the native permissions work? 

Used to be this - 

```
In this step, we create two functions called `androidProcessPermissions` and `iOSProcessPermissions`. These functions are responsible for informing the status of the permission grants to the SDK. 
```

but seems to be not needed anymore