### PR TITLE
feat(client): support join_ahead_time_seconds field in the BackstageSettingsRequest struct

### DIFF
--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -194,6 +194,13 @@ export interface BackstageSettingsRequest {
    * @memberof BackstageSettingsRequest
    */
   enabled?: boolean;
+
+  /**
+   * Optional: the number of seconds before the call starts that the user can join the call
+   * @type {number}
+   * @memberof BackstageSettingsRequest
+   */
+  join_ahead_time_seconds?: number;
 }
 /**
  *


### PR DESCRIPTION
* Adds support for the `join_ahead_time_seconds` field in the BackstageSettingsRequest struct