### PR TITLE
feat: handle device disconnection

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -507,6 +507,11 @@ export class Call {
 
     this.clientStore.unregisterCall(this);
     this.state.setCallingState(CallingState.LEFT);
+
+    this.camera.removeSubscriptions();
+    this.microphone.removeSubscriptions();
+    this.screenShare.removeSubscriptions();
+    this.speaker.removeSubscriptions();
   };
 
   /**
@@ -1004,7 +1009,11 @@ export class Call {
         await this.initCamera({ setStatus: true });
         await this.initMic({ setStatus: true });
       } catch (error) {
-        this.logger('warn', 'Camera and/or mic init failed during join call');
+        this.logger(
+          'warn',
+          'Camera and/or mic init failed during join call',
+          error,
+        );
       }
 
       // 3. once we have the "joinResponse", and possibly reconciled the local state

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -40,6 +40,7 @@ export abstract class InputMediaDeviceManager<
           async (isDisconnected) => {
             if (isDisconnected) {
               await this.disable();
+              this.select(undefined);
             }
           },
         ),
@@ -142,6 +143,10 @@ export abstract class InputMediaDeviceManager<
     this.state.setDevice(deviceId);
     await this.applySettingsToStream();
   }
+
+  removeSubscriptions = () => {
+    this.subscriptions.forEach((s) => s.unsubscribe());
+  };
 
   protected async applySettingsToStream() {
     if (this.state.status === 'enabled') {

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -1,4 +1,4 @@
-import { Observable, Subscription, combineLatest, pairwise, take } from 'rxjs';
+import { Observable, Subscription, combineLatest, pairwise } from 'rxjs';
 import { Call } from '../Call';
 import { CallingState } from '../store';
 import { InputMediaDeviceManagerState } from './InputMediaDeviceManagerState';
@@ -254,6 +254,7 @@ export abstract class InputMediaDeviceManager<
     if (this.trackType === TrackType.VIDEO) {
       return 'videoinput';
     }
+    return '';
   }
 
   private handleDisconnectedOrReplacedDevices() {
@@ -308,7 +309,7 @@ export abstract class InputMediaDeviceManager<
 
   private findDeviceInList(devices: MediaDeviceInfo[], deviceId: string) {
     return devices.find(
-      (d) => d.deviceId === deviceId && d.kind == this.mediaDeviceKind,
+      (d) => d.deviceId === deviceId && d.kind === this.mediaDeviceKind,
     );
   }
 }

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -204,9 +204,6 @@ export abstract class InputMediaDeviceManager<
       stream = this.state.mediaStream;
       this.unmuteTracks();
     } else {
-      if (this.state.mediaStream) {
-        this.stopTracks();
-      }
       const defaultConstraints = this.state.defaultConstraints;
       const constraints: MediaTrackConstraints = {
         ...defaultConstraints,
@@ -219,6 +216,14 @@ export abstract class InputMediaDeviceManager<
     }
     if (this.state.mediaStream !== stream) {
       this.state.setMediaStream(stream);
+      this.getTracks().forEach((track) => {
+        track.addEventListener('ended', async () => {
+          if (this.state.status === 'disabled' || this.disablePromise) {
+            return;
+          }
+          await this.disable();
+        });
+      });
     }
   }
 }

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -1,4 +1,4 @@
-import { Observable, Subscription } from 'rxjs';
+import { Observable, Subscription, take } from 'rxjs';
 import { Call } from '../Call';
 import { CallingState } from '../store';
 import { InputMediaDeviceManagerState } from './InputMediaDeviceManagerState';
@@ -245,6 +245,18 @@ export abstract class InputMediaDeviceManager<
             return;
           }
           await this.disable();
+          if (this.state.selectedDevice) {
+            this.listDevices()
+              .pipe(take(1))
+              .subscribe(async (devices) => {
+                if (
+                  devices &&
+                  devices.find((d) => d.deviceId === this.state.selectedDevice)
+                ) {
+                  await this.enable();
+                }
+              });
+          }
         });
       });
     }

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -240,6 +240,9 @@ export abstract class InputMediaDeviceManager<
           }
           if (this.state.status === 'enabled') {
             this.isTrackStoppedDueToTrackEnd = true;
+            setTimeout(() => {
+              this.isTrackStoppedDueToTrackEnd = false;
+            }, 2000);
             await this.disable();
           }
         });

--- a/packages/client/src/devices/__tests__/CameraManager.test.ts
+++ b/packages/client/src/devices/__tests__/CameraManager.test.ts
@@ -3,7 +3,12 @@ import { StreamClient } from '../../coordinator/connection/client';
 import { CallingState, StreamVideoWriteableStateStore } from '../../store';
 
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-import { mockCall, mockVideoDevices, mockVideoStream } from './mocks';
+import {
+  mockCall,
+  mockDeviceIds$,
+  mockVideoDevices,
+  mockVideoStream,
+} from './mocks';
 import { getVideoStream } from '../devices';
 import { TrackType } from '../../gen/video/sfu/models/models';
 import { CameraManager } from '../CameraManager';
@@ -17,6 +22,7 @@ vi.mock('../devices.ts', () => {
       return of(mockVideoDevices);
     }),
     getVideoStream: vi.fn(() => Promise.resolve(mockVideoStream())),
+    deviceIds$: mockDeviceIds$(),
   };
 });
 

--- a/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
+++ b/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
@@ -3,7 +3,12 @@ import { StreamClient } from '../../coordinator/connection/client';
 import { CallingState, StreamVideoWriteableStateStore } from '../../store';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockCall, mockVideoDevices, mockVideoStream } from './mocks';
+import {
+  MockTrack,
+  mockCall,
+  mockVideoDevices,
+  mockVideoStream,
+} from './mocks';
 import { InputMediaDeviceManager } from '../InputMediaDeviceManager';
 import { InputMediaDeviceManagerState } from '../InputMediaDeviceManagerState';
 import { of } from 'rxjs';
@@ -215,6 +220,18 @@ describe('InputMediaDeviceManager.test', () => {
       echoCancellation: true,
       autoGainControl: false,
     });
+  });
+
+  it('should set status to disabled if track ends', async () => {
+    await manager.enable();
+
+    await (
+      (manager.state.mediaStream?.getTracks()[0] as MockTrack).eventHandlers[
+        'ended'
+      ] as Function
+    )();
+
+    expect(manager.state.status).toBe('disabled');
   });
 
   afterEach(() => {

--- a/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
@@ -3,7 +3,12 @@ import { StreamClient } from '../../coordinator/connection/client';
 import { CallingState, StreamVideoWriteableStateStore } from '../../store';
 
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-import { mockAudioDevices, mockAudioStream, mockCall } from './mocks';
+import {
+  mockAudioDevices,
+  mockAudioStream,
+  mockCall,
+  mockDeviceIds$,
+} from './mocks';
 import { getAudioStream } from '../devices';
 import { TrackType } from '../../gen/video/sfu/models/models';
 import { MicrophoneManager } from '../MicrophoneManager';
@@ -22,6 +27,7 @@ vi.mock('../devices.ts', () => {
       return of(mockAudioDevices);
     }),
     getAudioStream: vi.fn(() => Promise.resolve(mockAudioStream())),
+    deviceIds$: mockDeviceIds$(),
   };
 });
 

--- a/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
+++ b/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
@@ -4,7 +4,7 @@ import { Call } from '../../Call';
 import { StreamClient } from '../../coordinator/connection/client';
 import { CallingState, StreamVideoWriteableStateStore } from '../../store';
 import * as RxUtils from '../../store/rxUtils';
-import { mockCall, mockScreenShareStream } from './mocks';
+import { mockCall, mockDeviceIds$, mockScreenShareStream } from './mocks';
 import { getScreenShareStream } from '../devices';
 import { TrackType } from '../../gen/video/sfu/models/models';
 
@@ -14,6 +14,7 @@ vi.mock('../devices.ts', () => {
     disposeOfMediaStream: vi.fn(),
     getScreenShareStream: vi.fn(() => Promise.resolve(mockScreenShareStream())),
     checkIfAudioOutputChangeSupported: vi.fn(() => Promise.resolve(true)),
+    deviceIds$: () => mockDeviceIds$(),
   };
 });
 

--- a/packages/client/src/devices/__tests__/SpeakerManager.test.ts
+++ b/packages/client/src/devices/__tests__/SpeakerManager.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, vi, it, expect } from 'vitest';
-import { mockAudioDevices } from './mocks';
+import {
+  disconnectDevice,
+  mockAudioDevices,
+  mockDeviceDisconnectWatcher,
+} from './mocks';
 import { of } from 'rxjs';
 import { SpeakerManager } from '../SpeakerManager';
 import { checkIfAudioOutputChangeSupported } from '../devices';
@@ -9,6 +13,7 @@ vi.mock('../devices.ts', () => {
   return {
     getAudioOutputDevices: vi.fn(() => of(mockAudioDevices)),
     checkIfAudioOutputChangeSupported: vi.fn(() => true),
+    watchForDisconnectedDevice: mockDeviceDisconnectWatcher(),
   };
 });
 
@@ -57,6 +62,15 @@ describe('SpeakerManager.test', () => {
     manager.setVolume(0.5);
 
     expect(manager.state.volume).toBe(0.5);
+  });
+
+  it('should disable device if selected device is disconnected', () => {
+    const deviceId = mockAudioDevices[1].deviceId;
+    manager.select(deviceId);
+
+    disconnectDevice();
+
+    expect(manager.state.selectedDevice).toBe('');
   });
 
   afterEach(() => {

--- a/packages/client/src/devices/__tests__/SpeakerManager.test.ts
+++ b/packages/client/src/devices/__tests__/SpeakerManager.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, beforeEach, describe, vi, it, expect } from 'vitest';
-import {
-  disconnectDevice,
-  mockAudioDevices,
-  mockDeviceDisconnectWatcher,
-} from './mocks';
+import { emitDeviceIds, mockAudioDevices, mockDeviceIds$ } from './mocks';
 import { of } from 'rxjs';
 import { SpeakerManager } from '../SpeakerManager';
 import { checkIfAudioOutputChangeSupported } from '../devices';
@@ -13,7 +9,7 @@ vi.mock('../devices.ts', () => {
   return {
     getAudioOutputDevices: vi.fn(() => of(mockAudioDevices)),
     checkIfAudioOutputChangeSupported: vi.fn(() => true),
-    watchForDisconnectedDevice: mockDeviceDisconnectWatcher(),
+    deviceIds$: mockDeviceIds$(),
   };
 });
 
@@ -65,10 +61,11 @@ describe('SpeakerManager.test', () => {
   });
 
   it('should disable device if selected device is disconnected', () => {
+    emitDeviceIds(mockAudioDevices);
     const deviceId = mockAudioDevices[1].deviceId;
     manager.select(deviceId);
 
-    disconnectDevice();
+    emitDeviceIds(mockAudioDevices.slice(2));
 
     expect(manager.state.selectedDevice).toBe('');
   });

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 import { CallingState, CallState } from '../../store';
 import { OwnCapability } from '../../gen/coordinator';
 import { Call } from '../../Call';
-import { Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 
 export const mockVideoDevices = [
   {
@@ -184,15 +184,16 @@ export const mockScreenShareStream = (includeAudio: boolean = true) => {
   } as any as MediaStream;
 };
 
-const deviceDisconnectSubject = new Subject<boolean>();
-export const mockDeviceDisconnectWatcher = () => {
+let deviceIds: Subject<MediaDeviceInfo[]>;
+export const mockDeviceIds$ = () => {
   global.navigator = {
-    // @ts-expect-error
+    //@ts-expect-error
     mediaDevices: {},
   };
-  return () => deviceDisconnectSubject;
+  deviceIds = new Subject();
+  return deviceIds;
 };
 
-export const disconnectDevice = () => {
-  deviceDisconnectSubject.next(true);
+export const emitDeviceIds = (values: MediaDeviceInfo[]) => {
+  deviceIds.next(values);
 };

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 import { CallingState, CallState } from '../../store';
 import { OwnCapability } from '../../gen/coordinator';
 import { Call } from '../../Call';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 
 export const mockVideoDevices = [
   {

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -156,7 +156,7 @@ export const mockScreenShareStream = (includeAudio: boolean = true) => {
 
   const tracks = [track];
   if (includeAudio) {
-    const track = {
+    const audioTrack = {
       eventHandlers: {},
       getSettings: () => ({
         deviceId: 'screen-audio',
@@ -170,10 +170,10 @@ export const mockScreenShareStream = (includeAudio: boolean = true) => {
         event: string,
         handler: EventListenerOrEventListenerObject,
       ) => {
-        track.eventHandlers[event] = handler;
+        audioTrack.eventHandlers[event] = handler;
       },
     };
-    tracks.push(track);
+    tracks.push(audioTrack);
   }
 
   return {

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import { CallingState, CallState } from '../../store';
 import { OwnCapability } from '../../gen/coordinator';
 import { Call } from '../../Call';
+import { BehaviorSubject, Subject } from 'rxjs';
 
 export const mockVideoDevices = [
   {
@@ -181,4 +182,17 @@ export const mockScreenShareStream = (includeAudio: boolean = true) => {
     getVideoTracks: () => tracks,
     getAudioTracks: () => tracks,
   } as any as MediaStream;
+};
+
+const deviceDisconnectSubject = new Subject<boolean>();
+export const mockDeviceDisconnectWatcher = () => {
+  global.navigator = {
+    // @ts-expect-error
+    mediaDevices: {},
+  };
+  return () => deviceDisconnectSubject;
+};
+
+export const disconnectDevice = () => {
+  deviceDisconnectSubject.next(true);
 };

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -80,8 +80,14 @@ export const mockCall = (): Partial<Call> => {
   };
 };
 
+export type MockTrack = Partial<MediaStreamTrack> & {
+  eventHandlers: { [key: string]: EventListenerOrEventListenerObject };
+  readyState: string;
+};
+
 export const mockAudioStream = () => {
-  const track = {
+  const track: MockTrack = {
+    eventHandlers: {},
     getSettings: () => ({
       deviceId: mockAudioDevices[0].deviceId,
     }),
@@ -90,15 +96,22 @@ export const mockAudioStream = () => {
     stop: () => {
       track.readyState = 'ended';
     },
+    addEventListener: (
+      event: string,
+      handler: EventListenerOrEventListenerObject,
+    ) => {
+      track.eventHandlers[event] = handler;
+    },
   };
   return {
     getTracks: () => [track],
     getAudioTracks: () => [track],
-  } as MediaStream;
+  } as any as MediaStream;
 };
 
 export const mockVideoStream = () => {
-  const track = {
+  const track: MockTrack = {
+    eventHandlers: {},
     getSettings: () => ({
       deviceId: mockVideoDevices[0].deviceId,
       width: 1280,
@@ -109,15 +122,22 @@ export const mockVideoStream = () => {
     stop: () => {
       track.readyState = 'ended';
     },
+    addEventListener: (
+      event: string,
+      handler: EventListenerOrEventListenerObject,
+    ) => {
+      track.eventHandlers[event] = handler;
+    },
   };
   return {
     getTracks: () => [track],
     getVideoTracks: () => [track],
-  } as MediaStream;
+  } as any as MediaStream;
 };
 
 export const mockScreenShareStream = (includeAudio: boolean = true) => {
   const track = {
+    eventHandlers: {},
     getSettings: () => ({
       deviceId: 'screen',
     }),
@@ -126,11 +146,18 @@ export const mockScreenShareStream = (includeAudio: boolean = true) => {
     stop: () => {
       track.readyState = 'ended';
     },
+    addEventListener: (
+      event: string,
+      handler: EventListenerOrEventListenerObject,
+    ) => {
+      track.eventHandlers[event] = handler;
+    },
   };
 
   const tracks = [track];
   if (includeAudio) {
-    tracks.push({
+    const track = {
+      eventHandlers: {},
       getSettings: () => ({
         deviceId: 'screen-audio',
       }),
@@ -139,12 +166,19 @@ export const mockScreenShareStream = (includeAudio: boolean = true) => {
       stop: () => {
         track.readyState = 'ended';
       },
-    });
+      addEventListener: (
+        event: string,
+        handler: EventListenerOrEventListenerObject,
+      ) => {
+        track.eventHandlers[event] = handler;
+      },
+    };
+    tracks.push(track);
   }
 
   return {
     getTracks: () => tracks,
     getVideoTracks: () => tracks,
     getAudioTracks: () => tracks,
-  } as MediaStream;
+  } as any as MediaStream;
 };

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -258,17 +258,34 @@ export const getScreenShareStream = async (
   }
 };
 
-const getDeviceIds = memoizedObservable(() =>
-  merge(
-    from(navigator.mediaDevices.enumerateDevices()),
-    getDeviceChangeObserver(),
-  ).pipe(shareReplay(1)),
-);
+export const deviceIds$ =
+  typeof navigator !== 'undefined' &&
+  typeof navigator.mediaDevices !== 'undefined'
+    ? memoizedObservable(() =>
+        merge(
+          from(navigator.mediaDevices.enumerateDevices()),
+          getDeviceChangeObserver(),
+        ).pipe(shareReplay(1)),
+      )()
+    : undefined;
 
 export const watchForDisconnectedDevice = (
+  kind: MediaDeviceKind,
   deviceId$: Observable<string | undefined>,
 ) => {
-  return combineLatest([getDeviceIds(), deviceId$]).pipe(
+  let devices$;
+  switch (kind) {
+    case 'audioinput':
+      devices$ = getAudioDevices();
+      break;
+    case 'videoinput':
+      devices$ = getVideoDevices();
+      break;
+    case 'audiooutput':
+      devices$ = getAudioOutputDevices();
+      break;
+  }
+  return combineLatest([devices$, deviceId$]).pipe(
     filter(
       ([devices, deviceId]) =>
         !!deviceId && !devices.find((d) => d.deviceId === deviceId),
@@ -284,12 +301,12 @@ export const watchForDisconnectedDevice = (
  * @param deviceId$ an Observable that specifies which device to watch for
  * @returns
  *
- * @deprecated use `watchForDisconnectedDevice`
+ * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
  */
 export const watchForDisconnectedAudioDevice = (
   deviceId$: Observable<string | undefined>,
 ) => {
-  return watchForDisconnectedDevice(deviceId$);
+  return watchForDisconnectedDevice('audioinput', deviceId$);
 };
 
 /**
@@ -299,12 +316,12 @@ export const watchForDisconnectedAudioDevice = (
  * @param deviceId$ an Observable that specifies which device to watch for
  * @returns
  *
- * @deprecated use `watchForDisconnectedDevice`
+ * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
  */
 export const watchForDisconnectedVideoDevice = (
   deviceId$: Observable<string | undefined>,
 ) => {
-  return watchForDisconnectedDevice(deviceId$);
+  return watchForDisconnectedDevice('videoinput', deviceId$);
 };
 
 /**
@@ -314,12 +331,12 @@ export const watchForDisconnectedVideoDevice = (
  * @param deviceId$ an Observable that specifies which device to watch for
  * @returns
  *
- * @deprecated use `watchForDisconnectedDevice`
+ * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
  */
 export const watchForDisconnectedAudioOutputDevice = (
   deviceId$: Observable<string | undefined>,
 ) => {
-  return watchForDisconnectedDevice(deviceId$);
+  return watchForDisconnectedDevice('audiooutput', deviceId$);
 };
 
 const watchForAddedDefaultDevice = (kind: MediaDeviceKind) => {
@@ -359,6 +376,8 @@ const watchForAddedDefaultDevice = (kind: MediaDeviceKind) => {
 /**
  * Notifies the subscriber about newly added default audio input device.
  * @returns Observable<boolean>
+ *
+ * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
  */
 export const watchForAddedDefaultAudioDevice = () =>
   watchForAddedDefaultDevice('audioinput');
@@ -366,6 +385,8 @@ export const watchForAddedDefaultAudioDevice = () =>
 /**
  * Notifies the subscriber about newly added default audio output device.
  * @returns Observable<boolean>
+ *
+ * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
  */
 export const watchForAddedDefaultAudioOutputDevice = () =>
   watchForAddedDefaultDevice('audiooutput');
@@ -373,6 +394,8 @@ export const watchForAddedDefaultAudioOutputDevice = () =>
 /**
  * Notifies the subscriber about newly added default video input device.
  * @returns Observable<boolean>
+ *
+ * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
  */
 export const watchForAddedDefaultVideoDevice = () =>
   watchForAddedDefaultDevice('videoinput');

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -258,23 +258,17 @@ export const getScreenShareStream = async (
   }
 };
 
-const watchForDisconnectedDevice = (
-  kind: MediaDeviceKind,
+const devices$ = memoizedObservable(() =>
+  merge(
+    from(navigator.mediaDevices.enumerateDevices()),
+    getDeviceChangeObserver(),
+  ).pipe(shareReplay(1)),
+);
+
+export const watchForDisconnectedDevice = (
   deviceId$: Observable<string | undefined>,
 ) => {
-  let devices$;
-  switch (kind) {
-    case 'audioinput':
-      devices$ = getAudioDevices();
-      break;
-    case 'videoinput':
-      devices$ = getVideoDevices();
-      break;
-    case 'audiooutput':
-      devices$ = getAudioOutputDevices();
-      break;
-  }
-  return combineLatest([devices$, deviceId$]).pipe(
+  return combineLatest([devices$(), deviceId$]).pipe(
     filter(
       ([devices, deviceId]) =>
         !!deviceId && !devices.find((d) => d.deviceId === deviceId),
@@ -289,11 +283,13 @@ const watchForDisconnectedDevice = (
  * @angular It's recommended to use the [`DeviceManagerService`](./DeviceManagerService.md) for a higher level API, use this low-level method only if the `DeviceManagerService` doesn't suit your requirements.
  * @param deviceId$ an Observable that specifies which device to watch for
  * @returns
+ *
+ * @deprecated use `watchForDisconnectedDevice`
  */
 export const watchForDisconnectedAudioDevice = (
   deviceId$: Observable<string | undefined>,
 ) => {
-  return watchForDisconnectedDevice('audioinput', deviceId$);
+  return watchForDisconnectedDevice(deviceId$);
 };
 
 /**
@@ -302,11 +298,13 @@ export const watchForDisconnectedAudioDevice = (
  * @angular It's recommended to use the [`DeviceManagerService`](./DeviceManagerService.md) for a higher level API, use this low-level method only if the `DeviceManagerService` doesn't suit your requirements.
  * @param deviceId$ an Observable that specifies which device to watch for
  * @returns
+ *
+ * @deprecated use `watchForDisconnectedDevice`
  */
 export const watchForDisconnectedVideoDevice = (
   deviceId$: Observable<string | undefined>,
 ) => {
-  return watchForDisconnectedDevice('videoinput', deviceId$);
+  return watchForDisconnectedDevice(deviceId$);
 };
 
 /**
@@ -315,11 +313,13 @@ export const watchForDisconnectedVideoDevice = (
  * @angular It's recommended to use the [`DeviceManagerService`](./DeviceManagerService.md) for a higher level API, use this low-level method only if the `DeviceManagerService` doesn't suit your requirements.
  * @param deviceId$ an Observable that specifies which device to watch for
  * @returns
+ *
+ * @deprecated use `watchForDisconnectedDevice`
  */
 export const watchForDisconnectedAudioOutputDevice = (
   deviceId$: Observable<string | undefined>,
 ) => {
-  return watchForDisconnectedDevice('audiooutput', deviceId$);
+  return watchForDisconnectedDevice(deviceId$);
 };
 
 const watchForAddedDefaultDevice = (kind: MediaDeviceKind) => {

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -258,7 +258,7 @@ export const getScreenShareStream = async (
   }
 };
 
-const devices$ = memoizedObservable(() =>
+const getDeviceIds = memoizedObservable(() =>
   merge(
     from(navigator.mediaDevices.enumerateDevices()),
     getDeviceChangeObserver(),
@@ -268,7 +268,7 @@ const devices$ = memoizedObservable(() =>
 export const watchForDisconnectedDevice = (
   deviceId$: Observable<string | undefined>,
 ) => {
-  return combineLatest([devices$(), deviceId$]).pipe(
+  return combineLatest([getDeviceIds(), deviceId$]).pipe(
     filter(
       ([devices, deviceId]) =>
         !!deviceId && !devices.find((d) => d.deviceId === deviceId),

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -1,13 +1,10 @@
 import {
-  combineLatest,
   concatMap,
   debounceTime,
-  filter,
   from,
   map,
   merge,
   Observable,
-  pairwise,
   shareReplay,
 } from 'rxjs';
 import { getLogger } from '../logger';
@@ -61,8 +58,7 @@ const getDevices = (
 /**
  * [Tells if the browser supports audio output change on 'audio' elements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId).
  *
- * @angular It's recommended to use the [`DeviceManagerService`](./DeviceManagerService.md) for a higher level API, use this low-level method only if the `DeviceManagerService` doesn't suit your requirements.
- */
+ *  */
 export const checkIfAudioOutputChangeSupported = () => {
   if (typeof document === 'undefined') return false;
   const element = document.createElement('audio');
@@ -268,137 +264,6 @@ export const deviceIds$ =
         ).pipe(shareReplay(1)),
       )()
     : undefined;
-
-export const watchForDisconnectedDevice = (
-  kind: MediaDeviceKind,
-  deviceId$: Observable<string | undefined>,
-) => {
-  let devices$;
-  switch (kind) {
-    case 'audioinput':
-      devices$ = getAudioDevices();
-      break;
-    case 'videoinput':
-      devices$ = getVideoDevices();
-      break;
-    case 'audiooutput':
-      devices$ = getAudioOutputDevices();
-      break;
-  }
-  return combineLatest([devices$, deviceId$]).pipe(
-    filter(
-      ([devices, deviceId]) =>
-        !!deviceId && !devices.find((d) => d.deviceId === deviceId),
-    ),
-    map(() => true),
-  );
-};
-
-/**
- * Notifies the subscriber if a given 'audioinput' device is disconnected
- *
- * @angular It's recommended to use the [`DeviceManagerService`](./DeviceManagerService.md) for a higher level API, use this low-level method only if the `DeviceManagerService` doesn't suit your requirements.
- * @param deviceId$ an Observable that specifies which device to watch for
- * @returns
- *
- * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
- */
-export const watchForDisconnectedAudioDevice = (
-  deviceId$: Observable<string | undefined>,
-) => {
-  return watchForDisconnectedDevice('audioinput', deviceId$);
-};
-
-/**
- * Notifies the subscriber if a given 'videoinput' device is disconnected
- *
- * @angular It's recommended to use the [`DeviceManagerService`](./DeviceManagerService.md) for a higher level API, use this low-level method only if the `DeviceManagerService` doesn't suit your requirements.
- * @param deviceId$ an Observable that specifies which device to watch for
- * @returns
- *
- * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
- */
-export const watchForDisconnectedVideoDevice = (
-  deviceId$: Observable<string | undefined>,
-) => {
-  return watchForDisconnectedDevice('videoinput', deviceId$);
-};
-
-/**
- * Notifies the subscriber if a given 'audiooutput' device is disconnected
- *
- * @angular It's recommended to use the [`DeviceManagerService`](./DeviceManagerService.md) for a higher level API, use this low-level method only if the `DeviceManagerService` doesn't suit your requirements.
- * @param deviceId$ an Observable that specifies which device to watch for
- * @returns
- *
- * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
- */
-export const watchForDisconnectedAudioOutputDevice = (
-  deviceId$: Observable<string | undefined>,
-) => {
-  return watchForDisconnectedDevice('audiooutput', deviceId$);
-};
-
-const watchForAddedDefaultDevice = (kind: MediaDeviceKind) => {
-  let devices$;
-  switch (kind) {
-    case 'audioinput':
-      devices$ = getAudioDevices();
-      break;
-    case 'videoinput':
-      devices$ = getVideoDevices();
-      break;
-    case 'audiooutput':
-      devices$ = getAudioOutputDevices();
-      break;
-    default:
-      throw new Error('Unknown MediaDeviceKind', kind);
-  }
-
-  return devices$.pipe(
-    pairwise(),
-    filter(([prev, current]) => {
-      const prevDefault = prev.find((device) => device.deviceId === 'default');
-      const currentDefault = current.find(
-        (device) => device.deviceId === 'default',
-      );
-      return !!(
-        current.length > prev.length &&
-        prevDefault &&
-        currentDefault &&
-        prevDefault.groupId !== currentDefault.groupId
-      );
-    }),
-    map(() => true),
-  );
-};
-
-/**
- * Notifies the subscriber about newly added default audio input device.
- * @returns Observable<boolean>
- *
- * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
- */
-export const watchForAddedDefaultAudioDevice = () =>
-  watchForAddedDefaultDevice('audioinput');
-
-/**
- * Notifies the subscriber about newly added default audio output device.
- * @returns Observable<boolean>
- *
- * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
- */
-export const watchForAddedDefaultAudioOutputDevice = () =>
-  watchForAddedDefaultDevice('audiooutput');
-
-/**
- * Notifies the subscriber about newly added default video input device.
- * @returns Observable<boolean>
- *
- * @deprecated use the [new device API](https://getstream.io/video/docs/javascript/guides/camera-and-microphone/)
- */
-export const watchForAddedDefaultVideoDevice = () =>
-  watchForAddedDefaultDevice('videoinput');
 
 /**
  * Deactivates MediaStream (stops and removes tracks) to be later garbage collected


### PR DESCRIPTION
This PRs adds the last missing piece to the new device management API: handling device disconnections.

## What's new?

### Audio, video manager
- If a device is disconnected, we deselect that device (not available in RN)
- If a track ends, we update the device manager status to `disabled`
- If the "default" device is replaced, we restart the device (not available in RN)

### Screenshare manager
- If a track ends, we update the device manager status to `disabled`

### Speaker manager
- If a device is disconnected, we deselect that device (not available in RN)

## Implementation details

### Watching for disconnected devices
The `deviceIds$` Observable notifies the manager about device connections/disconnections. This Observable uses `enumerateDevices`, so it will never ask for permissions (we only need to ask for permissions if we need device labels, but we don't need them for watching disconnected devices).

### Handling track ending
We add the `ended` event handler to all tracks of a media stream, if any track ends, we update the manager's status to `disabled`.

### Handling new default device
If a device's `deviceId` stays the same, but it's `groupId` is changed, a device is replaced. We restart the stream if the device was previously enabled.

⚠️ The PR also removed unused device helper methods, that are remainings of the old device API that's already removed, on the offchance a customer uses any of these helpers they should upgrade to the new, simlified device management API:
- For JS client: https://getstream.io/video/docs/javascript/guides/camera-and-microphone/
- For React: https://getstream.io/video/docs/react/guides/camera-and-microphone/
- For RN: https://getstream.io/video/docs/reactnative/core/camera-and-microphone/