### PR TITLE
fix(demo): respect server-side settings when applying device settings

### DIFF
--- a/sample-apps/react/react-video-demo/src/App.tsx
+++ b/sample-apps/react/react-video-demo/src/App.tsx
@@ -60,7 +60,8 @@ const Init = () => {
       tokenProvider,
       options: {
         logLevel:
-          log_level || import.meta.env.MODE === 'production' ? 'warn' : 'debug',
+          log_level ||
+          (import.meta.env.MODE === 'production' ? 'warn' : 'debug'),
       },
     });
     setClient(_client);
@@ -99,7 +100,10 @@ const Init = () => {
   useEffect(() => {
     if (!client) return;
     const call = client.call(callType, callId);
-    setActiveCall(call);
+    call
+      .getOrCreate()
+      .then(() => setActiveCall(call))
+      .catch((err) => console.error(`Failed to get or create call`, err));
 
     // @ts-ignore - for debugging
     window.call = call;

--- a/sample-apps/react/react-video-demo/src/App.tsx
+++ b/sample-apps/react/react-video-demo/src/App.tsx
@@ -100,9 +100,9 @@ const Init = () => {
   useEffect(() => {
     if (!client) return;
     const call = client.call(callType, callId);
+    setActiveCall(call);
     call
       .getOrCreate()
-      .then(() => setActiveCall(call))
       .catch((err) => console.error(`Failed to get or create call`, err));
 
     // @ts-ignore - for debugging


### PR DESCRIPTION
### Overview

Call settings need to be loaded in order to be able to properly apply local device preferences.
Also fixes an issue that prevented overriding the default log level at runtime.