### PR TITLE
chore: don't fetch full git history for CI

### DIFF
--- a/.github/workflows/deploy-react-sample-apps.yml
+++ b/.github/workflows/deploy-react-sample-apps.yml
@@ -68,8 +68,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/docusaurus-javascript-deploy.yml
+++ b/.github/workflows/docusaurus-javascript-deploy.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Node Setup
         uses: actions/setup-node@v4

--- a/.github/workflows/docusaurus-react-deploy.yml
+++ b/.github/workflows/docusaurus-react-deploy.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Node Setup
         uses: actions/setup-node@v4

--- a/.github/workflows/docusaurus-react-native-deploy.yml
+++ b/.github/workflows/docusaurus-react-native-deploy.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Node Setup
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Just a quick fix for our workflows, no need to fetch full git history unless it's used for versioning.