### PR TITLE
fix: workaround for samsung device ringtone quirks

### DIFF
--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/StreamVideoReactNativeModule.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/StreamVideoReactNativeModule.kt
@@ -4,6 +4,7 @@ import android.app.AppOpsManager
 import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Process
 import android.util.Rational
@@ -13,8 +14,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.facebook.react.bridge.Promise;
-import android.media.RingtoneManager;
-
+import com.streamvideo.reactnative.util.RingtoneUtil
 
 class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
 
@@ -36,7 +36,13 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
 
     @ReactMethod
     fun getDefaultRingtoneUrl(promise: Promise) {
-        promise.resolve(RingtoneManager.getActualDefaultRingtoneUri(reactApplicationContext, RingtoneManager.TYPE_RINGTONE).toString());
+        val defaultRingtoneUri: Uri? =
+            RingtoneUtil.getActualDefaultRingtoneUri(reactApplicationContext);
+        if (defaultRingtoneUri != null) {
+            promise.resolve(defaultRingtoneUri.toString());
+        } else {
+            promise.reject(NAME, "Cannot get default ringtone in Android - check native logs for more info");
+        }
     }
 
     @ReactMethod

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/RingtoneUtil.java
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/RingtoneUtil.java
@@ -1,0 +1,121 @@
+package com.streamvideo.reactnative.util;
+
+import android.annotation.SuppressLint;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.media.Ringtone;
+import android.media.RingtoneManager;
+import android.net.Uri;
+import android.provider.Settings;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Original source: https://github.com/signalapp/Signal-Android/blob/main/app/src/main/java/org/thoughtcrime/securesms/util/RingtoneUtil.java
+ * Some custom ROMs and some Samsung Android 11 devices have quirks around accessing the default ringtone. This attempts to deal
+ * with them with progressively worse approaches.
+ */
+public final class RingtoneUtil {
+
+    private static final String TAG = "com.streamvideo.reactnative.util.RingtoneUtil";
+
+    private RingtoneUtil() {}
+
+    public static @Nullable Ringtone getRingtone(@NonNull Context context, @NonNull Uri uri) {
+        Ringtone tone;
+        try {
+            tone = RingtoneManager.getRingtone(context, uri);
+        } catch (SecurityException e) {
+            Log.w(TAG, "Unable to get default ringtone due to permission", e);
+            tone = RingtoneManager.getRingtone(context, RingtoneUtil.getActualDefaultRingtoneUri(context));
+        }
+        return tone;
+    }
+
+    public static @Nullable Uri getActualDefaultRingtoneUri(@NonNull Context context) {
+        Log.i(TAG, "Attempting to get default ringtone directly via normal way");
+        try {
+            return RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_RINGTONE);
+        } catch (SecurityException e) {
+            Log.w(TAG, "Failed to get ringtone with first fallback approach", e);
+        }
+
+        Log.i(TAG, "Attempting to get default ringtone directly via reflection");
+        String uriString   = getStringForUser(context.getContentResolver(), getUserId(context));
+        Uri    ringtoneUri = uriString != null ? Uri.parse(uriString) : null;
+
+        if (ringtoneUri != null && getUserIdFromAuthority(ringtoneUri.getAuthority(), getUserId(context)) == getUserId(context)) {
+            ringtoneUri = getUriWithoutUserId(ringtoneUri);
+        }
+
+        return ringtoneUri;
+    }
+
+    @SuppressWarnings("JavaReflectionMemberAccess")
+    @SuppressLint("DiscouragedPrivateApi")
+    private static @Nullable String getStringForUser(@NonNull ContentResolver resolver, int userHandle) {
+        try {
+            Method getStringForUser = Settings.System.class.getMethod("getStringForUser", ContentResolver.class, String.class, int.class);
+            return (String) getStringForUser.invoke(Settings.System.class, resolver, Settings.System.RINGTONE, userHandle);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            Log.w(TAG, "Unable to getStringForUser via reflection", e);
+        }
+        return null;
+    }
+
+    @SuppressWarnings("JavaReflectionMemberAccess")
+    @SuppressLint("DiscouragedPrivateApi")
+    private static int getUserId(@NonNull Context context) {
+        try {
+            Object userId = Context.class.getMethod("getUserId").invoke(context);
+            if (userId instanceof Integer) {
+                return (Integer) userId;
+            } else {
+                Log.w(TAG, "getUserId did not return an integer");
+            }
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            Log.w(TAG, "Unable to getUserId via reflection", e);
+        }
+        return 0;
+    }
+
+    private static @Nullable Uri getUriWithoutUserId(@Nullable Uri uri) {
+        if (uri == null) {
+            return null;
+        }
+        Uri.Builder builder = uri.buildUpon();
+        builder.authority(getAuthorityWithoutUserId(uri.getAuthority()));
+        return builder.build();
+    }
+
+    private static @Nullable String getAuthorityWithoutUserId(@Nullable String auth) {
+        if (auth == null) {
+            return null;
+        }
+        int end = auth.lastIndexOf('@');
+        return auth.substring(end + 1);
+    }
+
+    private static int getUserIdFromAuthority(@Nullable String authority, int defaultUserId) {
+        if (authority == null) {
+            return defaultUserId;
+        }
+
+        int end = authority.lastIndexOf('@');
+        if (end == -1) {
+            return defaultUserId;
+        }
+
+        String userIdString = authority.substring(0, end);
+        try {
+            return Integer.parseInt(userIdString);
+        } catch (NumberFormatException e) {
+            return defaultUserId;
+        }
+    }
+}

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/RingtoneUtil.java
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/RingtoneUtil.java
@@ -47,7 +47,7 @@ public final class RingtoneUtil {
 
         Log.i(TAG, "Attempting to get default ringtone directly via reflection");
         String uriString   = getStringForUser(context.getContentResolver(), getUserId(context));
-        Uri    ringtoneUri = uriString != null ? Uri.parse(uriString) : null;
+        Uri ringtoneUri = uriString != null ? Uri.parse(uriString) : null;
 
         if (ringtoneUri != null && getUserIdFromAuthority(ringtoneUri.getAuthority(), getUserId(context)) == getUserId(context)) {
             ringtoneUri = getUriWithoutUserId(ringtoneUri);

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/RingtoneUtil.java
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/RingtoneUtil.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Method;
  */
 public final class RingtoneUtil {
 
-    private static final String TAG = "com.streamvideo.reactnative.util.RingtoneUtil";
+    private static final String TAG = "RingtoneUtil";
 
     private RingtoneUtil() {}
 

--- a/packages/react-native-sdk/src/utils/getAndroidDefaultRingtoneUrl.ts
+++ b/packages/react-native-sdk/src/utils/getAndroidDefaultRingtoneUrl.ts
@@ -6,7 +6,13 @@ export async function getAndroidDefaultRingtoneUrl(): Promise<
   if (Platform.OS !== 'android') {
     return undefined;
   }
-  const url =
-    await NativeModules.StreamVideoReactNative?.getDefaultRingtoneUrl();
-  return url;
+  try {
+    const url =
+      await NativeModules.StreamVideoReactNative?.getDefaultRingtoneUrl();
+    return url;
+  } catch (e) {
+    console.info(e);
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
**Problem**: Some custom ROMs and some Samsung Android 11 devices have quirks around accessing the default ringtone.

**Solution**: Copy the workaround from Signal app by getting it via reflection. And catch it incase its null due to DRM issues.