### PR TITLE
fix: do not check for expo notifications lib dependency unnecessarily

### DIFF
--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -39,9 +39,6 @@ export function setupFirebaseHandlerAndroid(pushConfig: PushConfig) {
     return;
   }
   if (pushConfig.isExpo) {
-    const Notifications = getExpoNotificationsLib();
-    const TaskManager = getExpoTaskManagerLib();
-
     const messaging = getFirebaseMessagingLibNoThrow(true);
     if (messaging) {
       // handles on app killed state in expo, expo-notifications cannot handle that
@@ -53,6 +50,8 @@ export function setupFirebaseHandlerAndroid(pushConfig: PushConfig) {
         firebaseMessagingOnMessageHandler(msg.data, pushConfig),
       ); // this is to listen to foreground messages, which we dont need for now
     } else {
+      const Notifications = getExpoNotificationsLib();
+      const TaskManager = getExpoTaskManagerLib();
       const BACKGROUND_NOTIFICATION_TASK =
         'STREAM-VIDEO-SDK-INTERNAL-BACKGROUND-NOTIFICATION-TASK';
 
@@ -103,6 +102,8 @@ export function setupFirebaseHandlerAndroid(pushConfig: PushConfig) {
       firebaseMessagingOnMessageHandler(msg.data, pushConfig),
     ); // this is to listen to foreground messages, which we dont need for now
   }
+
+  // the notification tap handlers are always registered with notifee for both platforms
   notifee.onBackgroundEvent(async (event) => {
     await onNotifeeEvent(event, pushConfig);
   });

--- a/packages/react-native-sdk/src/utils/push/ios.ts
+++ b/packages/react-native-sdk/src/utils/push/ios.ts
@@ -129,7 +129,11 @@ export async function initIosNonVoipToken(
   pushConfig: PushConfig,
   setUnsubscribeListener: (unsubscribe: () => void) => void,
 ) {
-  if (Platform.OS !== 'ios' || !pushConfig.ios.pushProviderName) {
+  if (
+    Platform.OS !== 'ios' ||
+    !pushConfig.ios.pushProviderName ||
+    !pushConfig.onTapNonRingingCallNotification
+  ) {
     return;
   }
   const setDeviceToken = async (token: string) => {


### PR DESCRIPTION
Fixes 2 bugs:

- android: expo notifcations should not have been checked for android even in ringing mode
- ios: expo notifications should be registered only when non ringing handlers were registered