### PR TITLE
chore: remove unused stream-video-buddy package

### DIFF
--- a/.github/workflows/egress-composite-e2e.yml
+++ b/.github/workflows/egress-composite-e2e.yml
@@ -58,12 +58,12 @@ jobs:
       - name: Install Playwright system dependencies (always)
         run: npx playwright install-deps
 
-      - name: Authenticate stream-video-buddy
-        uses: nick-fields/retry@v2.8.3
-        with:
-          timeout_minutes: 5
-          max_attempts: 2
-          command: yarn workspace @stream-io/egress-composite buddy auth
+      # - name: Authenticate stream-video-buddy
+      #   uses: nick-fields/retry@v2.8.3
+      #   with:
+      #     timeout_minutes: 5
+      #     max_attempts: 2
+      #     command: yarn workspace @stream-io/egress-composite buddy auth
 
       - name: Run Playwright tests
         run: yarn workspace @stream-io/egress-composite test:e2e

--- a/sample-apps/react/egress-composite/package.json
+++ b/sample-apps/react/egress-composite/package.json
@@ -8,8 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test:e2e": "playwright test",
-    "buddy": "stream-video-buddy"
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@emotion/css": "^11.11.2",
@@ -26,7 +25,6 @@
     "@vitejs/plugin-react": "^4.0.0",
     "axios": "^1.5.1",
     "nanoid": "^4.0.2",
-    "stream-video-buddy": "https://github.com/GetStream/stream-video-buddy#1.6.10",
     "typescript": "^4.9.5",
     "vercel": "^32.1.0",
     "vite": "^4.4.9"

--- a/sample-apps/react/egress-composite/playwright.config.ts
+++ b/sample-apps/react/egress-composite/playwright.config.ts
@@ -42,12 +42,12 @@ export default defineConfig({
     },
   ],
   webServer: [
-    {
-      timeout: 10000,
-      command: 'yarn buddy server --port 4567',
-      reuseExistingServer: false,
-      port: 4567,
-    },
+    // {
+    //   timeout: 10000,
+    //   command: 'yarn buddy server --port 4567',
+    //   reuseExistingServer: false,
+    //   port: 4567,
+    // },
     {
       timeout: 10000,
       command: 'yarn dev',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6891,7 +6891,6 @@ __metadata:
     nanoid: ^4.0.2
     react: ^18.2.0
     react-dom: ^18.2.0
-    stream-video-buddy: "https://github.com/GetStream/stream-video-buddy#1.6.10"
     typescript: ^4.9.5
     vercel: ^32.1.0
     vite: ^4.4.9
@@ -7576,7 +7575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.0":
+"@types/debug@npm:^4.0.0":
   version: 4.1.8
   resolution: "@types/debug@npm:4.1.8"
   dependencies:
@@ -11496,19 +11495,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clone-deep@npm:^0.2.4":
-  version: 0.2.4
-  resolution: "clone-deep@npm:0.2.4"
-  dependencies:
-    for-own: ^0.1.3
-    is-plain-object: ^2.0.1
-    kind-of: ^3.0.2
-    lazy-cache: ^1.0.3
-    shallow-clone: ^0.1.2
-  checksum: bcf9752052130c270c47d3e1c357497354b91d682f507e0079bec5950975b3293b619d9e100d70874606d716f2376e84956b045759a09af703e1038ecad6c438
-  languageName: node
-  linkType: hard
-
 "clone-deep@npm:^2.0.1":
   version: 2.0.2
   resolution: "clone-deep@npm:2.0.2"
@@ -11738,7 +11724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^9.4.1, commander@npm:^9.5.0":
+"commander@npm:^9.4.1":
   version: 9.5.0
   resolution: "commander@npm:9.5.0"
   checksum: c7a3e27aa59e913b54a1bafd366b88650bc41d6651f0cbe258d4ff09d43d6a7394232a4dadd0bf518b3e696fdf595db1028a0d82c785b88bd61f8a440cecfade
@@ -15653,15 +15639,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"for-own@npm:^0.1.3":
-  version: 0.1.5
-  resolution: "for-own@npm:0.1.5"
-  dependencies:
-    for-in: ^1.0.1
-  checksum: 07eb0a2e98eb55ce13b56dd11ef4fb5e619ba7380aaec388b9eec1946153d74fa734ce409e8434020557e9489a50c34bc004d55754f5863bf7d77b441d8dee8c
-  languageName: node
-  linkType: hard
-
 "for-own@npm:^1.0.0":
   version: 1.0.0
   resolution: "for-own@npm:1.0.0"
@@ -15834,7 +15811,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:10.1.0, fs-extra@npm:^10.0.0, fs-extra@npm:^10.1.0":
+"fs-extra@npm:10.1.0, fs-extra@npm:^10.1.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
   dependencies:
@@ -17578,7 +17555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-buffer@npm:^1.0.2, is-buffer@npm:^1.1.5, is-buffer@npm:~1.1.1, is-buffer@npm:~1.1.6":
+"is-buffer@npm:^1.1.5, is-buffer@npm:~1.1.1, is-buffer@npm:~1.1.6":
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
   checksum: 4a186d995d8bbf9153b4bd9ff9fd04ae75068fe695d29025d25e592d9488911eeece84eefbd8fa41b8ddcc0711058a71d4c466dcf6f1f6e1d83830052d8ca707
@@ -17938,7 +17915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^2.0.1, is-plain-object@npm:^2.0.3, is-plain-object@npm:^2.0.4":
+"is-plain-object@npm:^2.0.3, is-plain-object@npm:^2.0.4":
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
   dependencies:
@@ -19233,13 +19210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jssha@npm:^3.3.0":
-  version: 3.3.1
-  resolution: "jssha@npm:3.3.1"
-  checksum: 4f2b636305710d5275d5e48a323ceaed80b6400fd545321fccdb4e904392a7b808fa79cdf355073766a290d731756eb5bd5ceb2341cc53e57b686c7bb3a18488
-  languageName: node
-  linkType: hard
-
 "jsx-ast-utils@npm:^2.4.1 || ^3.0.0, jsx-ast-utils@npm:^3.3.3":
   version: 3.3.3
   resolution: "jsx-ast-utils@npm:3.3.3"
@@ -19289,15 +19259,6 @@ __metadata:
   version: 0.1.1
   resolution: "keymirror@npm:0.1.1"
   checksum: be8f0bc5ff7d561d729f935ef55b4dbbea7b56a4714f044a2212088730f4d52f73935c38c5a9604e0f1157611725ee493cb7d08d1f3eb34151c0aa999236206a
-  languageName: node
-  linkType: hard
-
-"kind-of@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "kind-of@npm:2.0.1"
-  dependencies:
-    is-buffer: ^1.0.2
-  checksum: 043df2943e113bca612d26224947395e9673bb3808d94aed30e47fbf0bafd618e2a29ff0ca2d5498f64332c320fff07f0aa9d6edfc20906a93c1b8792f11759c
   languageName: node
   linkType: hard
 
@@ -19376,20 +19337,6 @@ __metadata:
   dependencies:
     language-subtag-registry: ~0.3.2
   checksum: c81b5d8b9f5f9cfd06ee71ada6ddfe1cf83044dd5eeefcd1e420ad491944da8957688db4a0a9bc562df4afdc2783425cbbdfd152c01d93179cf86888903123cf
-  languageName: node
-  linkType: hard
-
-"lazy-cache@npm:^0.2.3":
-  version: 0.2.7
-  resolution: "lazy-cache@npm:0.2.7"
-  checksum: b4538aff20db586c354f31de3ed59ea2c8d5dc4f01141bf49f07601e7ca0d7ed43a3f49362ade49b1e18ab1f3d121df0f2c9ea9b599b44dd54fb0c0db253c8b9
-  languageName: node
-  linkType: hard
-
-"lazy-cache@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "lazy-cache@npm:1.0.4"
-  checksum: e6650c22e5de1cc3f4a0c25d2b35fe9cd400473c1b3562be9fceadf8f368d708b54d24f5aa51b321b090da65b36426823a8f706b8dbdd68270db0daba812c5d3
   languageName: node
   linkType: hard
 
@@ -20480,17 +20427,6 @@ __metadata:
     type-fest: ^0.18.0
     yargs-parser: ^20.2.3
   checksum: bc23bf1b4423ef6a821dff9734406bce4b91ea257e7f10a8b7f896f45b59649f07adc0926e2917eacd8cf1df9e4cd89c77623cf63dfd0f8bf54de07a32ee5a85
-  languageName: node
-  linkType: hard
-
-"merge-deep@npm:^3.0.1":
-  version: 3.0.3
-  resolution: "merge-deep@npm:3.0.3"
-  dependencies:
-    arr-union: ^3.1.0
-    clone-deep: ^0.2.4
-    kind-of: ^3.0.2
-  checksum: d2eb367b8300327c66a3e1e01eb06251f51b440bf5bfa5f0f8065ae95bf3af620d21fcd0ab2eb50e74f5119aac40ffd26c85e3bf82f79082e8757675f5885d3d
   languageName: node
   linkType: hard
 
@@ -23727,34 +23663,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-extra@npm:^4.3.6":
-  version: 4.3.6
-  resolution: "playwright-extra@npm:4.3.6"
-  dependencies:
-    debug: ^4.3.4
-  peerDependencies:
-    playwright: "*"
-    playwright-core: "*"
-  peerDependenciesMeta:
-    playwright:
-      optional: true
-    playwright-core:
-      optional: true
-  checksum: 2ecaef65036895a9c6aa8d97be7d01677690a103bf39b514b8a2c153cf29932b4b205040a6e132f145868323891dcfbb32c7b2d97f9ac64a9f25e2e83a2f706e
-  languageName: node
-  linkType: hard
-
-"playwright@npm:^1.35.0":
-  version: 1.37.1
-  resolution: "playwright@npm:1.37.1"
-  dependencies:
-    playwright-core: 1.37.1
-  bin:
-    playwright: cli.js
-  checksum: 99406ef3e15b83a659cb23ef1d92d9935789aad430580d1e0371087dfdf266891483c6f97cfa06bf5f49f081eacd44245d05d20714f98531edef4cc317044d6b
-  languageName: node
-  linkType: hard
-
 "plist@npm:^3.0.5":
   version: 3.1.0
   resolution: "plist@npm:3.1.0"
@@ -24334,84 +24242,6 @@ __metadata:
   version: 2.3.0
   resolution: "punycode@npm:2.3.0"
   checksum: 39f760e09a2a3bbfe8f5287cf733ecdad69d6af2fe6f97ca95f24b8921858b91e9ea3c9eeec6e08cede96181b3bb33f95c6ffd8c77e63986508aa2e8159fa200
-  languageName: node
-  linkType: hard
-
-"puppeteer-extra-plugin-stealth@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "puppeteer-extra-plugin-stealth@npm:2.11.2"
-  dependencies:
-    debug: ^4.1.1
-    puppeteer-extra-plugin: ^3.2.3
-    puppeteer-extra-plugin-user-preferences: ^2.4.1
-  peerDependencies:
-    playwright-extra: "*"
-    puppeteer-extra: "*"
-  peerDependenciesMeta:
-    playwright-extra:
-      optional: true
-    puppeteer-extra:
-      optional: true
-  checksum: 13ab2b906c1cd1a75bb346074e6ed75dd33da426e9b7d2e111dee6d497ae9ff42f44c2e5b0d48a04b545e862f9d27d8ecf61fa1863201afc8a9410121ed65a4b
-  languageName: node
-  linkType: hard
-
-"puppeteer-extra-plugin-user-data-dir@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "puppeteer-extra-plugin-user-data-dir@npm:2.4.1"
-  dependencies:
-    debug: ^4.1.1
-    fs-extra: ^10.0.0
-    puppeteer-extra-plugin: ^3.2.3
-    rimraf: ^3.0.2
-  peerDependencies:
-    playwright-extra: "*"
-    puppeteer-extra: "*"
-  peerDependenciesMeta:
-    playwright-extra:
-      optional: true
-    puppeteer-extra:
-      optional: true
-  checksum: f360b3bb22eeb899b23b6e2a38412ddfeda4b2333e08f77452732e16f094f33725272ee81150428e2c20b39d4d88edc87584d8344bd761c9ef8ae5d681968399
-  languageName: node
-  linkType: hard
-
-"puppeteer-extra-plugin-user-preferences@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "puppeteer-extra-plugin-user-preferences@npm:2.4.1"
-  dependencies:
-    debug: ^4.1.1
-    deepmerge: ^4.2.2
-    puppeteer-extra-plugin: ^3.2.3
-    puppeteer-extra-plugin-user-data-dir: ^2.4.1
-  peerDependencies:
-    playwright-extra: "*"
-    puppeteer-extra: "*"
-  peerDependenciesMeta:
-    playwright-extra:
-      optional: true
-    puppeteer-extra:
-      optional: true
-  checksum: e0e50145d1d32626a8bb75afeb0dc238d63c05a8d264e12bb249b06aa34f7c116f6ec531335e964ea715837759dacd505d2fa8f6c9d478e983303eb2cb701ec9
-  languageName: node
-  linkType: hard
-
-"puppeteer-extra-plugin@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "puppeteer-extra-plugin@npm:3.2.3"
-  dependencies:
-    "@types/debug": ^4.1.0
-    debug: ^4.1.1
-    merge-deep: ^3.0.1
-  peerDependencies:
-    playwright-extra: "*"
-    puppeteer-extra: "*"
-  peerDependenciesMeta:
-    playwright-extra:
-      optional: true
-    puppeteer-extra:
-      optional: true
-  checksum: 18c2780a151e023ed145cd7768a6cf2dba1c124bce920de5f7815dcd872550288554161b1474037e8819969b1adfad41bdc09a9aadfd155338abc6d22699b7ed
   languageName: node
   linkType: hard
 
@@ -26818,18 +26648,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shallow-clone@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "shallow-clone@npm:0.1.2"
-  dependencies:
-    is-extendable: ^0.1.1
-    kind-of: ^2.0.1
-    lazy-cache: ^0.2.3
-    mixin-object: ^2.0.1
-  checksum: cc4c85c6e42186fec33a81a85622c48dbcfdf280f3a7bd0800b4de57df8e365a8760aa2e31dd79df365b317dddb2fd0bbd92be0aab14dbd2de6a65992eab2177
-  languageName: node
-  linkType: hard
-
 "shallow-clone@npm:^1.0.0":
   version: 1.0.0
   resolution: "shallow-clone@npm:1.0.0"
@@ -27573,22 +27391,6 @@ __metadata:
   version: 1.0.1
   resolution: "stream-shift@npm:1.0.1"
   checksum: 59b82b44b29ec3699b5519a49b3cedcc6db58c72fb40c04e005525dfdcab1c75c4e0c180b923c380f204bed78211b9bad8faecc7b93dece4d004c3f6ec75737b
-  languageName: node
-  linkType: hard
-
-"stream-video-buddy@https://github.com/GetStream/stream-video-buddy#1.6.10":
-  version: 1.6.10
-  resolution: "stream-video-buddy@https://github.com/GetStream/stream-video-buddy.git#commit=b73181a7486f259ff270b1c172ecd715c9324806"
-  dependencies:
-    commander: ^9.5.0
-    express: ^4.18.2
-    jssha: ^3.3.0
-    playwright: ^1.35.0
-    playwright-extra: ^4.3.6
-    puppeteer-extra-plugin-stealth: ^2.11.2
-  bin:
-    stream-video-buddy: ./lib/index.js
-  checksum: 210f0e3af0e04da0cca1e8f99996abb8defa9afd889209d285f6a9e48c07d86ec3d309be6a54e5094a766adb84473f0c07786e557656080a904e03b6aa4e1a4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ditches `stream-video-buddy` package from the `egress-composite` application which was previously used for E2E tests but is no longer needed, reinstate once relevant again.