### PR TITLE
fix: embed scss sources in the source map

### DIFF
--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "start": "sass --watch index.scss ./dist/css/styles.css",
-    "build": "sass index.scss ./dist/css/styles.css"
+    "build": "sass --embed-sources index.scss ./dist/css/styles.css"
   },
   "devDependencies": {
     "rimraf": "^5.0.7",


### PR DESCRIPTION
### Overview

Bundles the full SCSS sources within the source map. This prevents warnings where some source map loaders fail to find the linked SCSS files when using the `@stream-io/video-react-sdk` NPM package.

- https://sass-lang.com/documentation/cli/dart-sass/#embed-sources