### PR TITLE
fix(DynascaleManager): update subscription upon cleanup

### DIFF
--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -16,6 +16,7 @@ import {
   distinctUntilChanged,
   distinctUntilKeyChanged,
   map,
+  shareReplay,
   takeWhile,
 } from 'rxjs';
 import { ViewportTracker } from './ViewportTracker';
@@ -167,6 +168,7 @@ export class DynascaleManager {
       ),
       takeWhile((participant) => !!participant),
       distinctUntilChanged(),
+      shareReplay(1),
     );
 
     // keep copy for resize observer handler
@@ -284,6 +286,7 @@ export class DynascaleManager {
     videoElement.muted = true;
 
     return () => {
+      requestTrackWithDimensions(DebounceType.IMMEDIATE, undefined);
       viewportVisibilityStateSubscription?.unsubscribe();
       publishedTracksSubscription?.unsubscribe();
       streamSubscription.unsubscribe();

--- a/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
+++ b/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
@@ -226,6 +226,12 @@ describe('DynascaleManager', () => {
       );
 
       cleanup?.();
+
+      expect(updateSubscription).toHaveBeenCalledWith(
+        'videoTrack',
+        { 'session-id': { dimension: undefined } },
+        DebounceType.IMMEDIATE,
+      );
     });
 
     it('video: should play video when track becomes available', () => {
@@ -271,6 +277,12 @@ describe('DynascaleManager', () => {
       expect(videoElement.srcObject).toBe(mediaStream);
 
       cleanup?.();
+
+      expect(updateSubscription).toHaveBeenCalledWith(
+        'videoTrack',
+        { 'session-id': { dimension: undefined } },
+        DebounceType.IMMEDIATE,
+      );
     });
 
     it('video: should update subscription when element becomes visible', () => {
@@ -353,6 +365,12 @@ describe('DynascaleManager', () => {
       );
 
       cleanup?.();
+
+      expect(updateSubscription).toHaveBeenCalledWith(
+        'videoTrack',
+        { 'session-id': { dimension: undefined } },
+        DebounceType.IMMEDIATE,
+      );
     });
 
     it('video: should update subscription when element resizes', () => {
@@ -417,6 +435,12 @@ describe('DynascaleManager', () => {
       );
 
       cleanup?.();
+
+      expect(updateSubscription).toHaveBeenCalledWith(
+        'videoTrack',
+        { 'session-id': { dimension: undefined } },
+        DebounceType.IMMEDIATE,
+      );
     });
   });
 });


### PR DESCRIPTION
- removing registered element from the screen wouldn't update subscriptions
- subscribing to `participant$` within `bindVideoElement` would call `map` operator 3 times on each `call.state.participants$` update per `bindVideoElement` call (per `sessionId`)