### PR TITLE
fix: tour UI

### DIFF
--- a/sample-apps/react/react-dogfood/components/TourPanel/TourSDKOptions.tsx
+++ b/sample-apps/react/react-dogfood/components/TourPanel/TourSDKOptions.tsx
@@ -2,17 +2,23 @@ import { Icon } from '@stream-io/video-react-sdk';
 
 export const TourSDKOptions = () => {
   return (
-    <>
-      <div className="rd__sdk-options">
-        <div className="rd__sdk-options__option">
-          <Icon icon="layout-speaker-live-stream" />
-          Livestreaming
-        </div>
-        <div className="rd__sdk-options__option">
-          <Icon icon="mic" />
-          Audio Rooms
-        </div>
+    <div className="rd__sdk-options">
+      <div className="rd__sdk-options__option">
+        <Icon icon="layout-speaker-live-stream" />
+        Livestreaming
       </div>
-    </>
+      <div className="rd__sdk-options__option">
+        <Icon icon="mic" />
+        Audio Rooms
+      </div>
+      <div className="rd__sdk-options__option">
+        <Icon icon="camera" />
+        Video Calling
+      </div>
+      <div className="rd__sdk-options__option">
+        <Icon icon="call-accept" />
+        Audio Calling
+      </div>
+    </div>
   );
 };

--- a/sample-apps/react/react-dogfood/style/TourPanel.scss
+++ b/sample-apps/react/react-dogfood/style/TourPanel.scss
@@ -5,6 +5,7 @@
   position: fixed;
   border-radius: var(--str-video__border-radius-lg);
   background-color: var(--str-video__base-color6);
+  box-shadow: 0 0 24px -4px rgba(0, 0, 0, 0.64);
   padding: var(--str-video__spacing-lg);
   gap: var(--str-video__spacing-lg);
 
@@ -143,9 +144,8 @@
 }
 
 .rd__sdk-options {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: var(--str-video__spacing-md);
   margin-top: var(--str-video__spacing-md);
 }

--- a/sample-apps/react/react-dogfood/style/layout.scss
+++ b/sample-apps/react/react-dogfood/style/layout.scss
@@ -122,7 +122,7 @@
 }
 
 .rd__highlight {
-  box-shadow: 0px 0px 48px 0px #005fff;
+  box-shadow: 0px 0px 16px 4px #005fff;
 }
 
 @include respond-above(sm) {


### PR DESCRIPTION
1. Add "video calling" and "audio calling" tags
2. Add drop shadow to the tour popup
3. More visible anchor highlights