### PR TITLE
feat(composite): support for participant.aspect-ratio

### DIFF
--- a/sample-apps/react/egress-composite/src/CompositeApp.tsx
+++ b/sample-apps/react/egress-composite/src/CompositeApp.tsx
@@ -23,6 +23,11 @@ import { useParticipantStyles } from './hooks/options/useParticipantStyles';
 export const CompositeApp = () => {
   const { client, call } = useInitializeClientAndCall();
 
+  // @ts-expect-error makes it easy to debug in the browser console
+  window.call = call;
+  // @ts-expect-error makes it easy to debug in the browser console
+  window.client = client;
+
   return (
     <StreamVideo client={client}>
       <StreamCall call={call}>

--- a/sample-apps/react/egress-composite/src/ConfigurationContext.tsx
+++ b/sample-apps/react/egress-composite/src/ConfigurationContext.tsx
@@ -75,6 +75,7 @@ export type ConfigurationValue = {
     'title.margin_inline'?: string | number;
 
     // ✅
+    'participant.aspect_ratio'?: string; // '16 / 9', '4 / 3', '1 / 1', '9 / 16'
     'participant.outline_color'?: string;
     'participant.outline_width'?: string;
     'participant.border_radius'?: string | number;

--- a/sample-apps/react/egress-composite/src/hooks/options/useParticipantStyles.ts
+++ b/sample-apps/react/egress-composite/src/hooks/options/useParticipantStyles.ts
@@ -6,6 +6,7 @@ import { useConfigurationContext } from '../../ConfigurationContext';
 export const useParticipantStyles = () => {
   const {
     options: {
+      'participant.aspect_ratio': participantAspectRatio = '4 / 3',
       'participant.border_radius': participantBorderRadius,
       'participant.outline_color': participantOutlineColor = '#005fff',
       'participant.outline_width': participantOutlineWidth = '2px',
@@ -19,6 +20,12 @@ export const useParticipantStyles = () => {
       css`
         & .str-video__participant-view {
           border-radius: ${participantBorderRadius};
+        }
+      `,
+    participantAspectRatio &&
+      css`
+        & .str-video__participant-view {
+          aspect-ratio: ${participantAspectRatio};
         }
       `,
     css`


### PR DESCRIPTION
### Overview

Adds `participant.aspect-ratio` configuration property that controls the aspect ratio of the `ParticipantView`.
It accepts any valid CSS aspect ratio (`16/9`, `9/16`, `1/1`...). It defaults to `4 / 3`.

Context: https://getstream.slack.com/archives/C022N8JNQGZ/p1716897250015959