### PR TITLE
fix: remove `isBlurringEnabled` prop

### DIFF
--- a/packages/react-sdk/docusaurus/docs/React/10-advanced/06-apply-video-filters.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/10-advanced/06-apply-video-filters.mdx
@@ -42,7 +42,6 @@ export default function App() {
     <StreamVideo client={client}>
       <StreamCall call={call}>
         <BackgroundFiltersProvider
-          isBlurringEnabled={true} // enables blurring
           backgroundFilter="blur" // initial filter
           backgroundImages={[
             'https://my-domain.com/bg/random-bg-1.jpg',

--- a/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
+++ b/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
@@ -21,19 +21,13 @@ import {
 
 export type BackgroundFiltersProps = {
   /**
-   * Enables or disables the background-blurring feature.
-   * @default true.
-   */
-  isBlurringEnabled?: boolean;
-
-  /**
    * A list of URLs to use as background images.
    */
   backgroundImages?: string[];
 
   /**
    * The background filter to apply to the video (by default).
-   * @default 'none'.
+   * @default undefined no filter applied
    */
   backgroundFilter?: BackgroundFilter;
 
@@ -138,7 +132,6 @@ export const BackgroundFiltersProvider = (
 ) => {
   const {
     children,
-    isBlurringEnabled = true,
     backgroundImages = [],
     backgroundFilter: bgFilterFromProps = undefined,
     backgroundImage: bgImageFromProps = undefined,
@@ -198,7 +191,6 @@ export const BackgroundFiltersProvider = (
         applyBackgroundBlurFilter,
         applyBackgroundImageFilter,
         backgroundImages,
-        isBlurringEnabled,
         tfFilePath,
         modelFilePath,
         basePath,

--- a/sample-apps/react/react-dogfood/components/Settings/VideoEffects.tsx
+++ b/sample-apps/react/react-dogfood/components/Settings/VideoEffects.tsx
@@ -10,7 +10,6 @@ export const VideoEffectsSettings = () => {
   const {
     isSupported,
     backgroundImages,
-    isBlurringEnabled,
     backgroundBlurLevel,
     backgroundImage,
     backgroundFilter,
@@ -44,45 +43,36 @@ export const VideoEffectsSettings = () => {
             >
               <Icon icon="close" />
             </CompositeButton>
-            {isBlurringEnabled && (
-              <>
-                <CompositeButton
-                  title="Blur"
-                  active={
-                    backgroundFilter === 'blur' &&
-                    backgroundBlurLevel === 'high'
-                  }
-                  onClick={() => applyBackgroundBlurFilter('high')}
-                >
-                  <Icon icon="blur-icon" />
-                </CompositeButton>
-                <CompositeButton
-                  title="Medium blur"
-                  active={
-                    backgroundFilter === 'blur' &&
-                    backgroundBlurLevel === 'medium'
-                  }
-                  onClick={() => applyBackgroundBlurFilter('medium')}
-                >
-                  <Icon
-                    icon="blur-icon"
-                    className="rd__video-effects__blur--medium"
-                  />
-                </CompositeButton>
-                <CompositeButton
-                  title="Low blur"
-                  active={
-                    backgroundFilter === 'blur' && backgroundBlurLevel === 'low'
-                  }
-                  onClick={() => applyBackgroundBlurFilter('low')}
-                >
-                  <Icon
-                    icon="blur-icon"
-                    className="rd__video-effects__blur--low"
-                  />
-                </CompositeButton>
-              </>
-            )}
+            <CompositeButton
+              title="Blur"
+              active={
+                backgroundFilter === 'blur' && backgroundBlurLevel === 'high'
+              }
+              onClick={() => applyBackgroundBlurFilter('high')}
+            >
+              <Icon icon="blur-icon" />
+            </CompositeButton>
+            <CompositeButton
+              title="Medium blur"
+              active={
+                backgroundFilter === 'blur' && backgroundBlurLevel === 'medium'
+              }
+              onClick={() => applyBackgroundBlurFilter('medium')}
+            >
+              <Icon
+                icon="blur-icon"
+                className="rd__video-effects__blur--medium"
+              />
+            </CompositeButton>
+            <CompositeButton
+              title="Low blur"
+              active={
+                backgroundFilter === 'blur' && backgroundBlurLevel === 'low'
+              }
+              onClick={() => applyBackgroundBlurFilter('low')}
+            >
+              <Icon icon="blur-icon" className="rd__video-effects__blur--low" />
+            </CompositeButton>
           </div>
         </div>
         {backgroundImages && backgroundImages.length > 0 && (

--- a/sample-apps/react/react-dogfood/pages/guest/join/[guestCallId].tsx
+++ b/sample-apps/react/react-dogfood/pages/guest/join/[guestCallId].tsx
@@ -127,7 +127,6 @@ export default function GuestCallRoom(props: GuestCallRoomProps) {
         <StreamCall call={call}>
           <BackgroundFiltersProvider
             basePath={`${basePath}/tf`}
-            isBlurringEnabled={true}
             backgroundImages={[
               `${basePath}/backgrounds/amsterdam-1.jpg`,
               `${basePath}/backgrounds/amsterdam-2.jpg`,

--- a/sample-apps/react/react-dogfood/pages/join/[callId].tsx
+++ b/sample-apps/react/react-dogfood/pages/join/[callId].tsx
@@ -235,7 +235,6 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
           <TourProvider>
             <BackgroundFiltersProvider
               basePath={`${basePath}/tf`}
-              isBlurringEnabled={true}
               backgroundImages={[
                 `${basePath}/backgrounds/amsterdam-1.jpg`,
                 `${basePath}/backgrounds/amsterdam-2.jpg`,


### PR DESCRIPTION
This prop was not used and didn't affect the filter state. To have no blurring initially, pass any `backgroundFilter` other than `"blur"` to the `BackgroundFiltersProvider`. To have no filters at all, pass `backgroundFilter={undefined}` (default).