### PR TITLE
fix(state): optimized Call State updates

### DIFF
--- a/.styles/Vocab/Base/accept.txt
+++ b/.styles/Vocab/Base/accept.txt
@@ -87,3 +87,6 @@ VoIP
 iOS
 Repo
 Screenshare
+proxied
+enum
+everytime

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -398,9 +398,8 @@ export class CallState {
      */
     const isShallowEqual = <T>(a: Array<T>, b: Array<T>): boolean => {
       if (a.length !== b.length) return false;
-      for (let i = 0; i < a.length; i++) {
-        if (b.indexOf(a[i]) === -1) return false;
-      }
+      for (const item of a) if (!b.includes(item)) return false;
+      for (const item of b) if (!a.includes(item)) return false;
       return true;
     };
 

--- a/packages/client/src/store/__tests__/CallState.test.ts
+++ b/packages/client/src/store/__tests__/CallState.test.ts
@@ -26,7 +26,6 @@ import * as TestData from '../../sorting/__tests__/participant-data';
 describe('CallState', () => {
   describe('API assertions', () => {
     it('every exposed observable$ should have a getter', () => {
-      // Object.getOwnPropertyDescriptors(call.state.__proto__)['backstage'].get.call(call.state)
       const state = new CallState();
       const observables = Object.keys(
         Object.getOwnPropertyDescriptors(state),

--- a/packages/client/src/store/__tests__/CallState.test.ts
+++ b/packages/client/src/store/__tests__/CallState.test.ts
@@ -133,6 +133,37 @@ describe('CallState', () => {
       expect(subscriber).toBeCalledTimes(4);
       subscription.unsubscribe();
     });
+
+    it(`shouldn't emit when string arrays (blockedUserIds) value didn't change`, () => {
+      const state = new CallState();
+      const updateWith = (value: string[]) => {
+        // @ts-expect-error incomplete data
+        state.updateFromCallResponse({ blocked_user_ids: value });
+      };
+
+      updateWith(['a', 'b']);
+
+      const subscriber = vi.fn();
+      const subscription = state.blockedUserIds$.subscribe(subscriber);
+      expect(subscriber).toBeCalledTimes(1);
+
+      updateWith(['a', 'b', 'b']);
+      expect(subscriber).toBeCalledTimes(2);
+
+      updateWith(['a', 'b', 'c']);
+      expect(subscriber).toBeCalledTimes(3);
+
+      updateWith(['a', 'b']);
+      expect(subscriber).toBeCalledTimes(4);
+
+      updateWith(['a', 'b', 'c']);
+      expect(subscriber).toBeCalledTimes(5);
+
+      updateWith(['b', 'c', 'a']);
+      expect(subscriber).toBeCalledTimes(5);
+
+      subscription.unsubscribe();
+    });
   });
 
   describe('updateOrAddParticipant', () => {


### PR DESCRIPTION
### Overview

**Observables emitting primitive values will emit only when the value changes**
`false` -> `false` - the subscribers won't run for the second update as the value didn't change


**updateOrAddParticipant doesn't iterate the participant array twice before updating or adding a participant**
We were iterating the participant array to figure out whether to add a participant or update an existing one. Then, we create a shallow clone of the array and apply the updates. This isn't optimal.
Now, these two operations are merged into one operation.