### PR TITLE
fix: improved input device error handling

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -388,7 +388,9 @@ export class Call {
         const currentUserId = this.currentUserId;
         if (currentUserId && blockedUserIds.includes(currentUserId)) {
           this.logger('info', 'Leaving call because of being blocked');
-          await this.leave({ reason: 'user blocked' });
+          await this.leave({ reason: 'user blocked' }).catch((err) => {
+            this.logger('error', 'Error leaving call after being blocked', err);
+          });
         }
       }),
     );
@@ -600,7 +602,7 @@ export class Call {
       this.clientStore.registerCall(this);
     }
 
-    this.applyDeviceConfig();
+    await this.applyDeviceConfig();
 
     return response;
   };
@@ -629,7 +631,7 @@ export class Call {
       this.clientStore.registerCall(this);
     }
 
-    this.applyDeviceConfig();
+    await this.applyDeviceConfig();
 
     return response;
   };
@@ -2019,9 +2021,18 @@ export class Call {
     );
   };
 
-  applyDeviceConfig = () => {
-    this.initCamera({ setStatus: false });
-    this.initMic({ setStatus: false });
+  /**
+   * Applies the device configuration from the backend.
+   *
+   * @internal
+   */
+  applyDeviceConfig = async () => {
+    await this.initCamera({ setStatus: false }).catch((err) => {
+      this.logger('warn', 'Camera init failed', err);
+    });
+    await this.initMic({ setStatus: false }).catch((err) => {
+      this.logger('warn', 'Mic init failed', err);
+    });
   };
 
   private async initCamera(options: { setStatus: boolean }) {

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -345,7 +345,8 @@ export class StreamVideoClient {
       QueryCallsResponse,
       QueryCallsRequest
     >('/calls', data);
-    const calls = response.calls.map((c) => {
+    const calls = [];
+    for (const c of response.calls) {
       const call = new Call({
         streamClient: this.streamClient,
         id: c.call.id,
@@ -356,12 +357,12 @@ export class StreamVideoClient {
         clientStore: this.writeableStateStore,
       });
       call.state.updateFromCallResponse(c.call);
-      call.applyDeviceConfig();
+      await call.applyDeviceConfig();
       if (data.watch) {
         this.writeableStateStore.registerCall(call);
       }
-      return call;
-    });
+      calls.push(call);
+    }
     return {
       ...response,
       calls: calls,

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -41,20 +41,24 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
           this.state.status$,
         ]),
         async ([callingState, ownCapabilities, deviceId, status]) => {
-          if (callingState === CallingState.LEFT) {
-            await this.stopSpeakingWhileMutedDetection();
-          }
-          if (callingState !== CallingState.JOINED) return;
-          if (!this.speakingWhileMutedNotificationEnabled) return;
+          try {
+            if (callingState === CallingState.LEFT) {
+              await this.stopSpeakingWhileMutedDetection();
+            }
+            if (callingState !== CallingState.JOINED) return;
+            if (!this.speakingWhileMutedNotificationEnabled) return;
 
-          if (ownCapabilities.includes(OwnCapability.SEND_AUDIO)) {
-            if (status === 'disabled') {
-              await this.startSpeakingWhileMutedDetection(deviceId);
+            if (ownCapabilities.includes(OwnCapability.SEND_AUDIO)) {
+              if (status === 'disabled') {
+                await this.startSpeakingWhileMutedDetection(deviceId);
+              } else {
+                await this.stopSpeakingWhileMutedDetection();
+              }
             } else {
               await this.stopSpeakingWhileMutedDetection();
             }
-          } else {
-            await this.stopSpeakingWhileMutedDetection();
+          } catch (err) {
+            this.logger('warn', 'Could not enable speaking while muted', err);
           }
         },
       ),

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -172,7 +172,7 @@ const getStream = async (constraints: MediaStreamConstraints) => {
   try {
     return await navigator.mediaDevices.getUserMedia(constraints);
   } catch (e) {
-    getLogger(['devices'])('error', `Failed get user media`, {
+    getLogger(['devices'])('error', `Failed to getUserMedia`, {
       error: e,
       constraints: constraints,
     });


### PR DESCRIPTION
### Overview

Improves the error handling for the input devices. 

In some conditions, our Device Manager APIs could throw an unrecoverable error that couldn't be handled anywhere as we weren't propagating it accordingly. Another problem is async observable subscriptions. Currently, there isn't a way for someone to handle errors in those subscriptions. Until we find a better day, I've wrapped them with a try/catch block.