### PR TITLE
fix(android):  no ringtone when incoming call was through foreground service

### DIFF
--- a/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
+++ b/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
@@ -91,9 +91,20 @@ export const useAndroidKeepCallAliveEffect = () => {
         if (foregroundServiceStartedRef.current) {
           return;
         }
-        // request for notification permission and then start the foreground service
-        await startForegroundService(activeCallCid);
-        foregroundServiceStartedRef.current = true;
+        notifee.getDisplayedNotifications().then((displayedNotifications) => {
+          const activeCallNotification = displayedNotifications.find(
+            (notification) => notification.id === activeCallCid
+          );
+          if (activeCallNotification) {
+            // this means that we have a incoming call notification shown as foreground service and we must stop it
+            notifee.stopForegroundService();
+            notifee.cancelDisplayedNotification(activeCallCid);
+          }
+          // request for notification permission and then start the foreground service
+          startForegroundService(activeCallCid).then(() => {
+            foregroundServiceStartedRef.current = true;
+          });
+        });
       };
       run();
     } else if (callingState === CallingState.RINGING) {

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
@@ -75,10 +75,8 @@ export class StreamVideoRN {
       return;
     }
     this.config.push = pushConfig;
-    const foregroundServiceChannel =
-      this.config.foregroundService.android.channel;
     // After getting the config we should setup callkeep events, firebase handler asap to handle incoming calls from a dead state
-    setupFirebaseHandlerAndroid(pushConfig, foregroundServiceChannel);
+    setupFirebaseHandlerAndroid(pushConfig);
     // setup ios handler for non-voip push notifications asap
     setupRemoteNotificationsHandleriOS(pushConfig);
   }

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -249,6 +249,10 @@ const firebaseMessagingOnMessageHandler = async (
       );
       return;
     }
+    /*
+     * Sound has to be set on channel level for android 8 and above and cant be updated later after creation!
+     * For android 7 and below, sound should be set on notification level
+     */
     // set default ringtone if not provided
     if (!incomingCallChannel.sound) {
       incomingCallChannel.sound = await getAndroidDefaultRingtoneUrl();

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -2,7 +2,6 @@ import notifee, {
   EventType,
   Event,
   AndroidCategory,
-  AndroidChannel,
 } from '@notifee/react-native';
 import { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 import {
@@ -45,10 +44,7 @@ const DECLINE_CALL_ACTION_ID = 'decline';
 type PushConfig = NonNullable<StreamVideoConfig['push']>;
 
 /** Setup Firebase push message handler **/
-export function setupFirebaseHandlerAndroid(
-  pushConfig: PushConfig,
-  foregroundServiceChannel: AndroidChannel
-) {
+export function setupFirebaseHandlerAndroid(pushConfig: PushConfig) {
   if (Platform.OS !== 'android') {
     return;
   }
@@ -58,18 +54,10 @@ export function setupFirebaseHandlerAndroid(
       // handles on app killed state in expo, expo-notifications cannot handle that
       messaging().setBackgroundMessageHandler(
         async (msg) =>
-          await firebaseMessagingOnMessageHandler(
-            msg.data,
-            pushConfig,
-            foregroundServiceChannel
-          )
+          await firebaseMessagingOnMessageHandler(msg.data, pushConfig)
       );
       messaging().onMessage((msg) =>
-        firebaseMessagingOnMessageHandler(
-          msg.data,
-          pushConfig,
-          foregroundServiceChannel
-        )
+        firebaseMessagingOnMessageHandler(msg.data, pushConfig)
       ); // this is to listen to foreground messages, which we dont need for now
     } else {
       const Notifications = getExpoNotificationsLib();
@@ -85,11 +73,7 @@ export function setupFirebaseHandlerAndroid(
           }
           // @ts-ignore
           const dataToProcess = data.notification?.data;
-          firebaseMessagingOnMessageHandler(
-            dataToProcess,
-            pushConfig,
-            foregroundServiceChannel
-          );
+          firebaseMessagingOnMessageHandler(dataToProcess, pushConfig);
         }
       );
       // background handler (does not handle on app killed state)
@@ -102,11 +86,7 @@ export function setupFirebaseHandlerAndroid(
           if (trigger.type === 'push') {
             const data = trigger?.remoteMessage?.data;
             if (data?.sender === 'stream.video') {
-              await firebaseMessagingOnMessageHandler(
-                data,
-                pushConfig,
-                foregroundServiceChannel
-              );
+              await firebaseMessagingOnMessageHandler(data, pushConfig);
               return {
                 shouldShowAlert: false,
                 shouldPlaySound: false,
@@ -126,18 +106,10 @@ export function setupFirebaseHandlerAndroid(
     const messaging = getFirebaseMessagingLib();
     messaging().setBackgroundMessageHandler(
       async (msg) =>
-        await firebaseMessagingOnMessageHandler(
-          msg.data,
-          pushConfig,
-          foregroundServiceChannel
-        )
+        await firebaseMessagingOnMessageHandler(msg.data, pushConfig)
     );
     messaging().onMessage((msg) =>
-      firebaseMessagingOnMessageHandler(
-        msg.data,
-        pushConfig,
-        foregroundServiceChannel
-      )
+      firebaseMessagingOnMessageHandler(msg.data, pushConfig)
     ); // this is to listen to foreground messages, which we dont need for now
   }
 
@@ -196,8 +168,7 @@ export async function initAndroidPushToken(
 
 const firebaseMessagingOnMessageHandler = async (
   data: FirebaseMessagingTypes.RemoteMessage['data'],
-  pushConfig: PushConfig,
-  foregroundServiceChannel: AndroidChannel
+  pushConfig: PushConfig
 ) => {
   /* Example data from firebase
     "message": {
@@ -278,25 +249,15 @@ const firebaseMessagingOnMessageHandler = async (
       );
       return;
     }
-    // if its a foreground service make sure we use the same channel id
-    // so that this notification can be replaced when call is active
-    let channelId: string;
-    if (asForegroundService) {
-      await notifee.createChannel(foregroundServiceChannel);
-      channelId = foregroundServiceChannel.id;
-    } else {
-      await notifee.createChannel(incomingCallChannel);
-      channelId = incomingCallChannel.id;
-    }
     // set default ringtone if not provided
-    let sound = incomingCallChannel.sound;
-    if (!sound) {
-      sound = await getAndroidDefaultRingtoneUrl();
+    if (!incomingCallChannel.sound) {
+      incomingCallChannel.sound = await getAndroidDefaultRingtoneUrl();
     }
-
+    await notifee.createChannel(incomingCallChannel);
     const { getTitle, getBody } = incomingCallNotificationTextGetters;
     const createdUserName = data.created_by_display_name as string;
 
+    const channelId = incomingCallChannel.id;
     await notifee.displayNotification({
       id: call_cid,
       title: getTitle(createdUserName),
@@ -305,7 +266,7 @@ const firebaseMessagingOnMessageHandler = async (
       android: {
         channelId,
         asForegroundService,
-        sound,
+        sound: incomingCallChannel.sound,
         vibrationPattern: incomingCallChannel.vibrationPattern,
         pressAction: {
           id: 'default',

--- a/sample-apps/react-native/dogfood/src/utils/setPushConfig.ts
+++ b/sample-apps/react-native/dogfood/src/utils/setPushConfig.ts
@@ -22,7 +22,7 @@ export function setPushConfig() {
         sound: 'default',
       },
       incomingCallChannel: {
-        id: 'stream_incoming_call_channel_update1',
+        id: 'stream_incoming_call_channel_update2',
         name: 'Incoming call notifications',
         importance: AndroidImportance.HIGH,
       },


### PR DESCRIPTION
Sound has to be set on channel level for Android 8 and above on creation and cannot be updated later. For Android 7 and below, the sound should be set on the notification level.

Since we relied on the notification level while moving to use the same foreground services, the sound broke if the foreground service channel was already created.