### PR TITLE
feat(react-dogfood): fix push-to-talk behavior

### DIFF
--- a/sample-apps/react/react-dogfood/hooks/useKeyboardShortcuts.ts
+++ b/sample-apps/react/react-dogfood/hooks/useKeyboardShortcuts.ts
@@ -34,6 +34,8 @@ export const usePushToTalk = (key: string) => {
       return;
     }
 
+    e.preventDefault();
+
     if (e.type === 'keydown' && isMute) {
       enableMicWithPushToTalkPromiseRef.current = microphone
         .enable()

--- a/sample-apps/react/react-dogfood/hooks/useKeyboardShortcuts.ts
+++ b/sample-apps/react/react-dogfood/hooks/useKeyboardShortcuts.ts
@@ -24,36 +24,39 @@ const isMacOS = () => {
 const [, raiseHandReaction] = defaultReactions;
 
 export const usePushToTalk = (key: string) => {
-  const [isTalking, setIsTalking] = useState(false);
-  const interactedRef = useRef(false);
-
   const { useMicrophoneState } = useCallStateHooks();
-  const { microphone } = useMicrophoneState();
+  const { microphone, isMute } = useMicrophoneState();
+  const hotkeyHandlerRef = useRef<(e: KeyboardEvent) => void>();
+  const enableMicWithPushToTalkPromiseRef = useRef<Promise<void> | null>(null);
+
+  hotkeyHandlerRef.current = (e) => {
+    if (e.metaKey || e.ctrlKey) {
+      return;
+    }
+
+    if (e.type === 'keydown' && isMute) {
+      enableMicWithPushToTalkPromiseRef.current = microphone
+        .enable()
+        .catch(console.error);
+    }
+
+    if (e.type === 'keyup' && enableMicWithPushToTalkPromiseRef.current) {
+      enableMicWithPushToTalkPromiseRef.current
+        .then(() => microphone.disable())
+        .catch(console.error);
+      enableMicWithPushToTalkPromiseRef.current = null;
+    }
+  };
 
   useEffect(() => {
     hotkeys(key, { keyup: true }, (e) => {
-      if (e.metaKey || e.ctrlKey) return;
-
-      if (e.type === 'keydown') {
-        interactedRef.current = true;
-        setIsTalking(true);
-      }
-
-      if (e.type === 'keyup') setIsTalking(false);
+      hotkeyHandlerRef.current?.(e);
     });
 
     return () => {
       hotkeys.unbind(key);
     };
   }, [key]);
-
-  useEffect(() => {
-    if (isTalking) microphone.enable().catch(console.error);
-
-    return () => {
-      if (interactedRef.current) microphone.disable().catch(console.error);
-    };
-  }, [isTalking, microphone]);
 };
 
 export const useKeyboardShortcuts = () => {


### PR DESCRIPTION
This PR fixes the following issues with push-to-talk:

1. Pressing space for push-to-talk conflicted with default browser behavior when there was a focused element on the page (both the focused element and push-to-talk were activated).
2. Pressing space disabled microphone when it was previously manually enabled.
3. Microphone was not always disabled at the end of push-to-talk if you managed to press and let go of the spacebar quickly enough.