### PR TITLE
fix(codecs): Set codec preferences based on receiving capabilities

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -289,12 +289,16 @@ export class Publisher {
       this.publishOptionsPerTrackType.set(trackType, opts);
 
       if ('setCodecPreferences' in transceiver && codecPreferences) {
-        logger(
-          'info',
-          `Setting ${TrackType[trackType]} codec preferences`,
-          codecPreferences,
-        );
-        transceiver.setCodecPreferences(codecPreferences);
+        try {
+          logger(
+            'info',
+            `Setting ${TrackType[trackType]} codec preferences`,
+            codecPreferences,
+          );
+          transceiver.setCodecPreferences(codecPreferences);
+        } catch (err) {
+          logger('warn', `Couldn't set codec preferences`, err);
+        }
       }
     } else {
       const previousTrack = transceiver.sender.track;

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -289,12 +289,12 @@ export class Publisher {
       this.publishOptionsPerTrackType.set(trackType, opts);
 
       if ('setCodecPreferences' in transceiver && codecPreferences) {
+        logger(
+          'info',
+          `Setting ${TrackType[trackType]} codec preferences`,
+          codecPreferences,
+        );
         try {
-          logger(
-            'info',
-            `Setting ${TrackType[trackType]} codec preferences`,
-            codecPreferences,
-          );
           transceiver.setCodecPreferences(codecPreferences);
         } catch (err) {
           logger('warn', `Couldn't set codec preferences`, err);

--- a/packages/client/src/rtc/codecs.ts
+++ b/packages/client/src/rtc/codecs.ts
@@ -7,17 +7,17 @@ export const getPreferredCodecs = (
 ): RTCRtpCodecCapability[] | undefined => {
   const logger = getLogger(['codecs']);
   if (!('getCapabilities' in RTCRtpSender)) {
-    logger?.('warn', 'RTCRtpSender.getCapabilities is not supported');
+    logger('warn', 'RTCRtpSender.getCapabilities is not supported');
     return;
   }
-  const cap = RTCRtpSender.getCapabilities(kind);
+  const cap = RTCRtpReceiver.getCapabilities(kind);
   if (!cap) return;
   const matched: RTCRtpCodecCapability[] = [];
   const partialMatched: RTCRtpCodecCapability[] = [];
   const unmatched: RTCRtpCodecCapability[] = [];
   cap.codecs.forEach((c) => {
     const codec = c.mimeType.toLowerCase();
-    logger?.('debug', `Found supported codec: ${codec}`);
+    logger('debug', `Found supported codec: ${codec}`);
     const shouldRemoveCodec =
       codecToRemove && codec === `${kind}/${codecToRemove.toLowerCase()}`;
     if (shouldRemoveCodec) return;
@@ -39,9 +39,7 @@ export const getPreferredCodecs = (
     matched.push(c);
   });
 
-  const result = [...matched, ...partialMatched, ...unmatched];
-  logger?.('info', `Preffered codecs: `, result);
-  return result;
+  return [...matched, ...partialMatched, ...unmatched];
 };
 
 export const getGenericSdp = async (direction: RTCRtpTransceiverDirection) => {

--- a/packages/client/src/rtc/codecs.ts
+++ b/packages/client/src/rtc/codecs.ts
@@ -6,8 +6,8 @@ export const getPreferredCodecs = (
   codecToRemove?: string,
 ): RTCRtpCodecCapability[] | undefined => {
   const logger = getLogger(['codecs']);
-  if (!('getCapabilities' in RTCRtpSender)) {
-    logger('warn', 'RTCRtpSender.getCapabilities is not supported');
+  if (!('getCapabilities' in RTCRtpReceiver)) {
+    logger('warn', 'RTCRtpReceiver.getCapabilities is not supported');
     return;
   }
   const cap = RTCRtpReceiver.getCapabilities(kind);


### PR DESCRIPTION
### Overview

Chrome 124 introduces a breaking change in how codec preferences are handled. This led to some compatibility issues in our SDK:
```
DOMException: Failed to execute 'setCodecPreferences' on 'RTCRtpTransceiver': 
Invalid codec preferences: invalid codec with name "AV1".

DOMException: Failed to execute 'setCodecPreferences' on 'RTCRtpTransceiver':
Invalid codec preferences: invalid codec with name "H264".
```

This PR adjusts the codec selection according to the recommendations listed here:
- https://issues.chromium.org/issues/328396178
- https://groups.google.com/g/discuss-webrtc/c/QS7y-7zR5ok