### PR TITLE
chore: don't destroy stream on unmount

### DIFF
--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/09-audio-volume-indicator.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/09-audio-volume-indicator.mdx
@@ -36,7 +36,7 @@ export const AudioVolumeIndicator = () => {
     const disposeSoundDetector = createSoundDetector(
       mediaStream,
       ({ audioLevel: al }) => setAudioLevel(al),
-      { detectionFrequencyInMs: 80 },
+      { detectionFrequencyInMs: 80, destroyStreamOnStop: false },
     );
 
     return () => {

--- a/sample-apps/react/react-dogfood/components/AudioVolumeIndicator.tsx
+++ b/sample-apps/react/react-dogfood/components/AudioVolumeIndicator.tsx
@@ -17,7 +17,7 @@ export const AudioVolumeIndicator = () => {
     const disposeSoundDetector = createSoundDetector(
       mediaStream,
       ({ audioLevel: al }) => setAudioLevel(al),
-      { detectionFrequencyInMs: 80 },
+      { detectionFrequencyInMs: 80, destroyStreamOnStop: false },
     );
 
     return () => {


### PR DESCRIPTION
### Overview

`AudioLevelIndicator` shouldn't destroy the MediaStream allocated by the MicrophoneManager.