### PR TITLE
chore: Node v22 compatibility

### DIFF
--- a/packages/audio-filters-web/rollup.config.mjs
+++ b/packages/audio-filters-web/rollup.config.mjs
@@ -1,7 +1,7 @@
 import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 
 /**
  * @type {import('rollup').RollupOptions}

--- a/packages/client/rollup.config.mjs
+++ b/packages/client/rollup.config.mjs
@@ -1,7 +1,7 @@
 import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 
 // these modules are used only in nodejs and are not needed in the browser
 const browserIgnoredModules = ['https', 'util', 'stream'];

--- a/packages/react-bindings/rollup.config.mjs
+++ b/packages/react-bindings/rollup.config.mjs
@@ -1,6 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
 
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 
 /**
  * @type {import('rollup').RollupOptions}

--- a/packages/react-sdk/rollup.config.mjs
+++ b/packages/react-sdk/rollup.config.mjs
@@ -2,7 +2,7 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import json from '@rollup/plugin-json';
 
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 
 /**
  * @type {import('rollup').RollupOptions}

--- a/packages/video-filters-web/rollup.config.mjs
+++ b/packages/video-filters-web/rollup.config.mjs
@@ -1,7 +1,7 @@
 import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 
 /**
  * @type {import('rollup').RollupOptions}


### PR DESCRIPTION
### Overview

Node v22 removes the deprecated `assert` keyword in favor of `with`:
- https://v8.dev/features/import-attributes#deprecation-and-eventual-removal-of-assert