### PR TITLE
docs(call-types): update tutorial links

### DIFF
--- a/.github/workflows/vale-doc-lint.yml
+++ b/.github/workflows/vale-doc-lint.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
         with:
+          version: 2.30.0
           # added, diff_context, file, nofilter
           # Default is added: results are filtered for added/modified files. Set to no filter when all files need to be checked.
           # More info: https://github.com/errata-ai/vale-action and https://github.com/reviewdog/reviewdog#filter-mode

--- a/packages/client/docusaurus/docs/javascript/02-guides/05-call-types.mdx
+++ b/packages/client/docusaurus/docs/javascript/02-guides/05-call-types.mdx
@@ -3,6 +3,18 @@ id: configuring-call-types
 title: Call Types
 ---
 
-import CallTypesPage from '../../../shared/video/_call-types.md';
+import CallTypesPage from '../../../shared/video/_call-types.mdx';
+import WithExternalLinks from '../../../shared/video/_withExternalLinks';
 
 <CallTypesPage />
+
+<WithExternalLinks
+  mapping={{
+    '/tutorials/video-calling/':
+      'https://getstream.io/video/sdk/javascript/tutorial/video-calling/',
+    '/tutorials/audio-room/':
+      'https://getstream.io/video/sdk/javascript/tutorial/audio-room/',
+    '/tutorials/livestream/':
+      'https://getstream.io/video/sdk/javascript/tutorial/livestreaming/',
+  }}
+/>

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/05-call-types.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/05-call-types.mdx
@@ -3,6 +3,18 @@ id: configuring-call-types
 title: Call Types
 ---
 
-import CallTypesPage from '../../../shared/video/_call-types.md';
+import CallTypesPage from '../../../shared/video/_call-types.mdx';
+import WithExternalLinks from '../../../shared/video/_withExternalLinks';
 
 <CallTypesPage />
+
+<WithExternalLinks
+  mapping={{
+    '/tutorials/video-calling/':
+      'https://getstream.io/video/sdk/reactnative/tutorial/video-calling/',
+    '/tutorials/audio-room/':
+      'https://getstream.io/video/sdk/reactnative/tutorial/audio-room/',
+    '/tutorials/livestream/':
+      'https://getstream.io/video/sdk/reactnative/tutorial/livestreaming/',
+  }}
+/>


### PR DESCRIPTION
### Overview

Follow-up to #1229. Updates the tutorial links defined in the shared Call Types page for JavaScript and React Native SDKs.