### PR TITLE
feat: mute screenshare_audio, update to the newest OpenAPI schema

### DIFF
--- a/packages/client/docusaurus/docs/javascript/10-advanced/06-events.mdx
+++ b/packages/client/docusaurus/docs/javascript/10-advanced/06-events.mdx
@@ -67,6 +67,7 @@ The list of call events:
 | `call.blocked_user`               | A user is blocked from the call                                | Call watchers    |
 | `call.created`                    | The call was created                                           | All call members |
 | `call.ended`                      | The call was ended                                             | All call members |
+| `call.hls_broadcasting_failed`    | The call failed to broadcast                                   | Call watchers    |
 | `call.hls_broadcasting_started`   | The call started to broadcast                                  | Call watchers    |
 | `call.hls_broadcasting_stopped`   | The call stopped broadcasting                                  | Call watchers    |
 | `call.live_started`               | The call left backstage mode                                   | Call watchers    |

--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -449,6 +449,31 @@ export interface CallEndedEvent {
   user?: UserResponse;
 }
 /**
+ * This event is sent when HLS broadcasting has failed
+ * @export
+ * @interface CallHLSBroadcastingFailedEvent
+ */
+export interface CallHLSBroadcastingFailedEvent {
+  /**
+   *
+   * @type {string}
+   * @memberof CallHLSBroadcastingFailedEvent
+   */
+  call_cid: string;
+  /**
+   *
+   * @type {string}
+   * @memberof CallHLSBroadcastingFailedEvent
+   */
+  created_at: string;
+  /**
+   * The type of event: "call.hls_broadcasting_failed" in this case
+   * @type {string}
+   * @memberof CallHLSBroadcastingFailedEvent
+   */
+  type: string;
+}
+/**
  * This event is sent when HLS broadcasting has started
  * @export
  * @interface CallHLSBroadcastingStartedEvent
@@ -2969,6 +2994,12 @@ export interface MuteUsersRequest {
   screenshare?: boolean;
   /**
    *
+   * @type {boolean}
+   * @memberof MuteUsersRequest
+   */
+  screenshare_audio?: boolean;
+  /**
+   *
    * @type {Array<string>}
    * @memberof MuteUsersRequest
    */
@@ -4471,6 +4502,7 @@ export type VideoEvent =
   | ({ type: 'call.blocked_user' } & BlockedUserEvent)
   | ({ type: 'call.created' } & CallCreatedEvent)
   | ({ type: 'call.ended' } & CallEndedEvent)
+  | ({ type: 'call.hls_broadcasting_failed' } & CallHLSBroadcastingFailedEvent)
   | ({
       type: 'call.hls_broadcasting_started';
     } & CallHLSBroadcastingStartedEvent)

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -401,13 +401,12 @@ export class CallState {
     this.eventHandlers = {
       // these events are not updating the call state:
       'call.permission_request': undefined,
+      'call.recording_failed': undefined,
+      'call.recording_ready': undefined,
       'call.user_muted': undefined,
       'connection.error': undefined,
       'connection.ok': undefined,
       'health.check': undefined,
-      'call.hls_broadcasting_failed': undefined,
-      'call.recording_failed': undefined,
-      'call.recording_ready': undefined,
       custom: undefined,
 
       // events that update call state:
@@ -418,6 +417,7 @@ export class CallState {
         this.updateFromCallResponse(e.call);
         this.setCurrentValue(this.endedBySubject, e.user);
       },
+      'call.hls_broadcasting_failed': this.updateFromHLSBroadcastingFailed,
       'call.hls_broadcasting_started': this.updateFromHLSBroadcastStarted,
       'call.hls_broadcasting_stopped': this.updateFromHLSBroadcastStopped,
       'call.live_started': (e) => this.updateFromCallResponse(e.call),
@@ -987,6 +987,13 @@ export class CallState {
   };
 
   private updateFromHLSBroadcastStopped = () => {
+    this.setCurrentValue(this.egressSubject, (egress) => ({
+      ...egress!,
+      broadcasting: false,
+    }));
+  };
+
+  private updateFromHLSBroadcastingFailed = () => {
     this.setCurrentValue(this.egressSubject, (egress) => ({
       ...egress!,
       broadcasting: false,

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -405,6 +405,7 @@ export class CallState {
       'connection.error': undefined,
       'connection.ok': undefined,
       'health.check': undefined,
+      'call.hls_broadcasting_failed': undefined,
       'call.recording_failed': undefined,
       'call.recording_ready': undefined,
       custom: undefined,

--- a/packages/client/src/store/__tests__/CallState.test.ts
+++ b/packages/client/src/store/__tests__/CallState.test.ts
@@ -505,6 +505,15 @@ describe('CallState', () => {
         });
         expect(state.egress?.broadcasting).toBe(false);
       });
+
+      it('handles call.hls_broadcasting_failed events', () => {
+        const state = new CallState();
+        // @ts-expect-error incomplete data
+        state.updateFromCallResponse({ egress: { broadcasting: true } });
+        // @ts-expect-error incomplete data
+        state.updateFromEvent({ type: 'call.hls_broadcasting_failed' });
+        expect(state.egress?.broadcasting).toBe(false);
+      });
     });
 
     describe('call.session events', () => {

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/03-events.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/03-events.mdx
@@ -67,6 +67,7 @@ The list of call events:
 | `call.blocked_user`               | A user is blocked from the call                                | Call watchers    |
 | `call.created`                    | The call was created                                           | All call members |
 | `call.ended`                      | The call was ended                                             | All call members |
+| `call.hls_broadcasting_failed`    | The call failed to broadcast                                   | Call watchers    |
 | `call.hls_broadcasting_started`   | The call started to broadcast                                  | Call watchers    |
 | `call.hls_broadcasting_stopped`   | The call stopped broadcasting                                  | Call watchers    |
 | `call.live_started`               | The call left backstage mode                                   | Call watchers    |

--- a/packages/react-sdk/docusaurus/docs/React/10-advanced/06-events.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/10-advanced/06-events.mdx
@@ -67,6 +67,7 @@ The list of call events:
 | `call.blocked_user`               | A user is blocked from the call                                | Call watchers    |
 | `call.created`                    | The call was created                                           | All call members |
 | `call.ended`                      | The call was ended                                             | All call members |
+| `call.hls_broadcasting_failed`    | The call failed to broadcast                                   | Call watchers    |
 | `call.hls_broadcasting_started`   | The call started to broadcast                                  | Call watchers    |
 | `call.hls_broadcasting_stopped`   | The call stopped broadcasting                                  | Call watchers    |
 | `call.live_started`               | The call left backstage mode                                   | Call watchers    |


### PR DESCRIPTION
### Overview

Allows remote muting of `screenshare_audio` tracks. Also, updates to the newest OpenAPI schema (GetStream/protocol) that introduces `call.hls_broadcasting_failed` event.