### PR TITLE
refactor(react-bindings): change useIsCallBroadcastingInProgress to useIsCallHLSBroadcastingInProgress

### DIFF
--- a/packages/react-bindings/src/hooks/callStateHooks.ts
+++ b/packages/react-bindings/src/hooks/callStateHooks.ts
@@ -49,7 +49,7 @@ export const useIsCallRecordingInProgress = (): boolean => {
  *
  * @category Call State
  */
-export const useIsCallBroadcastingInProgress = (): boolean => {
+export const useIsCallHLSBroadcastingInProgress = (): boolean => {
   const { egress$ } = useCallState();
   const egress = useObservableValue(egress$);
   if (!egress) return false;

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/03-call-and-participant-state.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/03-call-and-participant-state.mdx
@@ -51,33 +51,33 @@ The `StreamCall` component uses the `StreamCallProvider` under the hood.
 
 Here is an excerpt of the available call state hooks:
 
-| Name                              | Description                                                                                                   |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `useCall`                         | The `Call` instance that is registered with `StreamCall`. You need the `Call` instance to initiate API calls. |
-| `useCallBlockedUserIds`           | The list of blocked user IDs.                                                                                 |
-| `useCallCallingState`             | Provides information about the call state. For example, `RINGING`, `JOINED` or `RECONNECTING`.                |
-| `useCallCreatedAt`                | The time the call was created.                                                                                |
-| `useCallCreatedBy`                | The user that created the call.                                                                               |
-| `useCallCustomData`               | The custom data attached to the call.                                                                         |
-| `useCallEgress`                   | The egress information of the call.                                                                           |
-| `useCallEndedBy`                  | The user that ended the call.                                                                                 |
-| `useCallIngress`                  | The ingress information of the call.                                                                          |
-| `useCallMembers`                  | The list of call members                                                                                      |
-| `useCallSession`                  | The information for the current call session.                                                                 |
-| `useCallSettings`                 | The settings of the call.                                                                                     |
-| `useCallStartedAt`                | The actual start time of the current call session.                                                            |
-| `useCallStartsAt`                 | The scheduled start time of the call.                                                                         |
-| `useCallStatsReport`              | When stats gathering is enabled, this observable will emit a new value at a regular (configurable) interval.  |
-| `useCallThumbnail`                | The thumbnail of the call.                                                                                    |
-| `useCallUpdatedAt`                | The time the call was last updated.                                                                           |
-| `useDominantSpeaker`              | The participant that is the current dominant speaker of the call.                                             |
-| `useHasOngoingScreenShare`        | It will return `true` if at least one participant is sharing their screen.                                    |
-| `useHasPermissions`               | Returns `true` if the local participant has all the given permissions.                                        |
-| `useIsCallBroadcastingInProgress` | It's `true` if the call is being broadcasted.                                                                 |
-| `useIsCallLive`                   | It's `true` if the call is currently live.                                                                    |
-| `useIsCallRecordingInProgress`    | It's' `true` if the call is being recorded.                                                                   |
-| `useIsCallTranscribingInProgress` | It's `true` if the call is being transcribed.                                                                 |
-| `useOwnCapabilities`              | The capabilities of the local participant.                                                                    |
+| Name                                 | Description                                                                                                   |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `useCall`                            | The `Call` instance that is registered with `StreamCall`. You need the `Call` instance to initiate API calls. |
+| `useCallBlockedUserIds`              | The list of blocked user IDs.                                                                                 |
+| `useCallCallingState`                | Provides information about the call state. For example, `RINGING`, `JOINED` or `RECONNECTING`.                |
+| `useCallCreatedAt`                   | The time the call was created.                                                                                |
+| `useCallCreatedBy`                   | The user that created the call.                                                                               |
+| `useCallCustomData`                  | The custom data attached to the call.                                                                         |
+| `useCallEgress`                      | The egress information of the call.                                                                           |
+| `useCallEndedBy`                     | The user that ended the call.                                                                                 |
+| `useCallIngress`                     | The ingress information of the call.                                                                          |
+| `useCallMembers`                     | The list of call members                                                                                      |
+| `useCallSession`                     | The information for the current call session.                                                                 |
+| `useCallSettings`                    | The settings of the call.                                                                                     |
+| `useCallStartedAt`                   | The actual start time of the current call session.                                                            |
+| `useCallStartsAt`                    | The scheduled start time of the call.                                                                         |
+| `useCallStatsReport`                 | When stats gathering is enabled, this observable will emit a new value at a regular (configurable) interval.  |
+| `useCallThumbnail`                   | The thumbnail of the call.                                                                                    |
+| `useCallUpdatedAt`                   | The time the call was last updated.                                                                           |
+| `useDominantSpeaker`                 | The participant that is the current dominant speaker of the call.                                             |
+| `useHasOngoingScreenShare`           | It will return `true` if at least one participant is sharing their screen.                                    |
+| `useHasPermissions`                  | Returns `true` if the local participant has all the given permissions.                                        |
+| `useIsCallHLSBroadcastingInProgress` | It's `true` if the call is being broadcasted in HLS mode.                                                     |
+| `useIsCallLive`                      | It's `true` if the call is currently live.                                                                    |
+| `useIsCallRecordingInProgress`       | It's' `true` if the call is being recorded.                                                                   |
+| `useIsCallTranscribingInProgress`    | It's `true` if the call is being transcribed.                                                                 |
+| `useOwnCapabilities`                 | The capabilities of the local participant.                                                                    |
 
 In your IDE of choice, you can see the full list if you de-structure the `useCallStateHooks` object:
 

--- a/packages/react-native-sdk/src/components/Livestream/LivestreamControls/HostStartStreamButton.tsx
+++ b/packages/react-native-sdk/src/components/Livestream/LivestreamControls/HostStartStreamButton.tsx
@@ -43,7 +43,7 @@ export const HostStartStreamButton = ({
   hls,
 }: HostStartStreamButtonProps) => {
   const [isAwaitingResponse, setIsAwaitingResponse] = useState(false);
-  const { useIsCallLive, useIsCallBroadcastingInProgress } =
+  const { useIsCallLive, useIsCallHLSBroadcastingInProgress } =
     useCallStateHooks();
   const {
     theme: {
@@ -56,7 +56,7 @@ export const HostStartStreamButton = ({
 
   const call = useCall();
   const isCallLive = useIsCallLive();
-  const isCallBroadcasting = useIsCallBroadcastingInProgress();
+  const isCallBroadcasting = useIsCallHLSBroadcastingInProgress();
   const { t } = useI18n();
 
   const liveOrBroadcasting = isCallLive || isCallBroadcasting;

--- a/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/HostLivestreamTopView.tsx
+++ b/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/HostLivestreamTopView.tsx
@@ -42,10 +42,10 @@ export const HostLivestreamTopView = ({
   LiveIndicator = DefaultLiveIndicator,
   FollowerCount = DefaultFollowerCount,
 }: HostLivestreamTopViewProps) => {
-  const { useIsCallLive, useIsCallBroadcastingInProgress } =
+  const { useIsCallLive, useIsCallHLSBroadcastingInProgress } =
     useCallStateHooks();
   const isCallLive = useIsCallLive();
-  const isBroadcasting = useIsCallBroadcastingInProgress();
+  const isBroadcasting = useIsCallHLSBroadcastingInProgress();
 
   const liveOrBroadcasting = isCallLive || isBroadcasting;
   const {

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
@@ -47,33 +47,33 @@ The `StreamCall` component uses the `StreamCallProvider` under the hood.
 
 Here is an excerpt of the available call state hooks:
 
-| Name                              | Description                                                                                                   |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `useCall`                         | The `Call` instance that is registered with `StreamCall`. You need the `Call` instance to initiate API calls. |
-| `useCallBlockedUserIds`           | The list of blocked user IDs.                                                                                 |
-| `useCallCallingState`             | Provides information about the call state. For example, `RINGING`, `JOINED` or `RECONNECTING`.                |
-| `useCallCreatedAt`                | The time the call was created.                                                                                |
-| `useCallCreatedBy`                | The user that created the call.                                                                               |
-| `useCallCustomData`               | The custom data attached to the call.                                                                         |
-| `useCallEgress`                   | The egress information of the call.                                                                           |
-| `useCallEndedBy`                  | The user that ended the call.                                                                                 |
-| `useCallIngress`                  | The ingress information of the call.                                                                          |
-| `useCallMembers`                  | The list of call members                                                                                      |
-| `useCallSession`                  | The information for the current call session.                                                                 |
-| `useCallSettings`                 | The settings of the call.                                                                                     |
-| `useCallStartedAt`                | The actual start time of the current call session.                                                            |
-| `useCallStartsAt`                 | The scheduled start time of the call.                                                                         |
-| `useCallStatsReport`              | When stats gathering is enabled, this observable will emit a new value at a regular (configurable) interval.  |
-| `useCallThumbnail`                | The thumbnail of the call.                                                                                    |
-| `useCallUpdatedAt`                | The time the call was last updated.                                                                           |
-| `useDominantSpeaker`              | The participant that is the current dominant speaker of the call.                                             |
-| `useHasOngoingScreenShare`        | It will return `true` if at least one participant is sharing their screen.                                    |
-| `useHasPermissions`               | Returns `true` if the local participant has all the given permissions.                                        |
-| `useIsCallBroadcastingInProgress` | It's `true` if the call is being broadcasted.                                                                 |
-| `useIsCallLive`                   | It's `true` if the call is currently live.                                                                    |
-| `useIsCallRecordingInProgress`    | It's' `true` if the call is being recorded.                                                                   |
-| `useIsCallTranscribingInProgress` | It's `true` if the call is being transcribed.                                                                 |
-| `useOwnCapabilities`              | The capabilities of the local participant.                                                                    |
+| Name                                 | Description                                                                                                   |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `useCall`                            | The `Call` instance that is registered with `StreamCall`. You need the `Call` instance to initiate API calls. |
+| `useCallBlockedUserIds`              | The list of blocked user IDs.                                                                                 |
+| `useCallCallingState`                | Provides information about the call state. For example, `RINGING`, `JOINED` or `RECONNECTING`.                |
+| `useCallCreatedAt`                   | The time the call was created.                                                                                |
+| `useCallCreatedBy`                   | The user that created the call.                                                                               |
+| `useCallCustomData`                  | The custom data attached to the call.                                                                         |
+| `useCallEgress`                      | The egress information of the call.                                                                           |
+| `useCallEndedBy`                     | The user that ended the call.                                                                                 |
+| `useCallIngress`                     | The ingress information of the call.                                                                          |
+| `useCallMembers`                     | The list of call members                                                                                      |
+| `useCallSession`                     | The information for the current call session.                                                                 |
+| `useCallSettings`                    | The settings of the call.                                                                                     |
+| `useCallStartedAt`                   | The actual start time of the current call session.                                                            |
+| `useCallStartsAt`                    | The scheduled start time of the call.                                                                         |
+| `useCallStatsReport`                 | When stats gathering is enabled, this observable will emit a new value at a regular (configurable) interval.  |
+| `useCallThumbnail`                   | The thumbnail of the call.                                                                                    |
+| `useCallUpdatedAt`                   | The time the call was last updated.                                                                           |
+| `useDominantSpeaker`                 | The participant that is the current dominant speaker of the call.                                             |
+| `useHasOngoingScreenShare`           | It will return `true` if at least one participant is sharing their screen.                                    |
+| `useHasPermissions`                  | Returns `true` if the local participant has all the given permissions.                                        |
+| `useIsCallHLSBroadcastingInProgress` | It's `true` if the call is being broadcasted in HLS mode.                                                     |
+| `useIsCallLive`                      | It's `true` if the call is currently live.                                                                    |
+| `useIsCallRecordingInProgress`       | It's' `true` if the call is being recorded.                                                                   |
+| `useIsCallTranscribingInProgress`    | It's `true` if the call is being transcribed.                                                                 |
+| `useOwnCapabilities`                 | The capabilities of the local participant.                                                                    |
 
 In your IDE of choice, you can see the full list if you destructure the `useCallStateHooks` object:
 

--- a/sample-apps/react/livestream-app/src/hosts/ui/BackstageControls.tsx
+++ b/sample-apps/react/livestream-app/src/hosts/ui/BackstageControls.tsx
@@ -25,8 +25,8 @@ export const BackstageControls = () => {
 
 const ToggleLivestreamButton = (props: { call: Call }) => {
   const { call } = props;
-  const { useIsCallBroadcastingInProgress } = useCallStateHooks();
-  const isBroadcasting = useIsCallBroadcastingInProgress();
+  const { useIsCallHLSBroadcastingInProgress } = useCallStateHooks();
+  const isBroadcasting = useIsCallHLSBroadcastingInProgress();
   const [isAwaitingResponse, setIsAwaitingResponse] = useState(false);
   useEffect(() => {
     setIsAwaitingResponse((isAwaiting) => {

--- a/sample-apps/react/livestream-app/src/hosts/ui/BackstageHeader.tsx
+++ b/sample-apps/react/livestream-app/src/hosts/ui/BackstageHeader.tsx
@@ -15,10 +15,10 @@ import {
 export const BackstageHeader = () => {
   const call = useCall();
   const currentUser = useConnectedUser();
-  const { useIsCallBroadcastingInProgress, useCallCustomData } =
+  const { useIsCallHLSBroadcastingInProgress, useCallCustomData } =
     useCallStateHooks();
   const customData = useCallCustomData();
-  const isBroadcasting = useIsCallBroadcastingInProgress();
+  const isBroadcasting = useIsCallHLSBroadcastingInProgress();
   return (
     <div className="backstage-header">
       <div className="backstage-header-section pull-left">

--- a/sample-apps/react/livestream-app/src/viewers/HLSLivestream.tsx
+++ b/sample-apps/react/livestream-app/src/viewers/HLSLivestream.tsx
@@ -11,9 +11,9 @@ import { ViewerControls } from './ui/ViewerControls';
 import { Lobby } from './ui/Lobby';
 
 export const HLSLivestreamUI = () => {
-  const { useIsCallBroadcastingInProgress, useCallEgress } =
+  const { useIsCallHLSBroadcastingInProgress, useCallEgress } =
     useCallStateHooks();
-  const isBroadcasting = useIsCallBroadcastingInProgress();
+  const isBroadcasting = useIsCallHLSBroadcastingInProgress();
   const egress = useCallEgress();
   const hls = useMemo(() => new HLS(), []);
 

--- a/sample-apps/react/react-dogfood/components/DevMenu.tsx
+++ b/sample-apps/react/react-dogfood/components/DevMenu.tsx
@@ -65,8 +65,8 @@ export const DevMenu = () => {
 
 const StartStopBroadcasting = () => {
   const call = useCall();
-  const { useIsCallBroadcastingInProgress } = useCallStateHooks();
-  const isBroadcasting = useIsCallBroadcastingInProgress();
+  const { useIsCallHLSBroadcastingInProgress } = useCallStateHooks();
+  const isBroadcasting = useIsCallHLSBroadcastingInProgress();
   return (
     <MenuItem
       onClick={() => {


### PR DESCRIPTION
This PR focuses on changing the name of the useIsCallBroadcastingInProgress to useIsCallHLSBroadcastingInProgress. This was done in favor of the discussion - https://getstream.slack.com/archives/C04ATV49DU3/p1698237035492179.

**API change**
-----------------
- refactor the name of useIsCallBroadcastingInProgress to useIsCallHLSBroadcastingInProgress

**Related changes**
------------------
- Updated the sample apps with the new hook.
- Updated the call and participants guide with the new hook.
