### PR TITLE
fix(react-native-dogfood): do not allow invalid call ids

### DIFF
--- a/sample-apps/react-native/dogfood/src/screens/LiveStream/JoinLiveStream.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LiveStream/JoinLiveStream.tsx
@@ -51,11 +51,9 @@ export const JoinLiveStream = ({
     flexDirection: orientation === 'landscape' ? 'row' : 'column',
   };
 
-  const isValidCallId = () => {
-    // Allows only alphabets, numbers, -(hyphen) and _(underscore)
-    const callIdRegex = /^[A-Za-z0-9_-]*$/g;
-    return callId && callId.match(callIdRegex);
-  };
+  // Allows only alphabets, numbers, -(hyphen) and _(underscore)
+  const callIdRegex = /^[A-Za-z0-9_-]*$/g;
+  const isValidCallId = callId && callId.match(callIdRegex);
 
   return (
     <KeyboardAvoidingView
@@ -91,13 +89,13 @@ export const JoinLiveStream = ({
           <Button
             onPress={enterBackstageHandler}
             title={t('Enter Backstage')}
-            disabled={!isValidCallId()}
+            disabled={!isValidCallId}
           />
         ) : (
           <Button
             onPress={joinLiveStreamHandler}
             title={t('Join Live stream')}
-            disabled={!isValidCallId()}
+            disabled={!isValidCallId}
           />
         )}
       </View>

--- a/sample-apps/react-native/dogfood/src/screens/LiveStream/JoinLiveStream.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LiveStream/JoinLiveStream.tsx
@@ -51,6 +51,12 @@ export const JoinLiveStream = ({
     flexDirection: orientation === 'landscape' ? 'row' : 'column',
   };
 
+  const isValidCallId = () => {
+    // Allows only alphabets, numbers and -(hyphen)
+    const callIdRegex = /^[A-Za-z0-9_-]*$/g;
+    return callId && callId.match(callIdRegex);
+  };
+
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -85,13 +91,13 @@ export const JoinLiveStream = ({
           <Button
             onPress={enterBackstageHandler}
             title={t('Enter Backstage')}
-            disabled={!callId}
+            disabled={!isValidCallId()}
           />
         ) : (
           <Button
             onPress={joinLiveStreamHandler}
             title={t('Join Live stream')}
-            disabled={!callId}
+            disabled={!isValidCallId()}
           />
         )}
       </View>

--- a/sample-apps/react-native/dogfood/src/screens/LiveStream/JoinLiveStream.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LiveStream/JoinLiveStream.tsx
@@ -52,7 +52,7 @@ export const JoinLiveStream = ({
   };
 
   const isValidCallId = () => {
-    // Allows only alphabets, numbers and -(hyphen)
+    // Allows only alphabets, numbers, -(hyphen) and _(underscore)
     const callIdRegex = /^[A-Za-z0-9_-]*$/g;
     return callId && callId.match(callIdRegex);
   };

--- a/sample-apps/react-native/dogfood/src/screens/Meeting/GuestModeScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Meeting/GuestModeScreen.tsx
@@ -43,6 +43,12 @@ export const GuestModeScreen = ({
     });
   };
 
+  const isValidCallId = () => {
+    // Allows only alphabets, numbers and -(hyphen)
+    const callIdRegex = /^[A-Za-z0-9_-]*$/g;
+    return callId && callId.match(callIdRegex);
+  };
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>{t('Guest Mode')}</Text>
@@ -61,8 +67,13 @@ export const GuestModeScreen = ({
         />
       </View>
       <View>
-        <Button onPress={joinAsGuestHandler} title={t('Join As Guest')} />
         <Button
+          disabled={!isValidCallId()}
+          onPress={joinAsGuestHandler}
+          title={t('Join As Guest')}
+        />
+        <Button
+          disabled={!isValidCallId()}
           onPress={joinAnonymously}
           title={t('Continue Anonymously')}
           buttonStyle={styles.anonymousButton}

--- a/sample-apps/react-native/dogfood/src/screens/Meeting/GuestModeScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Meeting/GuestModeScreen.tsx
@@ -43,11 +43,9 @@ export const GuestModeScreen = ({
     });
   };
 
-  const isValidCallId = () => {
-    // Allows only alphabets, numbers, -(hyphen) and _(underscore)
-    const callIdRegex = /^[A-Za-z0-9_-]*$/g;
-    return callId && callId.match(callIdRegex);
-  };
+  // Allows only alphabets, numbers, -(hyphen) and _(underscore)
+  const callIdRegex = /^[A-Za-z0-9_-]*$/g;
+  const isValidCallId = callId && callId.match(callIdRegex);
 
   return (
     <View style={styles.container}>
@@ -68,12 +66,12 @@ export const GuestModeScreen = ({
       </View>
       <View>
         <Button
-          disabled={!isValidCallId()}
+          disabled={!isValidCallId}
           onPress={joinAsGuestHandler}
           title={t('Join As Guest')}
         />
         <Button
-          disabled={!isValidCallId()}
+          disabled={!isValidCallId}
           onPress={joinAnonymously}
           title={t('Continue Anonymously')}
           buttonStyle={styles.anonymousButton}

--- a/sample-apps/react-native/dogfood/src/screens/Meeting/GuestModeScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Meeting/GuestModeScreen.tsx
@@ -44,7 +44,7 @@ export const GuestModeScreen = ({
   };
 
   const isValidCallId = () => {
-    // Allows only alphabets, numbers and -(hyphen)
+    // Allows only alphabets, numbers, -(hyphen) and _(underscore)
     const callIdRegex = /^[A-Za-z0-9_-]*$/g;
     return callId && callId.match(callIdRegex);
   };

--- a/sample-apps/react-native/dogfood/src/screens/Meeting/JoinMeetingScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Meeting/JoinMeetingScreen.tsx
@@ -63,7 +63,7 @@ const JoinMeetingScreen = (props: JoinMeetingScreenProps) => {
   }, [linking, joinCallHandler]);
 
   const isValidCallId = () => {
-    // Allows only alphabets, numbers and -(hyphen)
+    // Allows only alphabets, numbers, -(hyphen) and _(underscore)
     const callIdRegex = /^[A-Za-z0-9_-]*$/g;
     return callId && callId.match(callIdRegex);
   };

--- a/sample-apps/react-native/dogfood/src/screens/Meeting/JoinMeetingScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Meeting/JoinMeetingScreen.tsx
@@ -62,6 +62,12 @@ const JoinMeetingScreen = (props: JoinMeetingScreenProps) => {
     }
   }, [linking, joinCallHandler]);
 
+  const isValidCallId = () => {
+    // Allows only alphabets, numbers and -(hyphen)
+    const callIdRegex = /^[A-Za-z0-9_-]*$/g;
+    return callId && callId.match(callIdRegex);
+  };
+
   const landscapeStyles: ViewStyle = {
     flexDirection: orientation === 'landscape' ? 'row' : 'column',
   };
@@ -97,7 +103,7 @@ const JoinMeetingScreen = (props: JoinMeetingScreenProps) => {
           <Button
             onPress={joinCallHandler}
             title={t('Join Call')}
-            disabled={!callId}
+            disabled={!isValidCallId()}
             buttonStyle={styles.joinCallButton}
           />
         </View>

--- a/sample-apps/react-native/dogfood/src/screens/Meeting/JoinMeetingScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Meeting/JoinMeetingScreen.tsx
@@ -62,11 +62,9 @@ const JoinMeetingScreen = (props: JoinMeetingScreenProps) => {
     }
   }, [linking, joinCallHandler]);
 
-  const isValidCallId = () => {
-    // Allows only alphabets, numbers, -(hyphen) and _(underscore)
-    const callIdRegex = /^[A-Za-z0-9_-]*$/g;
-    return callId && callId.match(callIdRegex);
-  };
+  // Allows only alphabets, numbers, -(hyphen) and _(underscore)
+  const callIdRegex = /^[A-Za-z0-9_-]*$/g;
+  const isValidCallId = callId && callId.match(callIdRegex);
 
   const landscapeStyles: ViewStyle = {
     flexDirection: orientation === 'landscape' ? 'row' : 'column',
@@ -103,7 +101,7 @@ const JoinMeetingScreen = (props: JoinMeetingScreenProps) => {
           <Button
             onPress={joinCallHandler}
             title={t('Join Call')}
-            disabled={!isValidCallId()}
+            disabled={!isValidCallId}
             buttonStyle={styles.joinCallButton}
           />
         </View>


### PR DESCRIPTION
Added a simple validation for custom call IDs in meeting and livestream join flow.

The call ID strings with alphabets, numbers, hyphens(-), and underscore(_) in them are only allowed and enabled the button for a call.

Regex Used for validation - `/^[A-Za-z0-9_-]*$/g`