### PR TITLE
fix(react-native-dogfood): issue in subsequent call join in livestream

### DIFF
--- a/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewLiveStream.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewLiveStream.tsx
@@ -143,13 +143,7 @@ export const ViewLiveStreamChilden = ({
       setCallJoined={setCallJoined}
     />
   ) : (
-    <StreamCall
-      call={call}
-      mediaDeviceInitialState={{
-        initialAudioEnabled: false,
-        initialVideoEnabled: false,
-      }}
-    >
+    <StreamCall call={call}>
       <SafeAreaView style={styles.livestream}>
         <ViewerLivestream onLeaveStreamHandler={handleLeaveCall} />
       </SafeAreaView>

--- a/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewLiveStream.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewLiveStream.tsx
@@ -1,4 +1,5 @@
 import {
+  CallingState,
   StreamCall,
   ViewerLivestream,
   useCallStateHooks,
@@ -89,55 +90,70 @@ export const ViewLiveStreamChilden = ({
   const {
     params: { callId },
   } = route;
+  const [callJoined, setCallJoined] = useState<boolean>(false);
   const { useIsCallLive } = useCallStateHooks();
   const isCallLive = useIsCallLive();
-
   const client = useAnonymousInitVideoClient({
     callId,
     callType,
   });
-  const [autoJoin, setAutoJoin] = useState(false);
   const call = useSetCall(callId, callType, client);
 
-  useEffect(() => {
-    const joinCall = async () => {
-      try {
-        if (!(call && autoJoin)) {
-          return;
-        }
-        await call?.join();
-      } catch (error) {
-        console.error('Failed to join call', error);
+  const handleJoinCall = async () => {
+    try {
+      if (!(call && isCallLive)) {
+        return;
       }
-    };
-    joinCall();
-  }, [call, autoJoin]);
+      if (
+        [CallingState.JOINED, CallingState.JOINING].includes(
+          call.state.callingState,
+        )
+      ) {
+        setCallJoined(true);
+        return;
+      }
+      await call?.join();
+      setCallJoined(true);
+    } catch (error) {
+      console.error('Failed to join call', error);
+    }
+  };
+
+  const handleLeaveCall = async () => {
+    try {
+      if (!call) {
+        return;
+      }
+      await call.leave();
+      setCallJoined(false);
+      navigation.goBack();
+    } catch (error) {
+      console.log('Failed to leave call', error);
+    }
+  };
 
   if (!call) {
     return null;
   }
 
-  return (
-    <>
-      {(!autoJoin || !isCallLive) && (
-        <ViewerLobby
-          autoJoin={autoJoin}
-          setAutoJoin={setAutoJoin}
-          isLive={isCallLive}
-        />
-      )}
-      {isCallLive && autoJoin && (
-        <StreamCall call={call}>
-          <SafeAreaView style={styles.livestream}>
-            <ViewerLivestream
-              onLeaveStreamHandler={() => {
-                navigation.goBack();
-              }}
-            />
-          </SafeAreaView>
-        </StreamCall>
-      )}
-    </>
+  return !(isCallLive && callJoined) ? (
+    <ViewerLobby
+      isLive={isCallLive}
+      handleJoinCall={handleJoinCall}
+      setCallJoined={setCallJoined}
+    />
+  ) : (
+    <StreamCall
+      call={call}
+      mediaDeviceInitialState={{
+        initialAudioEnabled: false,
+        initialVideoEnabled: false,
+      }}
+    >
+      <SafeAreaView style={styles.livestream}>
+        <ViewerLivestream onLeaveStreamHandler={handleLeaveCall} />
+      </SafeAreaView>
+    </StreamCall>
   );
 };
 

--- a/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewLiveStream.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewLiveStream.tsx
@@ -136,17 +136,19 @@ export const ViewLiveStreamChilden = ({
     return null;
   }
 
-  return !(isCallLive && callJoined) ? (
-    <ViewerLobby
-      isLive={isCallLive}
-      handleJoinCall={handleJoinCall}
-      setCallJoined={setCallJoined}
-    />
-  ) : (
+  return (
     <StreamCall call={call}>
-      <SafeAreaView style={styles.livestream}>
-        <ViewerLivestream onLeaveStreamHandler={handleLeaveCall} />
-      </SafeAreaView>
+      {!(isCallLive && callJoined) ? (
+        <ViewerLobby
+          isLive={isCallLive}
+          handleJoinCall={handleJoinCall}
+          setCallJoined={setCallJoined}
+        />
+      ) : (
+        <SafeAreaView style={styles.livestream}>
+          <ViewerLivestream onLeaveStreamHandler={handleLeaveCall} />
+        </SafeAreaView>
+      )}
     </StreamCall>
   );
 };

--- a/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewerLobby.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewerLobby.tsx
@@ -1,43 +1,35 @@
 import { useI18n } from '@stream-io/video-react-native-sdk';
-import React from 'react';
-import {
-  ActivityIndicator,
-  StyleSheet,
-  Switch,
-  Text,
-  View,
-} from 'react-native';
+import React, { useEffect } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 import { Button } from '../../components/Button';
 import { appTheme } from '../../theme';
 
 type LobbyProps = {
-  autoJoin: boolean;
   isLive: boolean;
-  setAutoJoin: (join: boolean) => void;
+  handleJoinCall?: () => void;
+  setCallJoined: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-export const ViewerLobby = ({ autoJoin, isLive, setAutoJoin }: LobbyProps) => {
+export const ViewerLobby = ({
+  isLive,
+  handleJoinCall,
+  setCallJoined,
+}: LobbyProps) => {
   const { t } = useI18n();
+  useEffect(() => {
+    setCallJoined(false);
+  }, [setCallJoined]);
   return (
     <View style={styles.container}>
-      {!isLive && <ActivityIndicator style={styles.activityIndicator} />}
       <Text style={styles.text}>
         {isLive
           ? t('Stream is ready!')
           : t('Waiting for the livestream to start')}
       </Text>
-      <View style={styles.switchView}>
-        <Switch
-          value={autoJoin}
-          onValueChange={(value: boolean) => setAutoJoin(value)}
-        />
-        <Text style={styles.switchText}>
-          {t('Join automatically, when stream is ready')}
-        </Text>
-      </View>
+      {!isLive && <ActivityIndicator style={styles.activityIndicator} />}
       <Button
         disabled={!isLive}
-        onPress={() => setAutoJoin(true)}
+        onPress={handleJoinCall}
         title={t('Join Stream')}
       />
     </View>
@@ -54,7 +46,8 @@ const styles = StyleSheet.create({
   },
   text: {
     color: appTheme.colors.static_white,
-    fontSize: 32,
+    fontSize: 20,
+    margin: 20,
   },
   activityIndicator: {
     marginBottom: 20,


### PR DESCRIPTION
Fix the dog food app livestream flow on the viewer's end, especially around subsequent joins. This involves the removal of the autoJoin flow and joining the call through the button after the waiting period is over. Moreover, on subsequent joins, the call state is checked, and if the state is joined/joining, the lobby is simply removed.