### PR TITLE
fix: add type check of deviceId before setting sinkId

### DIFF
--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -365,7 +365,8 @@ export class DynascaleManager {
         getSdkInfo()?.type === SdkType.REACT
           ? p?.audioOutputDeviceId
           : selectedDevice;
-      if ('setSinkId' in audioElement) {
+
+      if ('setSinkId' in audioElement && typeof deviceId === 'string') {
         // @ts-expect-error setSinkId is not yet in the lib
         audioElement.setSinkId(deviceId);
       }


### PR DESCRIPTION
Prevent setting `undefined` as `sinkId` which caused issues.

![image](https://github.com/GetStream/stream-video-js/assets/43254280/2f98a454-23cb-480c-a8c1-9cb3d9f6d219)
