### PR TITLE
fix: catch error for user connect in constructor

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -120,7 +120,9 @@ export class StreamVideoClient {
       const user = apiKeyOrArgs.user;
       const token = apiKeyOrArgs.token || apiKeyOrArgs.tokenProvider;
       if (user) {
-        this.connectUser(user, token);
+        this.connectUser(user, token).catch((err) => {
+          this.logger('error', 'Failed to connect', err);
+        });
       }
     }
   }


### PR DESCRIPTION
When some expired token or invalid user id is sent in constructor for client, the connect user call was unmatched leading to `unhandled promise rejection`

in case this happens in  push notifications. the `unhandled promise rejection` log wont be shown as the js bridge is destroyed

This PR is for catching that error and logging it using the logger