### PR TITLE
feat!: extend `isSupported` method

### DIFF
--- a/packages/audio-filters-web/package.json
+++ b/packages/audio-filters-web/package.json
@@ -25,6 +25,9 @@
     "LICENSE",
     "CHANGELOG.md"
   ],
+  "dependencies": {
+    "wasm-feature-detect": "^1.6.1"
+  },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7532,6 +7532,7 @@ __metadata:
     rimraf: ^5.0.5
     rollup: ^3.29.4
     typescript: ^5.4.3
+    wasm-feature-detect: ^1.6.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
BREAKING CHANGE: the return value of the `isSupported` method changed from `boolean` to `boolean | Promise<boolean>`