### PR TITLE
fix: check if `currentParticipant` is actually initialized

### DIFF
--- a/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
@@ -108,9 +108,7 @@ export const LivestreamLayout = (props: LivestreamLayoutProps) => {
             hasOngoingScreenShare &&
               'str-video__livestream-layout__floating-participant',
             (hasOngoingScreenShare &&
-              floatingParticipantProps?.position &&
-              `str-video__livestream-layout__floating-participant--${floatingParticipantProps.position}`) ??
-              'str-video__livestream-layout__floating-participant--top-right',
+              `str-video__livestream-layout__floating-participant--${floatingParticipantProps?.position ?? 'top-right'}`),
           )}
           participant={currentSpeaker}
           ParticipantViewUI={FloatingParticipantOverlay || Overlay}

--- a/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
@@ -102,19 +102,21 @@ export const LivestreamLayout = (props: LivestreamLayoutProps) => {
           muteAudio // audio is rendered by ParticipantsAudio
         />
       )}
-      <ParticipantView
-        className={clsx(
-          hasOngoingScreenShare &&
-            'str-video__livestream-layout__floating-participant',
-          (hasOngoingScreenShare &&
-            floatingParticipantProps?.position &&
-            `str-video__livestream-layout__floating-participant--${floatingParticipantProps.position}`) ??
-            'str-video__livestream-layout__floating-participant--top-right',
-        )}
-        participant={currentSpeaker}
-        ParticipantViewUI={FloatingParticipantOverlay || Overlay}
-        muteAudio // audio is rendered by ParticipantsAudio
-      />
+      {currentSpeaker && (
+        <ParticipantView
+          className={clsx(
+            hasOngoingScreenShare &&
+              'str-video__livestream-layout__floating-participant',
+            (hasOngoingScreenShare &&
+              floatingParticipantProps?.position &&
+              `str-video__livestream-layout__floating-participant--${floatingParticipantProps.position}`) ??
+              'str-video__livestream-layout__floating-participant--top-right',
+          )}
+          participant={currentSpeaker}
+          ParticipantViewUI={FloatingParticipantOverlay || Overlay}
+          muteAudio // audio is rendered by ParticipantsAudio
+        />
+      )}
     </div>
   );
 };

--- a/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
@@ -106,9 +106,12 @@ export const LivestreamLayout = (props: LivestreamLayoutProps) => {
         <ParticipantView
           className={clsx(
             hasOngoingScreenShare &&
-              'str-video__livestream-layout__floating-participant',
-            (hasOngoingScreenShare &&
-              `str-video__livestream-layout__floating-participant--${floatingParticipantProps?.position ?? 'top-right'}`),
+              clsx(
+                'str-video__livestream-layout__floating-participant',
+                `str-video__livestream-layout__floating-participant--${
+                  floatingParticipantProps?.position ?? 'top-right'
+                }`,
+              ),
           )}
           participant={currentSpeaker}
           ParticipantViewUI={FloatingParticipantOverlay || Overlay}


### PR DESCRIPTION
### Overview

Rendering `<LivestreamLayout />` before participants are initialized may lead to various errors where some of the rendered participants are `undefined` while TS says otherwise. 
Until we sort out the types, we are adding an explicit null check to the `currentParticipant` variable.