### PR TITLE
fix(ring calls): cancel auto-drop after rejecting a call

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -500,11 +500,12 @@ export class Call {
 
     this.dispatcher.offAll();
 
+    this.state.setCallingState(CallingState.LEFT);
+
     // Call all leave call hooks, e.g. to clean up global event handlers
     this.leaveCallHooks.forEach((hook) => hook());
 
     this.clientStore.unregisterCall(this);
-    this.state.setCallingState(CallingState.LEFT);
 
     this.camera.removeSubscriptions();
     this.microphone.removeSubscriptions();


### PR DESCRIPTION
The state of the call was previously updated after call listeners were detached. This will create no impact on the state of the call. This PR tends to fix this issue.