### PR TITLE
fix: show debug stats in every call layout

### DIFF
--- a/sample-apps/react/react-dogfood/components/CallLayout/SpeakerOneOnOne.tsx
+++ b/sample-apps/react/react-dogfood/components/CallLayout/SpeakerOneOnOne.tsx
@@ -67,7 +67,9 @@ export const SpeakerOneOnOne = ({
           <CustomParticipantViewUISpotlight
             ParticipantViewUI={ParticipantViewUI}
           />
-        ) : undefined
+        ) : (
+          ParticipantViewUI || DefaultParticipantViewUI
+        )
       }
       ParticipantViewUIBar={ParticipantViewUI || DefaultParticipantViewUI}
       participantsBarPosition={isOneOnOneCall ? null : 'bottom'}

--- a/sample-apps/react/react-dogfood/components/Debug/useIsDebugMode.ts
+++ b/sample-apps/react/react-dogfood/components/Debug/useIsDebugMode.ts
@@ -1,18 +1,9 @@
-import { useMemo } from 'react';
-
-const useQueryParams = () =>
-  useMemo(
-    () =>
-      typeof window === 'undefined'
-        ? null
-        : new URLSearchParams(window.location.search),
-    [],
-  );
+import { useSearchParams } from 'next/navigation';
 
 /**
  * Internal purpose hook. Enables certain development mode tools.
  */
 export const useIsDebugMode = () => {
-  const params = useQueryParams();
-  return !!params?.get('debug');
+  const params = useSearchParams();
+  return !!params.get('debug');
 };

--- a/sample-apps/react/react-dogfood/components/Stage.tsx
+++ b/sample-apps/react/react-dogfood/components/Stage.tsx
@@ -17,7 +17,7 @@ export const Stage = ({
   if (selectedLayout === 'LegacyGrid' || selectedLayout === 'LegacySpeaker') {
     return (
       <div className="str-video__stage">
-        <SelectedComponent call={call!} />
+        <SelectedComponent call={call!} {...LayoutMap[selectedLayout].props} />
       </div>
     );
   }


### PR DESCRIPTION
### Overview

A follow-up to #1182. Some layouts didn't properly receive the configured layout props. This PR fixes that.