### PR TITLE
fix: stop background filter when video track stops

### DIFF
--- a/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
+++ b/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
@@ -222,20 +222,22 @@ const BackgroundFilters = (props: { tfLite: TFLite }) => {
   const unregister = useRef<Promise<void>>();
   useEffect(() => {
     if (!call || !backgroundFilter) return;
+    const cleanup = () => {
+      signalFilterReadyRef.current = undefined;
+      setMediaStream(undefined);
+    };
     const register = (unregister.current || Promise.resolve()).then(() =>
       call.camera.registerFilter(async (ms) => {
         return new Promise<MediaStream>((resolve) => {
-          signalFilterReadyRef.current = resolve;
           setMediaStream(ms);
+          signalFilterReadyRef.current = resolve;
         });
-      }),
+      }, cleanup),
     );
 
     return () => {
       unregister.current = register
         .then((unregisterFilter) => unregisterFilter())
-        .then(() => (signalFilterReadyRef.current = undefined))
-        .then(() => setMediaStream(undefined))
         .catch((err) => console.error('Failed to unregister filter', err));
     };
   }, [backgroundFilter, call]);


### PR DESCRIPTION
Currently the background filter keeps working on the (black) frames after camera is disabled and video track is stopped. That's because the filter doesn't know that the source track is stopped.

This PR adds an optional cleanup function that can be specified when registering a filter. This cleanup function is called in two cases:

1. The filter is unregistered
2. The source track is muted

So now background filters specify a cleanup function that remove the canvas element, thus stopping the rendering pipeline.