### PR TITLE
fix(layout): wrapper does not grow when the container is a flexbox flop with flex-direction: column.

### DIFF
--- a/packages/styling/src/CallLayout/PaginatedGridLayout-layout.scss
+++ b/packages/styling/src/CallLayout/PaginatedGridLayout-layout.scss
@@ -2,6 +2,8 @@ $scope-name: 'str-video__paginated-grid-layout';
 
 .str-video__paginated-grid-layout__wrapper {
   flex-grow: 1;
+  width: 100%;
+  height: 100%;
 }
 
 .str-video__paginated-grid-layout {


### PR DESCRIPTION
This is visible when all the videos are disabled.

I don't think this is a great fix and you may have a better idea (maybe the placeholder should take up place?) but it's a best effort :) Feel free to disregard it, we are not blocked.

