### PR TITLE
fix(devices): API to disable speaking while muted notifications

### DIFF
--- a/packages/client/docusaurus/docs/javascript/02-guides/04-camera-and-microphone.mdx
+++ b/packages/client/docusaurus/docs/javascript/02-guides/04-camera-and-microphone.mdx
@@ -238,6 +238,7 @@ call.microphone.state.mediaStream$.subscribe(async (mediaStream) => {
 ### Speaking while muted notification
 
 When the microphone is disabled, the client will automatically start monitoring audio levels, to detect if the user is speaking.
+This feature is enabled by default unless the user doesn't have the permission to send audio or explicitly disabled.
 
 This is how you can subscribe to these notifications:
 
@@ -248,9 +249,13 @@ call.microphone.state.speakingWhileMuted$.subscribe((isSpeaking) => {
     console.log(`You're muted, unmute yourself to speak`);
   }
 }); // Reactive value
-```
 
-The notification is automatically disabled if the user doesn't have the permission to send audio.
+// to disable this feature completely:
+await call.microphone.setSpeakingWhileMutedNotificationEnabled(false);
+
+// to enable it back:
+await call.microphone.setSpeakingWhileMutedNotificationEnabled(true);
+```
 
 ### Noise Cancellation
 

--- a/packages/client/src/devices/CameraManagerState.ts
+++ b/packages/client/src/devices/CameraManagerState.ts
@@ -45,8 +45,11 @@ export class CameraManagerState extends InputMediaDeviceManagerState {
   /**
    * @internal
    */
-  setMediaStream(stream: MediaStream | undefined): void {
-    super.setMediaStream(stream);
+  setMediaStream(
+    stream: MediaStream | undefined,
+    rootStream: MediaStream | undefined,
+  ): void {
+    super.setMediaStream(stream, rootStream);
     if (stream) {
       // RN getSettings() doesn't return facingMode, so we don't verify camera direction
       const direction = isReactNative()

--- a/packages/client/src/devices/InputMediaDeviceManagerState.ts
+++ b/packages/client/src/devices/InputMediaDeviceManagerState.ts
@@ -9,6 +9,7 @@ import { RxUtils } from '../store';
 import { getLogger } from '../logger';
 
 export type InputDeviceStatus = 'enabled' | 'disabled' | undefined;
+export type TrackDisableMode = 'stop-tracks' | 'disable-tracks';
 
 export abstract class InputMediaDeviceManagerState<C = MediaTrackConstraints> {
   protected statusSubject = new BehaviorSubject<InputDeviceStatus>(undefined);
@@ -102,9 +103,7 @@ export abstract class InputMediaDeviceManagerState<C = MediaTrackConstraints> {
    * `undefined` means no permission is required.
    */
   constructor(
-    public readonly disableMode:
-      | 'stop-tracks'
-      | 'disable-tracks' = 'stop-tracks',
+    public readonly disableMode: TrackDisableMode = 'stop-tracks',
     private readonly permissionName: PermissionName | undefined = undefined,
   ) {}
 
@@ -146,13 +145,20 @@ export abstract class InputMediaDeviceManagerState<C = MediaTrackConstraints> {
   }
 
   /**
+   * Updates the `mediaStream` state variable.
+   *
    * @internal
    * @param stream the stream to set.
+   * @param rootStream the root stream, applicable when filters are used
+   * as this is the stream that holds the actual deviceId information.
    */
-  setMediaStream(stream: MediaStream | undefined) {
+  setMediaStream(
+    stream: MediaStream | undefined,
+    rootStream: MediaStream | undefined,
+  ) {
     this.setCurrentValue(this.mediaStreamSubject, stream);
-    if (stream) {
-      this.setDevice(this.getDeviceIdFromStream(stream));
+    if (rootStream) {
+      this.setDevice(this.getDeviceIdFromStream(rootStream));
     }
   }
 

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -3,6 +3,7 @@ import type { INoiseCancellation } from '@stream-io/audio-filters-web';
 import { Call } from '../Call';
 import { InputMediaDeviceManager } from './InputMediaDeviceManager';
 import { MicrophoneManagerState } from './MicrophoneManagerState';
+import { TrackDisableMode } from './InputMediaDeviceManagerState';
 import { getAudioDevices, getAudioStream } from './devices';
 import { TrackType } from '../gen/video/sfu/models/models';
 import { createSoundDetector } from '../helpers/sound-detector';
@@ -16,37 +17,48 @@ import { createSubscription } from '../store/rxUtils';
 import { RNSpeechDetector } from '../helpers/RNSpeechDetector';
 
 export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManagerState> {
+  private speakingWhileMutedNotificationEnabled = true;
   private soundDetectorCleanup?: Function;
   private rnSpeechDetector: RNSpeechDetector | undefined;
   private noiseCancellation: INoiseCancellation | undefined;
   private noiseCancellationChangeUnsubscribe: (() => void) | undefined;
   private noiseCancellationRegistration?: Promise<() => Promise<void>>;
 
-  constructor(call: Call) {
-    super(call, new MicrophoneManagerState(), TrackType.AUDIO);
+  constructor(
+    call: Call,
+    disableMode: TrackDisableMode = isReactNative()
+      ? 'disable-tracks'
+      : 'stop-tracks',
+  ) {
+    super(call, new MicrophoneManagerState(disableMode), TrackType.AUDIO);
 
-    combineLatest([
-      this.call.state.callingState$,
-      this.call.state.ownCapabilities$,
-      this.state.selectedDevice$,
-      this.state.status$,
-    ]).subscribe(async ([callingState, ownCapabilities, deviceId, status]) => {
-      if (callingState !== CallingState.JOINED) {
-        if (callingState === CallingState.LEFT) {
-          await this.stopSpeakingWhileMutedDetection();
-        }
-        return;
-      }
-      if (ownCapabilities.includes(OwnCapability.SEND_AUDIO)) {
-        if (status === 'disabled') {
-          await this.startSpeakingWhileMutedDetection(deviceId);
-        } else {
-          await this.stopSpeakingWhileMutedDetection();
-        }
-      } else {
-        await this.stopSpeakingWhileMutedDetection();
-      }
-    });
+    this.subscriptions.push(
+      createSubscription(
+        combineLatest([
+          this.call.state.callingState$,
+          this.call.state.ownCapabilities$,
+          this.state.selectedDevice$,
+          this.state.status$,
+        ]),
+        async ([callingState, ownCapabilities, deviceId, status]) => {
+          if (callingState === CallingState.LEFT) {
+            await this.stopSpeakingWhileMutedDetection();
+          }
+          if (callingState !== CallingState.JOINED) return;
+          if (!this.speakingWhileMutedNotificationEnabled) return;
+
+          if (ownCapabilities.includes(OwnCapability.SEND_AUDIO)) {
+            if (status === 'disabled') {
+              await this.startSpeakingWhileMutedDetection(deviceId);
+            } else {
+              await this.stopSpeakingWhileMutedDetection();
+            }
+          } else {
+            await this.stopSpeakingWhileMutedDetection();
+          }
+        },
+      ),
+    );
 
     this.subscriptions.push(
       createSubscription(this.call.state.callingState$, (callingState) => {
@@ -163,6 +175,20 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
     await this.call.notifyNoiseCancellationStopped();
   }
 
+  /**
+   * Enables or disables the speaking-while-muted notification.
+   *
+   * @param enabled the value to set.
+   */
+  async setSpeakingWhileMutedNotificationEnabled(enabled: boolean) {
+    this.speakingWhileMutedNotificationEnabled = enabled;
+    if (!enabled) {
+      await this.stopSpeakingWhileMutedDetection();
+    } else if (enabled && this.state.status === 'disabled') {
+      await this.startSpeakingWhileMutedDetection(this.state.selectedDevice);
+    }
+  }
+
   protected getDevices(): Observable<MediaDeviceInfo[]> {
     return getAudioDevices();
   }
@@ -208,9 +234,7 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
   }
 
   private async stopSpeakingWhileMutedDetection() {
-    if (!this.soundDetectorCleanup) {
-      return;
-    }
+    if (!this.soundDetectorCleanup) return;
     this.state.setSpeakingWhileMuted(false);
     try {
       await this.soundDetectorCleanup();

--- a/packages/client/src/devices/MicrophoneManagerState.ts
+++ b/packages/client/src/devices/MicrophoneManagerState.ts
@@ -1,5 +1,8 @@
 import { BehaviorSubject, distinctUntilChanged, Observable } from 'rxjs';
-import { InputMediaDeviceManagerState } from './InputMediaDeviceManagerState';
+import {
+  InputMediaDeviceManagerState,
+  TrackDisableMode,
+} from './InputMediaDeviceManagerState';
 
 export class MicrophoneManagerState extends InputMediaDeviceManagerState {
   private speakingWhileMutedSubject = new BehaviorSubject<boolean>(false);
@@ -11,9 +14,9 @@ export class MicrophoneManagerState extends InputMediaDeviceManagerState {
    */
   speakingWhileMuted$: Observable<boolean>;
 
-  constructor() {
+  constructor(disableMode: TrackDisableMode) {
     super(
-      'disable-tracks',
+      disableMode,
       // `microphone` is not in the W3C standard yet,
       // but it's supported by Chrome and Safari.
       'microphone' as PermissionName,

--- a/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
@@ -76,6 +76,7 @@ describe('MicrophoneManager', () => {
         streamClient: new StreamClient('abc123'),
         clientStore: new StreamVideoWriteableStateStore(),
       }),
+      'disable-tracks',
     );
   });
   it('list devices', () => {
@@ -147,65 +148,89 @@ describe('MicrophoneManager', () => {
     expect(manager.state.mediaStream).toBeUndefined();
   });
 
-  it(`should start sound detection if mic is disabled`, async () => {
-    await manager.enable();
-    // @ts-expect-error
-    vi.spyOn(manager, 'startSpeakingWhileMutedDetection');
-    await manager.disable();
+  describe('Speaking While Muted', () => {
+    it(`should start sound detection if mic is disabled`, async () => {
+      await manager.enable();
+      // @ts-expect-error
+      vi.spyOn(manager, 'startSpeakingWhileMutedDetection');
+      await manager.disable();
 
-    expect(manager['startSpeakingWhileMutedDetection']).toHaveBeenCalled();
-  });
-
-  it(`should stop sound detection if mic is enabled`, async () => {
-    manager.state.setSpeakingWhileMuted(true);
-    manager['soundDetectorCleanup'] = () => {};
-
-    await manager.enable();
-
-    expect(manager.state.speakingWhileMuted).toBe(false);
-  });
-
-  it('should update speaking while muted state', async () => {
-    const mock = createSoundDetector as Mock;
-    let handler: SoundStateChangeHandler;
-    mock.mockImplementation((_: MediaStream, h: SoundStateChangeHandler) => {
-      handler = h;
+      expect(manager['startSpeakingWhileMutedDetection']).toHaveBeenCalled();
     });
-    await manager['startSpeakingWhileMutedDetection']();
 
-    expect(manager.state.speakingWhileMuted).toBe(false);
+    it(`should stop sound detection if mic is enabled`, async () => {
+      manager.state.setSpeakingWhileMuted(true);
+      manager['soundDetectorCleanup'] = () => {};
 
-    handler!({ isSoundDetected: true, audioLevel: 2 });
+      await manager.enable();
 
-    expect(manager.state.speakingWhileMuted).toBe(true);
+      expect(manager.state.speakingWhileMuted).toBe(false);
+    });
 
-    handler!({ isSoundDetected: false, audioLevel: 0 });
+    it('should update speaking while muted state', async () => {
+      const mock = createSoundDetector as Mock;
+      let handler: SoundStateChangeHandler;
+      mock.mockImplementation((_: MediaStream, h: SoundStateChangeHandler) => {
+        handler = h;
+      });
+      await manager['startSpeakingWhileMutedDetection']();
 
-    expect(manager.state.speakingWhileMuted).toBe(false);
-  });
+      expect(manager.state.speakingWhileMuted).toBe(false);
 
-  it('should stop speaking while muted notifications if user loses permission to send audio', async () => {
-    await manager.enable();
-    await manager.disable();
+      handler!({ isSoundDetected: true, audioLevel: 2 });
 
-    // @ts-expect-error
-    vi.spyOn(manager, 'stopSpeakingWhileMutedDetection');
-    manager['call'].state.setOwnCapabilities([]);
+      expect(manager.state.speakingWhileMuted).toBe(true);
 
-    expect(manager['stopSpeakingWhileMutedDetection']).toHaveBeenCalled();
-  });
+      handler!({ isSoundDetected: false, audioLevel: 0 });
 
-  it('should start speaking while muted notifications if user gains permission to send audio', async () => {
-    await manager.enable();
-    await manager.disable();
+      expect(manager.state.speakingWhileMuted).toBe(false);
+    });
 
-    manager['call'].state.setOwnCapabilities([]);
+    it('should stop speaking while muted notifications if user loses permission to send audio', async () => {
+      await manager.enable();
+      await manager.disable();
 
-    // @ts-expect-error
-    vi.spyOn(manager, 'stopSpeakingWhileMutedDetection');
-    manager['call'].state.setOwnCapabilities([OwnCapability.SEND_AUDIO]);
+      // @ts-expect-error
+      vi.spyOn(manager, 'stopSpeakingWhileMutedDetection');
+      manager['call'].state.setOwnCapabilities([]);
 
-    expect(manager['stopSpeakingWhileMutedDetection']).toHaveBeenCalled();
+      expect(manager['stopSpeakingWhileMutedDetection']).toHaveBeenCalled();
+    });
+
+    it('should start speaking while muted notifications if user gains permission to send audio', async () => {
+      await manager.enable();
+      await manager.disable();
+
+      manager['call'].state.setOwnCapabilities([]);
+
+      // @ts-expect-error
+      vi.spyOn(manager, 'stopSpeakingWhileMutedDetection');
+      manager['call'].state.setOwnCapabilities([OwnCapability.SEND_AUDIO]);
+
+      expect(manager['stopSpeakingWhileMutedDetection']).toHaveBeenCalled();
+    });
+
+    it(`disables speaking while muted notifications`, async () => {
+      // @ts-expect-error - private api
+      vi.spyOn(manager, 'startSpeakingWhileMutedDetection');
+      // @ts-expect-error - private api
+      vi.spyOn(manager, 'stopSpeakingWhileMutedDetection');
+
+      await manager.setSpeakingWhileMutedNotificationEnabled(false);
+      await manager.disable();
+      expect(manager['stopSpeakingWhileMutedDetection']).toHaveBeenCalled();
+      expect(
+        manager['startSpeakingWhileMutedDetection'],
+      ).not.toHaveBeenCalled();
+    });
+
+    it(`enables speaking while muted notifications`, async () => {
+      // @ts-expect-error - private api
+      vi.spyOn(manager, 'startSpeakingWhileMutedDetection');
+      await manager.setSpeakingWhileMutedNotificationEnabled(true);
+      await manager.disable();
+      expect(manager['startSpeakingWhileMutedDetection']).toHaveBeenCalled();
+    });
   });
 
   describe('Noise Cancellation', () => {

--- a/packages/client/src/helpers/RNSpeechDetector.ts
+++ b/packages/client/src/helpers/RNSpeechDetector.ts
@@ -1,18 +1,6 @@
 import { BaseStats } from '../stats';
 import { SoundStateChangeHandler } from './sound-detector';
-
-/**
- * Flatten the stats report into an array of stats objects.
- *
- * @param report the report to flatten.
- */
-const flatten = (report: RTCStatsReport) => {
-  const stats: RTCStats[] = [];
-  report.forEach((s) => {
-    stats.push(s);
-  });
-  return stats;
-};
+import { flatten } from '../stats/utils';
 
 const AUDIO_LEVEL_THRESHOLD = 0.2;
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/04-camera-and-microphone.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/04-camera-and-microphone.mdx
@@ -141,6 +141,31 @@ const { useMicrophoneState } = useCallStateHooks();
 const { status } = useMicrophoneState(); // status returns enabled, disabled or undefined
 ```
 
+### Speaking while muted detection
+
+Our SDK provides a mechanism that can detect whether the user started to speak while being muted.
+Through this mechanism, you can display a notification to the user, or apply any custom logic.
+
+This feature is enabled by default unless the user doesn't have the permission to send audio or explicitly disabled.
+
+```tsx
+import { useCallStateHooks } from '@stream-io/video-react-native-sdk';
+
+const { useMicrophoneState } = useCallStateHooks();
+const { isSpeakingWhileMuted, microphone } = useMicrophoneState();
+
+if (isSpeakingWhileMuted) {
+  // your custom logic comes here
+  console.log('You are speaking while muted!');
+}
+
+// to disable this feature completely:
+await microphone.setSpeakingWhileMutedNotificationEnabled(false);
+
+// to enable it back:
+await microphone.setSpeakingWhileMutedNotificationEnabled(true);
+```
+
 ## Speaker management
 
 :::warning

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/04-camera-and-microphone.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/04-camera-and-microphone.mdx
@@ -158,16 +158,24 @@ if (hasBrowserPermission) {
 Our SDK provides a mechanism that can detect whether the user started to speak while being muted.
 Through this mechanism, you can display a notification to the user, or apply any custom logic.
 
+This feature is enabled by default unless the user doesn't have the permission to send audio or explicitly disabled.
+
 ```tsx
 import { useCallStateHooks } from '@stream-io/video-react-sdk';
 
 const { useMicrophoneState } = useCallStateHooks();
-const { isSpeakingWhileMuted } = useMicrophoneState();
+const { isSpeakingWhileMuted, microphone } = useMicrophoneState();
 
 if (isSpeakingWhileMuted) {
   // your custom logic comes here
   console.log('You are speaking while muted!');
 }
+
+// to disable this feature completely:
+await microphone.setSpeakingWhileMutedNotificationEnabled(false);
+
+// to enable it back:
+await microphone.setSpeakingWhileMutedNotificationEnabled(true);
 ```
 
 ### Noise Cancellation

--- a/packages/react-sdk/src/hooks/usePersistedDevicePreferences.ts
+++ b/packages/react-sdk/src/hooks/usePersistedDevicePreferences.ts
@@ -76,6 +76,7 @@ const useApplyDevicePreferences = (key: string) => {
   const settings = useCallSettings();
   useEffect(() => {
     if (!call || !settings) return;
+    if (call.state.callingState === CallingState.LEFT) return;
 
     const apply = async () => {
       const initMic = async (setting: LocalDevicePreference) => {

--- a/sample-apps/react/react-dogfood/components/MeetingUI.tsx
+++ b/sample-apps/react/react-dogfood/components/MeetingUI.tsx
@@ -13,7 +13,11 @@ import {
 
 import { Lobby, UserMode } from './Lobby';
 import { StreamChat } from 'stream-chat';
-import { useKeyboardShortcuts, useWakeLock } from '../hooks';
+import {
+  useKeyboardShortcuts,
+  usePersistedVideoFilter,
+  useWakeLock,
+} from '../hooks';
 import { ActiveCall } from './ActiveCall';
 import { Feedback } from './Feedback/Feedback';
 import { DefaultAppHeader } from './DefaultAppHeader';
@@ -121,8 +125,7 @@ export const MeetingUI = ({ chatClient, mode }: MeetingUIProps) => {
   useKeyboardShortcuts();
   useWakeLock();
   usePersistedDevicePreferences('@pronto/device-preferences');
-  // TODO OL: fix race conditions and enable this
-  // usePersistedVideoFilter('@pronto/video-filter');
+  usePersistedVideoFilter('@pronto/video-filter');
 
   let ComponentToRender: JSX.Element;
   if (show === 'error-join' || show === 'error-leave') {


### PR DESCRIPTION
### Overview

A joint PR that fixes a couple of related issues:
- Adds an API that disables speaking while muted notifications - fixes #1329
- The selected device can't be reliably detected when audio or video filters are used
- Audio tracks are now stopped (instead of disabled) on the Web - this should release the mic allocation
- Fixed an issue in `usePersistedDevicePreferences()` where the camera and mic were automatically enabled after a call had been left
- Pronto and Video Demo now remember the last used video filter and they enable it automatically