### PR TITLE
fix: use custom url scheme for deep-linking

### DIFF
--- a/sample-apps/react/react-video-demo/src/App.tsx
+++ b/sample-apps/react/react-video-demo/src/App.tsx
@@ -142,7 +142,9 @@ const Init = () => {
     if (appleItunesAppMeta) {
       appleItunesAppMeta.setAttribute(
         'content',
-        `app-id=1644313060, app-argument=${window.location.href}`,
+        `app-id=1644313060, app-argument=${window.location.href
+          .replace('http://', 'streamvideo://')
+          .replace('https://', 'streamvideo://')}`,
       );
     }
   }, []);


### PR DESCRIPTION
### Overview

Switches the deep linking scheme to `streamvideo://`