### PR TITLE
chore: publish current Pronto under a new instance

### DIFF
--- a/.github/workflows/deploy-react-sample-apps.yml
+++ b/.github/workflows/deploy-react-sample-apps.yml
@@ -45,7 +45,7 @@ jobs:
           - name: audio-rooms
             project-id: prj_0WnHcvVkXpM4PRc2ymVmrAHFILoT
           - name: react-dogfood
-            project-id: prj_4TTdjeVHEDhWWiFRfjIr1QFb5ell
+            project-id: prj_bUGd9z0sMAMxZmmgMaec3oiRbWzT
 
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -65,13 +65,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      # - uses: dorny/paths-filter@v2.11.1
-      #   id: changes
-      #   with:
-      #     filters: |
-      #       sample-apps:
-      #         - 'sample-apps/react/${{ matrix.application.folder || matrix.application.name }}/**/*'
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
### Overview

As we are preparing to roll out a redesigned Pronto / Dogfood app for internal purposes, we'd like to keep the existing app as a backup.
For that purpose, we've created a new project on Vercel (stream-calls-dogfood-legacy) that will host the current version and design of Pronto.

Soon, the existing domains `https://pronto.getstream.io` and `https://stream-calls-dogfood.vercel.app` will point to instances built from the following branch #1194 (and `main` once the linked PR is merged).

The legacy version will be available here: `https://stream-calls-dogfood-legacy.vercel.app`