### PR TITLE
fix: set `key` prop to the correct element

### DIFF
--- a/packages/react-sdk/src/core/components/Audio/ParticipantsAudio.tsx
+++ b/packages/react-sdk/src/core/components/Audio/ParticipantsAudio.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, Fragment } from 'react';
 import { SfuModels, StreamVideoParticipant } from '@stream-io/video-client';
 import { Audio } from './Audio';
 
@@ -33,7 +33,6 @@ export const ParticipantsAudio = (props: ParticipantsAudioProps) => {
             {...audioProps}
             trackType="audioTrack"
             participant={participant}
-            key={`${sessionId}-audio`}
           />
         );
 
@@ -46,15 +45,14 @@ export const ParticipantsAudio = (props: ParticipantsAudioProps) => {
               {...audioProps}
               trackType="screenShareAudioTrack"
               participant={participant}
-              key={`${sessionId}-screen-share-audio`}
             />
           );
 
         return (
-          <>
+          <Fragment key={sessionId}>
             {audioTrackElement}
             {screenShareAudioTrackElement}
-          </>
+          </Fragment>
         );
       })}
     </>


### PR DESCRIPTION
### Overview

Follow up on #1176. Sets the `key` prop on the top-most `Fragment` instead to the wrapped elements.