### PR TITLE
docs(react-native): broken links in documentation

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/02-joining-creating-calls.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/02-joining-creating-calls.mdx
@@ -14,7 +14,7 @@ This guide shows how to create, join, leave, and end calls and ring calls.
 
 You can create a call by specifying its `callType` and `callId`:
 
-The [Call Type](../../core/call-types) controls which features are enabled, and sets up permissions.
+The [Call Type](../../core/configuring-call-types) controls which features are enabled, and sets up permissions.
 You can reuse the same call multiple times. As an example, if you're building a telemedicine app calls will be connected to an appointment.
 Using your own appointment id as the call id makes it easy to find the call later.
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/02-joining-creating-calls.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/02-joining-creating-calls.mdx
@@ -14,7 +14,7 @@ This guide shows how to create, join, leave, and end calls and ring calls.
 
 You can create a call by specifying its `callType` and `callId`:
 
-The [Call Type](../../guides/configuring-call-types) controls which features are enabled, and sets up permissions.
+The [Call Type](../../core/call-types) controls which features are enabled, and sets up permissions.
 You can reuse the same call multiple times. As an example, if you're building a telemedicine app calls will be connected to an appointment.
 Using your own appointment id as the call id makes it easy to find the call later.
 
@@ -71,7 +71,7 @@ await call.leave();
 
 ### End call
 
-Ending a call requires a [special permission](../../guides/permissions-and-moderation). This action terminates the call for everyone.
+Ending a call requires a [special permission](../../core/permissions-and-moderation). This action terminates the call for everyone.
 
 ```typescript
 await call.endCall();
@@ -93,7 +93,7 @@ await call.getOrCreate(); // create if not present and load it
 These operations initialize the `call.state` and create a subscription for call updates to our backend.
 This means that this `call` instance will receive real-time updates in case it is modified somewhere else.
 
-Read more about call state here: [Call & Participant State](../../guides/call-and-participant-state/).
+Read more about call state here: [Call & Participant State](../../core/call-and-participant-state/).
 
 ### Update call
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/03-calling-state-and-lifecycle.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/03-calling-state-and-lifecycle.mdx
@@ -15,7 +15,7 @@ Every `call` instance should be created through the `client.call(type, id)` help
 
 Our `StreamVideoClient` is responsible for maintaining a WebSocket connection to our servers and also takes care about the API calls that are proxied from the `call` instance.
 
-As we learned in [Joining and Creating Calls](../../guides/joining-and-creating-calls/) guide, a call instance is managed like this:
+As we learned in [Joining and Creating Calls](../../core/joining-and-creating-calls/) guide, a call instance is managed like this:
 
 ```ts
 import { Call, StreamVideoClient } from '@stream-io/video-react-native-sdk';
@@ -42,7 +42,7 @@ Every `call` instance has a local state, exposed to integrators through:
 
 - `call.state.callingState` - a getter that returns the current value
 - `call.state.callingState$` - an observable that an integrator can subscribe to and be notified everytime the value changes
-- `useCallCallingState()` - a [call state hook](../../guides/call-and-participant-state/#call-state-hooks) that makes it easy to read and update the UI based on calling state values in React components.
+- `useCallCallingState()` - a [call state hook](../../core/call-and-participant-state/#call-state-hooks) that makes it easy to read and update the UI based on calling state values in React components.
 
 ## Call Instance
 

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/17-session-timers.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/17-session-timers.mdx
@@ -415,7 +415,7 @@ automatically, so our `SessionTimer` component always reflects the current
 settings.
 
 <!-- Similar to other permissions, the `CHANGE_MAX_DURATION` capability can be
-[requested](../../guides/permissions-and-moderation/#request-permissions) by the
+[requested](../../core/permissions-and-moderation/#request-permissions) by the
 user. The default `PermissionRequests` component is well suited for handling
 incoming permission requests. We also have a handy article on
 [how to implement your own UI](../permission-requests). -->

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/01-troubleshooting-guide.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/01-troubleshooting-guide.mdx
@@ -13,7 +13,7 @@ Connection issues usually happen when you provide an invalid token during the SD
 
 ### Expired tokens
 
-When you initialize the `StreamVideoClient` object, you provide a token, as described [here](../../guides/client-auth).
+When you initialize the `StreamVideoClient` object, you provide a token, as described [here](../../core/client-auth).
 The tokens generated in the docs have an expiry date, therefore, please make sure to always use a token with a valid expiry date.
 You can check the contents of a JWT token on websites like [this one](https://jwt.io).
 
@@ -61,4 +61,4 @@ in order for the ring functionality to work. One option is to use a `uuid` as a 
 
 ## Logging
 
-For easier debugging, you can turn on more verbose logging. To do that, [follow these instructions](../../guides/client-auth/#logging).
+For easier debugging, you can turn on more verbose logging. To do that, [follow these instructions](../../core/client-auth/#logging).

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/03-ringing.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/03-ringing.mdx
@@ -126,7 +126,7 @@ await call.leave();
 
 ## End call
 
-Ending a call requires a [special permission](../../guides/permissions-and-moderation). This action terminates the call for everyone.
+Ending a call requires a [special permission](../../core/permissions-and-moderation). This action terminates the call for everyone.
 
 ```typescript
 await call.endCall();

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/06-broadcasting.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/06-broadcasting.mdx
@@ -62,7 +62,7 @@ To connect your OBS project in a Stream Call, please follow the next steps:
 ### RTMP URL and stream key
 
 Our `call` instance exposes its RTMP address through `call.state.ingress` and `useCallIngress()` call state hook.
-`Stream Key` in our case is a standard [user token](../../guides/client-auth/#generating-a-token).
+`Stream Key` in our case is a standard [user token](../../core/client-auth/#generating-a-token).
 
 You can take this information and use it to configure OBS:
 


### PR DESCRIPTION
This PR fixes a bunch of broken links within the React Native SDK documentation.

As a follow-up to this, we should consolidate the page structure to be the same as for the other SDKs (the `react` one for example). That will come in a followup PR.