### PR TITLE
chore: reduce logging noise in Pronto

### DIFF
--- a/sample-apps/react/react-dogfood/helpers/logger.ts
+++ b/sample-apps/react/react-dogfood/helpers/logger.ts
@@ -19,6 +19,14 @@ export const customSentryLogger: Logger = (
     });
   }
 
+  if (
+    message.startsWith('[sfu-client]') &&
+    /audioLevelChanged|dominantSpeakerChanged/.test(message)
+  ) {
+    // reduce noise from audioLevelChanged and dominantSpeakerChanged events
+    return;
+  }
+
   // Call the SDK's default log method
   logToConsole(logLevel, message, ...args);
 };


### PR DESCRIPTION
### Overview

In large calls `audioLevelChanged` and `dominantSpeakerChanged` events are polluting the logs, and make it hard to spot issues.