### PR TITLE
chore: do not run rn sample app deployment unnecessarily

### DIFF
--- a/.github/workflows/react-native-workflow.yml
+++ b/.github/workflows/react-native-workflow.yml
@@ -20,6 +20,18 @@ env:
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/react-native-workflow.yml'
+      - 'sample-apps/react-native/dogfood/**'
+      - 'packages/react-native-sdk'
+      - '!**.md'
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     paths:
       - '.github/workflows/react-native-workflow.yml'
       - 'sample-apps/react-native/dogfood/**'
@@ -27,7 +39,7 @@ on:
       - 'packages/react-bindings/**'
       - 'packages/react-native-sdk/**'
       - '!**/docusaurus/**'
-
+      - '!**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/react-native-workflow.yml
+++ b/.github/workflows/react-native-workflow.yml
@@ -23,9 +23,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/react-native-workflow.yml'
       - 'sample-apps/react-native/dogfood/**'
-      - 'packages/react-native-sdk'
       - '!**.md'
   pull_request:
     types:


### PR DESCRIPTION
Currently RN sample app deployment runs on all package changes in main

With this PR it only runs on a dogfood path change..

so if we want a app/play store release, we need to make a version change in the dogfood app's package.json and push to main