### PR TITLE
fix: perform full reconnect if ice restart fails

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1014,6 +1014,11 @@ export class Call {
         dispatcher: this.dispatcher,
         state: this.state,
         connectionConfig,
+        onUnrecoverableError: () => {
+          reconnect('full', 'unrecoverable subscriber error').catch((err) => {
+            this.logger('debug', '[Rejoin]: Rejoin failed', err);
+          });
+        },
       });
     }
 
@@ -1031,6 +1036,11 @@ export class Call {
         connectionConfig,
         isDtxEnabled,
         isRedEnabled,
+        onUnrecoverableError: () => {
+          reconnect('full', 'unrecoverable publisher error').catch((err) => {
+            this.logger('debug', '[Rejoin]: Rejoin failed', err);
+          });
+        },
       });
     }
 

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -36,6 +36,7 @@ export type PublisherConstructorOpts = {
   isDtxEnabled: boolean;
   isRedEnabled: boolean;
   iceRestartDelay?: number;
+  onUnrecoverableError?: () => void;
 };
 
 /**
@@ -94,6 +95,7 @@ export class Publisher {
   private readonly isRedEnabled: boolean;
 
   private readonly unsubscribeOnIceRestart: () => void;
+  private readonly onUnrecoverableError?: () => void;
 
   private readonly iceRestartDelay: number;
   private isIceRestarting = false;
@@ -127,6 +129,7 @@ export class Publisher {
    * @param isDtxEnabled whether DTX is enabled.
    * @param isRedEnabled whether RED is enabled.
    * @param iceRestartDelay the delay in milliseconds to wait before restarting ICE once connection goes to `disconnected` state.
+   * @param onUnrecoverableError a callback to call when an unrecoverable error occurs.
    */
   constructor({
     connectionConfig,
@@ -136,6 +139,7 @@ export class Publisher {
     isDtxEnabled,
     isRedEnabled,
     iceRestartDelay = 2500,
+    onUnrecoverableError,
   }: PublisherConstructorOpts) {
     this.pc = this.createPeerConnection(connectionConfig);
     this.sfuClient = sfuClient;
@@ -143,11 +147,13 @@ export class Publisher {
     this.isDtxEnabled = isDtxEnabled;
     this.isRedEnabled = isRedEnabled;
     this.iceRestartDelay = iceRestartDelay;
+    this.onUnrecoverableError = onUnrecoverableError;
 
     this.unsubscribeOnIceRestart = dispatcher.on('iceRestart', (iceRestart) => {
       if (iceRestart.peerType !== PeerType.PUBLISHER_UNSPECIFIED) return;
       this.restartIce().catch((err) => {
         logger('warn', `ICERestart failed`, err);
+        this.onUnrecoverableError?.();
       });
     });
   }
@@ -813,14 +819,15 @@ export class Publisher {
       this.state.callingState !== CallingState.OFFLINE;
 
     if (state === 'failed') {
-      logger('warn', `Attempting to restart ICE`);
+      logger('debug', `Attempting to restart ICE`);
       this.restartIce().catch((e) => {
         logger('error', `ICE restart error`, e);
+        this.onUnrecoverableError?.();
       });
     } else if (state === 'disconnected' && hasNetworkConnection) {
       // when in `disconnected` state, the browser may recover automatically,
       // hence, we delay the ICE restart
-      logger('warn', `Scheduling ICE restart in ${this.iceRestartDelay} ms.`);
+      logger('debug', `Scheduling ICE restart in ${this.iceRestartDelay} ms.`);
       this.iceRestartTimeout = setTimeout(() => {
         // check if the state is still `disconnected` or `failed`
         // as the connection may have recovered (or failed) in the meantime
@@ -830,6 +837,7 @@ export class Publisher {
         ) {
           this.restartIce().catch((e) => {
             logger('error', `ICE restart error`, e);
+            this.onUnrecoverableError?.();
           });
         } else {
           logger(

--- a/packages/client/src/rtc/Subscriber.ts
+++ b/packages/client/src/rtc/Subscriber.ts
@@ -229,6 +229,13 @@ export class Subscriber {
       logger('debug', 'ICE restart is already in progress');
       return;
     }
+    if (this.pc.connectionState === 'new') {
+      logger(
+        'debug',
+        `ICE connection is not yet established, skipping restart.`,
+      );
+      return;
+    }
     const previousIsIceRestarting = this.isIceRestarting;
     try {
       this.isIceRestarting = true;

--- a/packages/client/src/rtc/__tests__/Subscriber.test.ts
+++ b/packages/client/src/rtc/__tests__/Subscriber.test.ts
@@ -168,6 +168,15 @@ describe('Subscriber', () => {
       expect(sfuClient.iceRestart).not.toHaveBeenCalled();
     });
 
+    it('should skip ICE restart when connection is still new', async () => {
+      sfuClient.iceRestart = vi.fn();
+      // @ts-ignore
+      subscriber['pc'].connectionState = 'new';
+
+      await subscriber.restartIce();
+      expect(sfuClient.iceRestart).not.toHaveBeenCalled();
+    });
+
     it(`should perform ICE restart when connection state changes to 'failed'`, () => {
       vi.spyOn(subscriber, 'restartIce').mockResolvedValue();
       // @ts-ignore

--- a/sample-apps/react/react-dogfood/components/DevMenu.tsx
+++ b/sample-apps/react/react-dogfood/components/DevMenu.tsx
@@ -215,7 +215,9 @@ const RestartPublisher = () => {
       hidden={!call}
       onClick={() => {
         if (!call) return;
-        call.publisher?.restartIce();
+        call.publisher?.restartIce().catch((err) => {
+          console.error(`Failed to restart ICE on the publisher`, err);
+        });
       }}
     >
       <Icon className="rd__button__icon" icon="recording-off" />
@@ -232,7 +234,9 @@ const RestartSubscriber = () => {
       hidden={!call}
       onClick={() => {
         if (!call) return;
-        call.subscriber?.restartIce();
+        call.subscriber?.restartIce().catch((err) => {
+          console.error(`Failed to restart ICE on the subscriber`, err);
+        });
       }}
     >
       <Icon className="rd__button__icon" icon="recording-on" />


### PR DESCRIPTION
### Overview

When networks change, we perform an ICE restart to re-establish connection to the SFU. 
However, when this process fails, the call stays in limbo mode (no tracks are flowing anymore). This is manifested by black tracks on the client's screens.

This PR updates the behavior of the SDK and now, we will perform full reconnect eagerly.
In the future, once we implement the Reconnect v2, this issue will be solved more elegantly.