### PR TITLE
chore(client): deprecate StreamVideoServerClient

### DIFF
--- a/packages/client/src/StreamVideoServerClient.ts
+++ b/packages/client/src/StreamVideoServerClient.ts
@@ -9,6 +9,11 @@ import {
   UpdateCallTypeResponse,
 } from './gen/coordinator';
 
+/**
+ * @deprecated Please use the `@stream-io/node-sdk` package instead.
+ *
+ * @see https://getstream.io/video/docs/api/
+ */
 export class StreamVideoServerClient extends StreamVideoClient {
   constructor(apiKey: string, options: StreamClientOptions) {
     super({ apiKey, options });


### PR DESCRIPTION
### Overview

`StreamVideoServerClient` is now deprecated and it will be completely removed from the SDK with a future release.
Existing customers should migrate to our `@stream-io/node-sdk` package. More information about it:
- https://getstream.io/video/docs/api/