### PR TITLE
fix: requestPermission should be no-op when permission is already granted

### DIFF
--- a/packages/react-sdk/src/hooks/useRequestPermission.ts
+++ b/packages/react-sdk/src/hooks/useRequestPermission.ts
@@ -5,8 +5,6 @@ import { useCall, useHasPermissions } from '@stream-io/video-react-bindings';
 export const useRequestPermission = (permission: OwnCapability) => {
   const call = useCall();
   const hasPermission = useHasPermissions(permission);
-  const canRequestPermission =
-    !!call?.permissionsContext.canRequest(permission);
   const [isAwaitingPermission, setIsAwaitingPermission] = useState(false); // TODO: load with possibly pending state
 
   useEffect(() => {
@@ -16,8 +14,11 @@ export const useRequestPermission = (permission: OwnCapability) => {
   }, [hasPermission]);
 
   const requestPermission = useCallback(async () => {
-    if (isAwaitingPermission || !canRequestPermission) return false;
     if (hasPermission) return true;
+
+    const canRequestPermission =
+      !!call?.permissionsContext.canRequest(permission);
+    if (isAwaitingPermission || !canRequestPermission) return false;
 
     setIsAwaitingPermission(true);
 
@@ -31,18 +32,12 @@ export const useRequestPermission = (permission: OwnCapability) => {
     }
 
     return false;
-  }, [
-    call,
-    canRequestPermission,
-    hasPermission,
-    isAwaitingPermission,
-    permission,
-  ]);
+  }, [call, hasPermission, isAwaitingPermission, permission]);
 
   return {
     requestPermission,
     hasPermission,
-    canRequestPermission,
+    canRequestPermission: !!call?.permissionsContext.canRequest(permission),
     isAwaitingPermission,
   };
 };

--- a/packages/react-sdk/src/hooks/useToggleAudioMuteState.ts
+++ b/packages/react-sdk/src/hooks/useToggleAudioMuteState.ts
@@ -27,7 +27,7 @@ export const useToggleAudioMuteState = () => {
       if (canPublish) return publishAudioStream();
     }
 
-    if (!isAudioMutedReference.current) stopPublishingAudio();
+    if (!isAudioMutedReference.current) await stopPublishingAudio();
   }, [publishAudioStream, requestPermission, stopPublishingAudio]);
 
   return { toggleAudioMuteState, isAwaitingPermission };

--- a/packages/react-sdk/src/hooks/useToggleScreenShare.ts
+++ b/packages/react-sdk/src/hooks/useToggleScreenShare.ts
@@ -36,7 +36,7 @@ export const useToggleScreenShare = () => {
       }
     }
 
-    call?.stopPublish(SfuModels.TrackType.SCREEN_SHARE);
+    await call?.stopPublish(SfuModels.TrackType.SCREEN_SHARE);
   }, [call, requestPermission]);
 
   return { toggleScreenShare, isAwaitingPermission, isScreenSharing };

--- a/packages/react-sdk/src/hooks/useToggleVideoMuteState.ts
+++ b/packages/react-sdk/src/hooks/useToggleVideoMuteState.ts
@@ -27,7 +27,7 @@ export const useToggleVideoMuteState = () => {
       if (canPublish) return publishVideoStream();
     }
 
-    if (!isVideoMutedReference.current) stopPublishingVideo();
+    if (!isVideoMutedReference.current) await stopPublishingVideo();
   }, [publishVideoStream, requestPermission, stopPublishingVideo]);
 
   return { toggleVideoMuteState, isAwaitingPermission };


### PR DESCRIPTION
### Overview

The `canRequestPermission` value is irrelevant when requested permission is already granted.

Previously, there was an edge case where, a participant may have `send-video` permission assigned but, the call settings prohibit requesting permission. In that case, `requestPermission` incorrectly returned `false`.