### PR TITLE
feat: Apply device config settings when call state becomes available

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -352,6 +352,7 @@ export class StreamVideoClient {
         clientStore: this.writeableStateStore,
       });
       call.state.updateFromCallResponse(c.call);
+      call.applyDeviceConfig();
       if (data.watch) {
         this.writeableStateStore.registerCall(call);
       }

--- a/packages/client/src/__tests__/StreamVideoClient.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.test.ts
@@ -8,9 +8,6 @@ import { User } from '../coordinator/connection/types';
 const apiKey = process.env.STREAM_API_KEY!;
 const secret = process.env.STREAM_SECRET!;
 
-vi.mock('../devices/CameraManager.ts');
-vi.mock('../devices/MicrophoneManager.ts');
-
 const tokenProvider = (userId: string) => {
   const serverClient = new StreamVideoServerClient(apiKey, { secret });
   return async () => {

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -51,6 +51,7 @@ export abstract class InputMediaDeviceManager<
     try {
       await this.enablePromise;
       this.state.setStatus('enabled');
+      this.enablePromise = undefined;
     } catch (error) {
       this.enablePromise = undefined;
       throw error;


### PR DESCRIPTION
This is a small enhancement I wanted to do for the longest time:
Previously device config settings from the backend were only applied when we joined the call. However, sometimes we have this information sooner in the following cases:
- `get` or `getOrCreate` is called
- `Call` is created after `queryCalls` response

This PR applies backend settings in those cases. An important thing to note: the `mic_default_on` and `camera_default_on` are NOT applied in the above cases, because applying those settings could start the camera/mic, these settings are only applied after we joined the call.