### PR TITLE
fix: export the LivestreamPlayer component

### DIFF
--- a/packages/react-native-sdk/src/components/Livestream/index.ts
+++ b/packages/react-native-sdk/src/components/Livestream/index.ts
@@ -3,3 +3,4 @@ export * from './LivestreamControls';
 export * from './LivestreamTopView';
 export * from './ViewerLivestream';
 export * from './LivestreamLayout';
+export * from './LivestreamPlayer';


### PR DESCRIPTION
### Overview

Adds the missing component export for the `LivestreamPlayer` component. #1373 