### PR TITLE
feat(react-bindings): allow configuring fallback language

### DIFF
--- a/packages/react-bindings/src/contexts/StreamI18nContext.tsx
+++ b/packages/react-bindings/src/contexts/StreamI18nContext.tsx
@@ -23,6 +23,7 @@ const StreamI18nContext = createContext<StreamI18nContextValue>({
 type CreateI18nParams = {
   i18nInstance?: StreamI18n;
   language?: string;
+  fallbackLanguage?: string;
   translationsOverrides?: TranslationsMap;
 };
 
@@ -44,12 +45,17 @@ export const StreamI18nProvider = ({
 export const useCreateI18n = ({
   i18nInstance,
   language,
+  fallbackLanguage,
   translationsOverrides,
 }: CreateI18nParams) => {
   const [i18n] = useState(
     () =>
       i18nInstance ||
-      new StreamI18n({ currentLanguage: language, translationsOverrides }),
+      new StreamI18n({
+        currentLanguage: language,
+        fallbackLanguage,
+        translationsOverrides,
+      }),
   );
   const [t, setTranslationFn] = useState<StreamI18n['t']>(
     () => defaultTranslationFunction,

--- a/packages/react-bindings/src/i18n/StreamI18n.ts
+++ b/packages/react-bindings/src/i18n/StreamI18n.ts
@@ -12,7 +12,8 @@ export const DEFAULT_NAMESPACE = 'stream-video';
 const DEFAULT_CONFIG = {
   debug: false,
   currentLanguage: DEFAULT_LANGUAGE,
-};
+  fallbackLanguage: false,
+} as const;
 
 const DEFAULT_TRANSLATIONS_REGISTRY = mapToRegistry({}, DEFAULT_NAMESPACE);
 
@@ -21,6 +22,8 @@ export const defaultTranslationFunction = (key: string) => key;
 export type StreamI18nConstructor = {
   /** Language into which the provided strings are translated */
   currentLanguage?: TranslationLanguage;
+  /** Fallback language which will be used if no translation is found for current language */
+  fallbackLanguage?: TranslationLanguage;
   /** Logs info level to console output. Helps find issues with loading not working. */
   debug?: boolean;
   /** Custom translations that will be merged with the defaults provided by the library. */
@@ -37,13 +40,14 @@ export class StreamI18n {
     const {
       debug = DEFAULT_CONFIG.debug,
       currentLanguage = DEFAULT_CONFIG.currentLanguage,
+      fallbackLanguage = DEFAULT_CONFIG.fallbackLanguage,
       translationsOverrides,
     } = options;
 
     this.i18nInstance = i18next.createInstance({
       debug,
       defaultNS: DEFAULT_NAMESPACE,
-      fallbackLng: false,
+      fallbackLng: fallbackLanguage,
       interpolation: { escapeValue: false },
       keySeparator: false,
       lng: currentLanguage,

--- a/sample-apps/react/react-dogfood/components/CallRecordingsPage/CallRecordingsPage.tsx
+++ b/sample-apps/react/react-dogfood/components/CallRecordingsPage/CallRecordingsPage.tsx
@@ -18,7 +18,7 @@ export const CallRecordingsPage = ({
   userToken,
 }: ServerSideCredentialsProps) => {
   const {
-    settings: { language },
+    settings: { language, fallbackLanguage },
   } = useSettings();
   const [recordings, setRecordings] = useState<CallRecording[] | undefined>();
   const [error, setError] = useState<Error | undefined>();
@@ -50,7 +50,11 @@ export const CallRecordingsPage = ({
   }
 
   return (
-    <StreamVideo client={videoClient} language={language}>
+    <StreamVideo
+      client={videoClient}
+      language={language}
+      fallbackLanguage={fallbackLanguage}
+    >
       <DefaultAppHeader />
       <div className="rd__call-recordings-page">
         <div className="rd__call-recordings-page__container">

--- a/sample-apps/react/react-dogfood/context/SettingsContext.tsx
+++ b/sample-apps/react/react-dogfood/context/SettingsContext.tsx
@@ -5,6 +5,7 @@ const defaultState: Settings = {};
 
 export type Settings = {
   language?: string;
+  fallbackLanguage?: string;
 };
 
 export type SettingsContextValue = {
@@ -16,10 +17,11 @@ const SettingsContext = createContext<SettingsContextValue>({
 });
 
 export const SettingsProvider = ({ children }: PropsWithChildren) => {
-  const { language } = useLanguage();
+  const { language, fallbackLanguage } = useLanguage();
 
   const settings: Settings = {
     language,
+    fallbackLanguage,
   };
 
   return (

--- a/sample-apps/react/react-dogfood/hooks/useLanguage.ts
+++ b/sample-apps/react/react-dogfood/hooks/useLanguage.ts
@@ -22,6 +22,7 @@ export const useLanguage = () => {
 
   return {
     language,
+    fallbackLanguage: 'en',
     setLanguage,
   };
 };

--- a/sample-apps/react/react-dogfood/pages/index.tsx
+++ b/sample-apps/react/react-dogfood/pages/index.tsx
@@ -23,7 +23,7 @@ import { useIsDemoEnvironment } from '../context/AppEnvironmentContext';
 export default function Home() {
   const { data: session, status } = useSession();
   const {
-    settings: { language },
+    settings: { language, fallbackLanguage },
   } = useSettings();
 
   useEffect(() => {
@@ -42,6 +42,7 @@ export default function Home() {
     <StreamI18nProvider
       translationsOverrides={translations}
       language={language}
+      fallbackLanguage={fallbackLanguage}
     >
       <HomeContent />
     </StreamI18nProvider>

--- a/sample-apps/react/react-dogfood/pages/join/[callId].tsx
+++ b/sample-apps/react/react-dogfood/pages/join/[callId].tsx
@@ -38,7 +38,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 const CallRoom = (props: ServerSideCredentialsProps) => {
   const router = useRouter();
   const {
-    settings: { language },
+    settings: { language, fallbackLanguage },
   } = useSettings();
   const callId = router.query['callId'] as string;
   const callType = (router.query['type'] as string) || 'default';
@@ -184,6 +184,7 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
       <StreamVideo
         client={client}
         language={language}
+        fallbackLanguage={fallbackLanguage}
         translationsOverrides={appTranslations}
       >
         <StreamCall call={call}>

--- a/sample-apps/react/react-dogfood/pages/leave/[callId].tsx
+++ b/sample-apps/react/react-dogfood/pages/leave/[callId].tsx
@@ -10,13 +10,14 @@ import { useSettings } from '../../context/SettingsContext';
 
 export default function Leave() {
   const {
-    settings: { language },
+    settings: { language, fallbackLanguage },
   } = useSettings();
 
   return (
     <StreamI18nProvider
       translationsOverrides={translations}
       language={language}
+      fallbackLanguage={fallbackLanguage}
     >
       <LeaveContent />
     </StreamI18nProvider>


### PR DESCRIPTION
Currently, `StreamI18nProvider` always sets i18next option `fallbackLng` to false. Instead, we want to be able to configure fallback language.

That comes in handy for react-dogfood, which automatically sets default language to user's navigator language. That means that i18n breaks in this app if user's locale is not one of our supported ones. This is fixed by setting fallback language set to `en`.