### PR TITLE
fix(publisher): ensure initial bitrate is set

### DIFF
--- a/packages/client/src/rtc/__tests__/videoLayers.test.ts
+++ b/packages/client/src/rtc/__tests__/videoLayers.test.ts
@@ -71,6 +71,26 @@ describe('videoLayers', () => {
     ]);
   });
 
+  it('should use predefined bitrate values when track dimensions cant be determined', () => {
+    const width = 0;
+    const height = 0;
+    const bitrate = 3000000;
+    const track = new MediaStreamTrack();
+    vi.spyOn(track, 'getSettings').mockReturnValue({ width, height });
+    const layers = findOptimalVideoLayers(track, { width, height, bitrate });
+    expect(layers).toEqual([
+      {
+        active: true,
+        rid: 'q',
+        width: 0,
+        height: 0,
+        maxBitrate: bitrate,
+        scaleResolutionDownBy: 1,
+        maxFramerate: 30,
+      },
+    ]);
+  });
+
   it('should announce one simulcast layer for resolutions less than 320px wide', () => {
     const track = new MediaStreamTrack();
     const width = 320;

--- a/packages/client/src/rtc/videoLayers.ts
+++ b/packages/client/src/rtc/videoLayers.ts
@@ -15,6 +15,12 @@ const defaultTargetResolution: TargetResolution = {
   height: 720,
 };
 
+const defaultBitratePerRid: Record<string, number> = {
+  q: 300000,
+  h: 750000,
+  f: DEFAULT_BITRATE,
+};
+
 /**
  * Determines the most optimal video layers for simulcasting
  * for the given track.
@@ -43,7 +49,8 @@ export const findOptimalVideoLayers = (
       rid,
       width: Math.round(w / downscaleFactor),
       height: Math.round(h / downscaleFactor),
-      maxBitrate: Math.round(maxBitrate / downscaleFactor),
+      maxBitrate:
+        Math.round(maxBitrate / downscaleFactor) || defaultBitratePerRid[rid],
       scaleResolutionDownBy: downscaleFactor,
       // Simulcast on iOS React-Native requires all encodings to share the same framerate
       maxFramerate: {


### PR DESCRIPTION
### Overview

Fixes an issue where the track's bitrate is announced as 0 but in reality it isn't.

Sometimes, the track settings aren't initialized on time and hence, the track dimensions are reported as 0x0 by the browser.
Naturally, we expect 0 bits for encoding these track dimensions. However, once the browser recovers and real track dimensions can be determined, we have already sent the track announcement.
Now, instead of announcing 0 bitrate, we report some default values for each simulcasted track. The actual value would be adjusted by the SFU once the Publisher peer connection begins sending the video tracks.