### PR TITLE
fix: do not use ended_at from call state to check ringing validity

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -437,12 +437,12 @@ export class Call {
         if (!isRinging) return;
         const callSession = this.state.session;
         const receiver_id = this.clientStore.connectedUser?.id;
-        const endedAt = this.state.endedAt;
+        const ended_at = callSession?.ended_at;
         const created_by_id = this.state.createdBy?.id;
         const rejected_by = callSession?.rejected_by;
         const accepted_by = callSession?.accepted_by;
         let leaveCallIdle = false;
-        if (endedAt) {
+        if (ended_at) {
           // call was ended before it was accepted or rejected so we should leave it to idle
           leaveCallIdle = true;
         } else if (created_by_id && rejected_by) {
@@ -466,10 +466,10 @@ export class Call {
             this.state.setCallingState(CallingState.IDLE);
           }
         } else {
-          this.scheduleAutoDrop();
           if (this.state.callingState === CallingState.IDLE) {
             this.state.setCallingState(CallingState.RINGING);
           }
+          this.scheduleAutoDrop();
           this.leaveCallHooks.add(registerRingingCallEventHandlers(this));
         }
       }),


### PR DESCRIPTION
**Behaviour**: 
we should not schedule timeout based rejects if the call had already ended, as BE will respond with 400

**Background**:
`callState.ended_at` represents the last time the call was ended
`callSession.ended_at` represents if the current call session's ended time

**Fix:**
we should not schedule timeout based rejects if `callSession.ended_at`  is present and not based on `callState.ended_at`