### PR TITLE
fix: `call.recording_failed` should update the call state

### DIFF
--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -427,7 +427,6 @@ export class CallState {
       'call.closed_caption': undefined,
       'call.deleted': undefined,
       'call.permission_request': undefined,
-      'call.recording_failed': undefined,
       'call.recording_ready': undefined,
       'call.transcription_ready': undefined,
       'call.user_muted': undefined,
@@ -469,6 +468,8 @@ export class CallState {
       'call.recording_started': () =>
         this.setCurrentValue(this.recordingSubject, true),
       'call.recording_stopped': () =>
+        this.setCurrentValue(this.recordingSubject, false),
+      'call.recording_failed': () =>
         this.setCurrentValue(this.recordingSubject, false),
       'call.rejected': (e) => this.updateFromCallResponse(e.call),
       'call.ring': (e) => this.updateFromCallResponse(e.call),

--- a/packages/client/src/store/__tests__/CallState.test.ts
+++ b/packages/client/src/store/__tests__/CallState.test.ts
@@ -683,6 +683,7 @@ describe('CallState', () => {
         const state = new CallState();
         // @ts-expect-error incomplete data
         state.updateFromEvent({ type: 'call.recording_started' });
+        expect(state.recording).toBe(true);
         // @ts-expect-error incomplete data
         state.updateFromEvent({ type: 'call.recording_failed' });
         expect(state.recording).toBe(false);

--- a/packages/client/src/store/__tests__/CallState.test.ts
+++ b/packages/client/src/store/__tests__/CallState.test.ts
@@ -679,6 +679,15 @@ describe('CallState', () => {
         expect(state.recording).toBe(false);
       });
 
+      it('handles call.recording_failed events', () => {
+        const state = new CallState();
+        // @ts-expect-error incomplete data
+        state.updateFromEvent({ type: 'call.recording_started' });
+        // @ts-expect-error incomplete data
+        state.updateFromEvent({ type: 'call.recording_failed' });
+        expect(state.recording).toBe(false);
+      });
+
       it('handles call.hls_broadcasting_started events', () => {
         const state = new CallState();
         state.updateFromCallResponse({


### PR DESCRIPTION
### Overview

When `call.recording_failed` event is emitted, we should update the call state and notify that the call isn't recorded anymore.