### PR TITLE
fix: join doesn't work on chrome 86

### DIFF
--- a/packages/client/src/rtc/codecs.ts
+++ b/packages/client/src/rtc/codecs.ts
@@ -51,7 +51,7 @@ export const getGenericSdp = async (direction: RTCRtpTransceiverDirection) => {
   let sdp = offer.sdp ?? '';
 
   tempPc.getTransceivers().forEach((t) => {
-    t.stop();
+    t.stop?.();
   });
   tempPc.close();
   return sdp;


### PR DESCRIPTION
@oliverlaz let me know that we can solve this chrome 86 issue reported by Serenis: https://getstream.slack.com/archives/C063KAQAWUS/p1717421617466309