### PR TITLE
fix(video-demo): ensure default device is selected

### DIFF
--- a/sample-apps/react/react-video-demo/src/components/ControlMenuPanel/ControlMenuPanel.data.ts
+++ b/sample-apps/react/react-video-demo/src/components/ControlMenuPanel/ControlMenuPanel.data.ts
@@ -8,7 +8,7 @@ export const KichinSink: Props = {
       groupId: 'video',
       kind: 'videoinput',
       label: 'Front face camera',
-    },
+    } as MediaDeviceInfo,
   ],
   title: 'Settings',
   selectDevice: () => {

--- a/sample-apps/react/react-video-demo/src/components/ControlMenuPanel/ControlMenuPanel.tsx
+++ b/sample-apps/react/react-video-demo/src/components/ControlMenuPanel/ControlMenuPanel.tsx
@@ -6,12 +6,7 @@ import DeviceList from '../DeviceList';
 export type Props = {
   className?: string;
   selectedDeviceId?: string;
-  devices: {
-    deviceId: string;
-    groupId: string;
-    kind: MediaDeviceKind;
-    label: string;
-  }[];
+  devices: MediaDeviceInfo[];
   title: string;
 
   selectDevice(kind: Partial<MediaDeviceKind>, deviceId: string): void;

--- a/sample-apps/react/react-video-demo/src/components/DeviceList/DeviceList.data.ts
+++ b/sample-apps/react/react-video-demo/src/components/DeviceList/DeviceList.data.ts
@@ -8,7 +8,7 @@ export const KichinSink: Props = {
       groupId: 'video',
       kind: 'videoinput',
       label: 'Front face camera',
-    },
+    } as MediaDeviceInfo,
   ],
   selectDevice: () => {
     console.log('selected device');

--- a/sample-apps/react/react-video-demo/src/components/DeviceList/DeviceList.tsx
+++ b/sample-apps/react/react-video-demo/src/components/DeviceList/DeviceList.tsx
@@ -7,13 +7,8 @@ export type Props = {
   className?: string;
   selectedDeviceId?: string;
   title?: string;
-  devices: {
-    deviceId: string;
-    groupId: string;
-    kind: MediaDeviceKind;
-    label: string;
-  }[];
-  selectDevice: (kind: Partial<MediaDeviceKind>, deviceId: string) => void;
+  devices: MediaDeviceInfo[];
+  selectDevice: (kind: MediaDeviceKind, deviceId: string) => void;
 };
 
 export const DeviceList: FC<Props> = ({
@@ -32,13 +27,15 @@ export const DeviceList: FC<Props> = ({
     [selectDevice],
   );
 
+  const hasPreference = devices.some((d) => d.deviceId === selectedDeviceId);
   return (
     <div className={rootClassName}>
       {title ? <h3 className={styles.heading}>{title}</h3> : null}
       <OptionsList>
-        {devices.map(({ kind, label, deviceId }) => {
-          const isSelected =
-            selectedDeviceId === deviceId || devices.length === 1;
+        {devices.map(({ kind, label, deviceId }, index) => {
+          const isSelected = hasPreference
+            ? selectedDeviceId === deviceId
+            : index === 0;
           return (
             <OptionsListItem
               key={deviceId}


### PR DESCRIPTION
### Overview

Ensure that a default video/audio device is selected.

Sometimes, the browsers may report a new `deviceId` for an already known device. Once that happens, our previously stored device preferences can't be respected, and we fall back on selecting the first device on the list.
This aligns with the behavior implemented in the React SDK-provided call controls.