### PR TITLE
fix(react-native): initial media stream management according to BE and SDK settings

### DIFF
--- a/packages/react-native-sdk/src/components/Call/CallControls/ToggleAudioPreviewButton.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallControls/ToggleAudioPreviewButton.tsx
@@ -1,8 +1,7 @@
-import { useCallStateHooks } from '@stream-io/video-react-bindings';
+import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
 import React from 'react';
 import { useTheme } from '../../../contexts';
 import { Mic, MicOff } from '../../../icons';
-import { useMediaStreamManagement } from '../../../providers';
 import { CallControlsButton } from './CallControlsButton';
 
 /**
@@ -29,17 +28,16 @@ export const ToggleAudioPreviewButton = ({
       variants: { buttonSizes },
     },
   } = useTheme();
+  const call = useCall();
   const { useMicrophoneState } = useCallStateHooks();
   const { status } = useMicrophoneState();
 
-  const { toggleInitialAudioMuteState } = useMediaStreamManagement();
-
-  const onPress = () => {
+  const onPress = async () => {
     if (onPressHandler) {
       onPressHandler();
       return;
     }
-    toggleInitialAudioMuteState();
+    await call?.microphone.toggle();
   };
 
   return (

--- a/packages/react-native-sdk/src/components/Call/CallControls/ToggleVideoPreviewButton.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallControls/ToggleVideoPreviewButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { useCallStateHooks } from '@stream-io/video-react-bindings';
-import { useMediaStreamManagement } from '../../../providers';
+import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
 import { useTheme } from '../../../contexts';
 import { CallControlsButton } from './CallControlsButton';
 import { Video, VideoSlash } from '../../../icons';
@@ -29,15 +28,15 @@ export const ToggleVideoPreviewButton = ({
       variants: { buttonSizes },
     },
   } = useTheme();
-  const { toggleInitialVideoMuteState } = useMediaStreamManagement();
+  const call = useCall();
   const { useCameraState } = useCallStateHooks();
   const { status } = useCameraState();
-  const onPress = () => {
+  const onPress = async () => {
     if (onPressHandler) {
       onPressHandler();
       return;
     }
-    toggleInitialVideoMuteState();
+    await call?.camera.toggle();
   };
 
   return (

--- a/packages/react-native-sdk/src/index.ts
+++ b/packages/react-native-sdk/src/index.ts
@@ -31,11 +31,6 @@ export * from './translations';
 
 // Overriding 'StreamVideo' from '@stream-io/video-react-bindings'
 // Explicitly re-exporting to resolve ambiguity.
-export {
-  StreamVideo,
-  StreamCall,
-  MediaStreamManagement,
-  useMediaStreamManagement,
-} from './providers';
+export { StreamVideo, StreamCall, MediaStreamManagement } from './providers';
 
 setClientDetails();

--- a/packages/react-native-sdk/src/providers/MediaStreamManagement.tsx
+++ b/packages/react-native-sdk/src/providers/MediaStreamManagement.tsx
@@ -50,25 +50,6 @@ export const MediaStreamManagement = ({
 
   const settings = useCallSettings();
 
-  // Apply SDK settings to set the initial audio/video enabled state
-  useEffect(() => {
-    setInitialDeviceState((prev) => {
-      let initAudio = prev.initialAudioEnabled;
-      if (typeof propInitialAudioEnabled !== 'undefined') {
-        initAudio = propInitialAudioEnabled;
-      }
-      let initVideo = prev.initialVideoEnabled;
-      if (typeof propInitialVideoEnabled !== 'undefined') {
-        initVideo = propInitialVideoEnabled;
-      }
-
-      return {
-        initialAudioEnabled: initAudio,
-        initialVideoEnabled: initVideo,
-      };
-    });
-  }, [propInitialAudioEnabled, propInitialVideoEnabled]);
-
   // Use backend settings to set initial audio/video enabled state
   // It is applied only if the prop was undefined -- meaning user did not provide any value
   useEffect(() => {
@@ -89,6 +70,25 @@ export const MediaStreamManagement = ({
       return { initialAudioEnabled: initAudio, initialVideoEnabled: initVideo };
     });
   }, [propInitialAudioEnabled, propInitialVideoEnabled, settings]);
+
+  // Apply SDK settings to set the initial audio/video enabled state
+  useEffect(() => {
+    setInitialDeviceState((prev) => {
+      let initAudio = prev.initialAudioEnabled;
+      if (typeof propInitialAudioEnabled !== 'undefined') {
+        initAudio = propInitialAudioEnabled;
+      }
+      let initVideo = prev.initialVideoEnabled;
+      if (typeof propInitialVideoEnabled !== 'undefined') {
+        initVideo = propInitialVideoEnabled;
+      }
+
+      return {
+        initialAudioEnabled: initAudio,
+        initialVideoEnabled: initVideo,
+      };
+    });
+  }, [propInitialAudioEnabled, propInitialVideoEnabled]);
 
   // The main logic
   // Enable or Disable the audio/video stream based on the initial state

--- a/packages/react-native-sdk/src/providers/MediaStreamManagement.tsx
+++ b/packages/react-native-sdk/src/providers/MediaStreamManagement.tsx
@@ -15,7 +15,7 @@ export type MediaDevicesInitialState = {
 
 /**
  *
- * Provides `MediaStreamManagementContextAPI` that allow the integrators to handle:
+ * Provides `MediaStreamManagement` wrapper that allow the integrators to handle:
  * 1. the initial device state enablement (for example in a custom lobby component)
  * 2. media stream publishing
  * @param params
@@ -50,6 +50,7 @@ export const MediaStreamManagement = ({
 
   const settings = useCallSettings();
 
+  // Apply SDK settings to set the initial audio/video enabled state
   useEffect(() => {
     setInitialDeviceState((prev) => {
       let initAudio = prev.initialAudioEnabled;
@@ -69,7 +70,7 @@ export const MediaStreamManagement = ({
   }, [propInitialAudioEnabled, propInitialVideoEnabled]);
 
   // Use backend settings to set initial audio/video enabled state
-  // ONLY if the prop was undefined -- meaning user did not provide any value
+  // It is applied only if the prop was undefined -- meaning user did not provide any value
   useEffect(() => {
     if (!settings) {
       return;


### PR DESCRIPTION
Currently, the initial media stream doesn't account for the fact that local SDK settings. That is fixed in the PR. The BE settings are also applied and the final result is accounted for when the call is joined. The priority is Local SDK settings > BE settings > User manual mutes/unmutes.

Note: The PR is tested both on android and iOS and works fine for all the cases.