### PR TITLE
fix: allow audio and screen share audio tracks, delay setSinkId

### DIFF
--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -362,6 +362,15 @@ export class DynascaleManager {
             audioElement.play().catch((e) => {
               this.logger('warn', `Failed to play stream`, e);
             });
+
+            // audio output device shall be set after the audio element is played
+            // otherwise, the browser will not pick it up, and will always
+            // play audio through the system's default device
+            const { selectedDevice } = this.call.speaker.state;
+            if (selectedDevice && 'setSinkId' in audioElement) {
+              // @ts-expect-error setSinkId is not yet in the lib
+              audioElement.setSinkId(selectedDevice);
+            }
           }
         });
       });

--- a/packages/react-sdk/src/core/components/Audio/ParticipantsAudio.tsx
+++ b/packages/react-sdk/src/core/components/Audio/ParticipantsAudio.tsx
@@ -20,33 +20,42 @@ export const ParticipantsAudio = (props: ParticipantsAudioProps) => {
     <>
       {participants.map((participant) => {
         if (participant.isLocalParticipant) return null;
-        const hasAudio = participant.publishedTracks.includes(
-          SfuModels.TrackType.AUDIO,
+        const {
+          publishedTracks,
+          audioStream,
+          screenShareAudioStream,
+          sessionId,
+        } = participant;
+
+        const hasAudio = publishedTracks.includes(SfuModels.TrackType.AUDIO);
+        const audioTrackElement = hasAudio && audioStream && (
+          <Audio
+            {...audioProps}
+            trackType="audioTrack"
+            participant={participant}
+            key={`${sessionId}-audio`}
+          />
         );
-        const hasScreenShareAudio = participant.publishedTracks.includes(
+
+        const hasScreenShareAudio = publishedTracks.includes(
           SfuModels.TrackType.SCREEN_SHARE_AUDIO,
         );
-        if (hasAudio && participant.audioStream) {
-          return (
-            <Audio
-              {...audioProps}
-              trackType="audioTrack"
-              participant={participant}
-              key={participant.sessionId}
-            />
-          );
-        }
-        if (hasScreenShareAudio && participant.screenShareAudioStream) {
-          return (
+        const screenShareAudioTrackElement = hasScreenShareAudio &&
+          screenShareAudioStream && (
             <Audio
               {...audioProps}
               trackType="screenShareAudioTrack"
               participant={participant}
-              key={participant.sessionId}
+              key={`${sessionId}-screen-share-audio`}
             />
           );
-        }
-        return null;
+
+        return (
+          <>
+            {audioTrackElement}
+            {screenShareAudioTrackElement}
+          </>
+        );
       })}
     </>
   );


### PR DESCRIPTION
### Overview

Fixes a bug where in React, it wasn't possible to playback both microphone and screen share audio track.
Fixes a bug where `sinkId` was set too early, and browsers were not respecting it.