### PR TITLE
feat: Fast Reconnection

### DIFF
--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -104,6 +104,12 @@ export class StreamSfuClient {
    */
   isMigratingAway = false;
 
+  /**
+   * A flag indicating that the client connection is broken for the current
+   * client and that a fast-reconnect with a new client should be attempted.
+   */
+  isFastReconnecting = false;
+
   private readonly rpc: SignalServerClient;
   private keepAliveInterval?: NodeJS.Timeout;
   private connectionCheckTimeout?: NodeJS.Timeout;
@@ -112,6 +118,24 @@ export class StreamSfuClient {
   private lastMessageTimestamp?: Date;
   private readonly unsubscribeIceTrickle: () => void;
   private readonly logger: Logger;
+
+  /**
+   * The normal closure code. Used for controlled shutdowns.
+   */
+  static NORMAL_CLOSURE = 1000;
+  /**
+   * The error code used when the SFU connection is unhealthy.
+   * Usually, this means that no message has been received from the SFU for
+   * a certain amount of time (`connectionCheckTimeout`).
+   */
+  static ERROR_CONNECTION_UNHEALTHY = 4001;
+
+  /**
+   * The error code used when the SFU connection is broken.
+   * Usually, this means that the WS connection has been closed unexpectedly.
+   * This error code is used to announce a fast-reconnect.
+   */
+  static ERROR_CONNECTION_BROKEN = 4002; // used in fast-reconnects
 
   /**
    * Constructs a new SFU client.
@@ -187,11 +211,13 @@ export class StreamSfuClient {
   }
 
   close = (
-    code: number = 1000,
-    reason: string = 'Requested signal connection close',
+    code: number = StreamSfuClient.NORMAL_CLOSURE,
+    reason: string = 'js-client: requested signal connection close',
   ) => {
     this.logger('debug', 'Closing SFU WS connection', code, reason);
-    this.signalWs.close(code, reason);
+    if (this.signalWs.readyState === this.signalWs.CLOSED) {
+      this.signalWs.close(code, reason);
+    }
 
     this.unsubscribeIceTrickle();
     clearInterval(this.keepAliveInterval);
@@ -293,8 +319,9 @@ export class StreamSfuClient {
     );
   };
 
-  send = (message: SfuRequest) => {
+  send = async (message: SfuRequest) => {
     return this.signalReady.then((signal) => {
+      if (signal.readyState !== signal.OPEN) return;
       this.logger(
         'debug',
         `Sending message to: ${this.edgeName}`,
@@ -305,9 +332,7 @@ export class StreamSfuClient {
   };
 
   private keepAlive = () => {
-    if (this.keepAliveInterval) {
-      clearInterval(this.keepAliveInterval);
-    }
+    clearInterval(this.keepAliveInterval);
     this.keepAliveInterval = setInterval(() => {
       this.logger('trace', 'Sending healthCheckRequest to SFU');
       const message = SfuRequest.create({
@@ -316,15 +341,14 @@ export class StreamSfuClient {
           healthCheckRequest: {},
         },
       });
-      void this.send(message);
+      this.send(message).catch((e) => {
+        this.logger('error', 'Error sending healthCheckRequest to SFU', e);
+      });
     }, this.pingIntervalInMs);
   };
 
   private scheduleConnectionCheck = () => {
-    if (this.connectionCheckTimeout) {
-      clearTimeout(this.connectionCheckTimeout);
-    }
-
+    clearTimeout(this.connectionCheckTimeout);
     this.connectionCheckTimeout = setTimeout(() => {
       if (this.lastMessageTimestamp) {
         const timeSinceLastMessage =
@@ -332,8 +356,8 @@ export class StreamSfuClient {
 
         if (timeSinceLastMessage > this.unhealthyTimeoutInMs) {
           this.close(
-            4001,
-            `SFU connection unhealthy. Didn't receive any healthcheck messages for ${this.unhealthyTimeoutInMs}ms`,
+            StreamSfuClient.ERROR_CONNECTION_UNHEALTHY,
+            `SFU connection unhealthy. Didn't receive any message for ${this.unhealthyTimeoutInMs}ms`,
           );
         }
       }

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -15,7 +15,7 @@ import {
 } from './videoLayers';
 import { getPreferredCodecs } from './codecs';
 import { trackTypeToParticipantStreamKey } from './helpers/tracks';
-import { CallState } from '../store';
+import { CallingState, CallState } from '../store';
 import { PublishOptions } from '../types';
 import { isReactNative } from '../helpers/platforms';
 import { enableHighQualityAudio, toggleDtx } from '../helpers/sdp-munging';
@@ -96,6 +96,7 @@ export class Publisher {
 
   private readonly iceRestartDelay: number;
   private isIceRestarting = false;
+  private iceRestartTimeout?: NodeJS.Timeout;
 
   /**
    * The SFU client instance to use for publishing and signaling.
@@ -159,6 +160,15 @@ export class Publisher {
   };
 
   /**
+   * Returns the current connection configuration.
+   *
+   * @internal
+   */
+  get connectionConfiguration() {
+    return this.pc.getConfiguration();
+  }
+
+  /**
    * Closes the publisher PeerConnection and cleans up the resources.
    */
   close = ({ stopTracks = true } = {}) => {
@@ -174,6 +184,7 @@ export class Publisher {
       });
     }
 
+    clearTimeout(this.iceRestartTimeout);
     this.unsubscribeOnIceRestart();
     this.pc.removeEventListener('negotiationneeded', this.onNegotiationNeeded);
     this.pc.close();
@@ -524,6 +535,15 @@ export class Publisher {
   };
 
   /**
+   * Sets the SFU client to use.
+   *
+   * @param sfuClient the SFU client to use.
+   */
+  setSfuClient = (sfuClient: StreamSfuClient) => {
+    this.sfuClient = sfuClient;
+  };
+
+  /**
    * Performs a migration of this publisher instance to a new SFU.
    *
    * Initiates a new `iceRestart` offer/answer exchange with the new SFU.
@@ -752,23 +772,28 @@ export class Publisher {
     const errorMessage =
       e instanceof RTCPeerConnectionIceErrorEvent &&
       `${e.errorCode}: ${e.errorText}`;
-    logger('error', `ICE Candidate error`, errorMessage);
+    const logLevel =
+      this.pc.iceConnectionState === 'connected' ? 'debug' : 'error';
+    logger(logLevel, `ICE Candidate error`, errorMessage);
   };
 
   private onIceConnectionStateChange = () => {
     const state = this.pc.iceConnectionState;
     logger('debug', `ICE Connection state changed to`, state);
 
+    const hasNetworkConnection =
+      this.state.callingState !== CallingState.OFFLINE;
+
     if (state === 'failed') {
       logger('warn', `Attempting to restart ICE`);
       this.restartIce().catch((e) => {
         logger('error', `ICE restart error`, e);
       });
-    } else if (state === 'disconnected') {
+    } else if (state === 'disconnected' && hasNetworkConnection) {
       // when in `disconnected` state, the browser may recover automatically,
       // hence, we delay the ICE restart
       logger('warn', `Scheduling ICE restart in ${this.iceRestartDelay} ms.`);
-      setTimeout(() => {
+      this.iceRestartTimeout = setTimeout(() => {
         // check if the state is still `disconnected` or `failed`
         // as the connection may have recovered (or failed) in the meantime
         if (

--- a/packages/client/src/rtc/flows/join.ts
+++ b/packages/client/src/rtc/flows/join.ts
@@ -3,7 +3,7 @@ import {
   JoinCallRequest,
   JoinCallResponse,
 } from '../../gen/coordinator';
-import { JoinCallData, StreamVideoParticipant } from '../../types';
+import { JoinCallData } from '../../types';
 import { StreamClient } from '../../coordinator/connection/client';
 
 /**
@@ -60,20 +60,4 @@ const toRtcConfiguration = (config?: ICEServer[]) => {
     })),
   };
   return rtcConfig;
-};
-
-/**
- * Reconciles the local state of the source participant into the target participant.
- *
- * @param target the participant to reconcile into.
- * @param source the participant to reconcile from.
- */
-export const reconcileParticipantLocalState = (
-  target: StreamVideoParticipant,
-  source?: StreamVideoParticipant,
-) => {
-  if (!source) return target;
-
-  // copy everything from source to target
-  return Object.assign(target, source);
 };

--- a/packages/client/src/rtc/signal.ts
+++ b/packages/client/src/rtc/signal.ts
@@ -4,7 +4,7 @@ import { getLogger } from '../logger';
 
 export const createWebSocketSignalChannel = (opts: {
   endpoint: string;
-  onMessage?: (message: SfuEvent) => void;
+  onMessage: (message: SfuEvent) => void;
 }) => {
   const logger = getLogger(['sfu-client']);
   const { endpoint, onMessage } = opts;
@@ -23,23 +23,21 @@ export const createWebSocketSignalChannel = (opts: {
     logger('info', 'Signaling WS channel is open', e);
   });
 
-  if (onMessage) {
-    ws.addEventListener('message', (e) => {
-      try {
-        const message =
-          e.data instanceof ArrayBuffer
-            ? SfuEvent.fromBinary(new Uint8Array(e.data))
-            : SfuEvent.fromJsonString(e.data.toString());
+  ws.addEventListener('message', (e) => {
+    try {
+      const message =
+        e.data instanceof ArrayBuffer
+          ? SfuEvent.fromBinary(new Uint8Array(e.data))
+          : SfuEvent.fromJsonString(e.data.toString());
 
-        onMessage(message);
-      } catch (err) {
-        logger(
-          'error',
-          'Failed to decode a message. Check whether the Proto models match.',
-          { event: e, error: err },
-        );
-      }
-    });
-  }
+      onMessage(message);
+    } catch (err) {
+      logger(
+        'error',
+        'Failed to decode a message. Check whether the Proto models match.',
+        { event: e, error: err },
+      );
+    }
+  });
   return ws;
 };


### PR DESCRIPTION
### Overview
Implements Fast Reconnection flow. This should significantly speed up the call drop recovery caused by a network switch.

### Implementation notes
In case the WebSocket connection interrupts (due to a network switch WiFi -> 5G, or anything else), we'll attempt to re-establish a connection to the existing SFU by reusing the existing credentials and configuration. When this fails, we will attempt a Full Reconnect, and involve the Coordinator in the picture, as we do it today.

### Notes
This PR is a rebase of #1212 against `main`.