### PR TITLE
docs: uncover the name of the JoinEndedCall permission

### DIFF
--- a/packages/client/docusaurus/docs/javascript/02-guides/02-joining-creating-calls.mdx
+++ b/packages/client/docusaurus/docs/javascript/02-guides/02-joining-creating-calls.mdx
@@ -97,7 +97,7 @@ Ending a call requires a [special permission](../../guides/permissions-and-moder
 await call.endCall();
 ```
 
-Only users with special permission can join an ended call.
+Only users with a special permission (`JoinEndedCall`) can join an ended call.
 
 ### Load call
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/02-joining-creating-calls.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/02-joining-creating-calls.mdx
@@ -77,7 +77,7 @@ Ending a call requires a [special permission](../../guides/permissions-and-moder
 await call.endCall();
 ```
 
-Only users with special permission can join an ended call.
+Only users with a special permission (`JoinEndedCall`) can join an ended call.
 
 ### Load call
 

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/02-joining-creating-calls.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/02-joining-creating-calls.mdx
@@ -97,7 +97,7 @@ Ending a call requires a [special permission](../../guides/permissions-and-moder
 await call.endCall();
 ```
 
-Only users with special permission can join an ended call.
+Only users with a special permission (`JoinEndedCall`) can join an ended call.
 
 ### Load call
 


### PR DESCRIPTION
### Overview

Our docs said that one with special permission can join an ended call, but the permission's name wasn't provided.