### PR TITLE
fix(pronto): ensure `pronto` environment is always initialized

### DIFF
--- a/sample-apps/react/react-dogfood/pages/api/auth/create-token.ts
+++ b/sample-apps/react/react-dogfood/pages/api/auth/create-token.ts
@@ -6,6 +6,14 @@ const config: SampleAppCallConfig = JSON.parse(
   process.env.SAMPLE_APP_CALL_CONFIG || '{}',
 );
 
+// 'pronto' is a special environment that we ensure it exists
+if (!config['pronto']) {
+  config.pronto = {
+    apiKey: process.env.STREAM_API_KEY,
+    secret: process.env.STREAM_SECRET_KEY,
+  };
+}
+
 export type EnvironmentName = 'pronto' | 'demo' | string;
 
 export type CreateJwtTokenErrorResponse = {


### PR DESCRIPTION
### Overview

SAMPLE_APP configuration is optional for local development, and we can't expect that everyone will have this configuration applied locally.
Because of that, unless `pronto` environment already exists, we will create it with the default STREAM_API_KEY and STREAM_SECRET_KEY credentials.