### PR TITLE
fix: various bug fixes and improvements

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -497,10 +497,7 @@ export class Call {
     this.publisher?.close();
     this.publisher = undefined;
 
-    this.sfuClient?.close(
-      StreamSfuClient.NORMAL_CLOSURE,
-      `js-client: ${reason}`,
-    );
+    this.sfuClient?.close(StreamSfuClient.NORMAL_CLOSURE, reason);
     this.sfuClient = undefined;
 
     this.dispatcher.offAll();
@@ -784,7 +781,7 @@ export class Call {
       if (strategy === 'fast') {
         sfuClient.close(
           StreamSfuClient.ERROR_CONNECTION_BROKEN,
-          `js-client: attempting fast reconnect - (${reason})`,
+          `attempting fast reconnect: ${reason}`,
         );
       } else if (strategy === 'full') {
         // in migration or recovery scenarios, we don't want to
@@ -804,7 +801,7 @@ export class Call {
         // clean up current connection
         sfuClient.close(
           StreamSfuClient.NORMAL_CLOSURE,
-          `js-client: attempting full reconnect - ${reason}`,
+          `attempting full reconnect: ${reason}`,
         );
       }
       await this.join({
@@ -814,10 +811,7 @@ export class Call {
 
       // clean up previous connection
       if (strategy === 'migrate') {
-        sfuClient.close(
-          StreamSfuClient.NORMAL_CLOSURE,
-          'js-client: attempting migration',
-        );
+        sfuClient.close(StreamSfuClient.NORMAL_CLOSURE, 'attempting migration');
       }
 
       this.logger(
@@ -908,7 +902,7 @@ export class Call {
         if (this.reconnectAttempts < this.maxReconnectAttempts) {
           sfuClient.isFastReconnecting = this.reconnectAttempts === 0;
           const strategy = sfuClient.isFastReconnecting ? 'fast' : 'full';
-          reconnect(strategy, `SFU WS closed with code: ${e.code}`).catch(
+          reconnect(strategy, `SFU closed the WS with code: ${e.code}`).catch(
             (err) => {
               this.logger(
                 'error',

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -210,9 +210,9 @@ export class StreamSfuClient {
   }
 
   close = (code: number, reason: string) => {
-    this.logger('debug', 'Closing SFU WS connection', code, reason);
+    this.logger('debug', `Closing SFU WS connection: ${code} - ${reason}`);
     if (this.signalWs.readyState !== this.signalWs.CLOSED) {
-      this.signalWs.close(code, reason);
+      this.signalWs.close(code, `js-client: ${reason}`);
     }
 
     this.unsubscribeIceTrickle();

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -209,10 +209,7 @@ export class StreamSfuClient {
     });
   }
 
-  close = (
-    code: number = StreamSfuClient.NORMAL_CLOSURE,
-    reason: string = 'js-client: requested signal connection close',
-  ) => {
+  close = (code: number, reason: string) => {
     this.logger('debug', 'Closing SFU WS connection', code, reason);
     if (this.signalWs.readyState !== this.signalWs.CLOSED) {
       this.signalWs.close(code, reason);

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -232,7 +232,7 @@ export class StreamVideoClient {
         // if `call.created` was received before `call.ring`.
         // In that case, we cleanup the already tracked call.
         const prevCall = this.writeableStateStore.findCall(call.type, call.id);
-        await prevCall?.leave();
+        await prevCall?.leave({ reason: 'cleaning-up in call.ring' });
         // we create a new call
         const theCall = new Call({
           streamClient: this.streamClient,

--- a/packages/client/src/devices/InputMediaDeviceManagerState.ts
+++ b/packages/client/src/devices/InputMediaDeviceManagerState.ts
@@ -7,7 +7,6 @@ import {
 import { isReactNative } from '../helpers/platforms';
 import { RxUtils } from '../store';
 import { getLogger } from '../logger';
-import { isSafari } from '../helpers/browsers';
 
 export type InputDeviceStatus = 'enabled' | 'disabled' | undefined;
 
@@ -67,15 +66,15 @@ export abstract class InputMediaDeviceManagerState<C = MediaTrackConstraints> {
     }
 
     let permissionState: PermissionStatus;
-    const notify = () =>
+    const notify = () => {
       subscriber.next(
-        // In Safari, the `change` event doesn't reliably emit and hence,
+        // In some browsers, the 'change' event doesn't reliably emit and hence,
         // permissionState stays in 'prompt' state forever.
+        // Typically, this happens when a user grants one-time permission.
         // Instead of checking if a permission is granted, we check if it isn't denied
-        isSafari()
-          ? permissionState.state !== 'denied'
-          : permissionState.state === 'granted',
+        permissionState.state !== 'denied',
       );
+    };
     navigator.permissions
       .query({ name: this.permissionName })
       .then((permissionStatus) => {

--- a/packages/client/src/devices/__tests__/InputMediaDeviceManagerState.test.ts
+++ b/packages/client/src/devices/__tests__/InputMediaDeviceManagerState.test.ts
@@ -54,7 +54,7 @@ describe('InputMediaDeviceManagerState', () => {
       expect(permissionStatus.addEventListener).toHaveBeenCalled();
     });
 
-    it('should emit false when prompt is needed', async () => {
+    it('should emit true when prompt is needed', async () => {
       const permissionStatus: Partial<PermissionStatus> = {
         state: 'prompt',
         addEventListener: vi.fn(),
@@ -63,30 +63,6 @@ describe('InputMediaDeviceManagerState', () => {
       globalThis.navigator ??= {} as Navigator;
       // @ts-ignore - navigator is readonly, but we need to mock it
       globalThis.navigator.permissions = { query };
-
-      const hasPermission = await new Promise((resolve) => {
-        state.hasBrowserPermission$.subscribe((v) => resolve(v));
-      });
-      expect(hasPermission).toBe(false);
-      expect(query).toHaveBeenCalledWith({ name: 'camera' });
-      expect(permissionStatus.addEventListener).toHaveBeenCalled();
-    });
-
-    it('should emit true when prompt is needed in Safari', async () => {
-      const permissionStatus: Partial<PermissionStatus> = {
-        state: 'prompt',
-        addEventListener: vi.fn(),
-      };
-      const query = vi.fn(() => Promise.resolve(permissionStatus));
-      globalThis.navigator ??= { userAgent: 'safari' } as Navigator;
-      // @ts-ignore - navigator is readonly, but we need to mock it
-      globalThis.navigator.permissions = { query };
-
-      Object.defineProperty(globalThis.navigator, 'userAgent', {
-        get() {
-          return 'safari';
-        },
-      });
 
       const hasPermission = await new Promise((resolve) => {
         state.hasBrowserPermission$.subscribe((v) => resolve(v));

--- a/packages/client/src/events/call.ts
+++ b/packages/client/src/events/call.ts
@@ -56,12 +56,12 @@ export const watchCallRejected = (call: Call) => {
         .every((m) => rejectedBy[m.user_id]);
       if (everyoneElseRejected) {
         call.logger('info', 'everyone rejected, leaving the call');
-        await call.leave();
+        await call.leave({ reason: 'ring: everyone rejected' });
       }
     } else {
       if (rejectedBy[eventCall.created_by.id]) {
         call.logger('info', 'call creator rejected, leaving call');
-        await call.leave();
+        await call.leave({ reason: 'ring: creator rejected' });
       }
     }
   };
@@ -78,7 +78,7 @@ export const watchCallEnded = (call: Call) => {
       callingState === CallingState.JOINED ||
       callingState === CallingState.JOINING
     ) {
-      await call.leave();
+      await call.leave({ reason: 'call.ended event received' });
     }
   };
 };

--- a/packages/client/src/events/internal.ts
+++ b/packages/client/src/events/internal.ts
@@ -69,7 +69,7 @@ export const watchLiveEnded = (dispatcher: Dispatcher, call: Call) => {
     if (e.error && e.error.code !== ErrorCode.LIVE_ENDED) return;
 
     if (!call.permissionsContext.hasPermission(OwnCapability.JOIN_BACKSTAGE)) {
-      call.leave().catch((err) => {
+      call.leave({ reason: 'live ended' }).catch((err) => {
         logger('error', 'Failed to leave call after live ended', err);
       });
     }

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -98,6 +98,15 @@ export enum CallingState {
 }
 
 /**
+ * Returns the default egress object - when no egress data is available.
+ */
+const defaultEgress: EgressResponse = {
+  broadcasting: false,
+  hls: { playlist_url: '' },
+  rtmps: [],
+};
+
+/**
  * Holds the state of the current call.
  * @react You don't have to use this class directly, as we are exposing the state through Hooks.
  */
@@ -978,15 +987,15 @@ export class CallState {
   };
 
   private updateFromHLSBroadcastStopped = () => {
-    this.setCurrentValue(this.egressSubject, (egress) => ({
-      ...egress!,
+    this.setCurrentValue(this.egressSubject, (egress = defaultEgress) => ({
+      ...egress,
       broadcasting: false,
     }));
   };
 
   private updateFromHLSBroadcastingFailed = () => {
-    this.setCurrentValue(this.egressSubject, (egress) => ({
-      ...egress!,
+    this.setCurrentValue(this.egressSubject, (egress = defaultEgress) => ({
+      ...egress,
       broadcasting: false,
     }));
   };
@@ -994,11 +1003,11 @@ export class CallState {
   private updateFromHLSBroadcastStarted = (
     event: CallHLSBroadcastingStartedEvent,
   ) => {
-    this.setCurrentValue(this.egressSubject, (egress) => ({
-      ...egress!,
+    this.setCurrentValue(this.egressSubject, (egress = defaultEgress) => ({
+      ...egress,
       broadcasting: true,
       hls: {
-        ...egress!.hls,
+        ...egress.hls,
         playlist_url: event.hls_playlist_url,
       },
     }));

--- a/packages/client/src/store/stateStore.ts
+++ b/packages/client/src/store/stateStore.ts
@@ -28,9 +28,11 @@ export class StreamVideoWriteableStateStore {
           if (call.state.callingState === CallingState.LEFT) continue;
 
           logger('info', `User disconnected, leaving call: ${call.cid}`);
-          await call.leave().catch((err) => {
-            logger('error', `Error leaving call: ${call.cid}`, err);
-          });
+          await call
+            .leave({ reason: 'client.disconnectUser() called' })
+            .catch((err) => {
+              logger('error', `Error leaving call: ${call.cid}`, err);
+            });
         }
       }
     });

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -173,6 +173,12 @@ export type CallLeaveOptions = {
    * @default `false`.
    */
   reject?: boolean;
+
+  /**
+   * The reason for leaving the call.
+   * This will be sent to the backend and will be visible in the logs.
+   */
+  reason?: string;
 };
 
 /**

--- a/packages/react-sdk/src/hooks/usePersistedDevicePreferences.ts
+++ b/packages/react-sdk/src/hooks/usePersistedDevicePreferences.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { CallingState } from '@stream-io/video-client';
 import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
 
 export type LocalDevicePreference = {
@@ -22,12 +23,14 @@ const usePersistDevicePreferences = (key: string) => {
     useSpeakerState,
     useCallSettings,
   } = useCallStateHooks();
+  const call = useCall();
   const mic = useMicrophoneState();
   const camera = useCameraState();
   const speaker = useSpeakerState();
   const settings = useCallSettings();
   useEffect(() => {
-    if (!settings) return;
+    if (!call || !settings) return;
+    if (call.state.callingState === CallingState.LEFT) return;
     try {
       const hasPreferences = !!window.localStorage.getItem(key);
       const { audio, video } = settings;
@@ -51,6 +54,7 @@ const usePersistDevicePreferences = (key: string) => {
       console.warn('Failed to save device preferences', err);
     }
   }, [
+    call,
     camera.isMute,
     camera.selectedDevice,
     key,


### PR DESCRIPTION
### Overview

Adds a few bug fixes and improvements to our SDKs:
1. **client**: SFU WS disconnects and reconnects now provide a more accurate reason. This should help us with the debugging.
2. **devices**: relax the constraints around one-time browser permission grants for every browser
3. **state**: under some rare occasions, `call.broadcast_*` might be delivered before the `egress` state is initialized. This resulted in an error (couldn't read property X from undefined). This is now fixed.
4. **react**: #1266 introduced a side-effect in `usePersistDevicePreferences` where the persisted device state was always reset to "off". This is now fixed too.