### PR TITLE
fix: replace dataSync with shortService for android foreground service type

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/04-push-notifications/03-ringing-setup/01-react-native.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/06-advanced/04-push-notifications/03-ringing-setup/01-react-native.mdx
@@ -77,13 +77,12 @@ Add the following in `AndroidManifest.xml`:
 <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 <!-- We declare the permissions to for using foreground service -->
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
 <service
     android:name="app.notifee.core.ForegroundService"
     tools:replace="android:foregroundServiceType"
     android:stopWithTask="true"
-    android:foregroundServiceType="dataSync" />
+    android:foregroundServiceType="shortService" />
 ```
 
 ### Request for notification permissions

--- a/packages/react-native-sdk/expo-config-plugin/README.md
+++ b/packages/react-native-sdk/expo-config-plugin/README.md
@@ -45,10 +45,10 @@ public class MainApplication extends Application implements ReactApplication {
 Add service named `app.notifee.core.ForegroundService`.
 
 ```xml
-<service android:name="app.notifee.core.ForegroundService" android:stopWithTask="true" android:foregroundServiceType="microphone"/>
+<service android:name="app.notifee.core.ForegroundService" android:stopWithTask="true" android:foregroundServiceType="shortService"/>
 ```
 
-The `@stream-io/video-react-native-sdk` also adds the appropriate android permissions such as `POST_NOTIFICATIONS`, `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_MICROPHONE`, `BLUETOOTH`, `BLUETOOTH_ADMIN` and `BLUETOOTH_CONNECT` to the `AndroidManifest.xml`.
+The `@stream-io/video-react-native-sdk` also adds the appropriate android permissions such as `POST_NOTIFICATIONS`, `FOREGROUND_SERVICE`, `BLUETOOTH`, `BLUETOOTH_ADMIN` and `BLUETOOTH_CONNECT` to the `AndroidManifest.xml`.
 
 ### iOS
 

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidPermissions.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidPermissions.test.ts
@@ -27,7 +27,6 @@ describe('withStreamVideoReactNativeSDKAndroidPermissions', () => {
       expect.arrayContaining([
         'android.permission.POST_NOTIFICATIONS',
         'android.permission.FOREGROUND_SERVICE',
-        'android.permission.FOREGROUND_SERVICE_DATA_SYNC',
         'android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION',
         'android.permission.BLUETOOTH',
         'android.permission.BLUETOOTH_CONNECT',

--- a/packages/react-native-sdk/expo-config-plugin/src/withAndroidManifest.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAndroidManifest.ts
@@ -20,9 +20,9 @@ function getNotifeeService() {
     <service
         android:name="app.notifee.core.ForegroundService"
         android:stopWithTask="true"
-        android:foregroundServiceType="dataSync" />
+        android:foregroundServiceType="shortService" />
  */
-  const foregroundServiceType = 'dataSync';
+  const foregroundServiceType = 'shortService';
   let head = prefixAndroidKeys({
     name: 'app.notifee.core.ForegroundService',
     stopWithTask: 'true',

--- a/packages/react-native-sdk/expo-config-plugin/src/withAndroidPermissions.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAndroidPermissions.ts
@@ -14,9 +14,6 @@ const withStreamVideoReactNativeSDKAndroidPermissions: ConfigPlugin<
       'android.permission.POST_NOTIFICATIONS',
       'android.permission.FOREGROUND_SERVICE'
     );
-    if (props?.ringingPushNotifications) {
-      permissions.push('android.permission.FOREGROUND_SERVICE_DATA_SYNC');
-    }
     if (props?.enableScreenshare) {
       permissions.push(
         'android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION'

--- a/sample-apps/react-native/dogfood/android/app/src/main/AndroidManifest.xml
+++ b/sample-apps/react-native/dogfood/android/app/src/main/AndroidManifest.xml
@@ -30,7 +30,6 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.CALL_PHONE" />
@@ -73,7 +72,7 @@
         <service
             android:name="app.notifee.core.ForegroundService"
             tools:replace="android:foregroundServiceType"
-            android:foregroundServiceType="dataSync"
+            android:foregroundServiceType="shortService"
             android:stopWithTask="true" />
     </application>
 </manifest>

--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -1140,7 +1140,7 @@ PODS:
   - RNVoipPushNotification (3.3.2):
     - React-Core
   - SocketRocket (0.6.1)
-  - stream-io-video-filters-react-native (0.2.1):
+  - stream-io-video-filters-react-native (0.2.4):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1148,7 +1148,7 @@ PODS:
   - stream-react-native-webrtc (118.1.0):
     - JitsiWebRTC (~> 118.0.0)
     - React-Core
-  - stream-video-react-native (0.10.5):
+  - stream-video-react-native (1.0.5):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1477,9 +1477,9 @@ SPEC CHECKSUMS:
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
   RNVoipPushNotification: 543e18f83089134a35e7f1d2eba4c8b1f7776b08
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  stream-io-video-filters-react-native: 90f5878de1c3655d2e1617062e12c96824248d4b
+  stream-io-video-filters-react-native: 8c345e6adf5164646696d45f9962c4199b2fe3b9
   stream-react-native-webrtc: 4ccf61161f77c57b9aa45f78cb7f69b7d91f3e9f
-  stream-video-react-native: b7cae2ff25354c68e70215a978943a8ebfa4663a
+  stream-video-react-native: a8220f05e0a89902a62f5f42017d64adfe4d7550
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 

--- a/sample-apps/react-native/expo-video-sample/android/app/src/main/AndroidManifest.xml
+++ b/sample-apps/react-native/expo-video-sample/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
   <uses-permission android:name="android.permission.CALL_PHONE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
@@ -37,7 +36,7 @@
         <action android:name="android.telecom.ConnectionService"/>
       </intent-filter>
     </service>
-    <service android:name="app.notifee.core.ForegroundService" android:stopWithTask="true" android:foregroundServiceType="dataSync" tools:replace="android:foregroundServiceType"/>
+    <service android:name="app.notifee.core.ForegroundService" android:stopWithTask="true" android:foregroundServiceType="shortService" tools:replace="android:foregroundServiceType"/>
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|smallestScreenSize" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait" android:supportsPictureInPicture="true" android:showWhenLocked="true" android:turnScreenOn="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
dataSync requires to add a permission. Which makes play store reject the app for review asking for proof. Using shortService means that there is no permission necessary. so its a win-win 