### PR TITLE
fix: beep only when participantCount is less than five

### DIFF
--- a/sample-apps/react/react-dogfood/hooks/useNotificationSounds.ts
+++ b/sample-apps/react/react-dogfood/hooks/useNotificationSounds.ts
@@ -11,19 +11,18 @@ export function useNotificationSounds() {
   );
 
   useEffect(() => {
-    if (!call) {
-      return;
-    }
-
+    if (!call) return;
     const unlistenJoin = call.on('call.session_participant_joined', (event) => {
-      if (!isSelf(event.participant.user.id)) {
-        beep('/beeps/joined.mp3');
+      const { participantCount } = call.state;
+      if (!isSelf(event.participant.user.id) && participantCount < 5) {
+        beep('/beeps/joined.mp3').catch((e) => console.error(e));
       }
     });
 
     const unlistenLeft = call.on('call.session_participant_left', (event) => {
-      if (!isSelf(event.participant.user.id)) {
-        beep('/beeps/left.mp3');
+      const { participantCount } = call.state;
+      if (!isSelf(event.participant.user.id) && participantCount < 5) {
+        beep('/beeps/left.mp3').catch((e) => console.error(e));
       }
     });
 


### PR DESCRIPTION
### Overview

Beeping is uncomfortable in large calls when many people are joining/leaving the call.
This PR enables beeping only when the participant count is less than 5.