### PR TITLE
feat: SFU stats reporting

### DIFF
--- a/.github/workflows/react-native-workflow.yml
+++ b/.github/workflows/react-native-workflow.yml
@@ -132,7 +132,7 @@ jobs:
     name: Deploy iOS
     needs: build_ios
     timeout-minutes: 60
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/call-stats-reporter' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -269,7 +269,7 @@ jobs:
     name: Deploy Android
     needs: build_android
     timeout-minutes: 60
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/call-stats-reporter' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/react-native-workflow.yml
+++ b/.github/workflows/react-native-workflow.yml
@@ -132,7 +132,7 @@ jobs:
     name: Deploy iOS
     needs: build_ios
     timeout-minutes: 60
-    if: ${{ github.ref == 'refs/heads/call-stats-reporter' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -269,7 +269,7 @@ jobs:
     name: Deploy Android
     needs: build_android
     timeout-minutes: 60
-    if: ${{ github.ref == 'refs/heads/call-stats-reporter' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -18,6 +18,7 @@ import { JoinRequest, SfuRequest } from './gen/video/sfu/event/events';
 import {
   ICERestartRequest,
   SendAnswerRequest,
+  SendStatsRequest,
   SetPublisherRequest,
   TrackSubscriptionDetails,
   UpdateMuteStatesRequest,
@@ -295,6 +296,17 @@ export class StreamSfuClient {
       () =>
         this.rpc.updateMuteStates({
           ...data,
+          sessionId: this.sessionId,
+        }),
+      this.logger,
+    );
+  };
+
+  sendStats = async (stats: Omit<SendStatsRequest, 'sessionId'>) => {
+    return retryable(
+      () =>
+        this.rpc.sendStats({
+          ...stats,
           sessionId: this.sessionId,
         }),
       this.logger,

--- a/packages/client/src/client-details.ts
+++ b/packages/client/src/client-details.ts
@@ -2,9 +2,14 @@ import { ClientDetails, Device, OS, Sdk } from './gen/video/sfu/models/models';
 import { isReactNative } from './helpers/platforms';
 import { UAParser } from 'ua-parser-js';
 
+type WebRTCInfoType = {
+  version: string;
+};
+
 let sdkInfo: Sdk | undefined;
 let osInfo: OS | undefined;
 let deviceInfo: Device | undefined;
+let webRtcInfo: WebRTCInfoType | undefined;
 
 export const setSdkInfo = (info: Sdk) => {
   sdkInfo = info;
@@ -30,13 +35,26 @@ export const getDeviceInfo = () => {
   return deviceInfo;
 };
 
-export const getClientDetails = (): ClientDetails => {
+export const getWebRTCInfo = () => {
+  return webRtcInfo;
+};
+
+export const setWebRTCInfo = (info: WebRTCInfoType) => {
+  webRtcInfo = info;
+};
+
+export type LocalClientDetailsType = ClientDetails & {
+  webRTCInfo?: WebRTCInfoType;
+};
+
+export const getClientDetails = (): LocalClientDetailsType => {
   if (isReactNative()) {
     // Since RN doesn't support web, sharing browser info is not required
     return {
       sdk: getSdkInfo(),
       os: getOSInfo(),
       device: getDeviceInfo(),
+      webRTCInfo: getWebRTCInfo(),
     };
   }
 

--- a/packages/client/src/client-details.ts
+++ b/packages/client/src/client-details.ts
@@ -54,7 +54,6 @@ export const getClientDetails = (): LocalClientDetailsType => {
       sdk: getSdkInfo(),
       os: getOSInfo(),
       device: getDeviceInfo(),
-      webRTCInfo: getWebRTCInfo(),
     };
   }
 

--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -2752,6 +2752,12 @@ export interface JoinCallResponse {
    * @memberof JoinCallResponse
    */
   own_capabilities: Array<OwnCapability>;
+  /**
+   *
+   * @type {StatsOptions}
+   * @memberof JoinCallResponse
+   */
+  stats_options: StatsOptions;
 }
 /**
  *
@@ -3858,6 +3864,19 @@ export interface StartTranscriptionResponse {
    * @memberof StartTranscriptionResponse
    */
   duration: string;
+}
+/**
+ *
+ * @export
+ * @interface StatsOptions
+ */
+export interface StatsOptions {
+  /**
+   *
+   * @type {number}
+   * @memberof StatsOptions
+   */
+  reporting_interval_ms: number;
 }
 /**
  *

--- a/packages/client/src/gen/video/sfu/signal_rpc/signal.client.ts
+++ b/packages/client/src/gen/video/sfu/signal_rpc/signal.client.ts
@@ -15,6 +15,8 @@ import type {
   ICETrickleResponse,
   SendAnswerRequest,
   SendAnswerResponse,
+  SendStatsRequest,
+  SendStatsResponse,
   SetPublisherRequest,
   SetPublisherResponse,
   UpdateMuteStatesRequest,
@@ -80,6 +82,13 @@ export interface ISignalServerClient {
     input: ICERestartRequest,
     options?: RpcOptions,
   ): UnaryCall<ICERestartRequest, ICERestartResponse>;
+  /**
+   * @generated from protobuf rpc: SendStats(stream.video.sfu.signal.SendStatsRequest) returns (stream.video.sfu.signal.SendStatsResponse);
+   */
+  sendStats(
+    input: SendStatsRequest,
+    options?: RpcOptions,
+  ): UnaryCall<SendStatsRequest, SendStatsResponse>;
 }
 /**
  * @generated from protobuf service stream.video.sfu.signal.SignalServer
@@ -190,6 +199,23 @@ export class SignalServerClient implements ISignalServerClient, ServiceInfo {
     const method = this.methods[5],
       opt = this._transport.mergeOptions(options);
     return stackIntercept<ICERestartRequest, ICERestartResponse>(
+      'unary',
+      this._transport,
+      method,
+      opt,
+      input,
+    );
+  }
+  /**
+   * @generated from protobuf rpc: SendStats(stream.video.sfu.signal.SendStatsRequest) returns (stream.video.sfu.signal.SendStatsResponse);
+   */
+  sendStats(
+    input: SendStatsRequest,
+    options?: RpcOptions,
+  ): UnaryCall<SendStatsRequest, SendStatsResponse> {
+    const method = this.methods[6],
+      opt = this._transport.mergeOptions(options);
+    return stackIntercept<SendStatsRequest, SendStatsResponse>(
       'unary',
       this._transport,
       method,

--- a/packages/client/src/gen/video/sfu/signal_rpc/signal.ts
+++ b/packages/client/src/gen/video/sfu/signal_rpc/signal.ts
@@ -26,6 +26,44 @@ import {
 } from '@protobuf-ts/runtime';
 
 /**
+ * @generated from protobuf message stream.video.sfu.signal.SendStatsRequest
+ */
+export interface SendStatsRequest {
+  /**
+   * @generated from protobuf field: string session_id = 1;
+   */
+  sessionId: string;
+  /**
+   * @generated from protobuf field: string subscriber_stats = 2;
+   */
+  subscriberStats: string;
+  /**
+   * @generated from protobuf field: string publisher_stats = 3;
+   */
+  publisherStats: string;
+  /**
+   * @generated from protobuf field: string webrtc_version = 4;
+   */
+  webrtcVersion: string;
+  /**
+   * @generated from protobuf field: string sdk = 5;
+   */
+  sdk: string;
+  /**
+   * @generated from protobuf field: string sdk_version = 6;
+   */
+  sdkVersion: string;
+}
+/**
+ * @generated from protobuf message stream.video.sfu.signal.SendStatsResponse
+ */
+export interface SendStatsResponse {
+  /**
+   * @generated from protobuf field: stream.video.sfu.models.Error error = 1;
+   */
+  error?: Error;
+}
+/**
  * @generated from protobuf message stream.video.sfu.signal.ICERestartRequest
  */
 export interface ICERestartRequest {
@@ -220,6 +258,212 @@ export interface SetPublisherResponse {
    */
   error?: Error;
 }
+// @generated message type with reflection information, may provide speed optimized methods
+class SendStatsRequest$Type extends MessageType<SendStatsRequest> {
+  constructor() {
+    super('stream.video.sfu.signal.SendStatsRequest', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 2,
+        name: 'subscriber_stats',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+      {
+        no: 3,
+        name: 'publisher_stats',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+      {
+        no: 4,
+        name: 'webrtc_version',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+      { no: 5, name: 'sdk', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 6,
+        name: 'sdk_version',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+    ]);
+  }
+  create(value?: PartialMessage<SendStatsRequest>): SendStatsRequest {
+    const message = globalThis.Object.create(this.messagePrototype!);
+    message.sessionId = '';
+    message.subscriberStats = '';
+    message.publisherStats = '';
+    message.webrtcVersion = '';
+    message.sdk = '';
+    message.sdkVersion = '';
+    if (value !== undefined)
+      reflectionMergePartial<SendStatsRequest>(this, message, value);
+    return message;
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: SendStatsRequest,
+  ): SendStatsRequest {
+    let message = target ?? this.create(),
+      end = reader.pos + length;
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag();
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string();
+          break;
+        case /* string subscriber_stats */ 2:
+          message.subscriberStats = reader.string();
+          break;
+        case /* string publisher_stats */ 3:
+          message.publisherStats = reader.string();
+          break;
+        case /* string webrtc_version */ 4:
+          message.webrtcVersion = reader.string();
+          break;
+        case /* string sdk */ 5:
+          message.sdk = reader.string();
+          break;
+        case /* string sdk_version */ 6:
+          message.sdkVersion = reader.string();
+          break;
+        default:
+          let u = options.readUnknownField;
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`,
+            );
+          let d = reader.skip(wireType);
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d,
+            );
+      }
+    }
+    return message;
+  }
+  internalBinaryWrite(
+    message: SendStatsRequest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions,
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId);
+    /* string subscriber_stats = 2; */
+    if (message.subscriberStats !== '')
+      writer.tag(2, WireType.LengthDelimited).string(message.subscriberStats);
+    /* string publisher_stats = 3; */
+    if (message.publisherStats !== '')
+      writer.tag(3, WireType.LengthDelimited).string(message.publisherStats);
+    /* string webrtc_version = 4; */
+    if (message.webrtcVersion !== '')
+      writer.tag(4, WireType.LengthDelimited).string(message.webrtcVersion);
+    /* string sdk = 5; */
+    if (message.sdk !== '')
+      writer.tag(5, WireType.LengthDelimited).string(message.sdk);
+    /* string sdk_version = 6; */
+    if (message.sdkVersion !== '')
+      writer.tag(6, WireType.LengthDelimited).string(message.sdkVersion);
+    let u = options.writeUnknownFields;
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer,
+      );
+    return writer;
+  }
+}
+/**
+ * @generated MessageType for protobuf message stream.video.sfu.signal.SendStatsRequest
+ */
+export const SendStatsRequest = new SendStatsRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class SendStatsResponse$Type extends MessageType<SendStatsResponse> {
+  constructor() {
+    super('stream.video.sfu.signal.SendStatsResponse', [
+      { no: 1, name: 'error', kind: 'message', T: () => Error },
+    ]);
+  }
+  create(value?: PartialMessage<SendStatsResponse>): SendStatsResponse {
+    const message = globalThis.Object.create(this.messagePrototype!);
+    if (value !== undefined)
+      reflectionMergePartial<SendStatsResponse>(this, message, value);
+    return message;
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: SendStatsResponse,
+  ): SendStatsResponse {
+    let message = target ?? this.create(),
+      end = reader.pos + length;
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag();
+      switch (fieldNo) {
+        case /* stream.video.sfu.models.Error error */ 1:
+          message.error = Error.internalBinaryRead(
+            reader,
+            reader.uint32(),
+            options,
+            message.error,
+          );
+          break;
+        default:
+          let u = options.readUnknownField;
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`,
+            );
+          let d = reader.skip(wireType);
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d,
+            );
+      }
+    }
+    return message;
+  }
+  internalBinaryWrite(
+    message: SendStatsResponse,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions,
+  ): IBinaryWriter {
+    /* stream.video.sfu.models.Error error = 1; */
+    if (message.error)
+      Error.internalBinaryWrite(
+        message.error,
+        writer.tag(1, WireType.LengthDelimited).fork(),
+        options,
+      ).join();
+    let u = options.writeUnknownFields;
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer,
+      );
+    return writer;
+  }
+}
+/**
+ * @generated MessageType for protobuf message stream.video.sfu.signal.SendStatsResponse
+ */
+export const SendStatsResponse = new SendStatsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class ICERestartRequest$Type extends MessageType<ICERestartRequest> {
   constructor() {
@@ -1538,6 +1782,12 @@ export const SignalServer = new ServiceType(
       options: {},
       I: ICERestartRequest,
       O: ICERestartResponse,
+    },
+    {
+      name: 'SendStats',
+      options: {},
+      I: SendStatsRequest,
+      O: SendStatsResponse,
     },
   ],
 );

--- a/packages/client/src/helpers/RNSpeechDetector.ts
+++ b/packages/client/src/helpers/RNSpeechDetector.ts
@@ -1,4 +1,4 @@
-import { BaseStats } from '../stats/types';
+import { BaseStats } from '../stats';
 import { SoundStateChangeHandler } from './sound-detector';
 
 /**

--- a/packages/client/src/rtc/flows/join.ts
+++ b/packages/client/src/rtc/flows/join.ts
@@ -21,8 +21,9 @@ export const join = async (
   id: string,
   data?: JoinCallData,
 ) => {
-  const joinCallResponse = await doJoin(httpClient, type, id, data);
-  const { call, credentials, members, own_capabilities } = joinCallResponse;
+  const { call, credentials, members, own_capabilities, stats_options } =
+    await doJoin(httpClient, type, id, data);
+
   return {
     connectionConfig: toRtcConfiguration(credentials.ice_servers),
     sfuServer: credentials.server,
@@ -30,6 +31,7 @@ export const join = async (
     metadata: call,
     members,
     ownCapabilities: own_capabilities,
+    statsOptions: stats_options,
   };
 };
 

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -4,7 +4,7 @@ import { getLogger } from '../logger';
 import { Publisher, Subscriber } from '../rtc';
 import { SdkType } from '../gen/video/sfu/models/models';
 import { flatten } from './utils';
-import { LocalClientDetailsType } from '../client-details';
+import { LocalClientDetailsType, getWebRTCInfo } from '../client-details';
 
 export type SfuStatsReporterOptions = {
   options: StatsOptions;
@@ -35,8 +35,9 @@ export class SfuStatsReporter {
     this.options = options;
     this.subscriber = subscriber;
     this.publisher = publisher;
+    const webRTCInfo = getWebRTCInfo();
 
-    const { sdk, browser, webRTCInfo } = clientDetails;
+    const { sdk, browser } = clientDetails;
 
     this.sdkName =
       sdk && sdk.type === SdkType.REACT

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -4,7 +4,7 @@ import { getLogger } from '../logger';
 import { Publisher, Subscriber } from '../rtc';
 import { SdkType } from '../gen/video/sfu/models/models';
 import { flatten } from './utils';
-import { LocalClientDetailsType, getWebRTCInfo } from '../client-details';
+import { getWebRTCInfo, LocalClientDetailsType } from '../client-details';
 
 export type SfuStatsReporterOptions = {
   options: StatsOptions;
@@ -76,7 +76,7 @@ export class SfuStatsReporter {
     if (this.options.reporting_interval_ms <= 0) return;
     this.intervalId = setInterval(() => {
       this.run().catch((err) => {
-        this.logger('error', 'Failed to report stats', err);
+        this.logger('warn', 'Failed to report stats', err);
       });
     }, this.options.reporting_interval_ms);
   };

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -1,0 +1,85 @@
+import { StreamSfuClient } from '../StreamSfuClient';
+import { StatsOptions } from '../gen/coordinator';
+import { getLogger } from '../logger';
+import { Publisher, Subscriber } from '../rtc';
+import { ClientDetails, SdkType } from '../gen/video/sfu/models/models';
+import { flatten } from './utils';
+
+export type SfuStatsReporterOptions = {
+  options: StatsOptions;
+  clientDetails: ClientDetails;
+  subscriber: Subscriber;
+  publisher: Publisher;
+};
+
+export class SfuStatsReporter {
+  private readonly logger = getLogger(['SfuStatsReporter']);
+
+  readonly options: StatsOptions;
+
+  private readonly sfuClient: StreamSfuClient;
+  private readonly subscriber: Subscriber;
+  private readonly publisher: Publisher;
+
+  private intervalId: NodeJS.Timeout | undefined;
+  private readonly sdkName: string;
+  private readonly sdkVersion: string;
+  private readonly webRTCVersion: string;
+
+  constructor(
+    sfuClient: StreamSfuClient,
+    { options, clientDetails, subscriber, publisher }: SfuStatsReporterOptions,
+  ) {
+    this.sfuClient = sfuClient;
+    this.options = options;
+    this.subscriber = subscriber;
+    this.publisher = publisher;
+
+    const { sdk, browser, device } = clientDetails;
+
+    this.sdkName =
+      sdk && sdk.type === SdkType.REACT
+        ? 'stream-react'
+        : sdk && sdk.type === SdkType.REACT_NATIVE
+        ? 'stream-react-native'
+        : 'stream-js';
+
+    this.sdkVersion = sdk
+      ? `${sdk.major}.${sdk.minor}.${sdk.patch}`
+      : '0.0.0-development';
+
+    this.webRTCVersion =
+      device?.version ||
+      `${browser?.name || ''}-${browser?.version || ''}` ||
+      'N/A';
+  }
+
+  private run = async () => {
+    const [subscriberStats, publisherStats] = await Promise.all([
+      this.subscriber.getStats().then(flatten).then(JSON.stringify),
+      this.publisher.getStats().then(flatten).then(JSON.stringify),
+    ]);
+
+    await this.sfuClient.sendStats({
+      sdk: this.sdkName,
+      sdkVersion: this.sdkVersion,
+      webrtcVersion: this.webRTCVersion,
+      subscriberStats,
+      publisherStats,
+    });
+  };
+
+  start = () => {
+    if (this.options.reporting_interval_ms <= 0) return;
+    this.intervalId = setInterval(() => {
+      this.run().catch((err) => {
+        this.logger('error', 'Failed to report stats', err);
+      });
+    }, this.options.reporting_interval_ms);
+  };
+
+  stop = () => {
+    clearInterval(this.intervalId);
+    this.intervalId = undefined;
+  };
+}

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -2,12 +2,13 @@ import { StreamSfuClient } from '../StreamSfuClient';
 import { StatsOptions } from '../gen/coordinator';
 import { getLogger } from '../logger';
 import { Publisher, Subscriber } from '../rtc';
-import { ClientDetails, SdkType } from '../gen/video/sfu/models/models';
+import { SdkType } from '../gen/video/sfu/models/models';
 import { flatten } from './utils';
+import { LocalClientDetailsType } from '../client-details';
 
 export type SfuStatsReporterOptions = {
   options: StatsOptions;
-  clientDetails: ClientDetails;
+  clientDetails: LocalClientDetailsType;
   subscriber: Subscriber;
   publisher: Publisher;
 };
@@ -35,7 +36,7 @@ export class SfuStatsReporter {
     this.subscriber = subscriber;
     this.publisher = publisher;
 
-    const { sdk, browser, device } = clientDetails;
+    const { sdk, browser, webRTCInfo } = clientDetails;
 
     this.sdkName =
       sdk && sdk.type === SdkType.REACT
@@ -48,8 +49,9 @@ export class SfuStatsReporter {
       ? `${sdk.major}.${sdk.minor}.${sdk.patch}`
       : '0.0.0-development';
 
+    // The WebRTC version if passed from the SDK, it is taken else the browser info is sent.
     this.webRTCVersion =
-      device?.version ||
+      webRTCInfo?.version ||
       `${browser?.name || ''}-${browser?.version || ''}` ||
       'N/A';
   }

--- a/packages/client/src/stats/index.ts
+++ b/packages/client/src/stats/index.ts
@@ -1,0 +1,3 @@
+export * from './stateStoreStatsReporter';
+export * from './SfuStatsReporter';
+export * from './types';

--- a/packages/client/src/stats/stateStoreStatsReporter.ts
+++ b/packages/client/src/stats/stateStoreStatsReporter.ts
@@ -7,6 +7,7 @@ import type {
 import { CallState } from '../store';
 import { Publisher, Subscriber } from '../rtc';
 import { getLogger } from '../logger';
+import { flatten } from './utils';
 
 export type StatsReporterOpts = {
   subscriber: Subscriber;
@@ -351,17 +352,4 @@ const aggregate = (stats: StatsReport): AggregatedStatsReport => {
   }
 
   return report;
-};
-
-/**
- * Flatten the stats report into an array of stats objects.
- *
- * @param report the report to flatten.
- */
-const flatten = (report: RTCStatsReport) => {
-  const stats: RTCStats[] = [];
-  report.forEach((s) => {
-    stats.push(s);
-  });
-  return stats;
 };

--- a/packages/client/src/stats/utils.ts
+++ b/packages/client/src/stats/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Flatten the stats report into an array of stats objects.
+ *
+ * @param report the report to flatten.
+ */
+export const flatten = (report: RTCStatsReport) => {
+  const stats: RTCStats[] = [];
+  report.forEach((s) => {
+    stats.push(s);
+  });
+  return stats;
+};

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -12,7 +12,7 @@ import {
   StreamVideoParticipantPatch,
   StreamVideoParticipantPatches,
 } from '../types';
-import { CallStatsReport } from '../stats/types';
+import { CallStatsReport } from '../stats';
 import {
   BlockedUserEvent,
   CallHLSBroadcastingStartedEvent,

--- a/packages/react-native-sdk/src/utils/setClientDetails.ts
+++ b/packages/react-native-sdk/src/utils/setClientDetails.ts
@@ -3,9 +3,11 @@ import {
   setDeviceInfo,
   setOSInfo,
   SfuModels,
+  setWebRTCInfo,
 } from '@stream-io/video-client';
 import { Platform } from 'react-native';
 import { version } from '../version';
+import RNWebRTCPackageJSON from '@stream-io/react-native-webrtc/package.json';
 
 const [major, minor, patch] = version.split('.');
 
@@ -55,5 +57,9 @@ export const setClientDetails = () => {
   setDeviceInfo({
     name: deviceName,
     version: '',
+  });
+
+  setWebRTCInfo({
+    version: RNWebRTCPackageJSON.version,
   });
 };


### PR DESCRIPTION
### Overview

Integrates the `SendStats` RPC method.

The SDK will now send WebRTC stats on predefined intervals to the currently connected SFU.
These stats will then be aggregated, processed, and displayed on our Dashboard to provide better observability to our customers about important call timeline events.

Notes: this PR replaces #1276 