### PR TITLE
fix(react-sdk): handle external full-screen toggling

### DIFF
--- a/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListingItem.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListingItem.tsx
@@ -222,6 +222,18 @@ export const ParticipantActionsContextMenu = ({
   };
 
   useEffect(() => {
+    // handles the case when fullscreen mode is toggled externally,
+    // e.g., by pressing ESC key or some other keyboard shortcut
+    const handleFullscreenChange = () => {
+      setFullscreenModeOn(!!document.fullscreenElement);
+    };
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!videoElement) return;
 
     const handlePictureInPicture = () => {


### PR DESCRIPTION
### Overview

Adds event handlers for the [`fullscreenchange`](https://developer.mozilla.org/en-US/docs/Web/API/Element/fullscreenchange_event) event.
Before this, the internal component state didn't update when fullscreen was toggled with keyboard shortcuts.