### PR TITLE
feat(speakers): Participant audio output levels

### DIFF
--- a/packages/client/docusaurus/docs/javascript/02-guides/03-call-and-participant-state.mdx
+++ b/packages/client/docusaurus/docs/javascript/02-guides/03-call-and-participant-state.mdx
@@ -83,34 +83,35 @@ If you want to display information about the joined participants of the call you
 
 The `StreamVideoParticipant` object contains the following information:
 
-| Name                      | Description                                                                 |
-| ------------------------- | --------------------------------------------------------------------------- |
-| `user`                    | The user object for this participant.                                       |
-| `publishedTracks`         | The track types the participant is currently publishing                     |
-| `joinedAt`                | The time the participant joined the call.                                   |
-| `connectionQuality`       | The participant's connection quality.                                       |
-| `isSpeaking`              | It's `true` if the participant is currently speaking.                       |
-| `isDominantSpeaker`       | It's `true` if the participant is the current dominant speaker in the call. |
-| `audioLevel`              | The audio level of the participant.                                         |
-| `audioStream`             | The published audio `MediaStream`.                                          |
-| `videoStream`             | The published video `MediaStream`.                                          |
-| `screenShareStream`       | The published screen share `MediaStream`.                                   |
-| `screenShareAudioStream`  | The published screen share audio `MediaStream`.                             |
-| `isLocalParticipant`      | It's `true` if the participant is the local participant.                    |
-| `pin`                     | Holds pinning information.                                                  |
-| `reaction`                | The last reaction this user has sent to this call.                          |
-| `viewportVisibilityState` | The viewport visibility state of the participant.                           |
+| Name                      | Description                                                                      |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| `audioLevel`              | The audio level of the participant (determined on the server).                   |
+| `audioStream`             | The published audio `MediaStream`.                                               |
+| `audioVolume`             | The audio volume level of the participant (overridable local audioVolume level). |
+| `connectionQuality`       | The participant's connection quality.                                            |
+| `isDominantSpeaker`       | It's `true` if the participant is the current dominant speaker in the call.      |
+| `isLocalParticipant`      | It's `true` if the participant is the local participant.                         |
+| `isSpeaking`              | It's `true` if the participant is currently speaking.                            |
+| `joinedAt`                | The time the participant joined the call.                                        |
+| `pin`                     | Holds pinning information.                                                       |
+| `publishedTracks`         | The track types the participant is currently publishing                          |
+| `reaction`                | The last reaction this user has sent to this call.                               |
+| `screenShareAudioStream`  | The published screen share audio `MediaStream`.                                  |
+| `screenShareStream`       | The published screen share `MediaStream`.                                        |
+| `user`                    | The user object for this participant.                                            |
+| `videoStream`             | The published video `MediaStream`.                                               |
+| `viewportVisibilityState` | The viewport visibility state of the participant.                                |
 
 ## Client state
 
 The client state can be accessed by `client.state`.
 
-Here are the list of client state properties:
+Here is the list of client state properties:
 
-| Reactie value    | Static value    | Description                                                                                                                                 |
-| ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `connectedUser$` | `connectedUser` | Returns the connected user.                                                                                                                 |
-| `calls$`         | `calls`         | A list of all notifications about created calls. These calls can be outgoing (I have called somebody) or incoming (somebody has called me). |
+| Reactie value    | Static value    | Description                                                                                                                                                                     |
+| ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `connectedUser$` | `connectedUser` | Returns the connected user.                                                                                                                                                     |
+| `calls$`         | `calls`         | A list of all tracked calls. These calls can be outgoing (I have called somebody) or incoming (somebody has called me). Loaded calls (`call.get()`) are also part of this list. |
 
 The `UserResponse` contains the following properties:
 

--- a/packages/client/docusaurus/docs/javascript/02-guides/04-camera-and-microphone.mdx
+++ b/packages/client/docusaurus/docs/javascript/02-guides/04-camera-and-microphone.mdx
@@ -303,3 +303,22 @@ call.speaker.state.volume$.subscribe((volume) => {
   console.log(volume);
 });
 ```
+
+### Set participant volume
+
+You can control the volume of a specific participant in the call:
+
+```typescript
+import { StreamVideoParticipant } from '@stream-io/video-client';
+
+let p: StreamVideoParticipant;
+
+// will set the volume of the participant to 50%
+call.speaker.setParticipantVolume(p.sessionId, 0.5);
+
+// will mute the participant
+call.speaker.setParticipantVolume(p.sessionId, 0);
+
+// will reset the volume to the default value
+call.speaker.setParticipantVolume(p.sessionId, undefined);
+```

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -283,7 +283,7 @@ export class Call {
 
     this.camera = new CameraManager(this);
     this.microphone = new MicrophoneManager(this);
-    this.speaker = new SpeakerManager();
+    this.speaker = new SpeakerManager(this);
     this.screenShare = new ScreenShareManager(this);
   }
 

--- a/packages/client/src/devices/SpeakerManager.ts
+++ b/packages/client/src/devices/SpeakerManager.ts
@@ -1,4 +1,5 @@
-import { Subscription, combineLatest } from 'rxjs';
+import { combineLatest, Subscription } from 'rxjs';
+import { Call } from '../Call';
 import { isReactNative } from '../helpers/platforms';
 import { SpeakerState } from './SpeakerState';
 import { deviceIds$, getAudioOutputDevices } from './devices';
@@ -6,8 +7,10 @@ import { deviceIds$, getAudioOutputDevices } from './devices';
 export class SpeakerManager {
   public readonly state = new SpeakerState();
   private subscriptions: Subscription[] = [];
+  private readonly call: Call;
 
-  constructor() {
+  constructor(call: Call) {
+    this.call = call;
     if (deviceIds$ && !isReactNative()) {
       this.subscriptions.push(
         combineLatest([deviceIds$!, this.state.selectedDevice$]).subscribe(
@@ -39,7 +42,7 @@ export class SpeakerManager {
   }
 
   /**
-   * Select device
+   * Select a device.
    *
    * Note: this method is not supported in React Native
    *
@@ -58,7 +61,7 @@ export class SpeakerManager {
 
   /**
    * Set the volume of the audio elements
-   * @param volume a number between 0 and 1
+   * @param volume a number between 0 and 1.
    *
    * Note: this method is not supported in React Native
    */
@@ -70,5 +73,23 @@ export class SpeakerManager {
       throw new Error('Volume must be between 0 and 1');
     }
     this.state.setVolume(volume);
+  }
+
+  /**
+   * Set the volume of a participant.
+   *
+   * Note: this method is not supported in React Native.
+   *
+   * @param sessionId the participant's session id.
+   * @param volume a number between 0 and 1. Set it to `undefined` to use the default volume.
+   */
+  setParticipantVolume(sessionId: string, volume: number | undefined) {
+    if (isReactNative()) {
+      throw new Error('This feature is not supported in React Native');
+    }
+    if (volume && (volume < 0 || volume > 1)) {
+      throw new Error('Volume must be between 0 and 1, or undefined');
+    }
+    this.call.state.updateParticipant(sessionId, { audioVolume: volume });
   }
 }

--- a/packages/client/src/devices/__tests__/SpeakerManager.test.ts
+++ b/packages/client/src/devices/__tests__/SpeakerManager.test.ts
@@ -79,8 +79,12 @@ describe('SpeakerManager.test', () => {
     });
 
     manager.setParticipantVolume('session-id', 0.5);
-    const participant = call.state.findParticipantBySessionId('session-id');
+    let participant = call.state.findParticipantBySessionId('session-id');
     expect(participant!.audioVolume).toBe(0.5);
+
+    manager.setParticipantVolume('session-id', undefined);
+    participant = call.state.findParticipantBySessionId('session-id');
+    expect(participant!.audioVolume).toBe(undefined);
 
     expect(() => manager.setParticipantVolume('session-id', 2)).toThrowError();
     expect(() => manager.setParticipantVolume('session-id', -1)).toThrowError();

--- a/packages/client/src/devices/__tests__/SpeakerManager.test.ts
+++ b/packages/client/src/devices/__tests__/SpeakerManager.test.ts
@@ -1,8 +1,11 @@
-import { afterEach, beforeEach, describe, vi, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { emitDeviceIds, mockAudioDevices, mockDeviceIds$ } from './mocks';
 import { of } from 'rxjs';
 import { SpeakerManager } from '../SpeakerManager';
 import { checkIfAudioOutputChangeSupported } from '../devices';
+import { Call } from '../../Call';
+import { StreamClient } from '../../coordinator/connection/client';
+import { StreamVideoWriteableStateStore } from '../../store';
 
 vi.mock('../devices.ts', () => {
   console.log('MOCKING devices');
@@ -17,7 +20,14 @@ describe('SpeakerManager.test', () => {
   let manager: SpeakerManager;
 
   beforeEach(() => {
-    manager = new SpeakerManager();
+    manager = new SpeakerManager(
+      new Call({
+        id: '',
+        type: '',
+        streamClient: new StreamClient('abc123'),
+        clientStore: new StreamVideoWriteableStateStore(),
+      }),
+    );
   });
 
   it('list devices', () => {
@@ -58,6 +68,22 @@ describe('SpeakerManager.test', () => {
     manager.setVolume(0.5);
 
     expect(manager.state.volume).toBe(0.5);
+  });
+
+  it('set participant volume', () => {
+    const call = manager['call'];
+    // @ts-expect-error - incomplete data
+    call.state.updateOrAddParticipant('session-id', {
+      audioVolume: undefined,
+      sessionId: 'session-id',
+    });
+
+    manager.setParticipantVolume('session-id', 0.5);
+    const participant = call.state.findParticipantBySessionId('session-id');
+    expect(participant!.audioVolume).toBe(0.5);
+
+    expect(() => manager.setParticipantVolume('session-id', 2)).toThrowError();
+    expect(() => manager.setParticipantVolume('session-id', -1)).toThrowError();
   });
 
   it('should disable device if selected device is disconnected', () => {

--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -8,6 +8,7 @@ import {
 } from '../types';
 import { TrackType, VideoDimension } from '../gen/video/sfu/models/models';
 import {
+  combineLatest,
   distinctUntilChanged,
   distinctUntilKeyChanged,
   map,
@@ -384,11 +385,12 @@ export class DynascaleManager {
           }
         });
 
-    const volumeSubscription = this.call.speaker.state.volume$.subscribe(
-      (volume) => {
-        audioElement.volume = volume;
-      },
-    );
+    const volumeSubscription = combineLatest([
+      this.call.speaker.state.volume$,
+      participant$.pipe(distinctUntilKeyChanged('audioVolume')),
+    ]).subscribe(([volume, p]) => {
+      audioElement.volume = p.audioVolume ?? volume;
+    });
 
     audioElement.autoplay = true;
 

--- a/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
+++ b/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
@@ -148,7 +148,12 @@ describe('DynascaleManager', () => {
       );
 
       call.speaker.setVolume(0.5);
+      expect(audioElement.volume).toBe(0.5);
 
+      call.speaker.setParticipantVolume('session-id', 0.7);
+      expect(audioElement.volume).toBe(0.7);
+
+      call.speaker.setParticipantVolume('session-id', undefined);
       expect(audioElement.volume).toBe(0.5);
 
       cleanup?.();

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -88,6 +88,14 @@ export interface StreamVideoParticipant extends Participant {
    * The visibility state of the participant's tracks within a defined viewport.
    */
   viewportVisibilityState?: Record<VideoTrackType, VisibilityState>;
+
+  /**
+   * The volume of the participant's audio stream (from 0 to 1).
+   * Set it to `undefined` to use the default volume.
+   *
+   * Note: this value is not applicable in React Native.
+   */
+  audioVolume?: number;
 }
 
 export type VideoTrackType = 'videoTrack' | 'screenShareTrack';

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/03-call-and-participant-state.mdx
@@ -7,7 +7,7 @@ You can access call, participant and client state using hooks. These hooks are r
 
 ## Call state
 
-To observe call state you need to provide a `Call` instance to the [`StreamCall` component](../../ui-components/core/stream-call).
+To observe call state, you need to provide a `Call` instance to the [`StreamCall` component](../../ui-components/core/stream-call).
 
 Let's see an example where we use the `useCall`, `useCallCallingState` and `useParticipants` hooks to display some basic information about the call:
 
@@ -140,23 +140,24 @@ const MyCallUI = () => {
 
 The `StreamVideoParticipant` object contains the following information:
 
-| Name                      | Description                                                                 |
-| ------------------------- | --------------------------------------------------------------------------- |
-| `user`                    | The user object for this participant.                                       |
-| `publishedTracks`         | The track types the participant is currently publishing                     |
-| `joinedAt`                | The time the participant joined the call.                                   |
-| `connectionQuality`       | The participant's connection quality.                                       |
-| `isSpeaking`              | It's `true` if the participant is currently speaking.                       |
-| `isDominantSpeaker`       | It's `true` if the participant is the current dominant speaker in the call. |
-| `audioLevel`              | The audio level of the participant.                                         |
-| `audioStream`             | The published audio `MediaStream`.                                          |
-| `videoStream`             | The published video `MediaStream`.                                          |
-| `screenShareStream`       | The published screen share `MediaStream`.                                   |
-| `screenShareAudioStream`  | The published screen share audio `MediaStream`.                             |
-| `isLocalParticipant`      | It's `true` if the participant is the local participant.                    |
-| `pin`                     | Holds pinning information.                                                  |
-| `reaction`                | The last reaction this user has sent to this call.                          |
-| `viewportVisibilityState` | The viewport visibility state of the participant.                           |
+| Name                      | Description                                                                      |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| `audioLevel`              | The audio level of the participant (determined on the server).                   |
+| `audioStream`             | The published audio `MediaStream`.                                               |
+| `audioVolume`             | The audio volume level of the participant (overridable local audioVolume level). |
+| `connectionQuality`       | The participant's connection quality.                                            |
+| `isDominantSpeaker`       | It's `true` if the participant is the current dominant speaker in the call.      |
+| `isLocalParticipant`      | It's `true` if the participant is the local participant.                         |
+| `isSpeaking`              | It's `true` if the participant is currently speaking.                            |
+| `joinedAt`                | The time the participant joined the call.                                        |
+| `pin`                     | Holds pinning information.                                                       |
+| `publishedTracks`         | The track types the participant is currently publishing                          |
+| `reaction`                | The last reaction this user has sent to this call.                               |
+| `screenShareAudioStream`  | The published screen share audio `MediaStream`.                                  |
+| `screenShareStream`       | The published screen share `MediaStream`.                                        |
+| `user`                    | The user object for this participant.                                            |
+| `videoStream`             | The published video `MediaStream`.                                               |
+| `viewportVisibilityState` | The viewport visibility state of the participant.                                |
 
 ## Client state
 
@@ -189,13 +190,13 @@ const MyHeader = () => {
 
 This approach makes it possible to access the client state and be notified about changes anywhere in your application without having to manually subscribe to WebSocket events.
 
-Here are the list of client-state hooks:
+Here is the list of client-state hooks:
 
-| Name                   | Description                                                                                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `useStreamVideoClient` | The `StreamVideoClient` instance.                                                                                                           |
-| `useConnectedUser`     | Returns the connected user.                                                                                                                 |
-| `useCalls`             | A list of all notifications about created calls. These calls can be outgoing (I have called somebody) or incoming (somebody has called me). |
+| Name                   | Description                                                                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useStreamVideoClient` | The `StreamVideoClient` instance.                                                                                                                                               |
+| `useConnectedUser`     | Returns the connected user.                                                                                                                                                     |
+| `useCalls`             | A list of all tracked calls. These calls can be outgoing (I have called somebody) or incoming (somebody has called me). Loaded calls (`call.get()`) are also part of this list. |
 
 The `UserResponse` contains the following properties:
 

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/04-camera-and-microphone.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/04-camera-and-microphone.mdx
@@ -208,6 +208,29 @@ const { speaker } = useSpeakerState();
 speaker.setVolume(0.5); // 0.5 is 50% of the maximum volume
 ```
 
+### Set participant volume
+
+```typescript
+import {
+  useCallStateHooks,
+  StreamVideoParticipant,
+} from '@stream-io/video-react-sdk';
+
+let p: StreamVideoParticipant;
+
+const { useSpeakerState } = useCallStateHooks();
+const { speaker } = useSpeakerState();
+
+// will set the volume of the participant to 50%
+speaker.setParticipantVolume(p.sessionId, 0.5);
+
+// will mute the participant
+speaker.setParticipantVolume(p.sessionId, 0);
+
+// will reset the volume to the default value
+speaker.setParticipantVolume(p.sessionId, undefined);
+```
+
 ## Persisting user's device preferences
 
 For user's convenience, you might want to persist the user's choices for the camera, microphone and speaker devices across sessions.


### PR DESCRIPTION
### Overview

Adds new API that allows control over the individual participant's audio output level.

**Example (Plain-JS):**
```typescript
// will set the volume of the participant to 50%
call.speaker.setParticipantVolume(p.sessionId, 0.5);
```

**Example (React):**
```typescript
const { useSpeakerState } = useCallStateHooks();
const { speaker } = useSpeakerState();

// will set the volume of the participant to 50%
speaker.setParticipantVolume(p.sessionId, 0.5);
```
