### PR TITLE
fix(sfu): ensure SFU WebSocket is closed

### DIFF
--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -215,7 +215,7 @@ export class StreamSfuClient {
     reason: string = 'js-client: requested signal connection close',
   ) => {
     this.logger('debug', 'Closing SFU WS connection', code, reason);
-    if (this.signalWs.readyState === this.signalWs.CLOSED) {
+    if (this.signalWs.readyState !== this.signalWs.CLOSED) {
       this.signalWs.close(code, reason);
     }
 


### PR DESCRIPTION
### Overview

Fixes a regression introduced with #1212 where the status of the underlying SFU WebSocket was incorrectly checked.