### PR TITLE
docs: fix outdated import

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/05-incoming-and-outcoming-call.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/05-incoming-and-outcoming-call.mdx
@@ -58,7 +58,7 @@ We can show the user info such as image, name, or additional details of the user
 ```tsx title="UserInfoComponent.tsx"
 import React from 'react';
 import {
-  useCallMembers,
+  useCallStateHooks,
   useConnectedUser,
   UserResponse,
 } from '@stream-io/video-react-native-sdk';
@@ -66,6 +66,7 @@ import { Image, StyleSheet, Text, View } from 'react-native';
 
 export const UserInfoComponent = () => {
   const connectedUser = useConnectedUser();
+  const { useCallMembers } = useCallStateHooks();
   const members = useCallMembers();
 
   const membersToShow: UserResponse[] = (members || [])


### PR DESCRIPTION
`useCallMembers` import was wrong in the docs, and this PR fixes this