### PR TITLE
docs(react-native): fix broken links

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/01-setup/01-introduction.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/01-setup/01-introduction.mdx
@@ -23,8 +23,8 @@ After the tutorials, the documentation explains how to use:
 It also explains advanced features such as:
 
 - [Ringing/Calls](./core/joining-and-creating-calls/)
-- [Requesting and Granting permissions](./ui-cookbook/permission-requests/)
+- [Requesting and Granting permissions](./core/permissions-and-moderation/)
 - [Participants Layout Switching](./ui-cookbook/runtime-layout-switching/)
-- Friendly support for [Push notifications](./advanced/push-notifications/setup), [deep linking](./advanced/deeplinking/) and Reconnection of calls.
+- Friendly support for [Push notifications](./advanced/push-notifications/overview), [deep linking](./advanced/deeplinking/) and Reconnection of calls.
 
 If you feel like anything is missing or could be improved, please don't hesitate to [contact us](https://getstream.io/contact/). We're happy to help.

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/01-setup/02-installation/01-react-native.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/01-setup/02-installation/01-react-native.mdx
@@ -120,4 +120,4 @@ To enable this feature you need to install the following dependencies:
 - `@react-native-firebase/app` and `@react-native-firebase/messaging` to receive notifications on Android.
 - `@react-native-voip-push-notification` to receive notifications on iOS.
 
-More about how to enable this feature can be found [in our push notification guide](../../advanced/push-notifications/setup).
+More about how to enable this feature can be found [in our push notification guide](../../../advanced/push-notifications/overview).

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/01-setup/03-quickstart.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/01-setup/03-quickstart.mdx
@@ -4,7 +4,7 @@ description: For when you're in a hurry and want to quickly get up and running
 ---
 
 In this guide, we will cover the basics of making your first call using Stream Video.
-If you haven't already, we recommend starting with the **[introduction](../../)** and **[installation](../installation)** steps first, as this guide will build on the material covered in those sections.
+If you haven't already, we recommend starting with the **[introduction](../../)** and **installation**([Native CLI](../installation/react-native) or [Expo](../installation/expo)) steps first, as this guide will build on the material covered in those sections.
 
 ## Client setup & Calls
 
@@ -80,10 +80,10 @@ export const MyVideoButton = () => {
   const { useCameraState } = useCallStateHooks();
   const { camera, isMute } = useCameraState();
   return (
-    <Button 
+    <Button
       title={isMute ? 'Turn on camera' : 'Turn off camera'}
-      onClick={() => camera.toggle()}>
-    </Button>
+      onClick={() => camera.toggle()}
+    ></Button>
   );
 };
 
@@ -93,8 +93,8 @@ export const MyMicrophoneButton = () => {
   return (
     <Button
       title={isMute ? 'Turn on microphone' : 'Turn off microphone'}
-      onClick={() => microphone.toggle()}>
-    </Button>
+      onClick={() => microphone.toggle()}
+    ></Button>
   );
 };
 ```

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/02-joining-creating-calls.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/02-joining-creating-calls.mdx
@@ -80,7 +80,7 @@ The caller will automatically join the call once the first callee accepts the ca
 The calling will automatically stop if all callee rejects the call.
 
 :::note
-When ring is true, a push notification will be sent to the members, provided their app have the required setup. For more details around push notifications, please check [this page](../../advanced/push-notifications/setup).
+When ring is true, a push notification will be sent to the members, provided their app have the required setup. For more details around push notifications, please check [this page](../../advanced/push-notifications/overview).
 :::
 
 ### Watch for incoming and outgoing calls

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/08-native-permissions.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/08-native-permissions.mdx
@@ -11,7 +11,7 @@ Once the function is called, we should see permissions being requested like belo
 
 ## Setup
 
-Ensure that relevant permissions are declared in your `AndroidManifest.xml` and `Info.plist` as mentioned in the [installation](../setup/installation/) guide. 
+Ensure that relevant permissions are declared in your `AndroidManifest.xml` and `Info.plist` as mentioned in the installation([Native CLI](../../setup/installation/react-native) or [Expo](../../setup/installation/expo)) guide.
 
 Additionally, to easily request permissions on both platforms, we will use the [`react-native-permissions`](https://github.com/zoontek/react-native-permissions) library. You can run the following command to install it:
 
@@ -20,7 +20,7 @@ yarn add react-native-permissions
 ```
 
 :::note
-Do not forget to perform the additional setup steps for iOS mentioned in the [`react-native-permissions` library documentation](https://github.com/zoontek/react-native-permissions#ios) 
+Do not forget to perform the additional setup steps for iOS mentioned in the [`react-native-permissions` library documentation](https://github.com/zoontek/react-native-permissions#ios)
 :::
 
 ## Step 1 - Add a function to request permissions in the app
@@ -30,7 +30,6 @@ In this step, we create a function called `requestAndUpdatePermissions`. This fu
 ```ts title=src/utils/requestAndUpdatePermissions.ts
 import { Platform } from 'react-native';
 import { PERMISSIONS, requestMultiple } from 'react-native-permissions';
-
 
 export const requestAndUpdatePermissions = async () => {
   if (Platform.OS === 'ios') {
@@ -68,9 +67,7 @@ const MyApp = () => {
 
   return (
     <StreamVideo client={client}>
-      <StreamCall call={call}>
-        {/*  You UI */}
-      </StreamCall>
+      <StreamCall call={call}>{/*  You UI */}</StreamCall>
     </StreamVideo>
   );
 };

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/10-reactions-and-custom-events.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/10-reactions-and-custom-events.mdx
@@ -10,8 +10,7 @@ Custom events let participants send and receive arbitrary WebSocket messages. Fo
 ## Reactions
 
 :::tip
-[`CallControls `](../../ui-components/call/call-controls/) utilizes [`ReactionsModal`](../../ui-components/utility/reactions-modal/) and components support reactions out-of-the-box, but for advanced use-cases you can also build your own reaction system.
-
+[`CallControls `](../../ui-components/call/call-controls/) optionally utilizes [`ReactionsButton`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Call/CallControls/ReactionsButton.tsx) component that support reactions out-of-the-box, but for advanced use-cases you can also build your own reaction system.
 :::
 
 ### Sending reactions

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/core/stream-call.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/core/stream-call.mdx
@@ -3,7 +3,7 @@ id: stream-call
 title: StreamCall
 ---
 
-The `<StreamCall />` component is a declarative component wrapper around `Call` objects. It utilizes the `StreamCallProvider` to make the [call and its state](../../core/call-and-participant-state/) available to all child components.
+The `<StreamCall />` component is a declarative component wrapper around `Call` objects. It utilizes the `StreamCallProvider` to make the [call and its state](../../../core/call-and-participant-state/) available to all child components.
 
 ## General usage
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/participant-view.mdx
@@ -124,4 +124,4 @@ Our [UI cookbook](../../../ui-cookbook/overview) tells all the important informa
 - [Network Quality Indicator](../../../ui-cookbook/network-quality-indicator)
 - [Custom Label](../../../ui-cookbook/participant-label)
 - [Video Renderer](../../../ui-cookbook/video-renderer)
-- [Reactions](../../../ui-cookbook/reaction)
+- [Reactions](../../../ui-cookbook/reactions)

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/02-replacing-call-controls.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/02-replacing-call-controls.mdx
@@ -23,7 +23,7 @@ Implementing call controls buttons will often be in reality associated with hand
 
 ### Button to accept a call
 
-We will need a call accept button when building an app that makes use of [ring call workflow](../../advanced/ringing). To accept a call we just invoke `call.join()`. So the minimal call accept button could look like this:
+We will need a call accept button when building an app that makes use of [ring call workflow](../../core/joining-and-creating-calls/#ring-call). To accept a call we just invoke `call.join()`. So the minimal call accept button could look like this:
 
 ```tsx
 import { Pressable, Text, StyleSheet } from 'react-native';
@@ -105,7 +105,7 @@ const styles = StyleSheet.create({
 
 ### Button to reject a call
 
-We will need a call reject button when building an app that makes use of [ring call workflow](../../advanced/ringing). To reject a call we just invoke `call.leave()` function with an object parameter having key as `reject` and value of it being `true`. So the minimal call reject button could look like this:
+We will need a call reject button when building an app that makes use of [ring call workflow](../../core/joining-and-creating-calls/#ring-call). To reject a call we just invoke `call.leave()` function with an object parameter having key as `reject` and value of it being `true`. So the minimal call reject button could look like this:
 
 ```tsx
 import { Pressable, Text, StyleSheet } from 'react-native';

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/10-network-quality-indicator.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/10-network-quality-indicator.mdx
@@ -18,7 +18,7 @@ In this guide we'll learn how to build and implement our own primitive network q
 
 ## Custom Network Quality Indicator
 
-You'll most likely be displaying this indicator component inside each participant view ([Participant](../../ui-components/core/participant)) within a call layout. To achieve the customization you can follow the snippet below:
+You'll most likely be displaying this indicator component inside each participant view ([Participant](../../ui-components/participants/participant-view)) within a call layout. To achieve the customization you can follow the snippet below:
 
 ![Preview of the Custom Network quality indicator](../assets/05-ui-cookbook/10-network-quality-indicator/network-quality-indicator-custom.png)
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/14-watching-a-livestream.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/14-watching-a-livestream.mdx
@@ -9,7 +9,7 @@ import ViewerLivestreamScreenShare from '../assets/05-ui-cookbook/14-watching-a-
 
 The Video API allows you to assign specific roles for users in a livestream, such as hosts and viewers. Our SDK provides dedicated livestreaming components for both of these roles.
 
-The `ViewerLivestream` component leverages the WebRTC protocol for seamless livestream viewing within the SDK. To enable external publishing, you can access HLS credentials from the dashboard. For additional information, please refer to our [livestream tutorial](../../tutorials/livestream).
+The `ViewerLivestream` component leverages the WebRTC protocol for seamless livestream viewing within the SDK. To enable external publishing, you can access HLS credentials from the dashboard. For additional information, please refer to our [livestream tutorial](https://getstream.io/video/sdk/reactnative/tutorial/livestreaming/).
 
 This guide describes how to customize watching a livestream through our SDK.
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/02-chat-with-video.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/02-chat-with-video.mdx
@@ -213,7 +213,7 @@ The `apiKey`, `userData` and the `tokenProvider` comes up from the `ChatWrapper`
 
 ### Step 1: Wrapping the `ChatWrapper`
 
-If we extend our [Video Calling Tutorial](../../tutorials/video-calling/), our `ChatWrapper` component can we wrapped as a parent/child of the `StreamVideo` as:
+If we extend our [Video Calling Tutorial](https://getstream.io/video/sdk/reactnative/tutorial/video-calling/), our `ChatWrapper` component can we wrapped as a parent/child of the `StreamVideo` as:
 
 ```tsx title="App.tsx" {16,24}
 import React, { useEffect, useState } from 'react';
@@ -320,7 +320,7 @@ The `ChatButton` component takes up an `onPressHandler`, which is responsible to
 
 ![Preview of the call controls with chat button](../assets/06-advanced/02-chat-integration/call-controls-chat.png).
 
-In the VideoCallUI component of our [Video Calling Tutorial](../../tutorials/video-calling/), we will add the above:
+In the VideoCallUI component of our [Video Calling Tutorial](https://getstream.io/video/sdk/reactnative/tutorial/video-calling/), we will add the above:
 
 ```tsx title="src/components/VideoCallUI.tsx" {13-16,25,35-38,40-42,46}
 import React from 'react';
@@ -916,7 +916,7 @@ const styles = StyleSheet.create({
 
 ### Step 3: Creating and passing the Video Wrapper
 
-Adhering to the [Getting and Setting the credentials](../../tutorials/video-calling/#step-3---getting-and-setting-the-credentials) step of the [Video Call Tutorial](../../tutorials/video-calling/), we will create a video wrapper that wraps and provides the Stream's Video client to the rest of the app.
+Adhering to the [Getting and Setting the credentials](https://getstream.io/video/sdk/reactnative/tutorial/video-calling/#step-3---getting-and-setting-the-credentials) step of the [Video Call Tutorial](https://getstream.io/video/sdk/reactnative/tutorial/video-calling/), we will create a video wrapper that wraps and provides the Stream's Video client to the rest of the app.
 
 ```tsx title="src/components/VideoWrapper.tsx"
 import React, { PropsWithChildren, useEffect, useState } from 'react';
@@ -1221,4 +1221,4 @@ Now that you have the final project for the **Chat in Video** and **Video in Cha
 If you're looking to explore more Stream Video based topics, we suggest the following to further customize and improve your Video experience:
 
 - [Deep Linking Guide](../deeplinking/) - Easily integrate deep linking in your app using the guide.
-- [Push Notifications Guide](../push-notifications/) - Every Chat and/or Video app needs Push Notifications to notify users for incoming calls. This guide will teach you how to set up different providers and seamlessly integrate push into your app.
+- [Push Notifications Guide](../push-notifications/overview) - Every Chat and/or Video app needs Push Notifications to notify users for incoming calls. This guide will teach you how to set up different providers and seamlessly integrate push into your app.

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/04-push-notifications/03-ringing-setup/02-expo.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/04-push-notifications/03-ringing-setup/02-expo.mdx
@@ -7,18 +7,18 @@ import TabItem from '@theme/TabItem';
 
 This guide discusses how to add push notifications for ringing calls to your project. It will discuss both Android and iOS and go through all the necessary steps.
 
-The normal user experience in a ringing app, when a user receives a call, is to show a push notification. The user can then interact with the notification to accept or reject the call. In this guide, you will learn how to set up your Expo app to get push notifications from Stream for the incoming calls that your user will receive. 
+The normal user experience in a ringing app, when a user receives a call, is to show a push notification. The user can then interact with the notification to accept or reject the call. In this guide, you will learn how to set up your Expo app to get push notifications from Stream for the incoming calls that your user will receive.
 
-| Android preview | iOS preview |
-|---|---|
-| ![Android preview of the Firebase push notification](../../../assets/06-advanced/04-push-notifications/android-preview.png) | ![iOS preview of VoIP notification using Apple Push Notification service (APNs)](../../../assets/06-advanced/04-push-notifications/ios-preview.png)
+| Android preview                                                                                                             | iOS preview                                                                                                                                         |
+| --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ![Android preview of the Firebase push notification](../../../assets/06-advanced/04-push-notifications/android-preview.png) | ![iOS preview of VoIP notification using Apple Push Notification service (APNs)](../../../assets/06-advanced/04-push-notifications/ios-preview.png) |
 
 ## Add push provider credentials to Stream
 
 Please follow the below guides for adding appropriate push providers to Stream:
 
-- Android - [Firebase Cloud Messaging](../push-providers/firebase/)
-- iOS - [Apple Push Notification Service (APNs)](../push-providers/apn-voip/)
+- Android - [Firebase Cloud Messaging](../../push-providers/firebase/)
+- iOS - [Apple Push Notification Service (APNs)](../../push-providers/apn-voip/)
 
 ## Install Dependencies
 
@@ -58,6 +58,7 @@ So what did we install precisely?
 The **google-services.json** file contains unique and non-secret identifiers of your Firebase project. For more information, see [Understand Firebase Projects](https://firebase.google.com/docs/projects/learn-more#config-files-objects).
 
 :::
+
 ## Add the config plugin properties
 
 In **app.json**, in the `plugins` field, add the `ringingPushNotifications` property to the `@stream-io/video-react-native-sdk` plugin. Also, add the `@config-plugins/react-native-callkeep` plugin.
@@ -85,7 +86,7 @@ In **app.json**, in the `plugins` field, add the `ringingPushNotifications` prop
 
 :::note
 
-- The `disableVideoIos` field is used for apps with audio only calls. Pass true to this property to disable video in iOS [CallKit](https://developer.apple.com/documentation/callkit). 
+- The `disableVideoIos` field is used for apps with audio only calls. Pass true to this property to disable video in iOS [CallKit](https://developer.apple.com/documentation/callkit).
 - The `includesCallsInRecentsIos` field is used to show call history. Pass true to show the history of calls made in the iOS native dialer
 
 :::
@@ -152,7 +153,7 @@ export function setPushConfig() {
         // This is the advised importance of receiving incoming call notifications.
         // This will ensure that the notification will appear on-top-of applications.
         importance: AndroidImportance.HIGH,
-        sound: "default",
+        sound: 'default',
       },
       // configure the functions to create the texts shown in the notification
       // for incoming calls in Android.

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/06-broadcasting.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/06-broadcasting.mdx
@@ -14,7 +14,7 @@ We can choose from two approaches to broadcasting the media:
 It is up to the integrators to decide, what approach will be used in their apps for the audience to consume the streams.
 
 :::tip
-We have built a [livestream app tutorial](../../tutorials/livestream) that relies on the broadcasting feature. The demo expands on how to implement both, the HLS and the WebRTC approach to streaming.
+We have built a [livestream app tutorial](https://getstream.io/video/sdk/reactnative/tutorial/livestreaming/) that relies on the broadcasting feature. The demo expands on how to implement both, the HLS and the WebRTC approach to streaming.
 :::
 
 ## Call type for broadcasting

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/duration-badge.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/duration-badge.mdx
@@ -2,4 +2,4 @@ Component to customize the Duration badge component on the viewer's live stream'
 
 | Type                          | Default Value                                                                                                                                                     |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`DurationBadge`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamTopView/DurationBadge.tsx) |
+| `ComponentType`\| `undefined` | [`DurationBadge`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/DurationBadge.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/follower-count.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/follower-count.mdx
@@ -2,4 +2,4 @@ Component to customize the Follower count indicator on the viewer's live stream'
 
 | Type                          | Default Value                                                                                                                                                     |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`FollowerCount`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamTopView/FollowerCount.tsx) |
+| `ComponentType`\| `undefined` | [`FollowerCount`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/FollowerCount.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/host-livestream/host-livestream-controls.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/host-livestream/host-livestream-controls.mdx
@@ -2,4 +2,4 @@ Component to customize the bottom view controls at the host's live stream.
 
 | Type                          | Default Value                                                                                                                                                                        |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ComponentType`\| `undefined` | [`HostLiveStreamControls`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamControls/HostLiveStreamControls.tsx) |
+| `ComponentType`\| `undefined` | [`HostLiveStreamControls`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamControls/HostLivestreamControls.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/host-livestream/host-livestream-top-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/host-livestream/host-livestream-top-view.mdx
@@ -2,4 +2,4 @@ Component to customize the top view at the host's live stream.
 
 | Type                          | Default Value                                                                                                                                                                     |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`HostLiveStreamTopView`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamTopView/HostLiveStreamTopView.tsx) |
+| `ComponentType`\| `undefined` | [`HostLiveStreamTopView`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/HostLivestreamTopView.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/host-livestream/host-start-stream-button.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/host-livestream/host-start-stream-button.mdx
@@ -2,4 +2,4 @@ Component to customize the host's start/end live stream button.
 
 | Type                          | Default Value                                                                                                                                                                      |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`HostStartStreamButton`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamControls/HostStartStreamButton.tsx) |
+| `ComponentType`\| `undefined` | [`HostStartStreamButton`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamControls/HostStartStreamButton.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/live-indicator.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/live-indicator.mdx
@@ -2,4 +2,4 @@ Component to customize the Live indicator on the viewer's live stream's top view
 
 | Type                          | Default Value                                                                                                                                                     |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`LiveIndicator`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamTopView/LiveIndicator.tsx) |
+| `ComponentType`\| `undefined` | [`LiveIndicator`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/LiveIndicator.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/livestream-layout.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/livestream-layout.mdx
@@ -2,4 +2,4 @@ Component to customize the live stream video layout.
 
 | Type                          | Default Value                                                                                                                                                          |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`LiveStreamLayout`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamLayout/LiveStreamLayout.tsx) |
+| `ComponentType`\| `undefined` | [`LiveStreamLayout`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamLayout/LivestreamLayout.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/livestream-media-controls.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/livestream-media-controls.mdx
@@ -2,4 +2,4 @@ Component to customize the host's media control(audio/video) buttons.
 
 | Type                          | Default Value                                                                                                                                                                          |
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`LiveStreamMediaControls`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamControls/LiveStreamMediaControls.tsx) |
+| `ComponentType`\| `undefined` | [`LiveStreamMediaControls`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamControls/LivestreamMediaControls.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/viewer-livestream/viewer-leave-stream-button.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/viewer-livestream/viewer-leave-stream-button.mdx
@@ -2,4 +2,4 @@ Component to customize the leave stream button for the viewer.
 
 | Type                          | Default Value                                                                                                                                                                          |
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`ViewerLeaveStreamButton`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamControls/ViewerLeaveStreamButton.tsx) |
+| `ComponentType`\| `undefined` | [`ViewerLeaveStreamButton`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamControls/ViewerLeaveStreamButton.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/viewer-livestream/viewer-livestream-controls.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/viewer-livestream/viewer-livestream-controls.mdx
@@ -2,4 +2,4 @@ Component to customize the bottom view controls at the viewer's live stream.
 
 | Type                          | Default Value                                                                                                                                                                            |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`ViewerLiveStreamControls`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamControls/ViewerLiveStreamControls.tsx) |
+| `ComponentType`\| `undefined` | [`ViewerLiveStreamControls`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamControls/ViewerLivestreamControls.tsx) |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/viewer-livestream/viewer-livestream-top-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/viewer-livestream/viewer-livestream-top-view.mdx
@@ -2,4 +2,4 @@ Component to customize the top view at the viewer's live stream.
 
 | Type                          | Default Value                                                                                                                                                                         |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComponentType`\| `undefined` | [`ViewerLiveStreamTopView`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LiveStreamTopView/ViewerLiveStreamTopView.tsx) |
+| `ComponentType`\| `undefined` | [`ViewerLiveStreamTopView`](https://github.com/GetStream/stream-video-js/blob/main/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/ViewerLivestreamTopView.tsx) |


### PR DESCRIPTION
Fixed all the broken links in the SDK docs except for:

```
[WARNING] Docusaurus found broken links!

Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /chat/docs/sdk/reactnative/core/configuring-call-types/:
   -> linking to ../../tutorials/video-calling/ (resolved as: /chat/docs/sdk/reactnative/tutorials/video-calling/)
   -> linking to ../../tutorials/audio-room/ (resolved as: /chat/docs/sdk/reactnative/tutorials/audio-room/)
   -> linking to ../../tutorials/livestream/ (resolved as: /chat/docs/sdk/reactnative/tutorials/livestream/)
   -> linking to ../../guides/permissions-and-moderation/ (resolved as: /chat/docs/sdk/reactnative/guides/permissions-and-moderation/)
```

Since this is within the shared folder and we will have to fix it some other way so that SDK tutorials are pointed.