### PR TITLE
fix(react-native): Cannot find interface declaration for 'RCTEventEmitter'

### DIFF
--- a/packages/react-native-sdk/ios/StreamVideoReactNative.h
+++ b/packages/react-native-sdk/ios/StreamVideoReactNative.h
@@ -1,7 +1,9 @@
+#import <React/RCTEventEmitter.h>
+
 @interface StreamVideoReactNative : RCTEventEmitter <RCTBridgeModule>
 
--(void)screenShareEventReceived:(NSString*)event;
+- (void)screenShareEventReceived:(NSString *)event;
 
-+(void)setup;
++ (void)setup;
 
 @end


### PR DESCRIPTION
Fixes:
![Screenshot 2023-11-10 at 11 00 36 AM](https://github.com/GetStream/stream-video-js/assets/39884168/a868e6f4-83cd-4ebc-9a37-3ea865150c3f)
