### PR TITLE
fix: in some browsers event.key could be undefined

### DIFF
--- a/packages/react-sdk/src/components/Menu/MenuToggle.tsx
+++ b/packages/react-sdk/src/components/Menu/MenuToggle.tsx
@@ -110,6 +110,7 @@ export const MenuToggle = <E extends HTMLElement>({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
+        event.key && // key can be undefined in some browsers
         event.key.toLowerCase() === 'escape' &&
         !event.altKey &&
         !event.ctrlKey


### PR DESCRIPTION
### Overview

In some browsers, `key` might be undefined. When this is the case, an error.