### PR TITLE
fix: use `@stream-io/video-client` as a tag prefix

### DIFF
--- a/packages/client/project.json
+++ b/packages/client/project.json
@@ -20,7 +20,6 @@
             {"type": "test", "hidden": true}
         ]
         },
-        "tagPrefix": "client",
         "push": true,
         "skipCommitTypes": ["chore", "ci", "refactor", "test", "docs"],
         "postTargets": ["@stream-io/video-client:update-version", "@stream-io/video-client:github", "@stream-io/video-client:npm"]


### PR DESCRIPTION
### Overview

Should fix the misleading `"@stream-io/video-client updated to version 0.1.0"` message in the generated CHANGELOG on dependent packages.

Beforehand, a new tag `@stream-io/video-client-0.3.27` has been manually created.