### PR TITLE
fix: remove automatic call leave in call content

### DIFF
--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -136,24 +136,12 @@ export const CallContent = ({
    */
   useIncallManager({ media: 'video', auto: true });
 
-  const call = useCall();
-  const activeCallRef = useRef(call);
-  activeCallRef.current = call;
-
   const handleFloatingViewParticipantSwitch = () => {
     if (remoteParticipants.length !== 1) {
       return;
     }
     setShowRemoteParticipantInFloatingView((prevState) => !prevState);
   };
-
-  useEffect(() => {
-    return () => {
-      if (activeCallRef.current?.state.callingState !== CallingState.LEFT) {
-        activeCallRef.current?.leave();
-      }
-    };
-  }, []);
 
   const participantViewProps: ParticipantViewComponentProps = {
     ParticipantLabel: isInPiPMode ? null : ParticipantLabel,

--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
 import {
   CallTopView as DefaultCallTopView,
@@ -15,8 +15,8 @@ import {
   CallControls as DefaultCallControls,
   HangUpCallButtonProps,
 } from '../CallControls';
-import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
-import { CallingState, StreamReaction } from '@stream-io/video-client';
+import { useCallStateHooks } from '@stream-io/video-react-bindings';
+import { StreamReaction } from '@stream-io/video-client';
 import { useIncallManager } from '../../../hooks';
 import { Z_INDEX } from '../../../constants';
 import { useDebouncedValue } from '../../../utils/hooks';

--- a/sample-apps/react-native/dogfood/src/components/MeetingUI.tsx
+++ b/sample-apps/react-native/dogfood/src/components/MeetingUI.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import {
   CallingState,
@@ -31,6 +31,16 @@ export const MeetingUI = ({ callId, navigation, route }: Props) => {
   const call = useCall();
   const { useCallCallingState } = useCallStateHooks();
   const callingState = useCallCallingState();
+
+  // Leave the call if the call is not left and the component is unmounted.
+  useEffect(() => {
+    return () => {
+      if (call && call.state.callingState !== CallingState.LEFT) {
+        call.leave();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const returnToHomeHandler = () => {
     navigation.navigate('JoinMeetingScreen');

--- a/sample-apps/react-native/dogfood/src/navigators/Call.tsx
+++ b/sample-apps/react-native/dogfood/src/navigators/Call.tsx
@@ -2,9 +2,11 @@ import React, { useCallback, useEffect } from 'react';
 import JoinCallScreen from '../screens/Call/JoinCallScreen';
 
 import {
+  CallingState,
   RingingCallContent,
   StreamCall,
   useCalls,
+  Call as StreamCallType,
 } from '@stream-io/video-react-native-sdk';
 import { Alert, StyleSheet } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -47,11 +49,24 @@ const Calls = () => {
 
   return (
     <StreamCall call={firstCall}>
+      <CallLeaveOnUnmount call={firstCall} />
       <SafeAreaView style={[styles.container, { top }]}>
         <RingingCallContent landscape={orientation === 'landscape'} />
       </SafeAreaView>
     </StreamCall>
   );
+};
+
+const CallLeaveOnUnmount = ({ call }: { call: StreamCallType }) => {
+  useEffect(() => {
+    return () => {
+      if (call && call.state.callingState !== CallingState.LEFT) {
+        call.leave();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
 };
 
 export const Call = () => {

--- a/sample-apps/react-native/expo-video-sample/app/ringing.tsx
+++ b/sample-apps/react-native/expo-video-sample/app/ringing.tsx
@@ -2,6 +2,8 @@ import {
   useCalls,
   StreamCall,
   RingingCallContent,
+  CallingState,
+  Call,
 } from '@stream-io/video-react-native-sdk';
 import { useEffect } from 'react';
 import { Alert, StyleSheet } from 'react-native';
@@ -34,12 +36,25 @@ export default function JoinRingingCallScreen() {
 
   return (
     <StreamCall call={firstCall}>
+      <CallLeaveOnUnmount call={firstCall} />
       <SafeAreaView style={styles.flexedContainer}>
         <RingingCallContent />
       </SafeAreaView>
     </StreamCall>
   );
 }
+
+const CallLeaveOnUnmount = ({ call }: { call: Call }) => {
+  useEffect(() => {
+    return () => {
+      if (call && call.state.callingState !== CallingState.LEFT) {
+        call.leave();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
+};
 
 const styles = StyleSheet.create({
   flexedContainer: {

--- a/sample-apps/react-native/expo-video-sample/components/MeetingUI.tsx
+++ b/sample-apps/react-native/expo-video-sample/components/MeetingUI.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   CallContent,
   CallingState,
   Lobby,
+  useCall,
   useCallStateHooks,
 } from '@stream-io/video-react-native-sdk';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -13,6 +14,18 @@ import { CallControlsComponent } from './CallControlsComponent';
 export const MeetingUI = () => {
   const { useCallCallingState } = useCallStateHooks();
   const callingState = useCallCallingState();
+
+  const call = useCall();
+
+  // Leave the call if the call is not left and the component is unmounted.
+  useEffect(() => {
+    return () => {
+      if (call && call.state.callingState !== CallingState.LEFT) {
+        call.leave();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (callingState === CallingState.IDLE) {
     return <Lobby />;


### PR DESCRIPTION
Currently callcontent component automatically leaves the call on unmount. This is undesired if an integrator wants to keep the call alive, for example only the audio track.. with a minimised call kinda view.. 

this PR removes that behaviour 