### PR TITLE
fix: refactor ClosedCaptions components with custom queue hook

### DIFF
--- a/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
+++ b/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
@@ -12,7 +12,7 @@ const useDeduplicatedQueue = (initialQueue: CallClosedCaption[] = []) => {
     setQueue((prevQueue) => {
       const key = `${newCaption.speaker_id}-${newCaption.start_time}`;
       const isDuplicate = prevQueue.some(
-        (caption) => `${caption.speaker_id}-${caption.start_time}` === key
+        (caption) => `${caption.speaker_id}-${caption.start_time}` === key,
       );
 
       if (isDuplicate) {
@@ -41,7 +41,9 @@ export const ClosedCaptions = () => {
 
   useEffect(() => {
     const id = setTimeout(() => {
-      setQueue((prevQueue) => prevQueue.length !== 0 ? prevQueue.slice(1) : prevQueue);
+      setQueue((prevQueue) =>
+        prevQueue.length !== 0 ? prevQueue.slice(1) : prevQueue,
+      );
     }, 2700);
     return () => clearTimeout(id);
   }, [queue]);

--- a/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
+++ b/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
@@ -1,36 +1,59 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   CallClosedCaption,
   useCall,
   useCallStateHooks,
 } from '@stream-io/video-react-sdk';
 
+const useDeduplicatedQueue = (initialQueue: CallClosedCaption[] = []) => {
+  const [queue, setQueue] = useState<CallClosedCaption[]>(initialQueue);
+
+  const addToQueue = useCallback((newCaption: CallClosedCaption) => {
+    setQueue((prevQueue) => {
+      const key = `${newCaption.speaker_id}-${newCaption.start_time}`;
+      const isDuplicate = prevQueue.some(
+        (caption) => `${caption.speaker_id}-${caption.start_time}` === key
+      );
+
+      if (isDuplicate) {
+        return prevQueue;
+      }
+
+      return [...prevQueue, newCaption];
+    });
+  }, []);
+
+  return [queue, addToQueue, setQueue] as const;
+};
+
 export const ClosedCaptions = () => {
   const call = useCall();
-  const [queue, setQueue] = useState<CallClosedCaption[]>([]);
+  const [queue, addToQueue, setQueue] = useDeduplicatedQueue();
+
   useEffect(() => {
     if (!call) return;
     return call.on('call.closed_caption', (e) => {
       if (e.type !== 'call.closed_caption') return;
       if (e.closed_caption.text.trim() === '') return;
-      setQueue((prev) => [...prev.slice(-1), e.closed_caption]);
+      addToQueue(e.closed_caption);
     });
-  }, [call]);
+  }, [call, addToQueue]);
 
   useEffect(() => {
     const id = setTimeout(() => {
-      setQueue(queue.length !== 0 ? queue.slice(1) : queue);
+      setQueue((prevQueue) => prevQueue.length !== 0 ? prevQueue.slice(1) : prevQueue);
     }, 2700);
     return () => clearTimeout(id);
   }, [queue]);
 
   const userNameMapping = useUserIdToUserNameMapping();
+
   return (
     <div className="rd__closed-captions">
-      {queue.map(({ speaker_id, text }, index) => (
+      {queue.slice(-2).map(({ speaker_id, text, start_time }, index) => (
         <p
           className="rd__closed-captions__line"
-          key={speaker_id + index + text}
+          key={`${speaker_id}-${start_time}`}
         >
           <span className="rd__closed-captions__speaker">
             {userNameMapping[speaker_id] || speaker_id}:
@@ -44,25 +67,27 @@ export const ClosedCaptions = () => {
 
 export const ClosedCaptionsSidebar = () => {
   const call = useCall();
-  const [queue, setQueue] = useState<CallClosedCaption[]>([]);
+  const [queue, addToQueue] = useDeduplicatedQueue();
+
   useEffect(() => {
     if (!call) return;
     return call.on('call.closed_caption', (e) => {
       if (e.type !== 'call.closed_caption') return;
       if (e.closed_caption.text.trim() === '') return;
-      setQueue((prev) => [...prev, e.closed_caption]);
+      addToQueue(e.closed_caption);
     });
-  }, [call]);
+  }, [call, addToQueue]);
 
   const userNameMapping = useUserIdToUserNameMapping();
+
   return (
     <div className="rd__closed-captions-sidebar">
       <h3>Closed Captions</h3>
       <div className="rd__closed-captions-sidebar__container">
-        {queue.map(({ speaker_id, text }, index) => (
+        {queue.map(({ speaker_id, text, start_time }) => (
           <p
             className="rd__closed-captions__line"
-            key={speaker_id + index + text}
+            key={`${speaker_id}-${start_time}`}
           >
             <span className="rd__closed-captions__speaker">
               {userNameMapping[speaker_id] || speaker_id}:


### PR DESCRIPTION
This PR introduces a custom hook useDeduplicatedQueue to improve the management of closed captions in both the ClosedCaptions and ClosedCaptionsSidebar components. The changes enhance caption deduplication and provide a more consistent approach to queue handling across components.

Key changes:
- Add useDeduplicatedQueue custom hook
- Refactor ClosedCaptions and ClosedCaptionsSidebar to use the new hook
- Improve caption deduplication logic