### PR TITLE
feat(react-native): add ability to customize the objectFit for participant view

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
@@ -83,6 +83,22 @@ This prop is used to override the root container style of the component.
 | ---------------------------------------------------------- |
 | [ViewStyle](https://reactnative.dev/docs/view-style-props) |
 
+### `videoZOrder`
+
+The zOrder for the video that will be displayed.
+
+| Type     | Default Value |
+| -------- | ------------- |
+| `number` | `0`           |
+
+### `objectFit`
+
+Represents how the video view fits within the parent view.
+
+| Type                                   | Default Value |
+| -------------------------------------- | ------------- |
+| `'contain'` \| `'cover'` \|`undefined` | `cover`       |
+
 ### `ParticipantLabel`
 
 <ParticipantLabel />

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/floating-participant-view.mdx
@@ -85,7 +85,7 @@ This prop is used to override the root container style of the component.
 
 ### `videoZOrder`
 
-The zOrder for the video that will be displayed.
+The `zOrder` for the video that will be displayed.
 
 | Type     | Default Value |
 | -------- | ------------- |

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/participant-view.mdx
@@ -96,6 +96,22 @@ When set to false, the video stream will not be shown even if it is available.
 | --------- | ------------- |
 | `boolean` | `true`        |
 
+### `videoZOrder`
+
+The zOrder for the video that will be displayed.
+
+| Type     | Default Value |
+| -------- | ------------- |
+| `number` | `0`           |
+
+### `objectFit`
+
+Represents how the video view fits within the parent view.
+
+| Type                                   | Default Value |
+| -------------------------------------- | ------------- |
+| `'contain'` \| `'cover'` \|`undefined` | `cover`       |
+
 ### `ParticipantLabel`
 
 <ParticipantLabel />

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/participant-view.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/participants/participant-view.mdx
@@ -98,7 +98,7 @@ When set to false, the video stream will not be shown even if it is available.
 
 ### `videoZOrder`
 
-The zOrder for the video that will be displayed.
+The `zOrder` for the video that will be displayed.
 
 | Type     | Default Value |
 | -------- | ------------- |

--- a/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
+++ b/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
@@ -18,6 +18,7 @@ import { FloatingViewAlignment } from './FloatingView/common';
 import {
   ParticipantView as DefaultParticipantView,
   ParticipantViewComponentProps,
+  ParticipantViewProps,
 } from '../ParticipantView';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { StreamVideoParticipant } from '@stream-io/video-client';
@@ -33,7 +34,8 @@ export type FloatingParticipantViewAlignment =
  */
 export type FloatingParticipantViewProps = ParticipantViewComponentProps &
   Pick<CallParticipantsListComponentProps, 'ParticipantView'> &
-  Pick<CallContentProps, 'supportedReactions'> & {
+  Pick<CallContentProps, 'supportedReactions'> &
+  Pick<ParticipantViewProps, 'objectFit' | 'videoZOrder'> & {
     /**
      * Determines where the floating participant video will be placed.
      */
@@ -90,6 +92,8 @@ export const FloatingParticipantView = ({
   ParticipantReaction,
   VideoRenderer,
   supportedReactions,
+  videoZOrder = 1,
+  objectFit,
 }: FloatingParticipantViewProps) => {
   const {
     theme: { colors, floatingParticipantsView },
@@ -164,7 +168,8 @@ export const FloatingParticipantView = ({
                 ]}
                 // video z order must be one above the one used in grid view
                 // (which uses the default: 0)
-                videoZOrder={1}
+                videoZOrder={videoZOrder}
+                objectFit={objectFit}
                 supportedReactions={supportedReactions}
                 {...participantViewProps}
               />

--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantView.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantView.tsx
@@ -82,6 +82,12 @@ export type ParticipantViewProps = ParticipantViewComponentProps &
      * @default true
      */
     isVisible?: boolean;
+    /**
+     * Represents how the video view fits within the parent view.
+     *
+     * In the fashion of https://www.w3.org/TR/html5/embedded-content-0.html#dom-video-videowidth and https://www.w3.org/TR/html5/rendering.html#video-object-fit, resembles the CSS style object-fit.
+     */
+    objectFit?: 'contain' | 'cover';
   };
 
 /**
@@ -99,6 +105,7 @@ export const ParticipantView = ({
   VideoRenderer = DefaultVideoRenderer,
   ParticipantNetworkQualityIndicator = DefaultParticipantNetworkQualityIndicator,
   ParticipantVideoFallback = DefaultParticipantVideoFallback,
+  objectFit = 'cover',
   videoZOrder = 0,
   supportedReactions,
 }: ParticipantViewProps) => {
@@ -137,6 +144,7 @@ export const ParticipantView = ({
           participant={participant}
           trackType={trackType}
           ParticipantVideoFallback={ParticipantVideoFallback}
+          objectFit={objectFit}
           videoZOrder={videoZOrder}
         />
       )}

--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer.tsx
@@ -30,6 +30,7 @@ export type VideoRendererProps = Pick<
   | 'trackType'
   | 'participant'
   | 'isVisible'
+  | 'objectFit'
   | 'videoZOrder'
 >;
 
@@ -43,6 +44,7 @@ export const VideoRenderer = ({
   participant,
   isVisible = true,
   ParticipantVideoFallback = DefaultParticipantVideoFallback,
+  objectFit,
   videoZOrder = 0,
 }: VideoRendererProps) => {
   const {
@@ -206,7 +208,7 @@ export const VideoRenderer = ({
           style={[styles.videoStream, videoRenderer.videoStream]}
           streamURL={videoStreamToRender.toURL()}
           mirror={mirror}
-          objectFit={isScreenSharing ? 'contain' : 'cover'}
+          objectFit={objectFit ?? (isScreenSharing ? 'contain' : 'cover')}
           zOrder={videoZOrder}
         />
       ) : (


### PR DESCRIPTION
The `objectFit` within the VideoRenderer was not customizable until now. This PR intoduces ability to customize the same.

Eg:
```
  const CustomParticipantView = useCallback((props: ParticipantViewProps) => {
    return <ParticipantView objectFit="contain" {...props} />;
  }, []);

 <CallContent
        ParticipantView={CustomParticipantView}
      />
```

![Screenshot_1704449788](https://github.com/GetStream/stream-video-js/assets/39884168/73868ea5-9e15-45c8-8b33-294e33ac4f7e)

```
  const CustomParticipantView = useCallback((props: ParticipantViewProps) => {
    return <ParticipantView objectFit="cover" {...props} />;
  }, []);

 <CallContent
        ParticipantView={CustomParticipantView}
      />
```
![Screenshot_1704450055](https://github.com/GetStream/stream-video-js/assets/39884168/f814f0d7-a57b-477f-884e-59892470cd12)

