### PR TITLE
chore(deps): remove the unused `rxjs` dependency from the `react-sdk`

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -34,8 +34,7 @@
     "@stream-io/video-client": "workspace:^",
     "@stream-io/video-react-bindings": "workspace:^",
     "clsx": "^2.0.0",
-    "prop-types": "^15.8.1",
-    "rxjs": "~7.8.1"
+    "prop-types": "^15.8.1"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7854,7 +7854,6 @@ __metadata:
     react-dom: ^18.2.0
     rimraf: ^5.0.5
     rollup: ^3.29.4
-    rxjs: ~7.8.1
     typescript: ^5.2.2
   peerDependencies:
     react: ^18.0.0


### PR DESCRIPTION
### Overview

`rxjs` isn't directly used in `react-sdk` anymore (see #1127).
This PR removes the dependency from the list of dependencies.