### PR TITLE
docs(react): update tutorial links for React

### DIFF
--- a/packages/react-sdk/docusaurus/docs/React/02-guides/05-call-types.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/05-call-types.mdx
@@ -4,5 +4,17 @@ title: Call Types
 ---
 
 import CallTypesPage from '../../../shared/video/_call-types.md';
+import WithExternalLinks from '../../../shared/video/_withExternalLinks';
 
 <CallTypesPage />
+
+<WithExternalLinks
+  mapping={{
+    '/tutorials/video-calling/':
+      'https://getstream.io/video/sdk/react/tutorial/video-calling/',
+    '/tutorials/audio-room/':
+      'https://getstream.io/video/sdk/react/tutorial/audio-room/',
+    '/tutorials/livestream/':
+      'https://getstream.io/video/sdk/react/tutorial/livestreaming/',
+  }}
+/>


### PR DESCRIPTION
### Overview

Built on top of https://github.com/GetStream/stream-chat-docusaurus-cli/pull/124

Our tutorial links should point to the main website as they live there now.