### PR TITLE
feat(react-native): host and viewer livestream chat integration

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/livestream/viewer-livestream.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/04-ui-components/livestream/viewer-livestream.mdx
@@ -10,6 +10,7 @@ import ViewerLivestreamScreenShare from '../../assets/04-ui-components/livestrea
 import ViewerLivestreamTopView from '../../common-content/ui-components/livestream/viewer-livestream/viewer-livestream-top-view.mdx';
 import LivestreamLayout from '../../common-content/ui-components/livestream/livestream-layout.mdx';
 import ViewerLivestreamControls from '../../common-content/ui-components/livestream/viewer-livestream/viewer-livestream-controls.mdx';
+import ViewerLivestreamControlsRightElement from '../../common-content/ui-components/livestream/viewer-livestream/viewer-live-stream-controls-right-element.mdx';
 import DurationBadge from '../../common-content/ui-components/livestream/duration-badge.mdx';
 import FollowerCount from '../../common-content/ui-components/livestream/follower-count.mdx';
 import LiveIndicator from '../../common-content/ui-components/livestream/live-indicator.mdx';
@@ -76,6 +77,10 @@ const VideoCallUI = () => {
 ### `ViewerLivestreamControls`
 
 <ViewerLivestreamControls />
+
+### `ViewerLiveStreamControlsRightElement`
+
+<ViewerLivestreamControlsRightElement />
 
 ### `DurationBadge`
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/viewer-livestream/viewer-live-stream-controls-right-element.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/common-content/ui-components/livestream/viewer-livestream/viewer-live-stream-controls-right-element.mdx
@@ -1,0 +1,5 @@
+Component to add or customize the elements on the right side on the controls of the viewer's live stream.
+
+| Type                          | Default Value |
+| ----------------------------- | ------------- |
+| `ComponentType`\| `undefined` | null          |

--- a/packages/react-native-sdk/src/components/Livestream/LivestreamControls/ViewerLivestreamControls.tsx
+++ b/packages/react-native-sdk/src/components/Livestream/LivestreamControls/ViewerLivestreamControls.tsx
@@ -16,6 +16,10 @@ export type ViewerLivestreamControlsProps = ViewerLeaveStreamButtonProps & {
    * Component to customize the leave stream button on the viewer's end live stream.
    */
   ViewerLeaveStreamButton?: React.ComponentType<ViewerLeaveStreamButtonProps> | null;
+  /**
+   * Component to add or customize the right side elements on the viewer's side of live stream.
+   */
+  ViewerLiveStreamControlsRightElement?: React.ComponentType | null;
 };
 
 /**
@@ -23,6 +27,7 @@ export type ViewerLivestreamControlsProps = ViewerLeaveStreamButtonProps & {
  */
 export const ViewerLivestreamControls = ({
   ViewerLeaveStreamButton = DefaultViewerLeaveStreamButton,
+  ViewerLiveStreamControlsRightElement = null,
   onLeaveStreamHandler,
 }: ViewerLivestreamControlsProps) => {
   const {
@@ -48,7 +53,11 @@ export const ViewerLivestreamControls = ({
       </View>
       <View
         style={[styles.rightElement, viewerLivestreamControls.rightElement]}
-      />
+      >
+        {ViewerLiveStreamControlsRightElement && (
+          <ViewerLiveStreamControlsRightElement />
+        )}
+      </View>
     </View>
   );
 };

--- a/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/index.ts
+++ b/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/index.ts
@@ -2,3 +2,4 @@ export * from './DurationBadge';
 export * from './FollowerCount';
 export * from './LiveIndicator';
 export * from './HostLivestreamTopView';
+export * from './ViewerLivestreamTopView';

--- a/packages/react-native-sdk/src/components/Livestream/ViewerLivestream/ViewerLivestream.tsx
+++ b/packages/react-native-sdk/src/components/Livestream/ViewerLivestream/ViewerLivestream.tsx
@@ -59,6 +59,7 @@ export const ViewerLivestream = ({
   FollowerCount,
   DurationBadge,
   ViewerLeaveStreamButton,
+  ViewerLiveStreamControlsRightElement,
   onLeaveStreamHandler,
 }: ViewerLivestreamProps) => {
   const {
@@ -106,6 +107,9 @@ export const ViewerLivestream = ({
         {ViewerLivestreamControls && (
           <ViewerLivestreamControls
             ViewerLeaveStreamButton={ViewerLeaveStreamButton}
+            ViewerLiveStreamControlsRightElement={
+              ViewerLiveStreamControlsRightElement
+            }
             onLeaveStreamHandler={onLeaveStreamHandler}
           />
         )}

--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -1205,7 +1205,7 @@ PODS:
   - stream-react-native-webrtc (118.0.1):
     - JitsiWebRTC (~> 118.0.0)
     - React-Core
-  - stream-video-react-native (0.4.2):
+  - stream-video-react-native (0.5.11):
     - React-Core
     - stream-react-native-webrtc
   - TOCropViewController (2.6.1)
@@ -1572,10 +1572,10 @@ SPEC CHECKSUMS:
   RNVoipPushNotification: 543e18f83089134a35e7f1d2eba4c8b1f7776b08
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   stream-react-native-webrtc: 31fe9ee69d5b4fc191380a78efa292377494b7ac
-  stream-video-react-native: 713c9b707c9acfa9d0d694e7fcf539509adac337
+  stream-video-react-native: 8bb87ac3a4eee30d39e9c507101f311f50fd3ab5
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   Yoga: 64cd2a583ead952b0315d5135bf39e053ae9be70
 
 PODFILE CHECKSUM: d648756febffefcf3982743a0f0035d6871ef40b
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/sample-apps/react-native/dogfood/package.json
+++ b/sample-apps/react-native/dogfood/package.json
@@ -18,6 +18,7 @@
     "lint:ci": "eslint --cache 'src/**/*.{ts,tsx}'"
   },
   "dependencies": {
+    "@gorhom/bottom-sheet": "^4.6.1",
     "@notifee/react-native": "^7.8.0",
     "@react-native-camera-roll/camera-roll": "^5.6.0",
     "@react-native-clipboard/clipboard": "^1.11.1",

--- a/sample-apps/react-native/dogfood/src/assets/Chat.tsx
+++ b/sample-apps/react-native/dogfood/src/assets/Chat.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Svg, Path } from 'react-native-svg';
+import { ColorValue } from 'react-native/types';
+
+type Props = {
+  color: ColorValue;
+};
+
+export const Chat = ({ color }: Props) => (
+  <Svg viewBox="0 0 21 20">
+    <Path
+      d="M 17.1887 0.353516 H 2.37385 C 1.35534 0.353516 0.522003 1.18685 0.522003 2.20537 V 18.872 L 4.22571 15.1683 H 17.1887 C 18.2072 15.1683 19.0405 14.335 19.0405 13.3165 V 2.20537 C 19.0405 1.18685 18.2072 0.353516 17.1887 0.353516 Z M 17.1887 13.3165 H 4.22571 L 2.37385 15.1683 V 2.20537 H 17.1887 V 13.3165 Z"
+      fill={color}
+    />
+  </Svg>
+);

--- a/sample-apps/react-native/dogfood/src/components/LiveStream/LiveStreamMediaControls.tsx
+++ b/sample-apps/react-native/dogfood/src/components/LiveStream/LiveStreamMediaControls.tsx
@@ -1,0 +1,61 @@
+import {
+  LivestreamAudioControlButton,
+  LivestreamVideoControlButton,
+} from '@stream-io/video-react-native-sdk';
+import React from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { appTheme } from '../../theme';
+import { Chat } from '../../assets/Chat';
+
+/**
+ * Props for the LivestreamMediaControls component.
+ */
+export type LivestreamMediaControlsProps = {
+  handlePresentModalPress: () => void;
+};
+
+/**
+ * The LivestreamMediaControls component controls the media publish/unpublish for the host's live stream.
+ */
+export const LivestreamMediaControls = ({
+  handlePresentModalPress,
+}: LivestreamMediaControlsProps) => {
+  return (
+    <View style={styles.container}>
+      <LivestreamAudioControlButton />
+      <LivestreamVideoControlButton />
+      <Pressable
+        onPress={handlePresentModalPress}
+        style={[
+          styles.chatContainer,
+          {
+            backgroundColor: appTheme.colors.dark_gray,
+          },
+        ]}
+      >
+        <View style={[styles.icon]}>
+          <Chat color={appTheme.colors.static_white} />
+        </View>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  chatContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginHorizontal: 4,
+    borderRadius: 4,
+    height: 40,
+    width: 40,
+  },
+  icon: {
+    height: 20,
+    width: 20,
+  },
+});

--- a/sample-apps/react-native/dogfood/src/components/LivestreamChat.tsx
+++ b/sample-apps/react-native/dogfood/src/components/LivestreamChat.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { Platform, SafeAreaView, StyleSheet } from 'react-native';
+import {
+  Channel,
+  MessageInput,
+  MessageList,
+  useChatContext,
+} from 'stream-chat-react-native';
+import { AuthenticationProgress } from '../components/AuthenticatingProgress';
+import { Channel as ChannelType } from 'stream-chat';
+import { StreamChatGenerics } from '../../types';
+import { useBottomSheetInternal } from '@gorhom/bottom-sheet';
+
+export type LivestreamChatProps = {
+  callId: string;
+  callType: string;
+};
+
+export const LivestreamChat = ({ callId, callType }: LivestreamChatProps) => {
+  const [channel, setChannel] = useState<
+    ChannelType<StreamChatGenerics> | undefined
+  >(undefined);
+  const { client } = useChatContext();
+  const { shouldHandleKeyboardEvents } = useBottomSheetInternal();
+
+  // Done as per https://ui.gorhom.dev/components/bottom-sheet/keyboard-handling/ to solve the issue around keyboard hiding the text input in the chat inside bottom sheet.
+  useEffect(() => {
+    return () => {
+      // Reset the flag on unmount
+      shouldHandleKeyboardEvents.value = false;
+    };
+  }, [shouldHandleKeyboardEvents]);
+
+  useEffect(() => {
+    const createChannel = async () => {
+      const newChannel = await client.channel(callType, callId);
+      setChannel(newChannel);
+    };
+    createChannel();
+  }, [client, callId, callType]);
+
+  if (!channel) {
+    return <AuthenticationProgress />;
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Channel
+        additionalTextInputProps={
+          Platform.OS === 'ios'
+            ? {
+                // Done as per https://ui.gorhom.dev/components/bottom-sheet/keyboard-handling/ to solve keyboard hiding the text input in the chat inside bottom sheet.
+                onBlur: () => {
+                  shouldHandleKeyboardEvents.value = false;
+                },
+                onFocus: () => {
+                  shouldHandleKeyboardEvents.value = true;
+                },
+              }
+            : {}
+        }
+        channel={channel}
+        onLongPressMessage={() => null}
+      >
+        <MessageList />
+        <MessageInput InputButtons={undefined} />
+      </Channel>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    height: '100%',
+    width: '100%',
+  },
+});

--- a/sample-apps/react-native/dogfood/src/components/NavigationHeader.tsx
+++ b/sample-apps/react-native/dogfood/src/components/NavigationHeader.tsx
@@ -45,6 +45,7 @@ export const NavigationHeader = ({ route }: NativeStackHeaderProps) => {
               ]);
 
               appStoreSetState({
+                apiKey: '',
                 userId: '',
                 userName: '',
                 userImageUrl: '',

--- a/sample-apps/react-native/dogfood/src/components/VideoWrapper.tsx
+++ b/sample-apps/react-native/dogfood/src/components/VideoWrapper.tsx
@@ -3,7 +3,10 @@ import {
   StreamVideo,
   StreamVideoClient,
 } from '@stream-io/video-react-native-sdk';
-import { useAppGlobalStoreValue } from '../contexts/AppContext';
+import {
+  useAppGlobalStoreSetState,
+  useAppGlobalStoreValue,
+} from '../contexts/AppContext';
 import { createToken } from '../modules/helpers/createToken';
 import translations from '../translations';
 
@@ -14,6 +17,7 @@ export const VideoWrapper = ({ children }: PropsWithChildren<{}>) => {
   const appEnvironment = useAppGlobalStoreValue(
     (store) => store.appEnvironment,
   );
+  const setState = useAppGlobalStoreSetState();
 
   const [videoClient, setVideoClient] = useState<StreamVideoClient | undefined>(
     undefined,
@@ -35,6 +39,7 @@ export const VideoWrapper = ({ children }: PropsWithChildren<{}>) => {
         { user_id: user.id },
         appEnvironment,
       );
+      setState({ apiKey: apiKey });
       _videoClient = new StreamVideoClient({
         apiKey,
         user,
@@ -49,7 +54,7 @@ export const VideoWrapper = ({ children }: PropsWithChildren<{}>) => {
       _videoClient?.disconnectUser();
       setVideoClient(undefined);
     };
-  }, [appEnvironment, user]);
+  }, [appEnvironment, setState, user]);
 
   if (!videoClient) {
     return null;

--- a/sample-apps/react-native/dogfood/src/contexts/AppContext.tsx
+++ b/sample-apps/react-native/dogfood/src/contexts/AppContext.tsx
@@ -4,6 +4,7 @@ export type AppMode = 'Meeting' | 'Call' | 'Audio-Room' | 'LiveStream' | 'None';
 export type AppEnvironment = 'pronto' | 'demo' | 'None';
 
 type AppGlobalStore = {
+  apiKey: string;
   userId: string;
   userImageUrl?: string;
   userName: string;
@@ -18,6 +19,7 @@ export const {
   useStoreSetState: useAppGlobalStoreSetState,
 } = createStoreContext<AppGlobalStore>(
   {
+    apiKey: '',
     userId: '',
     userImageUrl: '',
     userName: '',
@@ -25,5 +27,5 @@ export const {
     appEnvironment: 'None',
     chatLabelNoted: false,
   },
-  ['appEnvironment', 'userId', 'userName', 'userImageUrl', 'appMode'],
+  ['apiKey', 'appEnvironment', 'userId', 'userName', 'userImageUrl', 'appMode'],
 );

--- a/sample-apps/react-native/dogfood/src/hooks/useAnonymousInitVideoClient.ts
+++ b/sample-apps/react-native/dogfood/src/hooks/useAnonymousInitVideoClient.ts
@@ -1,39 +1,18 @@
 import { StreamVideoClient } from '@stream-io/video-react-native-sdk';
 import { useEffect, useState } from 'react';
 
-import { createToken } from '../modules/helpers/createToken';
 import { useAppGlobalStoreValue } from '../contexts/AppContext';
 
-type InitAnonymousVideoClientType = {
-  callId?: string;
-  callType?: string;
-};
+export const useAnonymousInitVideoClient = () => {
+  const apiKey = useAppGlobalStoreValue((store) => store.apiKey);
 
-export const useAnonymousInitVideoClient = ({
-  callId,
-  callType,
-}: InitAnonymousVideoClientType) => {
-  const appEnvironment = useAppGlobalStoreValue(
-    (store) => store.appEnvironment,
-  );
   const [client, setClient] = useState<StreamVideoClient>();
 
   useEffect(() => {
     let _client: StreamVideoClient | undefined;
     const run = async () => {
-      const anonymousUser = {
-        id: '!anon',
-      };
-      const { token, apiKey } = await createToken(
-        {
-          user_id: anonymousUser.id,
-          call_cids: `${callType}:${callId}`,
-        },
-        appEnvironment,
-      );
       _client = new StreamVideoClient({
         apiKey,
-        token,
         user: { type: 'anonymous' },
       });
       setClient(_client);
@@ -46,7 +25,7 @@ export const useAnonymousInitVideoClient = ({
         .catch((error) => console.error('Unable to disconnect user', error));
       setClient(undefined);
     };
-  }, [callId, callType, appEnvironment]);
+  }, [apiKey]);
 
   return client;
 };

--- a/sample-apps/react-native/dogfood/src/screens/LiveStream/HostLiveStream.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LiveStream/HostLiveStream.tsx
@@ -4,12 +4,32 @@ import {
   HostLivestream,
   useConnectedUser,
   useStreamVideoClient,
+  HostLivestreamTopView,
 } from '@stream-io/video-react-native-sdk';
-import React, { useEffect, useMemo } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  BottomSheetModal,
+  BottomSheetView,
+  BottomSheetModalProvider,
+} from '@gorhom/bottom-sheet';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { LiveStreamParamList } from '../../../types';
-import { StyleSheet, Text } from 'react-native';
+import { Dimensions, StyleSheet, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { appTheme } from '../../theme';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { LivestreamChat } from '../../components/LivestreamChat';
+import { LivestreamMediaControls } from '../../components/LiveStream/LiveStreamMediaControls';
 
 type HostLiveStreamScreenProps = NativeStackScreenProps<
   LiveStreamParamList,
@@ -17,8 +37,40 @@ type HostLiveStreamScreenProps = NativeStackScreenProps<
 >;
 
 export const HostLiveStreamScreen = ({ route }: HostLiveStreamScreenProps) => {
+  const { height } = Dimensions.get('window');
+  const [headerFooterHidden, setHeaderFooterHidden] = useState(false);
   const client = useStreamVideoClient();
   const connectedUser = useConnectedUser();
+  const bottomSheetModalRef = useRef<BottomSheetModal>(null);
+
+  const snapPoints = useMemo(() => ['10%', '50%'], []);
+  const currentPosition = useSharedValue(height);
+
+  const handlePresentModalPress = useCallback(() => {
+    bottomSheetModalRef.current?.present();
+  }, []);
+
+  const animatedStyles = useAnimatedStyle(() => {
+    return {
+      height: currentPosition.value,
+    };
+  });
+
+  const handleSheetChanges = useCallback(
+    (index: number) => {
+      if (index === -1) {
+        // Sheet is closed
+        setHeaderFooterHidden(false);
+        currentPosition.value = withTiming(height);
+      } else {
+        // Sheet is open
+        setHeaderFooterHidden(true);
+        currentPosition.value = withTiming((height * 50) / 100);
+      }
+    },
+    [currentPosition, height],
+  );
+
   const callType = 'livestream';
   const {
     params: { callId },
@@ -57,16 +109,58 @@ export const HostLiveStreamScreen = ({ route }: HostLiveStreamScreenProps) => {
   }
 
   return (
-    <StreamCall call={call}>
-      <SafeAreaView style={styles.container}>
-        <HostLivestream />
-      </SafeAreaView>
-    </StreamCall>
+    <BottomSheetModalProvider>
+      <StreamCall call={call}>
+        <Animated.View style={[styles.animatedContainer, animatedStyles]}>
+          <SafeAreaView edges={['top']} style={styles.container}>
+            <HostLivestream
+              HostLivestreamTopView={
+                !headerFooterHidden ? HostLivestreamTopView : null
+              }
+              // eslint-disable-next-line react/no-unstable-nested-components
+              LivestreamMediaControls={() => (
+                <LivestreamMediaControls
+                  handlePresentModalPress={handlePresentModalPress}
+                />
+              )}
+            />
+          </SafeAreaView>
+        </Animated.View>
+      </StreamCall>
+      <BottomSheetModal
+        enablePanDownToClose={true}
+        handleStyle={{ backgroundColor: appTheme.colors.static_grey }}
+        ref={bottomSheetModalRef}
+        index={1}
+        snapPoints={snapPoints}
+        onChange={handleSheetChanges}
+      >
+        <BottomSheetView style={styles.contentContainer}>
+          <LivestreamChat callId={callId} callType={callType} />
+        </BottomSheetView>
+      </BottomSheetModal>
+    </BottomSheetModalProvider>
   );
 };
 
 const styles = StyleSheet.create({
+  animatedContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: '100%', // Adjust the height according to your design
+    elevation: 5,
+  },
   container: {
     flex: 1,
+  },
+  mediaControlsContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  contentContainer: {
+    flex: 1,
+    alignItems: 'center',
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3388,6 +3388,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gorhom/bottom-sheet@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "@gorhom/bottom-sheet@npm:4.6.1"
+  dependencies:
+    "@gorhom/portal": 1.0.14
+    invariant: ^2.2.4
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-native": "*"
+    react: "*"
+    react-native: "*"
+    react-native-gesture-handler: ">=1.10.1"
+    react-native-reanimated: ">=2.2.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-native":
+      optional: true
+  checksum: fc30da15c5d7e7c7b81ad2450e6ecb3884f0e040bc1ed5f467b1f846e2598519608a21c14cd50ea8288caac3cdfd9ad2c7742c31c77dd137804f94148105f389
+  languageName: node
+  linkType: hard
+
 "@gorhom/portal@npm:1.0.14":
   version: 1.0.14
   resolution: "@gorhom/portal@npm:1.0.14"
@@ -7035,6 +7057,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
+    "@gorhom/bottom-sheet": ^4.6.1
     "@notifee/react-native": ^7.8.0
     "@react-native-camera-roll/camera-roll": ^5.6.0
     "@react-native-clipboard/clipboard": ^1.11.1


### PR DESCRIPTION
This PR tends to add chat in the bottom sheet for viewers and host live streams.
For `ViewerLiveStream` a new prop is introduced(`ViewerLiveStreamControlsRightElement`) for the right element of the controls so that integrators can add custom elements if they would like to on the right side without much of additional customization.
Comments around the integration of live stream in dogfood app for the viewer's end are also improved in the PR.