### PR TITLE
fix(video-preview): accept `className` prop

### DIFF
--- a/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/video-preview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/03-ui-components/participants/video-preview.mdx
@@ -35,6 +35,22 @@ const MyVideoPreview = () => {
 
 ## Props
 
+### `className`
+
+| Type                    | Default     |
+| ----------------------- | ----------- |
+| `string` \| `undefined` | `undefined` |
+
+Additional CSS class to add to the component container.
+
+### `mirror`
+
+| Type                     | Default |
+| ------------------------ | ------- |
+| `boolean` \| `undefined` | `true`  |
+
+Enforces mirroring of the video on the X axis.
+
 ### `DisabledVideoPreview`
 
 | Type                           |
@@ -48,14 +64,6 @@ Component rendered when user turns off the video.
   alt="Default component for DisabledVideoPreview"
   width={300}
 />
-
-### `mirror`
-
-| Type                     | Default |
-| ------------------------ | ------- |
-| `boolean` \| `undefined` | `true`  |
-
-Enforces mirroring of the video on the X axis.
 
 ### `NoCameraPreview`
 

--- a/packages/react-sdk/src/components/VideoPreview/VideoPreview.tsx
+++ b/packages/react-sdk/src/components/VideoPreview/VideoPreview.tsx
@@ -19,15 +19,14 @@ export type VideoPreviewProps = {
    * Additional CSS class name to apply to the root element.
    */
   className?: string;
-
-  /**
-   * Component rendered when user turns off the video.
-   */
-  DisabledVideoPreview?: ComponentType;
   /**
    * Enforces mirroring of the video on the X axis. Defaults to true.
    */
   mirror?: boolean;
+  /**
+   * Component rendered when user turns off the video.
+   */
+  DisabledVideoPreview?: ComponentType;
   /**
    * Component rendered when no camera devices are available.
    */

--- a/packages/react-sdk/src/components/VideoPreview/VideoPreview.tsx
+++ b/packages/react-sdk/src/components/VideoPreview/VideoPreview.tsx
@@ -1,18 +1,25 @@
 import { ComponentType } from 'react';
 import clsx from 'clsx';
-import { useCallStateHooks } from '@stream-io/video-react-bindings';
+import { useCallStateHooks, useI18n } from '@stream-io/video-react-bindings';
 import { BaseVideo } from '../../core/components/Video';
 import { LoadingIndicator } from '../LoadingIndicator';
 
 const DefaultDisabledVideoPreview = () => {
-  return <div>Video is disabled</div>;
+  const { t } = useI18n();
+  return <div>{t('Video is disabled')}</div>;
 };
 
 const DefaultNoCameraPreview = () => {
-  return <div>No camera found</div>;
+  const { t } = useI18n();
+  return <div>{t('No camera found')}</div>;
 };
 
 export type VideoPreviewProps = {
+  /**
+   * Additional CSS class name to apply to the root element.
+   */
+  className?: string;
+
   /**
    * Component rendered when user turns off the video.
    */
@@ -32,6 +39,7 @@ export type VideoPreviewProps = {
 };
 
 export const VideoPreview = ({
+  className,
   mirror = true,
   DisabledVideoPreview = DefaultDisabledVideoPreview,
   NoCameraPreview = DefaultNoCameraPreview,
@@ -63,5 +71,9 @@ export const VideoPreview = ({
     contents = <DisabledVideoPreview />;
   }
 
-  return <div className="str-video__video-preview-container">{contents}</div>;
+  return (
+    <div className={clsx('str-video__video-preview-container', className)}>
+      {contents}
+    </div>
+  );
 };

--- a/packages/react-sdk/src/translations/en.json
+++ b/packages/react-sdk/src/translations/en.json
@@ -49,6 +49,8 @@
   "Microphone off": "Microphone off",
   "Camera on": "Camera on",
   "Camera off": "Camera off",
+  "No camera found": "No camera found",
+  "Video is disabled": "Video is disabled",
   "Pinned": "Pinned",
   "Unpin": "Unpin",
   "Pin": "Pin",


### PR DESCRIPTION
### Overview

Exposes `className` prop on the `VideoPreview` component that allows easier styling with CSS-in-js libraries as `styled-components`.