### PR TITLE
fix(filters)!: fixes off-by-one version conflict

### DIFF
--- a/packages/video-filters-web/project.json
+++ b/packages/video-filters-web/project.json
@@ -24,8 +24,20 @@
         "push": true,
         "skipCommitTypes": ["chore", "ci", "refactor", "test", "docs"],
         "postTargets": [
+          "@stream-io/video-filters-web:update-version",
           "@stream-io/video-filters-web:github",
           "@stream-io/video-filters-web:publish"
+        ]
+      }
+    },
+    "update-version": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "yarn build:video-filters-web",
+            "forwardAllArgs": false
+          }
         ]
       }
     },


### PR DESCRIPTION
### Overview

Fixes a build/release problem where the bundled package version won't match with the one in `package.json`.

Note: this PR is flagged as "breaking!" as I want to release `v0.1.0` of this package.