### PR TITLE
chore(pronto): default to h264 in Safari

### DIFF
--- a/sample-apps/react/react-dogfood/pages/join/[callId].tsx
+++ b/sample-apps/react/react-dogfood/pages/join/[callId].tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import {
   BackgroundFiltersProvider,
+  Browsers,
   Call,
   CallingState,
   CallRequest,
@@ -25,6 +26,7 @@ import { useSettings } from '../../context/SettingsContext';
 import {
   useAppEnvironment,
   useIsDemoEnvironment,
+  useIsProntoEnvironment,
 } from '../../context/AppEnvironmentContext';
 import { TourProvider } from '../../context/TourContext';
 import appTranslations from '../../translations';
@@ -51,6 +53,7 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
   // support for connecting to any application using an API key and user token
   const apiKeyOverride = !!router.query['api_key'];
 
+  const isProntoEnvironment = useIsProntoEnvironment();
   const isDemoEnvironment = useIsDemoEnvironment();
   useEffect(() => {
     if (!isDemoEnvironment) return;
@@ -152,6 +155,10 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
   useEffect(() => {
     if (!client) return;
     const _call = client.call(callType, callId);
+    if (isProntoEnvironment && Browsers.isSafari()) {
+      console.log('Setting preferred codec to h264');
+      _call.camera.setPreferredCodec('h264');
+    }
     setCall(_call);
 
     // @ts-ignore - for debugging
@@ -165,7 +172,7 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
         window.call = undefined;
       }
     };
-  }, [callId, callType, client]);
+  }, [callId, callType, client, isProntoEnvironment]);
 
   useEffect(() => {
     if (!call) return;


### PR DESCRIPTION
### Overview

Let's test a bit with Pronto before we make #1437 the default SDK behavior.