### PR TITLE
fix: prioritize h264 baseline profile

### DIFF
--- a/packages/client/src/rtc/__tests__/codecs.test.ts
+++ b/packages/client/src/rtc/__tests__/codecs.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getPreferredCodecs } from '../codecs';
+import './mocks/webrtc.mocks';
+
+describe('codecs', () => {
+  it('should return preferred audio codec', () => {
+    RTCRtpReceiver.getCapabilities = vi.fn().mockReturnValue(audioCodecs);
+    const codecs = getPreferredCodecs('audio', 'red');
+    expect(codecs).toBeDefined();
+    expect(codecs?.map((c) => c.mimeType)).toEqual([
+      'audio/red',
+      'audio/opus',
+      'audio/G722',
+      'audio/PCMU',
+      'audio/PCMA',
+      'audio/CN',
+      'audio/telephone-event',
+    ]);
+  });
+
+  it('should return preferred video codec', () => {
+    RTCRtpReceiver.getCapabilities = vi.fn().mockReturnValue(videoCodecs);
+    const codecs = getPreferredCodecs('video', 'vp8');
+    expect(codecs).toBeDefined();
+    // prettier-ignore
+    expect(codecs?.map((c) => [c.mimeType, c.sdpFmtpLine])).toEqual([
+      ['video/VP8', undefined],
+      ['video/H264', 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f'],
+      ['video/rtx', undefined],
+      ['video/H264', 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f'],
+      ['video/H264', 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f'],
+      ['video/H264', 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f'],
+      ['video/VP9', 'profile-id=0'],
+      ['video/VP9', 'profile-id=2'],
+      ['video/red', undefined],
+      ['video/ulpfec', undefined],
+      ['video/flexfec-03', 'repair-window=10000000'],
+    ]);
+  });
+
+  it('should pick the baseline H264 codec', () => {
+    RTCRtpReceiver.getCapabilities = vi.fn().mockReturnValue(videoCodecs);
+    const codecs = getPreferredCodecs('video', 'h264');
+    expect(codecs).toBeDefined();
+    // prettier-ignore
+    expect(codecs?.map((c) => [c.mimeType, c.sdpFmtpLine])).toEqual([
+      ['video/H264', 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f'],
+      ['video/H264', 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f'],
+      ['video/H264', 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f'],
+      ['video/H264', 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f'],
+      ['video/rtx', undefined],
+      ['video/VP8', undefined],
+      ['video/VP9', 'profile-id=0'],
+      ['video/VP9', 'profile-id=2'],
+      ['video/red', undefined],
+      ['video/ulpfec', undefined],
+      ['video/flexfec-03', 'repair-window=10000000'],
+    ]);
+  });
+
+  it('should pick the baseline H264 codec with optional packetization-mode', () => {
+    RTCRtpReceiver.getCapabilities = vi
+      .fn()
+      .mockReturnValue(videoCodecsFirefox);
+    const codecs = getPreferredCodecs('video', 'h264');
+    expect(codecs).toBeDefined();
+    // prettier-ignore
+    expect(codecs?.map((c) => [c.mimeType, c.sdpFmtpLine])).toEqual([
+      ['video/H264', 'profile-level-id=42e01f;level-asymmetry-allowed=1'],
+      ['video/H264', 'profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1'],
+      ['video/VP8', 'max-fs=12288;max-fr=60'],
+      ['video/rtx', undefined],
+      ['video/VP9', 'max-fs=12288;max-fr=60'],
+      ['video/ulpfec', undefined],
+      ['video/red', undefined],
+    ]);
+  });
+});
+
+// prettier-ignore
+const videoCodecsFirefox: RTCRtpCapabilities = {
+  codecs: [
+    {
+      mimeType: 'video/VP8',
+      sdpFmtpLine: 'max-fs=12288;max-fr=60',
+      clockRate: 90000,
+    },
+    { mimeType: 'video/rtx', clockRate: 90000 },
+    {
+      mimeType: 'video/VP9',
+      sdpFmtpLine: 'max-fs=12288;max-fr=60',
+      clockRate: 90000,
+    },
+    {
+      mimeType: 'video/H264',
+      sdpFmtpLine: 'profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1',
+      clockRate: 90000,
+    },
+    {
+      mimeType: 'video/H264',
+      sdpFmtpLine: 'profile-level-id=42e01f;level-asymmetry-allowed=1',
+      clockRate: 90000,
+    },
+    { mimeType: 'video/ulpfec', clockRate: 90000 },
+    { mimeType: 'video/red', clockRate: 90000 },
+  ],
+  headerExtensions: [
+    { uri: 'urn:ietf:params:rtp-hdrext:sdes:mid' },
+    { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time' },
+    { uri: 'urn:ietf:params:rtp-hdrext:toffset' },
+    { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay' },
+  ],
+};
+
+// prettier-ignore
+const videoCodecs: RTCRtpCapabilities = {
+  codecs: [
+    {
+      mimeType: 'video/H264',
+      sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f',
+      clockRate: 90000,
+    },
+    { mimeType: 'video/rtx', clockRate: 90000 },
+    {
+      mimeType: 'video/H264',
+      sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f',
+      clockRate: 90000,
+    },
+    {
+      mimeType: 'video/H264',
+      sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f',
+      clockRate: 90000,
+    },
+    {
+      mimeType: 'video/H264',
+      sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f',
+      clockRate: 90000,
+    },
+    { mimeType: 'video/VP8', clockRate: 90000 },
+    { mimeType: 'video/VP9', sdpFmtpLine: 'profile-id=0', clockRate: 90000 },
+    { mimeType: 'video/VP9', sdpFmtpLine: 'profile-id=2', clockRate: 90000 },
+    { mimeType: 'video/red', clockRate: 90000 },
+    { mimeType: 'video/ulpfec', clockRate: 90000 },
+    {
+      mimeType: 'video/flexfec-03',
+      sdpFmtpLine: 'repair-window=10000000',
+      clockRate: 90000,
+    },
+  ],
+  headerExtensions: [
+    { uri: 'urn:ietf:params:rtp-hdrext:toffset' },
+    { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time' },
+    { uri: 'urn:3gpp:video-orientation' },
+    {
+      uri: 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01',
+    },
+    { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay' },
+    { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/video-content-type' },
+    { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/video-timing' },
+    { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/color-space' },
+    { uri: 'urn:ietf:params:rtp-hdrext:sdes:mid' },
+    { uri: 'urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id' },
+    { uri: 'urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id' },
+  ],
+};
+
+const audioCodecs: RTCRtpCapabilities = {
+  codecs: [
+    {
+      clockRate: 48000,
+      mimeType: 'audio/opus',
+      sdpFmtpLine: 'minptime=10;useinbandfec=1',
+    },
+    { clockRate: 48000, mimeType: 'audio/red', sdpFmtpLine: '=111/111' },
+    { channels: 1, clockRate: 8000, mimeType: 'audio/G722' },
+    { channels: 1, clockRate: 8000, mimeType: 'audio/PCMU' },
+    { channels: 1, clockRate: 8000, mimeType: 'audio/PCMA' },
+    { channels: 1, clockRate: 8000, mimeType: 'audio/CN' },
+    { channels: 1, clockRate: 8000, mimeType: 'audio/telephone-event' },
+  ],
+  headerExtensions: [
+    { uri: 'urn:ietf:params:rtp-hdrext:ssrc-audio-level' },
+    { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time' },
+    { uri: 'urn:ietf:params:rtp-hdrext:sdes:mid' },
+  ],
+};

--- a/packages/client/src/rtc/__tests__/codecs.test.ts
+++ b/packages/client/src/rtc/__tests__/codecs.test.ts
@@ -89,17 +89,18 @@ const videoCodecsFirefox: RTCRtpCapabilities = {
     {
       mimeType: 'video/VP9',
       sdpFmtpLine: 'max-fs=12288;max-fr=60',
-      clockRate: 90000,
+      clockRate: 90000,,
     },
     {
       mimeType: 'video/H264',
-      sdpFmtpLine: 'profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1',
-      clockRate: 90000,
+      sdpFmtpLine:
+        'profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1',
+      clockRa,te: 90000,
     },
     {
       mimeType: 'video/H264',
       sdpFmtpLine: 'profile-level-id=42e01f;level-asymmetry-allowed=1',
-      clockRate: 90000,
+      clockR,ate: 90000,
     },
     { mimeType: 'video/ulpfec', clockRate: 90000 },
     { mimeType: 'video/red', clockRate: 90000 },
@@ -151,9 +152,7 @@ const videoCodecs: RTCRtpCapabilities = {
     { uri: 'urn:ietf:params:rtp-hdrext:toffset' },
     { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time' },
     { uri: 'urn:3gpp:video-orientation' },
-    {
-      uri: 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01',
-    },
+    { uri: 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01' },
     { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay' },
     { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/video-content-type' },
     { uri: 'http://www.webrtc.org/experiments/rtp-hdrext/video-timing' },
@@ -164,19 +163,20 @@ const videoCodecs: RTCRtpCapabilities = {
   ],
 };
 
+// prettier-ignore
 const audioCodecs: RTCRtpCapabilities = {
   codecs: [
     {
-      clockRate: 48000,
       mimeType: 'audio/opus',
       sdpFmtpLine: 'minptime=10;useinbandfec=1',
+      clockRate: 48000,
     },
-    { clockRate: 48000, mimeType: 'audio/red', sdpFmtpLine: '=111/111' },
-    { channels: 1, clockRate: 8000, mimeType: 'audio/G722' },
-    { channels: 1, clockRate: 8000, mimeType: 'audio/PCMU' },
-    { channels: 1, clockRate: 8000, mimeType: 'audio/PCMA' },
-    { channels: 1, clockRate: 8000, mimeType: 'audio/CN' },
-    { channels: 1, clockRate: 8000, mimeType: 'audio/telephone-event' },
+    { mimeType: 'audio/red', sdpFmtpLine: '=111/111', clockRate: 48000 },
+    { mimeType: 'audio/G722', clockRate: 8000, channels: 1 },
+    { mimeType: 'audio/PCMU', clockRate: 8000, channels: 1 },
+    { mimeType: 'audio/PCMA', clockRate: 8000, channels: 1 },
+    { mimeType: 'audio/CN', clockRate: 8000, channels: 1 },
+    { mimeType: 'audio/telephone-event', clockRate: 8000, channels: 1 },
   ],
   headerExtensions: [
     { uri: 'urn:ietf:params:rtp-hdrext:ssrc-audio-level' },

--- a/packages/client/src/rtc/__tests__/codecs.test.ts
+++ b/packages/client/src/rtc/__tests__/codecs.test.ts
@@ -80,28 +80,11 @@ describe('codecs', () => {
 // prettier-ignore
 const videoCodecsFirefox: RTCRtpCapabilities = {
   codecs: [
-    {
-      mimeType: 'video/VP8',
-      sdpFmtpLine: 'max-fs=12288;max-fr=60',
-      clockRate: 90000,
-    },
+    { mimeType: 'video/VP8', sdpFmtpLine: 'max-fs=12288;max-fr=60', clockRate: 90000 },
     { mimeType: 'video/rtx', clockRate: 90000 },
-    {
-      mimeType: 'video/VP9',
-      sdpFmtpLine: 'max-fs=12288;max-fr=60',
-      clockRate: 90000,,
-    },
-    {
-      mimeType: 'video/H264',
-      sdpFmtpLine:
-        'profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1',
-      clockRa,te: 90000,
-    },
-    {
-      mimeType: 'video/H264',
-      sdpFmtpLine: 'profile-level-id=42e01f;level-asymmetry-allowed=1',
-      clockR,ate: 90000,
-    },
+    { mimeType: 'video/VP9', sdpFmtpLine: 'max-fs=12288;max-fr=60', clockRate: 90000 },
+    { mimeType: 'video/H264', sdpFmtpLine: 'profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1', clockRate: 90000 },
+    { mimeType: 'video/H264', sdpFmtpLine: 'profile-level-id=42e01f;level-asymmetry-allowed=1', clockRate: 90000 },
     { mimeType: 'video/ulpfec', clockRate: 90000 },
     { mimeType: 'video/red', clockRate: 90000 },
   ],
@@ -116,37 +99,17 @@ const videoCodecsFirefox: RTCRtpCapabilities = {
 // prettier-ignore
 const videoCodecs: RTCRtpCapabilities = {
   codecs: [
-    {
-      mimeType: 'video/H264',
-      sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f',
-      clockRate: 90000,
-    },
+    { mimeType: 'video/H264', sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f', clockRate: 90000 },
     { mimeType: 'video/rtx', clockRate: 90000 },
-    {
-      mimeType: 'video/H264',
-      sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f',
-      clockRate: 90000,
-    },
-    {
-      mimeType: 'video/H264',
-      sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f',
-      clockRate: 90000,
-    },
-    {
-      mimeType: 'video/H264',
-      sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f',
-      clockRate: 90000,
-    },
+    { mimeType: 'video/H264', sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f', clockRate: 90000 },
+    { mimeType: 'video/H264', sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f', clockRate: 90000 },
+    { mimeType: 'video/H264', sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f', clockRate: 90000 },
     { mimeType: 'video/VP8', clockRate: 90000 },
     { mimeType: 'video/VP9', sdpFmtpLine: 'profile-id=0', clockRate: 90000 },
     { mimeType: 'video/VP9', sdpFmtpLine: 'profile-id=2', clockRate: 90000 },
     { mimeType: 'video/red', clockRate: 90000 },
     { mimeType: 'video/ulpfec', clockRate: 90000 },
-    {
-      mimeType: 'video/flexfec-03',
-      sdpFmtpLine: 'repair-window=10000000',
-      clockRate: 90000,
-    },
+    { mimeType: 'video/flexfec-03', sdpFmtpLine: 'repair-window=10000000', clockRate: 90000 },
   ],
   headerExtensions: [
     { uri: 'urn:ietf:params:rtp-hdrext:toffset' },
@@ -166,11 +129,7 @@ const videoCodecs: RTCRtpCapabilities = {
 // prettier-ignore
 const audioCodecs: RTCRtpCapabilities = {
   codecs: [
-    {
-      mimeType: 'audio/opus',
-      sdpFmtpLine: 'minptime=10;useinbandfec=1',
-      clockRate: 48000,
-    },
+    { mimeType: 'audio/opus', sdpFmtpLine: 'minptime=10;useinbandfec=1', clockRate: 48000 },
     { mimeType: 'audio/red', sdpFmtpLine: '=111/111', clockRate: 48000 },
     { mimeType: 'audio/G722', clockRate: 8000, channels: 1 },
     { mimeType: 'audio/PCMU', clockRate: 8000, channels: 1 },

--- a/packages/client/src/rtc/__tests__/mocks/webrtc.mocks.ts
+++ b/packages/client/src/rtc/__tests__/mocks/webrtc.mocks.ts
@@ -60,3 +60,10 @@ const RTCTrackEvent = vi.fn(
   },
 );
 vi.stubGlobal('RTCTrackEvent', RTCTrackEvent);
+
+const RTCRtpReceiverMock = vi.fn((): Partial<typeof RTCRtpReceiver> => {
+  return {
+    getCapabilities: vi.fn(),
+  };
+});
+vi.stubGlobal('RTCRtpReceiver', RTCRtpReceiverMock);


### PR DESCRIPTION
### Overview

When using `h264` as the preferred codec, we make sure that the baseline profile `42e01f` and `packetization-mode=0` are used to maximize compatibility between browsers and devices.