### PR TITLE
feat(react-sdk): update CompositeButton layout

### DIFF
--- a/packages/react-sdk/src/components/Button/CompositeButton.tsx
+++ b/packages/react-sdk/src/components/Button/CompositeButton.tsx
@@ -1,6 +1,12 @@
 import clsx from 'clsx';
 import { MenuToggle, ToggleMenuButtonProps } from '../Menu';
-import { ComponentType, forwardRef, JSX, PropsWithChildren } from 'react';
+import {
+  ComponentProps,
+  ComponentType,
+  forwardRef,
+  JSX,
+  PropsWithChildren,
+} from 'react';
 import { Placement } from '@floating-ui/react';
 
 import { IconButton } from './IconButton';
@@ -14,9 +20,9 @@ export type IconButtonWithMenuProps<E extends HTMLElement = HTMLButtonElement> =
     className?: string;
     menuPlacement?: Placement;
     ToggleMenuButton?: ComponentType<ToggleMenuButtonProps<E>>;
-    title?: string;
     variant?: 'primary' | 'secondary';
-  }>;
+  }> &
+    ComponentProps<'button'>;
 
 export const CompositeButton = forwardRef<
   HTMLDivElement,
@@ -32,6 +38,8 @@ export const CompositeButton = forwardRef<
     title,
     ToggleMenuButton = DefaultToggleMenuButton,
     variant,
+    onClick,
+    ...restButtonProps
   },
   ref,
 ) {
@@ -39,6 +47,7 @@ export const CompositeButton = forwardRef<
     <div
       className={clsx('str-video__composite-button', className, {
         'str-video__composite-button--caption': caption,
+        'str-video__composite-button--menu': Menu,
       })}
       title={title}
       ref={ref}
@@ -52,7 +61,16 @@ export const CompositeButton = forwardRef<
             variant === 'secondary' && active,
         })}
       >
-        {children}
+        <button
+          className={clsx('str-video__composite-button__button')}
+          onClick={(e) => {
+            e.preventDefault();
+            onClick?.(e);
+          }}
+          {...restButtonProps}
+        >
+          {children}
+        </button>
         {Menu && (
           <MenuToggle placement={menuPlacement} ToggleButton={ToggleMenuButton}>
             {isComponentType(Menu) ? <Menu /> : Menu}

--- a/packages/react-sdk/src/components/Button/CompositeButton.tsx
+++ b/packages/react-sdk/src/components/Button/CompositeButton.tsx
@@ -62,6 +62,7 @@ export const CompositeButton = forwardRef<
         })}
       >
         <button
+          type="button"
           className={clsx('str-video__composite-button__button')}
           onClick={(e) => {
             e.preventDefault();

--- a/packages/react-sdk/src/components/CallControls/CallStatsButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/CallStatsButton.tsx
@@ -2,8 +2,9 @@ import { forwardRef } from 'react';
 import { useI18n } from '@stream-io/video-react-bindings';
 
 import { CallStats } from '../CallStats';
-import { CompositeButton, IconButton } from '../Button/';
+import { CompositeButton } from '../Button/';
 import { MenuToggle, ToggleMenuButtonProps } from '../Menu';
+import { Icon } from '../Icon';
 
 export type CallStatsButtonProps = {
   caption?: string;
@@ -28,8 +29,9 @@ const ToggleMenuButton = forwardRef<
       active={menuShown}
       caption={caption}
       title={caption || t('Statistics')}
+      data-testid="stats-button"
     >
-      <IconButton icon="stats" data-testid="stats-button" />
+      <Icon icon="stats" />
     </CompositeButton>
   );
 });

--- a/packages/react-sdk/src/components/CallControls/ReactionsButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ReactionsButton.tsx
@@ -5,8 +5,9 @@ import { OwnCapability, StreamReaction } from '@stream-io/video-client';
 import { Restricted, useCall, useI18n } from '@stream-io/video-react-bindings';
 
 import { MenuToggle, MenuVisualType, ToggleMenuButtonProps } from '../Menu';
-import { CompositeButton, IconButton } from '../Button';
+import { CompositeButton } from '../Button';
 import { defaultEmojiReactionMap } from '../Reaction';
+import { Icon } from '../Icon';
 
 export const defaultReactions: StreamReaction[] = [
   {
@@ -68,7 +69,7 @@ const ToggleReactionsMenuButton = forwardRef<
       variant="primary"
       title={t('Reactions')}
     >
-      <IconButton icon="reactions" />
+      <Icon icon="reactions" />
     </CompositeButton>
   );
 });

--- a/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
@@ -102,7 +102,6 @@ export const RecordCallConfirmationButton = ({
         title={caption || t('Record call')}
         variant="secondary"
         data-testid="recording-start-button"
-        title={caption}
         onClick={isAwaitingResponse ? undefined : toggleCallRecording}
       >
         {isAwaitingResponse ? (

--- a/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from 'react';
 
 import { OwnCapability } from '@stream-io/video-client';
 import { Restricted, useI18n } from '@stream-io/video-react-bindings';
-import { CompositeButton, IconButton, TextButton } from '../Button/';
+import { CompositeButton } from '../Button/';
 import { Icon } from '../Icon';
 import {
   MenuToggle,
@@ -35,13 +35,11 @@ const RecordEndConfirmation = () => {
         {t('Are you sure you want end the recording?')}
       </p>
       <div className="str-video__end-recording__actions">
-        <CompositeButton variant="secondary">
-          <TextButton onClick={close}>{t('Cancel')}</TextButton>
+        <CompositeButton variant="secondary" onClick={close}>
+          {t('Cancel')}
         </CompositeButton>
-        <CompositeButton variant="primary">
-          <TextButton onClick={toggleCallRecording}>
-            {isAwaitingResponse ? <Icon icon="loading" /> : t('End recording')}
-          </TextButton>
+        <CompositeButton variant="primary" onClick={toggleCallRecording}>
+          {isAwaitingResponse ? <LoadingIndicator /> : t('End recording')}
         </CompositeButton>
       </div>
     </div>
@@ -53,8 +51,13 @@ const ToggleEndRecordingMenuButton = forwardRef<
   ToggleMenuButtonProps
 >(function ToggleEndRecordingMenuButton(props, ref) {
   return (
-    <CompositeButton ref={ref} active={true} variant="secondary">
-      <IconButton icon="recording-off" data-testid="recording-stop-button" />
+    <CompositeButton
+      ref={ref}
+      active={true}
+      variant="secondary"
+      data-testid="recording-stop-button"
+    >
+      <Icon icon="recording-off" />
     </CompositeButton>
   );
 });
@@ -98,16 +101,14 @@ export const RecordCallConfirmationButton = ({
         caption={caption}
         title={caption || t('Record call')}
         variant="secondary"
+        data-testid="recording-start-button"
+        title={caption}
+        onClick={isAwaitingResponse ? undefined : toggleCallRecording}
       >
         {isAwaitingResponse ? (
           <LoadingIndicator tooltip={t('Waiting for recording to start...')} />
         ) : (
-          <IconButton
-            icon="recording-off"
-            data-testid="recording-start-button"
-            title={caption}
-            onClick={toggleCallRecording}
-          />
+          <Icon icon="recording-off" />
         )}
       </CompositeButton>
     </Restricted>
@@ -118,6 +119,14 @@ export const RecordCallButton = ({ caption }: RecordCallButtonProps) => {
   const { t } = useI18n();
   const { toggleCallRecording, isAwaitingResponse, isCallRecordingInProgress } =
     useToggleCallRecording();
+
+  let title = caption || t('Record call');
+
+  if (isAwaitingResponse) {
+    title = isCallRecordingInProgress
+      ? t('Waiting for recording to stop...')
+      : t('Waiting for recording to start...');
+  }
 
   return (
     <Restricted
@@ -130,25 +139,19 @@ export const RecordCallButton = ({ caption }: RecordCallButtonProps) => {
         active={isCallRecordingInProgress}
         caption={caption}
         variant="secondary"
+        data-testid={
+          isCallRecordingInProgress
+            ? 'recording-stop-button'
+            : 'recording-start-button'
+        }
+        title={title}
+        onClick={isAwaitingResponse ? undefined : toggleCallRecording}
       >
         {isAwaitingResponse ? (
-          <LoadingIndicator
-            tooltip={
-              isCallRecordingInProgress
-                ? t('Waiting for recording to stop...')
-                : t('Waiting for recording to start...')
-            }
-          />
+          <LoadingIndicator />
         ) : (
-          <IconButton
+          <Icon
             icon={isCallRecordingInProgress ? 'recording-on' : 'recording-off'}
-            data-testid={
-              isCallRecordingInProgress
-                ? 'recording-stop-button'
-                : 'recording-start-button'
-            }
-            title={caption || t('Record call')}
-            onClick={toggleCallRecording}
           />
         )}
       </CompositeButton>

--- a/packages/react-sdk/src/components/CallControls/ScreenShareButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ScreenShareButton.tsx
@@ -4,7 +4,7 @@ import {
   useCallStateHooks,
   useI18n,
 } from '@stream-io/video-react-bindings';
-import { CompositeButton, IconButton } from '../Button/';
+import { CompositeButton } from '../Button/';
 import { PermissionNotification } from '../Notification';
 import { useRequestPermission } from '../../hooks';
 import { Icon } from '../Icon';
@@ -45,7 +45,6 @@ export const ScreenShareButton = (props: ScreenShareButtonProps) => {
               ? 'screen-share-stop-button'
               : 'screen-share-start-button'
           }
-          title={caption || t('Share screen')}
           disabled={disableScreenShareButton}
           onClick={async () => {
             if (!hasPermission) {

--- a/packages/react-sdk/src/components/CallControls/ScreenShareButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ScreenShareButton.tsx
@@ -7,6 +7,7 @@ import {
 import { CompositeButton, IconButton } from '../Button/';
 import { PermissionNotification } from '../Notification';
 import { useRequestPermission } from '../../hooks';
+import { Icon } from '../Icon';
 
 export type ScreenShareButtonProps = {
   caption?: string;
@@ -39,24 +40,25 @@ export const ScreenShareButton = (props: ScreenShareButtonProps) => {
           caption={caption}
           title={caption || t('Share screen')}
           variant="primary"
+          data-testid={
+            isSomeoneScreenSharing
+              ? 'screen-share-stop-button'
+              : 'screen-share-start-button'
+          }
+          title={caption || t('Share screen')}
+          disabled={disableScreenShareButton}
+          onClick={async () => {
+            if (!hasPermission) {
+              await requestPermission();
+            } else {
+              await screenShare.toggle();
+            }
+          }}
         >
-          <IconButton
+          <Icon
             icon={
               isSomeoneScreenSharing ? 'screen-share-on' : 'screen-share-off'
             }
-            data-testid={
-              isSomeoneScreenSharing
-                ? 'screen-share-stop-button'
-                : 'screen-share-start-button'
-            }
-            disabled={disableScreenShareButton}
-            onClick={async () => {
-              if (!hasPermission) {
-                await requestPermission();
-              } else {
-                await screenShare.toggle();
-              }
-            }}
           />
         </CompositeButton>
       </PermissionNotification>

--- a/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
@@ -1,47 +1,45 @@
-import { ComponentType } from 'react';
 import { OwnCapability } from '@stream-io/video-client';
 import {
   Restricted,
   useCallStateHooks,
   useI18n,
 } from '@stream-io/video-react-bindings';
-import { CompositeButton, IconButton } from '../Button';
+import { CompositeButton, IconButtonWithMenuProps } from '../Button';
 import { PermissionNotification } from '../Notification';
 import { useRequestPermission } from '../../hooks';
+import { Icon } from '../Icon';
 
-export type ToggleAudioPreviewButtonProps = {
-  caption?: string;
-  Menu?: ComponentType;
-};
+export type ToggleAudioPreviewButtonProps = Pick<
+  IconButtonWithMenuProps,
+  'caption' | 'Menu' | 'menuPlacement'
+>;
 
 export const ToggleAudioPreviewButton = (
   props: ToggleAudioPreviewButtonProps,
 ) => {
-  const { caption, Menu } = props;
+  const { caption, ...restCompositeButtonProps } = props;
   const { t } = useI18n();
   const { useMicrophoneState } = useCallStateHooks();
   const { microphone, isMute, hasBrowserPermission } = useMicrophoneState();
 
   return (
     <CompositeButton
-      Menu={Menu}
       active={isMute}
       caption={caption}
       variant="secondary"
+      title={
+        !hasBrowserPermission
+          ? t('Check your browser audio permissions')
+          : caption || t('Mic')
+      }
+      disabled={!hasBrowserPermission}
+      data-testid={
+        isMute ? 'preview-audio-unmute-button' : 'preview-audio-mute-button'
+      }
+      onClick={() => microphone.toggle()}
+      {...restCompositeButtonProps}
     >
-      <IconButton
-        icon={!isMute ? 'mic' : 'mic-off'}
-        title={
-          !hasBrowserPermission
-            ? t('Check your browser audio permissions')
-            : caption || t('Mic')
-        }
-        disabled={!hasBrowserPermission}
-        data-testid={
-          isMute ? 'preview-audio-unmute-button' : 'preview-audio-mute-button'
-        }
-        onClick={() => microphone.toggle()}
-      />
+      <Icon icon={!isMute ? 'mic' : 'mic-off'} />
       {!hasBrowserPermission && (
         <span
           className="str-video__no-media-permission"
@@ -53,16 +51,16 @@ export const ToggleAudioPreviewButton = (
   );
 };
 
-export type ToggleAudioPublishingButtonProps = {
-  caption?: string;
-  Menu?: ComponentType;
-};
+export type ToggleAudioPublishingButtonProps = Pick<
+  IconButtonWithMenuProps,
+  'caption' | 'Menu' | 'menuPlacement'
+>;
 
 export const ToggleAudioPublishingButton = (
   props: ToggleAudioPublishingButtonProps,
 ) => {
   const { t } = useI18n();
-  const { caption, Menu } = props;
+  const { caption, ...restCompositeButtonProps } = props;
 
   const { hasPermission, requestPermission, isAwaitingPermission } =
     useRequestPermission(OwnCapability.SEND_AUDIO);
@@ -80,7 +78,6 @@ export const ToggleAudioPublishingButton = (
         messageRevoked={t('You can no longer speak.')}
       >
         <CompositeButton
-          Menu={Menu}
           active={isMute}
           caption={caption}
           title={
@@ -89,19 +86,18 @@ export const ToggleAudioPublishingButton = (
               : caption || t('Mic')
           }
           variant="secondary"
+          disabled={!hasBrowserPermission || !hasPermission}
+          data-testid={isMute ? 'audio-unmute-button' : 'audio-mute-button'}
+          onClick={async () => {
+            if (!hasPermission) {
+              await requestPermission();
+            } else {
+              await microphone.toggle();
+            }
+          }}
+          {...restCompositeButtonProps}
         >
-          <IconButton
-            icon={isMute ? 'mic-off' : 'mic'}
-            disabled={!hasBrowserPermission || !hasPermission}
-            data-testid={isMute ? 'audio-unmute-button' : 'audio-mute-button'}
-            onClick={async () => {
-              if (!hasPermission) {
-                await requestPermission();
-              } else {
-                await microphone.toggle();
-              }
-            }}
-          />
+          <Icon icon={isMute ? 'mic-off' : 'mic'} />
           {(!hasBrowserPermission || !hasPermission) && (
             <span className="str-video__no-media-permission">!</span>
           )}

--- a/packages/react-sdk/src/components/CallControls/ToggleAudioOutputButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleAudioOutputButton.tsx
@@ -1,11 +1,11 @@
-import { CompositeButton, IconButton } from '../Button';
+import { CompositeButton, IconButtonWithMenuProps } from '../Button';
 import { useI18n } from '@stream-io/video-react-bindings';
-import { ComponentType } from 'react';
+import { Icon } from '../Icon';
 
-export type ToggleAudioOutputButtonProps = {
-  caption?: string;
-  Menu?: ComponentType;
-};
+export type ToggleAudioOutputButtonProps = Pick<
+  IconButtonWithMenuProps,
+  'caption' | 'Menu' | 'menuPlacement'
+>;
 
 export const ToggleAudioOutputButton = (
   props: ToggleAudioOutputButtonProps,
@@ -18,8 +18,9 @@ export const ToggleAudioOutputButton = (
       Menu={Menu}
       caption={caption}
       title={caption || t('Speakers')}
+      data-testid="audio-output-button"
     >
-      <IconButton icon="speaker" data-testid="audio-output-button" />
+      <Icon icon="speaker" />
     </CompositeButton>
   );
 };

--- a/packages/react-sdk/src/components/CallControls/ToggleVideoButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleVideoButton.tsx
@@ -1,4 +1,3 @@
-import { ComponentType } from 'react';
 import {
   Restricted,
   useCallStateHooks,
@@ -6,26 +5,26 @@ import {
 } from '@stream-io/video-react-bindings';
 
 import { OwnCapability } from '@stream-io/video-client';
-import { CompositeButton, IconButton } from '../Button/';
+import { CompositeButton, IconButtonWithMenuProps } from '../Button/';
 import { PermissionNotification } from '../Notification';
 import { useRequestPermission } from '../../hooks';
+import { Icon } from '../Icon';
 
-export type ToggleVideoPreviewButtonProps = {
-  caption?: string;
-  Menu?: ComponentType;
-};
+export type ToggleVideoPreviewButtonProps = Pick<
+  IconButtonWithMenuProps,
+  'caption' | 'Menu' | 'menuPlacement'
+>;
 
 export const ToggleVideoPreviewButton = (
   props: ToggleVideoPreviewButtonProps,
 ) => {
-  const { caption, Menu } = props;
+  const { caption, ...restCompositeButtonProps } = props;
   const { t } = useI18n();
   const { useCameraState } = useCallStateHooks();
   const { camera, isMute, hasBrowserPermission } = useCameraState();
 
   return (
     <CompositeButton
-      Menu={Menu}
       active={isMute}
       caption={caption}
       title={
@@ -34,15 +33,14 @@ export const ToggleVideoPreviewButton = (
           : caption || t('Video')
       }
       variant="secondary"
+      data-testid={
+        isMute ? 'preview-video-unmute-button' : 'preview-video-mute-button'
+      }
+      onClick={() => camera.toggle()}
+      disabled={!hasBrowserPermission}
+      {...restCompositeButtonProps}
     >
-      <IconButton
-        icon={!isMute ? 'camera' : 'camera-off'}
-        data-testid={
-          isMute ? 'preview-video-unmute-button' : 'preview-video-mute-button'
-        }
-        onClick={() => camera.toggle()}
-        disabled={!hasBrowserPermission}
-      />
+      <Icon icon={!isMute ? 'camera' : 'camera-off'} />
       {!hasBrowserPermission && (
         <span
           className="str-video__no-media-permission"
@@ -54,16 +52,16 @@ export const ToggleVideoPreviewButton = (
   );
 };
 
-type ToggleVideoPublishingButtonProps = {
-  caption?: string;
-  Menu?: ComponentType;
-};
+type ToggleVideoPublishingButtonProps = Pick<
+  IconButtonWithMenuProps,
+  'caption' | 'Menu' | 'menuPlacement'
+>;
 
 export const ToggleVideoPublishingButton = (
   props: ToggleVideoPublishingButtonProps,
 ) => {
   const { t } = useI18n();
-  const { caption, Menu } = props;
+  const { caption, ...restCompositeButtonProps } = props;
 
   const { hasPermission, requestPermission, isAwaitingPermission } =
     useRequestPermission(OwnCapability.SEND_VIDEO);
@@ -83,28 +81,26 @@ export const ToggleVideoPublishingButton = (
         messageRevoked={t('You can no longer share your video.')}
       >
         <CompositeButton
-          Menu={Menu}
           active={isMute}
           caption={caption}
           variant="secondary"
-        >
-          <IconButton
-            icon={isMute ? 'camera-off' : 'camera'}
-            title={
-              !hasBrowserPermission || !hasPermission
-                ? t('Check your browser video permissions')
-                : caption || t('Video')
+          title={
+            !hasBrowserPermission || !hasPermission
+              ? t('Check your browser video permissions')
+              : caption || t('Video')
+          }
+          disabled={!hasBrowserPermission || !hasPermission}
+          data-testid={isMute ? 'video-unmute-button' : 'video-mute-button'}
+          onClick={async () => {
+            if (!hasPermission) {
+              await requestPermission();
+            } else {
+              await camera.toggle();
             }
-            disabled={!hasBrowserPermission || !hasPermission}
-            data-testid={isMute ? 'video-unmute-button' : 'video-mute-button'}
-            onClick={async () => {
-              if (!hasPermission) {
-                await requestPermission();
-              } else {
-                await camera.toggle();
-              }
-            }}
-          />
+          }}
+          {...restCompositeButtonProps}
+        >
+          <Icon icon={isMute ? 'camera-off' : 'camera'} />
           {!hasBrowserPermission && (
             <span className="str-video__no-media-permission">!</span>
           )}

--- a/packages/styling/src/Button/Button-layout.scss
+++ b/packages/styling/src/Button/Button-layout.scss
@@ -32,11 +32,9 @@
 }
 
 .str-video__composite-button {
-  display: flex;
-  align-items: center;
-  height: 100%;
-
   &--caption {
+    display: flex;
+    align-items: center;
     flex-direction: column;
     gap: 0.25rem;
   }
@@ -44,18 +42,25 @@
   .str-video__composite-button__button-group {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem;
-    height: 38px;
-    position: relative;
 
-    .str-video__call-controls__button {
-      padding: 0;
+    .str-video__composite-button__button {
+      all: unset;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      height: calc(38px - 1rem);
+      padding: 0.5rem;
+
+      &:hover {
+        cursor: pointer;
+      }
     }
 
-    .str-video__call-controls__button.str-video__menu-toggle-button {
-      height: 100%;
-      padding-inline: 2px;
+    .str-video__menu-toggle-button {
+      padding: 0;
+      margin-left: -30px;
+      margin-right: 8px;
     }
 
     .str-video__loading-indicator__icon {
@@ -64,6 +69,10 @@
       -webkit-mask-size: 1.25rem;
       mask-size: 1.25rem;
     }
+  }
+
+  &.str-video__composite-button--menu .str-video__composite-button__button {
+    padding-right: 2.5rem;
   }
 }
 
@@ -85,16 +94,6 @@
   }
 
   .str-video__icon {
-    &--caret-down {
-      width: 0.5rem;
-      height: 0.5rem;
-    }
-
-    &--caret-up {
-      width: 0.5rem;
-      height: 0.5rem;
-    }
-
     &--call-end {
       width: 1.5rem;
       height: 1.5rem;

--- a/packages/styling/src/Button/Button-theme.scss
+++ b/packages/styling/src/Button/Button-theme.scss
@@ -24,6 +24,10 @@
     --str-video__button-secondary-active
   );
 
+  --str-video__composite-button__button-group-active-secondary-hover--background-color: var(
+    --str-video__button-secondary-hover
+  );
+
   /* The hover background color of the component */
   --str-video__composite-button__button-group-hover--background-color: var(
     --str-video__button-primary-hover
@@ -42,12 +46,25 @@
   );
   border-radius: var(--str-video__border-radius-circle);
 
-  .str-video__menu-toggle-button .str-video__call-controls__button {
-    background-color: transparent;
-  }
-
   .str-video__call-controls__button.str-video__menu-toggle-button {
-    background-color: var(--str-video__background-color1);
+    background-color: var(--str-video__button-primary-base);
+
+    &:hover {
+      background-color: var(--str-video__button-primary-hover);
+    }
+
+    &--active {
+      background-color: var(--str-video__brand-color1);
+      color: white;
+
+      &:hover {
+        background-color: var(--str-video__brand-color1);
+      }
+
+      &:disabled {
+        background-color: var(--str-video__brand-color1);
+      }
+    }
   }
 }
 
@@ -63,36 +80,18 @@
   background-color: var(
     --str-video__composite-button__button-group-active--background-color
   );
-
-  .str-video__call-controls__button {
-    background-color: var(
-      --str-video__composite-button__button-group-active--background-color
-    );
-  }
 }
 
 .str-video__composite-button__button-group--active-primary {
   background-color: var(
     --str-video__composite-button__button-group-active-primary--background-color
   );
-
-  .str-video__call-controls__button {
-    background-color: var(
-      --str-video__composite-button__button-group-active-primary--background-color
-    );
-  }
 }
 
 .str-video__composite-button__button-group--active-secondary {
   background-color: var(
     --str-video__composite-button__button-group-active-secondary--background-color
   );
-
-  .str-video__call-controls__button {
-    background-color: var(
-      --str-video__composite-button__button-group-active-secondary--background-color
-    );
-  }
 }
 
 .str-video__composite-button__button-group:hover {
@@ -100,9 +99,9 @@
     --str-video__composite-button__button-group-hover--background-color
   );
 
-  .str-video__call-controls__button {
+  &.str-video__composite-button__button-group--active-secondary:hover {
     background-color: var(
-      --str-video__composite-button__button-group-hover--background-color
+      --str-video__composite-button__button-group-active-secondary-hover--background-color
     );
   }
 

--- a/sample-apps/react/react-dogfood/components/ActiveCall.tsx
+++ b/sample-apps/react/react-dogfood/components/ActiveCall.tsx
@@ -5,7 +5,7 @@ import {
   CallParticipantsList,
   CancelCallConfirmButton,
   CompositeButton,
-  IconButton,
+  Icon,
   PermissionRequests,
   ReactionsButton,
   RecordCallConfirmationButton,
@@ -213,7 +213,7 @@ export const ActiveCall = (props: ActiveCallProps) => {
             </div>
 
             <ToggleParticipantListButton
-              enabled={showParticipants}
+              active={showParticipants}
               onClick={() => {
                 setSidebarContent(showParticipants ? null : 'participants');
               }}
@@ -224,14 +224,13 @@ export const ActiveCall = (props: ActiveCallProps) => {
               disableOnChatOpen={showChat}
             >
               <div className="str-chat__chat-button__wrapper">
-                <CompositeButton active={showChat}>
-                  <IconButton
-                    enabled={showChat}
-                    disabled={!chatClient}
-                    title="Chat"
-                    onClick={() => setSidebarContent(showChat ? null : 'chat')}
-                    icon="chat"
-                  />
+                <CompositeButton
+                  active={showChat}
+                  disabled={!chatClient}
+                  title="Chat"
+                  onClick={() => setSidebarContent(showChat ? null : 'chat')}
+                >
+                  <Icon icon="chat" />
                 </CompositeButton>
                 {!showChat && (
                   <UnreadCountBadge

--- a/sample-apps/react/react-dogfood/components/CallStatsWrapper.tsx
+++ b/sample-apps/react/react-dogfood/components/CallStatsWrapper.tsx
@@ -1,8 +1,4 @@
-import {
-  CallStats,
-  CompositeButton,
-  IconButton,
-} from '@stream-io/video-react-sdk';
+import { CallStats, CompositeButton, Icon } from '@stream-io/video-react-sdk';
 
 export const ToggleStatsButton = (props: {
   active?: boolean;
@@ -10,8 +6,13 @@ export const ToggleStatsButton = (props: {
 }) => {
   const { active, onClick } = props;
   return (
-    <CompositeButton active={active} variant="primary">
-      <IconButton icon="stats" title="Stats" onClick={onClick} />
+    <CompositeButton
+      active={active}
+      variant="primary"
+      title="Stats"
+      onClick={onClick}
+    >
+      <Icon icon="stats" />
     </CompositeButton>
   );
 };

--- a/sample-apps/react/react-dogfood/components/Settings/SettingsTabModal.tsx
+++ b/sample-apps/react/react-dogfood/components/Settings/SettingsTabModal.tsx
@@ -178,7 +178,7 @@ const ToggleSettingsMenuButton = forwardRef<
 >(function ToggleSettingsMenuButton(props, ref) {
   return (
     <CompositeButton ref={ref} active={props.menuShown} variant="primary">
-      <IconButton icon="device-settings" />
+      <Icon icon="device-settings" />
     </CompositeButton>
   );
 });

--- a/sample-apps/react/react-dogfood/components/ToggleDeveloperButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleDeveloperButton.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from 'react';
 
 import {
   CompositeButton,
-  IconButton,
+  Icon,
   MenuToggle,
   MenuVisualType,
   ToggleMenuButtonProps,
@@ -16,7 +16,7 @@ export const ToggleMenuButton = forwardRef<
 >(function ToggleMenuButton(props, ref) {
   return (
     <CompositeButton ref={ref} active={props.menuShown} variant="primary">
-      <IconButton icon="developer" />
+      <Icon icon="developer" />
     </CompositeButton>
   );
 });

--- a/sample-apps/react/react-dogfood/components/ToggleDocumentationButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleDocumentationButton.tsx
@@ -3,7 +3,6 @@ import { forwardRef } from 'react';
 import {
   Icon,
   CompositeButton,
-  IconButton,
   MenuToggle,
   MenuVisualType,
   ToggleMenuButtonProps,
@@ -21,7 +20,7 @@ export const ToggleMenuButton = forwardRef<
       active={props.menuShown}
       variant="primary"
     >
-      <IconButton icon="caret-down" />
+      <Icon icon="caret-down" />
     </CompositeButton>
   );
 });

--- a/sample-apps/react/react-dogfood/components/ToggleDualCameraButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleDualCameraButton.tsx
@@ -1,48 +1,17 @@
-import { forwardRef } from 'react';
 import clsx from 'clsx';
 
 import {
   DeviceSelectorVideo,
-  Icon,
-  MenuToggle,
-  MenuVisualType,
-  ToggleMenuButtonProps,
   ToggleVideoPublishingButton,
-  useCallStateHooks,
 } from '@stream-io/video-react-sdk';
 
-const ToggleMenuButton = forwardRef<HTMLDivElement, ToggleMenuButtonProps>(
-  function ToggleMenuButton(props, ref) {
-    return (
-      <div
-        ref={ref}
-        className={clsx('rd__dual-toggle__device-selector', {
-          'rd__dual-toggle__device-selector--active': props.menuShown,
-        })}
-      >
-        <Icon icon={props.menuShown ? 'caret-down' : 'caret-up'} />
-      </div>
-    );
-  },
-);
-
 export const ToggleDualCameraButton = () => {
-  const { useCameraState } = useCallStateHooks();
-  const { status } = useCameraState();
   return (
-    <div
-      className={clsx('rd__dual-toggle', {
-        'rd__dual-toggle--active': status === 'disabled',
-      })}
-    >
-      <ToggleVideoPublishingButton />
-      <MenuToggle
-        placement="top"
-        ToggleButton={ToggleMenuButton}
-        visualType={MenuVisualType.MENU}
-      >
-        <DeviceSelectorVideo visualType="list" />
-      </MenuToggle>
+    <div className={clsx('rd__dual-toggle')}>
+      <ToggleVideoPublishingButton
+        Menu={<DeviceSelectorVideo visualType="list" />}
+        menuPlacement="top"
+      />
     </div>
   );
 };

--- a/sample-apps/react/react-dogfood/components/ToggleDualMicButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleDualMicButton.tsx
@@ -1,50 +1,15 @@
-import { forwardRef } from 'react';
-import clsx from 'clsx';
-
 import {
   DeviceSelectorAudioInput,
-  Icon,
-  MenuToggle,
-  MenuVisualType,
   ToggleAudioPublishingButton,
-  ToggleMenuButtonProps,
-  useCallStateHooks,
 } from '@stream-io/video-react-sdk';
 
-export const ToggleMenuButton = forwardRef<
-  HTMLDivElement,
-  ToggleMenuButtonProps
->(function ToggleMenuButton(props, ref) {
-  return (
-    <div
-      ref={ref}
-      className={clsx('rd__dual-toggle__device-selector', {
-        'rd__dual-toggle__device-selector--active': props.menuShown,
-      })}
-    >
-      <Icon icon={props.menuShown ? 'caret-down' : 'caret-up'} />
-    </div>
-  );
-});
-
 export const ToggleDualMicButton = () => {
-  const { useMicrophoneState } = useCallStateHooks();
-  const { status } = useMicrophoneState();
-
   return (
-    <div
-      className={clsx('rd__dual-toggle', {
-        'rd__dual-toggle--active': status === 'disabled',
-      })}
-    >
-      <ToggleAudioPublishingButton />
-      <MenuToggle
-        placement="top"
-        ToggleButton={ToggleMenuButton}
-        visualType={MenuVisualType.MENU}
-      >
-        <DeviceSelectorAudioInput visualType="list" title={undefined} />
-      </MenuToggle>
+    <div className="rd__dual-toggle">
+      <ToggleAudioPublishingButton
+        Menu={<DeviceSelectorAudioInput visualType="list" title={undefined} />}
+        menuPlacement="top"
+      />
     </div>
   );
 };

--- a/sample-apps/react/react-dogfood/components/ToggleFeedbackButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleFeedbackButton.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from 'react';
 
 import {
   CompositeButton,
-  IconButton,
+  Icon,
   MenuToggle,
   MenuVisualType,
   ToggleMenuButtonProps,
@@ -14,7 +14,7 @@ const ToggleMenuButton = forwardRef<HTMLDivElement, ToggleMenuButtonProps>(
   function ToggleMenuButton(props, ref) {
     return (
       <CompositeButton ref={ref} active={props.menuShown} variant="primary">
-        <IconButton icon="feedback" />
+        <Icon icon="feedback" />
       </CompositeButton>
     );
   },

--- a/sample-apps/react/react-dogfood/components/ToggleLayoutButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleLayoutButton.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from 'react';
 
 import {
   CompositeButton,
-  IconButton,
+  Icon,
   MenuToggle,
   MenuVisualType,
   ToggleMenuButtonProps,
@@ -19,8 +19,13 @@ export const ToggleMenuButton = forwardRef<
   ToggleMenuButtonProps
 >(function ToggleMenuButton(props, ref) {
   return (
-    <CompositeButton ref={ref} active={props.menuShown} variant="primary">
-      <IconButton icon="grid" title="Layout" />
+    <CompositeButton
+      ref={ref}
+      active={props.menuShown}
+      variant="primary"
+      title="Layout"
+    >
+      <Icon icon="grid" />
     </CompositeButton>
   );
 });

--- a/sample-apps/react/react-dogfood/components/ToggleMoreOptionsListButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleMoreOptionsListButton.tsx
@@ -5,7 +5,6 @@ import {
   defaultReactions,
   DefaultReactionsMenu,
   Icon,
-  IconButton,
   MenuToggle,
   MenuVisualType,
   ToggleMenuButtonProps,
@@ -72,7 +71,7 @@ export const ToggleMenuButton = forwardRef<
 >(function ToggleMenuButton(props, ref) {
   return (
     <CompositeButton ref={ref} active={props.menuShown} variant="primary">
-      <IconButton icon="more" />
+      <Icon icon="more" />
     </CompositeButton>
   );
 });

--- a/sample-apps/react/react-dogfood/components/ToggleParticipantListButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleParticipantListButton.tsx
@@ -1,24 +1,23 @@
 import {
-  ButtonWithIconProps,
   CompositeButton,
-  IconButton,
+  Icon,
+  IconButtonWithMenuProps,
   useCallStateHooks,
 } from '@stream-io/video-react-sdk';
 
 export type ToggleParticipantListButtonProps = { caption?: string } & Omit<
-  ButtonWithIconProps,
+  IconButtonWithMenuProps,
   'icon' | 'ref'
 >;
 
 export const ToggleParticipantListButton = (
   props: ToggleParticipantListButtonProps,
 ) => {
-  const { enabled, caption } = props;
   const { useParticipantCount } = useCallStateHooks();
   const participantCount = useParticipantCount();
   return (
-    <CompositeButton active={enabled} caption={caption}>
-      <IconButton icon="participants" {...props} title="Participants" />
+    <CompositeButton title="Participants" {...props}>
+      <Icon icon="participants" />
       {participantCount > 1 && (
         <span className="rd__particpant-count">{participantCount}</span>
       )}

--- a/sample-apps/react/react-dogfood/components/ToggleParticipantsPreview.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleParticipantsPreview.tsx
@@ -4,7 +4,6 @@ import {
   CallPreview,
   CompositeButton,
   Icon,
-  IconButton,
   MenuToggle,
   MenuVisualType,
   ToggleMenuButtonProps,
@@ -63,7 +62,7 @@ const ToggleMenuButton = forwardRef<HTMLDivElement, ToggleMenuButtonProps>(
         className="rd__participants-preview__button"
         title="Participants already in the call"
       >
-        <IconButton icon="participants" />
+        <Icon icon="participants" />
         {total > 0 && (
           <span className="rd__participants-preview__count">{total}</span>
         )}

--- a/sample-apps/react/react-dogfood/style/Button/Button.scss
+++ b/sample-apps/react/react-dogfood/style/Button/Button.scss
@@ -79,75 +79,7 @@ a.rd__button {
 }
 
 .rd__dual-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--str-video__spacing-xs);
-  padding: 2px 4px; //var(--str-video__spacing-xs);
-  border-radius: var(--str-video__border-radius-circle);
-  background-color: var(--str-video__button-primary-base);
-
-  .str-video__composite-button .str-video__composite-button__button-group {
-    height: 34px;
-    width: 34px;
-    justify-content: center;
-  }
-
   .str-video__device-settings__device-kind {
     margin-bottom: var(--str-video__spacing-lg);
-  }
-
-  &:hover {
-    background-color: var(--str-video__button-default-hover);
-    .str-video__call-controls__button,
-    .str-video__composite-button__button-group {
-      background-color: transparent;
-    }
-  }
-
-  &--active {
-    background-color: var(--str-video__button-secondary-active);
-
-    &:hover {
-      background-color: var(--str-video__button-secondary-hover);
-    }
-  }
-
-  &__device-selector {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--str-video__spacing-xs);
-    border-radius: var(--str-video__border-radius-circle);
-    background-color: var(--str-video__button-primary-base);
-    color: var(--str-video__text-color1);
-    font-size: var(--str-video__font-size-sm);
-    font-weight: 500;
-    border: 1px solid transparent;
-
-    &:hover {
-      background-color: var(--str-video__button-primary-hover);
-      cursor: pointer;
-    }
-
-    &:disabled {
-      background-color: var(--str-video__button-primary-disabled);
-      cursor: not-allowed;
-    }
-
-    &--active {
-      background-color: var(--str-video__brand-color1);
-      color: white;
-
-      &:hover {
-        background-color: var(--str-video__brand-color1);
-        cursor: pointer;
-      }
-
-      &:disabled {
-        background-color: var(--str-video__brand-color1);
-        cursor: not-allowed;
-      }
-    }
   }
 }


### PR DESCRIPTION
🚂 #1194 

Previously, CompositeButton relied on its `children` to be a button themselves. That led to a mismatch between a hover target (the whole CompositeButton) and a click target (e.g. an IconButton passed as `children`).

With this update, CompositeButton renders a `button` element itself. So, you should no longer pass IconButton or TextButton as `children` - just pass an `Icon` or text.

This is a breaking change, since props for CompositeButton have changed.

As a bonus, most of the styling for react-dogfood's DualButton was removed, since it just re-implemented CompositeButton with a slightly different styling.