### PR TITLE
fix: improve error handling across the SDK

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -285,7 +285,10 @@ export class Call {
           debounce((v) => timer(v.type)),
           map((v) => v.data),
         ),
-        (subscriptions) => this.sfuClient?.updateSubscriptions(subscriptions),
+        (subscriptions) =>
+          this.sfuClient?.updateSubscriptions(subscriptions).catch((err) => {
+            this.logger('debug', `Failed to update track subscriptions`, err);
+          }),
       ),
     );
 

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -196,7 +196,7 @@ export abstract class InputMediaDeviceManager<
     }
   }
 
-  protected abstract getDevices(): Observable<MediaDeviceInfo[] | undefined>;
+  protected abstract getDevices(): Observable<MediaDeviceInfo[]>;
 
   protected abstract getStream(constraints: C): Promise<MediaStream>;
 

--- a/packages/react-bindings/src/hooks/callStateHooks.ts
+++ b/packages/react-bindings/src/hooks/callStateHooks.ts
@@ -17,6 +17,9 @@ import { useCall } from '../contexts';
 import { useObservableValue } from './useObservableValue';
 import { isReactNative } from '../helpers/platforms';
 
+// kind-of memoized, used as a default value
+const EMPTY_DEVICES_ARRAY = Object.freeze([]) as unknown as MediaDeviceInfo[];
+
 /**
  * Utility hook, which provides the current call's state.
  *
@@ -358,7 +361,7 @@ export const useCameraState = () => {
   const direction = useObservableValue(state.direction$);
   const mediaStream = useObservableValue(state.mediaStream$);
   const selectedDevice = useObservableValue(state.selectedDevice$);
-  const devices = useObservableValue(devices$);
+  const devices = useObservableValue(devices$, EMPTY_DEVICES_ARRAY);
   const hasBrowserPermission = useObservableValue(state.hasBrowserPermission$);
   const isMute = status !== 'enabled';
   const optimisticIsMute = optimisticStatus !== 'enabled';
@@ -394,7 +397,7 @@ export const useMicrophoneState = () => {
   const optimisticStatus = useObservableValue(state.optimisticStatus$);
   const mediaStream = useObservableValue(state.mediaStream$);
   const selectedDevice = useObservableValue(state.selectedDevice$);
-  const devices = useObservableValue(devices$);
+  const devices = useObservableValue(devices$, EMPTY_DEVICES_ARRAY);
   const hasBrowserPermission = useObservableValue(state.hasBrowserPermission$);
   const isSpeakingWhileMuted = useObservableValue(state.speakingWhileMuted$);
   const isMute = status !== 'enabled';
@@ -430,7 +433,7 @@ export const useSpeakerState = () => {
   const { speaker } = call as Call;
 
   const devices$ = useMemo(() => speaker.listDevices(), [speaker]);
-  const devices = useObservableValue(devices$);
+  const devices = useObservableValue(devices$, EMPTY_DEVICES_ARRAY);
   const selectedDevice = useObservableValue(speaker.state.selectedDevice$);
 
   return {

--- a/packages/react-bindings/src/hooks/useObservableValue.ts
+++ b/packages/react-bindings/src/hooks/useObservableValue.ts
@@ -5,17 +5,35 @@ import { RxUtils } from '@stream-io/video-client';
 /**
  * Utility hook which provides the current value of the given observable.
  * @internal
+ *
+ * @param observable$ the observable to read data from.
+ * @param defaultValue a default value. Used when the observable data can't be read or emits an error.
  */
-export const useObservableValue = <T>(observable$: Observable<T>) => {
-  const [value, setValue] = useState<T>(() =>
-    RxUtils.getCurrentValue(observable$),
-  );
+export const useObservableValue = <T>(
+  observable$: Observable<T>,
+  defaultValue?: T,
+) => {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      return RxUtils.getCurrentValue(observable$);
+    } catch (err) {
+      if (typeof defaultValue === 'undefined') throw err;
+      return defaultValue;
+    }
+  });
+
   useEffect(() => {
-    const subscription = observable$.subscribe(setValue);
+    const subscription = observable$.subscribe({
+      next: setValue,
+      error: (err) => {
+        console.log('An error occurred while reading an observable', err);
+        if (defaultValue) setValue(defaultValue);
+      },
+    });
     return () => {
       subscription.unsubscribe();
     };
-  }, [observable$]);
+  }, [defaultValue, observable$]);
 
   return value;
 };

--- a/sample-apps/react/react-dogfood/components/CallRecordings.tsx
+++ b/sample-apps/react/react-dogfood/components/CallRecordings.tsx
@@ -14,10 +14,13 @@ export const CallRecordings = () => {
 
   const fetchCallRecordings = useCallback(() => {
     if (!call) return;
-    call.queryRecordings().then(({ recordings }) => {
-      setCallRecordings(recordings);
-      setLoadingCallRecordings(false);
-    });
+    call
+      .queryRecordings()
+      .then(({ recordings }) => {
+        setCallRecordings(recordings);
+        setLoadingCallRecordings(false);
+      })
+      .catch((err) => console.error(`Failed to query recordings`, err));
   }, [call]);
 
   useEffect(() => {
@@ -39,7 +42,6 @@ export const CallRecordings = () => {
     );
 
     const unsubscribeRecordingReady = call.on('call.recording_ready', (e) => {
-      if (e.type !== 'call.recording_ready') return;
       const { call_recording: recording } = e;
       setCallRecordings((prev) => [...prev, recording]);
       setLoadingCallRecordings(false);


### PR DESCRIPTION
### Overview

Improves how unhandled promise rejections and unhandled observable errors are handled across the SDK.

We used to ignore promise rejections in the PeerConnection event handlers. This lead to situations where tools like Sentry were reporting too many incidents due to this. Now, the SDK gracefully handles these errors.

In the device management part, the `.listDevices()` method throws an error when the user rejects the prompted browser permissions. Now, instead of erroring, we return an empty list.