### PR TITLE
fix(react-native): react-native-callkeep optional dependency import issue in SDK

### DIFF
--- a/packages/react-native-sdk/src/utils/push/libs/callkeep.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/callkeep.ts
@@ -2,6 +2,10 @@ export type RNCallKeepType = typeof import('react-native-callkeep').default;
 
 let callkeep: RNCallKeepType | undefined;
 
+try {
+  callkeep = require('react-native-callkeep').default;
+} catch (_e) {}
+
 export function getCallKeepLib() {
   if (!callkeep) {
     throw Error(


### PR DESCRIPTION
Fixes the issue of not being able to import and use `react-native-callkeep` as an optional dependency in the SDK. This bug was introduced in the previous version of the SDK.