### PR TITLE
feat: support target_resolution backend setting for screensharing

### DIFF
--- a/packages/client/src/devices/ScreenShareManager.ts
+++ b/packages/client/src/devices/ScreenShareManager.ts
@@ -5,6 +5,7 @@ import { Call } from '../Call';
 import { TrackType } from '../gen/video/sfu/models/models';
 import { getScreenShareStream } from './devices';
 import { ScreenShareSettings } from '../types';
+import { createSubscription } from '../store/rxUtils';
 
 export class ScreenShareManager extends InputMediaDeviceManager<
   ScreenShareState,
@@ -12,6 +13,21 @@ export class ScreenShareManager extends InputMediaDeviceManager<
 > {
   constructor(call: Call) {
     super(call, new ScreenShareState(), TrackType.SCREEN_SHARE);
+
+    this.subscriptions.push(
+      createSubscription(call.state.settings$, (settings) => {
+        const maybeTargetResolution = settings?.screensharing.target_resolution;
+
+        if (maybeTargetResolution) {
+          this.setDefaultConstraints({
+            video: {
+              width: maybeTargetResolution.width,
+              height: maybeTargetResolution.height,
+            },
+          });
+        }
+      }),
+    );
   }
 
   /**

--- a/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
+++ b/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
@@ -82,7 +82,7 @@ describe('ScreenShareManager', () => {
     expect(manager.state.selectedDevice).toEqual('screen');
   });
 
-  it.only('should use call settings to set up constraints', async () => {
+  it('should use call settings to set up constraints', async () => {
     const call = manager['call'];
     call.state.setCurrentValue(call.state['settingsSubject'], {
       screensharing: {

--- a/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
+++ b/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
@@ -7,6 +7,7 @@ import * as RxUtils from '../../store/rxUtils';
 import { mockCall, mockDeviceIds$, mockScreenShareStream } from './mocks';
 import { getScreenShareStream } from '../devices';
 import { TrackType } from '../../gen/video/sfu/models/models';
+import { CallSettingsResponse } from '../../gen/coordinator';
 
 vi.mock('../devices.ts', () => {
   console.log('MOCKING devices API');
@@ -79,6 +80,26 @@ describe('ScreenShareManager', () => {
     await manager.enable();
     expect(manager.state.selectedDevice).toBeDefined();
     expect(manager.state.selectedDevice).toEqual('screen');
+  });
+
+  it.only('should use call settings to set up constraints', async () => {
+    const call = manager['call'];
+    call.state.setCurrentValue(call.state['settingsSubject'], {
+      screensharing: {
+        target_resolution: {
+          width: 800,
+          height: 600,
+          bitrate: 192000,
+        },
+      },
+    } as CallSettingsResponse);
+
+    expect(manager.state.defaultConstraints).toMatchObject({
+      video: {
+        width: 800,
+        height: 600,
+      },
+    });
   });
 
   it('publishes screen share stream', async () => {

--- a/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
+++ b/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
@@ -59,9 +59,11 @@ describe('ScreenShareManager', () => {
     await manager.enable();
     expect(manager.state.status).toEqual('enabled');
 
-    expect(getScreenShareStream).toHaveBeenCalledWith({
-      deviceId: undefined,
-    });
+    expect(getScreenShareStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceId: undefined,
+      }),
+    );
   });
 
   it('get stream with no audio', async () => {
@@ -69,10 +71,12 @@ describe('ScreenShareManager', () => {
     await manager.enable();
     expect(manager.state.status).toEqual('enabled');
 
-    expect(getScreenShareStream).toHaveBeenCalledWith({
-      deviceId: undefined,
-      audio: false,
-    });
+    expect(getScreenShareStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceId: undefined,
+        audio: false,
+      }),
+    );
   });
 
   it('should get device id from stream', async () => {
@@ -85,6 +89,7 @@ describe('ScreenShareManager', () => {
   it('should use call settings to set up constraints', async () => {
     const call = manager['call'];
     call.state.setCurrentValue(call.state['settingsSubject'], {
+      // @ts-expect-error partial data
       screensharing: {
         target_resolution: {
           width: 800,
@@ -92,14 +97,17 @@ describe('ScreenShareManager', () => {
           bitrate: 192000,
         },
       },
-    } as CallSettingsResponse);
-
-    expect(manager.state.defaultConstraints).toMatchObject({
-      video: {
-        width: 800,
-        height: 600,
-      },
     });
+
+    await manager.enable();
+    expect(getScreenShareStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        video: {
+          width: 800,
+          height: 600,
+        },
+      }),
+    );
   });
 
   it('publishes screen share stream', async () => {

--- a/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
+++ b/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
@@ -7,7 +7,6 @@ import * as RxUtils from '../../store/rxUtils';
 import { mockCall, mockDeviceIds$, mockScreenShareStream } from './mocks';
 import { getScreenShareStream } from '../devices';
 import { TrackType } from '../../gen/video/sfu/models/models';
-import { CallSettingsResponse } from '../../gen/coordinator';
 
 vi.mock('../devices.ts', () => {
   console.log('MOCKING devices API');

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -86,11 +86,7 @@ export const mockCall = (): Partial<Call> => {
       },
       // @ts-expect-error partial data
       screensharing: {
-        target_resolution: {
-          width: 1920,
-          height: 1080,
-          bitrate: 3000000,
-        },
+        target_resolution: undefined,
       },
     },
   });

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -84,6 +84,14 @@ export const mockCall = (): Partial<Call> => {
           mode: NoiseCancellationSettingsModeEnum.AVAILABLE,
         },
       },
+      // @ts-expect-error partial data
+      screensharing: {
+        target_resolution: {
+          width: 1920,
+          height: 1080,
+          bitrate: 3000000,
+        },
+      },
     },
   });
   return {

--- a/packages/client/src/events/__tests__/call.test.ts
+++ b/packages/client/src/events/__tests__/call.test.ts
@@ -305,6 +305,10 @@ const fakeMetadata = (): CallResponse => {
         auto_cancel_timeout_ms: 30000,
         incoming_call_timeout_ms: 30000,
       },
+      // @ts-ignore
+      screensharing: {
+        target_resolution: undefined,
+      },
     },
   };
 };

--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -4104,6 +4104,12 @@ export interface ScreensharingSettings {
    * @memberof ScreensharingSettings
    */
   enabled: boolean;
+  /**
+   *
+   * @type {TargetResolution}
+   * @memberof ScreensharingSettings
+   */
+  target_resolution?: TargetResolution;
 }
 /**
  *
@@ -4123,6 +4129,12 @@ export interface ScreensharingSettingsRequest {
    * @memberof ScreensharingSettingsRequest
    */
   enabled?: boolean;
+  /**
+   *
+   * @type {TargetResolution}
+   * @memberof ScreensharingSettingsRequest
+   */
+  target_resolution?: TargetResolution;
 }
 /**
  *

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -240,11 +240,18 @@ export class Publisher {
     if (!transceiver) {
       const { settings } = this.state;
       const targetResolution = settings?.video.target_resolution;
+      const screenShareBitrate =
+        settings?.screensharing.target_resolution?.bitrate;
+
       const videoEncodings =
         trackType === TrackType.VIDEO
           ? findOptimalVideoLayers(track, targetResolution)
           : trackType === TrackType.SCREEN_SHARE
-          ? findOptimalScreenSharingLayers(track, opts.screenShareSettings)
+          ? findOptimalScreenSharingLayers(
+              track,
+              opts.screenShareSettings,
+              screenShareBitrate,
+            )
           : undefined;
 
       let preferredCodec = opts.preferredCodec;

--- a/packages/client/src/rtc/__tests__/videoLayers.test.ts
+++ b/packages/client/src/rtc/__tests__/videoLayers.test.ts
@@ -28,6 +28,17 @@ describe('videoLayers', () => {
     ]);
   });
 
+  it('should use default max bitrate if none is provided in preferences', () => {
+    const track = new MediaStreamTrack();
+    vi.spyOn(track, 'getSettings').mockReturnValue({
+      width: 1920,
+      height: 1080,
+    });
+
+    const layers = findOptimalScreenSharingLayers(track, undefined, 192000);
+    expect(layers).toMatchObject([{ maxBitrate: 192000 }]);
+  });
+
   it('should find optimal video layers', () => {
     const track = new MediaStreamTrack();
     const width = 1920;

--- a/packages/client/src/rtc/videoLayers.ts
+++ b/packages/client/src/rtc/videoLayers.ts
@@ -131,6 +131,7 @@ const withSimulcastConstraints = (
 export const findOptimalScreenSharingLayers = (
   videoTrack: MediaStreamTrack,
   preferences?: ScreenShareSettings,
+  defaultMaxBitrate?: number,
 ): OptimalVideoLayer[] => {
   const settings = videoTrack.getSettings();
   return [
@@ -140,7 +141,7 @@ export const findOptimalScreenSharingLayers = (
       width: settings.width || 0,
       height: settings.height || 0,
       scaleResolutionDownBy: 1,
-      maxBitrate: preferences?.maxBitrate ?? 3000000,
+      maxBitrate: preferences?.maxBitrate ?? defaultMaxBitrate ?? 3000000,
       maxFramerate: preferences?.maxFramerate ?? 30,
     },
   ];

--- a/packages/client/src/rtc/videoLayers.ts
+++ b/packages/client/src/rtc/videoLayers.ts
@@ -131,7 +131,7 @@ const withSimulcastConstraints = (
 export const findOptimalScreenSharingLayers = (
   videoTrack: MediaStreamTrack,
   preferences?: ScreenShareSettings,
-  defaultMaxBitrate?: number,
+  defaultMaxBitrate = 3000000,
 ): OptimalVideoLayer[] => {
   const settings = videoTrack.getSettings();
   return [
@@ -141,7 +141,7 @@ export const findOptimalScreenSharingLayers = (
       width: settings.width || 0,
       height: settings.height || 0,
       scaleResolutionDownBy: 1,
-      maxBitrate: preferences?.maxBitrate ?? defaultMaxBitrate ?? 3000000,
+      maxBitrate: preferences?.maxBitrate ?? defaultMaxBitrate,
       maxFramerate: preferences?.maxFramerate ?? 30,
     },
   ];


### PR DESCRIPTION
Adds support for a `target_resolution` setting on backend screensharing settings.