### PR TITLE
feat(react-native): add support for kotlin in expo config plugin

### DIFF
--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withMainActivity.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withMainActivity.ts
@@ -98,16 +98,5 @@ describe('withStreamVideoReactNativeSDKAppDelegate', () => {
       },
     };
     expect(() => withMainActivity(config, props)).toThrow();
-
-    config = {
-      name: 'test-app',
-      slug: 'test-app',
-      modResults: {
-        // unsupported language contents
-        language: 'kt',
-        contents: ExpoModulesMainActivity,
-      },
-    };
-    expect(() => withMainActivity(config, props)).toThrow();
   });
 });

--- a/packages/react-native-sdk/expo-config-plugin/src/withMainActivity.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withMainActivity.ts
@@ -8,62 +8,72 @@ const withStreamVideoReactNativeSDKMainActivity: ConfigPlugin<ConfigProps> = (
   props,
 ) => {
   return withMainActivity(configuration, (config) => {
-    if (['java'].includes(config.modResults.language)) {
-      try {
-        /*
-          import com.streamvideo.reactnative.StreamVideoReactNative;
-          import android.util.Rational;
-          import androidx.lifecycle.Lifecycle;
-          import android.app.PictureInPictureParams;
-        */
-        config.modResults.contents = addImports(
+    const isMainActivityJava = config.modResults.language === 'java';
+
+    try {
+      config.modResults.contents = addImports(
+        config.modResults.contents,
+        [
+          'com.streamvideo.reactnative.StreamVideoReactNative',
+          'android.os.Build',
+          'android.util.Rational',
+          'androidx.lifecycle.Lifecycle',
+          'android.app.PictureInPictureParams',
+        ],
+        isMainActivityJava,
+      );
+      config.modResults.contents = addOnPictureInPictureModeChanged(
+        config.modResults.contents,
+        isMainActivityJava,
+      );
+      if (props?.androidPictureInPicture?.enableAutomaticEnter) {
+        config.modResults.contents = addOnUserLeaveHint(
           config.modResults.contents,
-          [
-            'com.streamvideo.reactnative.StreamVideoReactNative',
-            'android.os.Build',
-            'android.util.Rational',
-            'androidx.lifecycle.Lifecycle',
-            'android.app.PictureInPictureParams',
-          ],
-          config.modResults.language === 'java',
-        );
-        config.modResults.contents = addOnPictureInPictureModeChanged(
-          config.modResults.contents,
-        );
-        if (props?.androidPictureInPicture?.enableAutomaticEnter) {
-          config.modResults.contents = addOnUserLeaveHint(
-            config.modResults.contents,
-          );
-        }
-      } catch (error: any) {
-        throw new Error(
-          "Cannot add StreamVideoReactNativeSDK to the project's MainApplication because it's malformed.",
+          isMainActivityJava,
         );
       }
-    } else {
+    } catch (error: any) {
       throw new Error(
-        'Cannot setup StreamVideoReactNativeSDK because the MainApplication is not in Java',
+        "Cannot add StreamVideoReactNativeSDK to the project's MainApplication because it's malformed.",
       );
     }
+
     return config;
   });
 };
 
-function addOnPictureInPictureModeChanged(contents: string) {
+function addOnPictureInPictureModeChanged(contents: string, isJava: boolean) {
   if (
     !contents.includes('StreamVideoReactNative.onPictureInPictureModeChanged')
   ) {
-    const statementToInsert = `
-  @Override
-  public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {
-    super.onPictureInPictureModeChanged(isInPictureInPictureMode);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && getLifecycle().getCurrentState() == Lifecycle.State.CREATED) {
-      // when user clicks on Close button of PIP
-      finishAndRemoveTask();
+    let statementToInsert = '';
+
+    if (isJava) {
+      statementToInsert = `
+      @Override
+      public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && getLifecycle().getCurrentState() == Lifecycle.State.CREATED) {
+          // when user clicks on Close button of PIP
+          finishAndRemoveTask();
+        } else {
+          StreamVideoReactNative.onPictureInPictureModeChanged(isInPictureInPictureMode);
+        }
+      }`;
     } else {
-      StreamVideoReactNative.onPictureInPictureModeChanged(isInPictureInPictureMode);
+      // Kotlin
+      statementToInsert = `         
+      override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
+          super.onPictureInPictureModeChanged(isInPictureInPictureMode)
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && lifecycle.currentState == Lifecycle.State.CREATED) {
+              // when user clicks on Close button of PIP
+              finishAndRemoveTask()
+          } else {
+              StreamVideoReactNative.onPictureInPictureModeChanged(isInPictureInPictureMode)
+          }
+      }`;
     }
-  }`;
+
     contents = addNewLinesToMainActivity(
       contents,
       statementToInsert.trim().split('\n'),
@@ -72,21 +82,35 @@ function addOnPictureInPictureModeChanged(contents: string) {
   return contents;
 }
 
-function addOnUserLeaveHint(contents: string) {
+function addOnUserLeaveHint(contents: string, isJava: boolean) {
   if (
     !contents.includes(
       'StreamVideoReactNative.canAutoEnterPictureInPictureMode',
     )
   ) {
-    const statementToInsert = `
-  @Override
-  public void onUserLeaveHint () {
-    if (StreamVideoReactNative.canAutoEnterPictureInPictureMode) {
-      PictureInPictureParams.Builder builder = new PictureInPictureParams.Builder();
-      builder.setAspectRatio(new Rational(480, 640));
-      enterPictureInPictureMode(builder.build());
+    let statementToInsert = '';
+
+    if (isJava) {
+      statementToInsert = `
+      @Override
+      public void onUserLeaveHint () {
+        if (StreamVideoReactNative.canAutoEnterPictureInPictureMode) {
+          PictureInPictureParams.Builder builder = new PictureInPictureParams.Builder();
+          builder.setAspectRatio(new Rational(480, 640));
+          enterPictureInPictureMode(builder.build());
+        }
+      }`;
+    } else {
+      statementToInsert = `           
+      override fun onUserLeaveHint () {
+        if (StreamVideoReactNative.canAutoEnterPictureInPictureMode) {
+          val builder = PictureInPictureParams.Builder()
+          builder.setAspectRatio(Rational(480, 640))
+          enterPictureInPictureMode(builder.build())
+        }
+      }`;
     }
-  }`;
+
     contents = addNewLinesToMainActivity(
       contents,
       statementToInsert.trim().split('\n'),


### PR DESCRIPTION
Partially resolves #1231 

Hello,

according to our conversation in #1231 , I'm contributing a fix to add support for Kotlin inside MainActivity which ensures that this config plugin works with Expo SDK 50 and React Native 0.73. I already tested this change with Expo SDK 50 Beta and it worked fine for me, except for instantiating the `StreamVideoClient`, but that's an unrelated issue. 

Let me know if anything else needs to be adjusted.