### PR TITLE
fix(react-native): floating participant speaking border jump issue

### DIFF
--- a/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
+++ b/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
@@ -161,7 +161,6 @@ export const FloatingParticipantView = ({
                   styles.participantViewContainer,
                   style,
                   {
-                    backgroundColor: colors.static_grey,
                     shadowColor: colors.static_black,
                   },
                   floatingParticipantsView.participantViewContainer,
@@ -199,7 +198,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.23,
     shadowRadius: 2.62,
     elevation: 4,
-    borderWidth: 0,
   },
   videoFallback: {
     ...StyleSheet.absoluteFillObject,


### PR DESCRIPTION
This PR fixes the jumping issue when the participant speaks. 

Video after fixing the issue 

https://github.com/GetStream/stream-video-js/assets/39884168/4f7c1a3f-aeed-4e66-93c8-0b3a31625333