### PR TITLE
chore(client): inform WS connect errors

### DIFF
--- a/packages/client/src/coordinator/connection/connection.ts
+++ b/packages/client/src/coordinator/connection/connection.ts
@@ -382,7 +382,7 @@ export class StableWSConnection {
         );
         postInsights?.('ws_fatal', insights);
       }
-      this.client.rejectConnectionId?.();
+      this.client.rejectConnectionId?.(err);
       throw err;
     }
   }


### PR DESCRIPTION
For this code

```
async () => {
      try {
        await call?.getOrCreate();
      } catch (error) {
        console.error('Failed to get or create call', error);
      }
    };
```

Say if WS connect has failed.

**Current behaviour of the log:**

```
Failed to get or create call undefined
```

**Changed behaviour in this PR:**

```
Failed to get or create call [Error: WS connection failed due to blah blah]
```