### PR TITLE
feat(client): add stopOnLeave param to device manager

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -512,6 +512,18 @@ export class Call {
     this.microphone.removeSubscriptions();
     this.screenShare.removeSubscriptions();
     this.speaker.removeSubscriptions();
+
+    const stopOnLeavePromises: Promise<void>[] = [];
+    if (this.camera.stopOnLeave) {
+      stopOnLeavePromises.push(this.camera.disable(true));
+    }
+    if (this.microphone.stopOnLeave) {
+      stopOnLeavePromises.push(this.microphone.disable(true));
+    }
+    if (this.screenShare.stopOnLeave) {
+      stopOnLeavePromises.push(this.screenShare.disable(true));
+    }
+    await Promise.all(stopOnLeavePromises);
   };
 
   /**

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -23,7 +23,7 @@ export abstract class InputMediaDeviceManager<
   /**
    * if true, stops the media stream when call is left
    */
-  stopOnLeave = false;
+  stopOnLeave = true;
   logger: Logger;
   private subscriptions: Subscription[] = [];
   private isTrackStoppedDueToTrackEnd = false;

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -20,6 +20,10 @@ export abstract class InputMediaDeviceManager<
    * @internal
    */
   disablePromise?: Promise<void>;
+  /**
+   * if true, stops the media stream when call is left
+   */
+  stopOnLeave = false;
   logger: Logger;
   private subscriptions: Subscription[] = [];
   private isTrackStoppedDueToTrackEnd = false;
@@ -67,12 +71,13 @@ export abstract class InputMediaDeviceManager<
   }
 
   /**
-   * Stops the stream.
+   * Stops or pauses the stream based on state.disableMode
+   * @param {boolean} [forceStop=false] when true, stops the tracks regardless of the state.disableMode
    */
-  async disable() {
+  async disable(forceStop: boolean = false) {
     this.state.prevStatus = this.state.status;
-    if (this.state.status === 'disabled') return;
-    const stopTracks = this.state.disableMode === 'stop-tracks';
+    if (!forceStop && this.state.status === 'disabled') return;
+    const stopTracks = forceStop || this.state.disableMode === 'stop-tracks';
     this.disablePromise = this.muteStream(stopTracks);
     try {
       await this.disablePromise;

--- a/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
+++ b/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
@@ -123,6 +123,19 @@ describe('InputMediaDeviceManager.test', () => {
     expect(manager.stopPublishStream).toHaveBeenCalledWith(true);
   });
 
+  it('disable device with forceStop', async () => {
+    manager['call'].state.setCallingState(CallingState.JOINED);
+    await manager.enable();
+
+    expect(manager.state.mediaStream).toBeDefined();
+
+    await manager.disable(true);
+
+    expect(manager.stopPublishStream).toHaveBeenCalledWith(true);
+    expect(manager.state.mediaStream).toBeUndefined();
+    expect(manager.state.status).toBe('disabled');
+  });
+
   it('toggle device', async () => {
     vi.spyOn(manager, 'disable');
     vi.spyOn(manager, 'enable');

--- a/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
@@ -113,6 +113,20 @@ describe('MicrophoneManager', () => {
     expect(manager.state.mediaStream!.getAudioTracks()[0].enabled).toBe(false);
   });
 
+  it('disable mic with forceStop should remove the stream', async () => {
+    await manager.enable();
+
+    expect(manager.state.mediaStream!.getAudioTracks()[0].enabled).toBe(true);
+
+    await manager.disable();
+
+    expect(manager.state.mediaStream!.getAudioTracks()[0].enabled).toBe(false);
+
+    await manager.disable(true);
+
+    expect(manager.state.mediaStream).toBeUndefined();
+  });
+
   it(`should start sound detection if mic is disabled`, async () => {
     await manager.enable();
     // @ts-expect-error


### PR DESCRIPTION
## Goal

Adds a parameter to device manager to enable automatically stopping streams when call is left

fixes #1236