### PR TITLE
fix(react-native): device unmute and mute behaviour using the new device API

### DIFF
--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -69,6 +69,7 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
   protected getDevices(): Observable<MediaDeviceInfo[]> {
     return getVideoDevices();
   }
+
   protected getStream(
     constraints: MediaTrackConstraints,
   ): Promise<MediaStream> {
@@ -82,9 +83,11 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
     }
     return getVideoStream(constraints);
   }
+
   protected publishStream(stream: MediaStream): Promise<void> {
     return this.call.publishVideoStream(stream);
   }
+
   protected stopPublishStream(stopTracks: boolean): Promise<void> {
     return this.call.stopPublish(TrackType.VIDEO, stopTracks);
   }

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -141,25 +141,6 @@ export abstract class InputMediaDeviceManager<
 
   protected abstract getTrack(): undefined | MediaStreamTrack;
 
-  protected async muteStream(stopTracks: boolean = true) {
-    if (!this.state.mediaStream) {
-      return;
-    }
-    this.logger('debug', `${stopTracks ? 'Stopping' : 'Disabling'} stream`);
-    if (this.call.state.callingState === CallingState.JOINED) {
-      await this.stopPublishStream(stopTracks);
-    }
-    this.muteLocalStream(stopTracks);
-    if (this.getTrack()?.readyState === 'ended') {
-      // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the stream
-      if (typeof this.state.mediaStream.release === 'function') {
-        // @ts-expect-error
-        this.state.mediaStream.release();
-      }
-      this.state.setMediaStream(undefined);
-    }
-  }
-
   private muteTrack() {
     const track = this.getTrack();
     if (!track || !track.enabled) {
@@ -191,6 +172,25 @@ export abstract class InputMediaDeviceManager<
     stopTracks ? this.stopTrack() : this.muteTrack();
   }
 
+  protected async muteStream(stopTracks: boolean = true) {
+    if (!this.state.mediaStream) {
+      return;
+    }
+    this.logger('debug', `${stopTracks ? 'Stopping' : 'Disabling'} stream`);
+    if (this.call.state.callingState === CallingState.JOINED) {
+      await this.stopPublishStream(stopTracks);
+    }
+    this.muteLocalStream(stopTracks);
+    if (this.getTrack()?.readyState === 'ended') {
+      // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the stream
+      if (typeof this.state.mediaStream.release === 'function') {
+        // @ts-expect-error
+        this.state.mediaStream.release();
+      }
+      this.state.setMediaStream(undefined);
+    }
+  }
+
   protected async unmuteStream() {
     this.logger('debug', 'Starting stream');
     let stream: MediaStream;
@@ -198,9 +198,6 @@ export abstract class InputMediaDeviceManager<
       stream = this.state.mediaStream;
       this.unmuteTrack();
     } else {
-      if (this.state.mediaStream) {
-        this.stopTrack();
-      }
       const constraints = { deviceId: this.state.selectedDevice };
       stream = await this.getStream(constraints);
     }

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -42,14 +42,17 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
   protected getDevices(): Observable<MediaDeviceInfo[]> {
     return getAudioDevices();
   }
+
   protected getStream(
     constraints: MediaTrackConstraints,
   ): Promise<MediaStream> {
     return getAudioStream(constraints);
   }
+
   protected publishStream(stream: MediaStream): Promise<void> {
     return this.call.publishAudioStream(stream);
   }
+
   protected stopPublishStream(stopTracks: boolean): Promise<void> {
     return this.call.stopPublish(TrackType.AUDIO, stopTracks);
   }

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -305,6 +305,7 @@ export class Publisher {
     const transceiver = this.pc
       .getTransceivers()
       .find((t) => t === this.transceiverRegistry[trackType] && t.sender.track);
+
     if (
       transceiver &&
       transceiver.sender.track &&
@@ -312,14 +313,18 @@ export class Publisher {
         ? transceiver.sender.track.readyState === 'live'
         : transceiver.sender.track.enabled)
     ) {
-      stopTrack
-        ? transceiver.sender.track.stop()
-        : (transceiver.sender.track.enabled = false);
+      // Since React Native follows the new Device API this is not needed
+      if (!isReactNative()) {
+        stopTrack
+          ? transceiver.sender.track.stop()
+          : (transceiver.sender.track.enabled = false);
+      }
+
       // We don't need to notify SFU if unpublishing in response to remote soft mute
       if (!this.state.localParticipant?.publishedTracks.includes(trackType)) {
         return;
       } else {
-        return this.notifyTrackMuteStateChanged(
+        return await this.notifyTrackMuteStateChanged(
           undefined,
           transceiver.sender.track,
           trackType,

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -313,12 +313,9 @@ export class Publisher {
         ? transceiver.sender.track.readyState === 'live'
         : transceiver.sender.track.enabled)
     ) {
-      // Since React Native follows the new Device API this is not needed
-      if (!isReactNative()) {
-        stopTrack
-          ? transceiver.sender.track.stop()
-          : (transceiver.sender.track.enabled = false);
-      }
+      stopTrack
+        ? transceiver.sender.track.stop()
+        : (transceiver.sender.track.enabled = false);
 
       // We don't need to notify SFU if unpublishing in response to remote soft mute
       if (!this.state.localParticipant?.publishedTracks.includes(trackType)) {

--- a/packages/react-native-sdk/src/providers/MediaStreamManagement.tsx
+++ b/packages/react-native-sdk/src/providers/MediaStreamManagement.tsx
@@ -151,15 +151,11 @@ export const MediaStreamManagement = ({
   }, [call, initialAudioEnabled, initialVideoEnabled]);
 
   const toggleInitialAudioMuteState = useCallback(() => {
-    call?.microphone.state.status === 'enabled'
-      ? call?.microphone.disable()
-      : call?.microphone.enable();
+    call?.microphone.toggle();
   }, [call]);
 
   const toggleInitialVideoMuteState = useCallback(() => {
-    call?.camera.state.status === 'enabled'
-      ? call?.camera.disable()
-      : call?.camera.enable();
+    call?.camera.toggle();
   }, [call]);
 
   const contextValue = useMemo(() => {


### PR DESCRIPTION
This PR tends to solve the `track.enabled` not changing to be `true` when unmuting the stream because it was previously done by the `unPublishStream` call. This PR tends to solve that behavior.

Note: The PR doesn't solve the bug of the microphone issue on RN yet but improves it one step further.