### PR TITLE
chore: include RPC method name in error logs

### DIFF
--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -388,7 +388,11 @@ const retryable = async <I extends object, O extends SfuResponseWithError>(
 
     // if the RPC call failed, log the error and retry
     if (rpcCallResult.response.error) {
-      logger('error', 'SFU RPC Error:', rpcCallResult.response.error);
+      logger(
+        'error',
+        `SFU RPC Error (${rpcCallResult.method.name}):`,
+        rpcCallResult.response.error,
+      );
     }
     retryAttempt++;
   } while (


### PR DESCRIPTION
### Overview

In order to make it easier to spot which RPC call resulted in an error, we now include the RPC method's name in the logs.