### PR TITLE
fix(client): receive audioLevels when joined the call with mic muted

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1110,8 +1110,12 @@ export class Call {
    * The previous audio stream will be stopped.
    *
    * @param audioStream the audio stream to publish.
+   * @param disableTrackWhilePublish if the track should be disabled while published. This is mainly useful for React Native SDK.
    */
-  publishAudioStream = async (audioStream: MediaStream) => {
+  publishAudioStream = async (
+    audioStream: MediaStream,
+    disableTrackWhilePublish?: boolean,
+  ) => {
     // we should wait until we get a JoinResponse from the SFU,
     // otherwise we risk breaking the ICETrickle flow.
     await this.assertCallJoined();
@@ -1130,6 +1134,7 @@ export class Call {
       audioStream,
       audioTrack,
       TrackType.AUDIO,
+      { disableTrackWhilePublish },
     );
   };
 
@@ -1879,7 +1884,10 @@ export class Call {
           }
         } else {
           // In case of React Native we need to publish the stream everytime to get the audioLevels
-          await this.publishAudioStream(this.microphone.state.mediaStream);
+          await this.publishAudioStream(
+            this.microphone.state.mediaStream,
+            true,
+          );
         }
       }
 

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -125,6 +125,7 @@ import {
   ScreenShareManager,
   SpeakerManager,
 } from './devices';
+import { isReactNative } from './helpers/platforms';
 
 /**
  * An object representation of a `Call`.
@@ -1869,11 +1870,17 @@ export class Call {
     if (options.setStatus) {
       // Publish media stream that was set before we joined
       if (
-        this.microphone.state.status === 'enabled' &&
         this.microphone.state.mediaStream &&
         !this.publisher?.isPublishing(TrackType.AUDIO)
       ) {
-        await this.publishAudioStream(this.microphone.state.mediaStream);
+        if (!isReactNative()) {
+          if (this.microphone.state.status === 'enabled') {
+            await this.publishAudioStream(this.microphone.state.mediaStream);
+          }
+        } else {
+          // In case of React Native we need to publish the stream everytime to get the audioLevels
+          await this.publishAudioStream(this.microphone.state.mediaStream);
+        }
       }
 
       // Start mic if backend config specifies, and there is no local setting

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -61,6 +61,16 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
   private async startSpeakingWhileMutedDetection(deviceId?: string) {
     await this.stopSpeakingWhileMutedDetection();
     if (isReactNative()) {
+      // If there is no stream we create one and publish it first.
+      if (!this.call.publisher?.isPublishing(this.trackType)) {
+        const stream = await this.getStream({ deviceId });
+        this.state.setMediaStream(stream);
+        // We mute the stream before publish. We pass `false` here since for audio we disable tracks and don't stop it.
+        this.muteStream(false);
+        if (stream) {
+          await this.publishStream(stream);
+        }
+      }
       this.soundDetectorCleanup = detectAudioLevels(
         this.call.state.callStatsReport$,
         (event) => {

--- a/packages/client/src/devices/MicrophoneManagerState.ts
+++ b/packages/client/src/devices/MicrophoneManagerState.ts
@@ -6,8 +6,6 @@ export class MicrophoneManagerState extends InputMediaDeviceManagerState {
 
   /**
    * An Observable that emits `true` if the user's microphone is muted but they'are speaking.
-   *
-   * This feature is not available in the React Native SDK.
    */
   speakingWhileMuted$: Observable<boolean>;
 
@@ -26,8 +24,6 @@ export class MicrophoneManagerState extends InputMediaDeviceManagerState {
 
   /**
    * `true` if the user's microphone is muted but they'are speaking.
-   *
-   * This feature is not available in the React Native SDK.
    */
   get speakingWhileMuted() {
     return this.getCurrentValue(this.speakingWhileMuted$);

--- a/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
+++ b/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
@@ -96,6 +96,7 @@ describe('InputMediaDeviceManager.test', () => {
 
     expect(manager.publishStream).toHaveBeenCalledWith(
       manager.state.mediaStream,
+      undefined,
     );
   });
 

--- a/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
@@ -88,6 +88,7 @@ describe('MicrophoneManager', () => {
 
     expect(manager['call'].publishAudioStream).toHaveBeenCalledWith(
       manager.state.mediaStream,
+      undefined,
     );
   });
 

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -255,8 +255,10 @@ export class Publisher {
       // by an external factor as permission revokes, device disconnected, etc.
       // keep in mind that `track.stop()` doesn't trigger this event.
       track.addEventListener('ended', handleTrackEnded);
-      if (!track.enabled) {
-        track.enabled = true;
+      if (!opts.disableTrackWhilePublish) {
+        if (!track.enabled) {
+          track.enabled = true;
+        }
       }
 
       transceiver = this.pc.addTransceiver(track, {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -141,6 +141,10 @@ export type SubscriptionChanges = {
 export type PublishOptions = {
   preferredCodec?: string | null;
   screenShareSettings?: ScreenShareSettings;
+  /**
+   * Boolean that decides whether the track should be disabled while publishing
+   */
+  disableTrackWhilePublish?: boolean;
 };
 
 export type ScreenShareSettings = {

--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -524,7 +524,7 @@ PODS:
   - stream-react-native-webrtc (118.0.1):
     - JitsiWebRTC (~> 118.0.0)
     - React-Core
-  - stream-video-react-native (0.2.11):
+  - stream-video-react-native (0.2.14):
     - React-Core
     - stream-react-native-webrtc
   - TOCropViewController (2.6.1)
@@ -835,7 +835,7 @@ SPEC CHECKSUMS:
   RNVoipPushNotification: 543e18f83089134a35e7f1d2eba4c8b1f7776b08
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   stream-react-native-webrtc: 31fe9ee69d5b4fc191380a78efa292377494b7ac
-  stream-video-react-native: 87db9cd0f19ea8052db8ec74602f63847fe1816f
+  stream-video-react-native: 77590f3dfcdc79352de2b60996caad9b6f564829
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   Yoga: f7decafdc5e8c125e6fa0da38a687e35238420fa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/sample-apps/react-native/dogfood/src/components/CallControlsComponent.tsx
+++ b/sample-apps/react-native/dogfood/src/components/CallControlsComponent.tsx
@@ -42,7 +42,7 @@ export const CallControlsComponent = ({
   };
 
   return (
-    <View>
+    <>
       {isSpeakingWhileMuted && (
         <View style={styles.speakingLabelContainer}>
           <Text style={styles.label}>You are muted. Unmute to speak.</Text>
@@ -60,7 +60,7 @@ export const CallControlsComponent = ({
         <ToggleCameraFaceButton />
         <HangUpCallButton onPressHandler={onHangupCallHandler} />
       </View>
-    </View>
+    </>
   );
 };
 
@@ -68,7 +68,6 @@ const styles = StyleSheet.create({
   speakingLabelContainer: {
     backgroundColor: appTheme.colors.static_overlay,
     paddingVertical: 10,
-    width: '100%',
   },
   label: {
     textAlign: 'center',


### PR DESCRIPTION
Client Changes:
- The `muteStream` API is changed now to `muteOrDestroyStream`.
- The `unmuteStream` API is changed to `unmuteOrCreateStream`.
- We have introduced a `disableTrackWhilePublish` argument that will not enable the track while publish, which currently happens every time [here](https://github.com/GetStream/stream-video-js/blob/main/packages/client/src/rtc/Publisher.ts#L258-L260).