### PR TITLE
docs(react-native): remove the outdated react native permissions lib setup

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/08-native-permissions.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/08-native-permissions.mdx
@@ -19,25 +19,9 @@ Additionally, to easily request permissions on both platforms, we will use the [
 yarn add react-native-permissions
 ```
 
-#### iOS
-
-Additionally, for iOS, you need to update your `package.json` by adding the permissions used in your app.
-
-```js title=package.json
-{
-  "reactNativePermissionsIOS": [
-    "Camera",
-    "Microphone",
-  ],
-}
-```
-
-After that, we need to run the following commands:
-
-```bash title=Terminal
-npx react-native setup-ios-permissions
-npx pod-install
-```
+:::note
+Do not forget to perform the additional setup steps for iOS mentioned in the [`react-native-permissions` library documentation](https://github.com/zoontek/react-native-permissions#ios) 
+:::
 
 ## Step 1 - Add a function to request permissions in the app
 


### PR DESCRIPTION
react native permissions lib has moved to a new setup and our docs had the old setup.. 

to avoid this in future, its better to just link to their setup