### PR TITLE
fix: allow video target bitrate override

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1324,9 +1324,10 @@ export class Call {
         case TrackType.VIDEO:
           const videoStream = this.camera.state.mediaStream;
           if (videoStream) {
-            await this.publishVideoStream(videoStream, {
-              preferredCodec: this.camera.preferredCodec,
-            });
+            await this.publishVideoStream(
+              videoStream,
+              this.camera.publishOptions,
+            );
           }
           break;
         case TrackType.SCREEN_SHARE:
@@ -2209,9 +2210,10 @@ export class Call {
         this.camera.state.mediaStream &&
         !this.publisher?.isPublishing(TrackType.VIDEO)
       ) {
-        await this.publishVideoStream(this.camera.state.mediaStream, {
-          preferredCodec: this.camera.preferredCodec,
-        });
+        await this.publishVideoStream(
+          this.camera.state.mediaStream,
+          this.camera.publishOptions,
+        );
       }
 
       // Start camera if backend config specifies, and there is no local setting

--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -4,6 +4,7 @@ import { CameraDirection, CameraManagerState } from './CameraManagerState';
 import { InputMediaDeviceManager } from './InputMediaDeviceManager';
 import { getVideoDevices, getVideoStream } from './devices';
 import { TrackType } from '../gen/video/sfu/models/models';
+import { PublishOptions } from '../types';
 
 type PreferredCodec = 'vp8' | 'h264' | string;
 
@@ -20,8 +21,27 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
    */
   preferredCodec: PreferredCodec | undefined;
 
+  /**
+   * The preferred bitrate for encoding the video.
+   *
+   * @internal internal use only, not part of the public API.
+   */
+  preferredBitrate: number | undefined;
+
   constructor(call: Call) {
     super(call, new CameraManagerState(), TrackType.VIDEO);
+  }
+
+  /**
+   * The publish options for the camera.
+   *
+   * @internal internal use only, not part of the public API.
+   */
+  get publishOptions(): PublishOptions {
+    return {
+      preferredCodec: this.preferredCodec,
+      preferredBitrate: this.preferredBitrate,
+    };
   }
 
   /**
@@ -88,6 +108,16 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
     this.preferredCodec = codec;
   }
 
+  /**
+   * Sets the preferred bitrate for encoding the video.
+   *
+   * @internal internal use only, not part of the public API.
+   * @param bitrate the bitrate to use for encoding the video.
+   */
+  setPreferredBitrate(bitrate: number | undefined) {
+    this.preferredBitrate = bitrate;
+  }
+
   protected getDevices(): Observable<MediaDeviceInfo[]> {
     return getVideoDevices();
   }
@@ -107,9 +137,7 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
   }
 
   protected publishStream(stream: MediaStream): Promise<void> {
-    return this.call.publishVideoStream(stream, {
-      preferredCodec: this.preferredCodec,
-    });
+    return this.call.publishVideoStream(stream, this.publishOptions);
   }
 
   protected stopPublishStream(stopTracks: boolean): Promise<void> {

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -13,7 +13,7 @@ import {
   findOptimalVideoLayers,
   OptimalVideoLayer,
 } from './videoLayers';
-import { getPreferredCodecs } from './codecs';
+import { getPreferredCodecs, getRNOptimalCodec } from './codecs';
 import { trackTypeToParticipantStreamKey } from './helpers/tracks';
 import { CallingState, CallState } from '../store';
 import { PublishOptions } from '../types';
@@ -22,7 +22,6 @@ import { enableHighQualityAudio, toggleDtx } from '../helpers/sdp-munging';
 import { Logger } from '../coordinator/connection/types';
 import { getLogger } from '../logger';
 import { Dispatcher } from './Dispatcher';
-import { getOSInfo } from '../client-details';
 import { VideoLayerSetting } from '../gen/video/sfu/event/events';
 import { TargetResolutionResponse } from '../gen/shims';
 
@@ -260,29 +259,17 @@ export class Publisher {
       const screenShareBitrate =
         settings?.screensharing.target_resolution?.bitrate;
 
+      const { preferredBitrate, preferredCodec, screenShareSettings } = opts;
       const videoEncodings =
         trackType === TrackType.VIDEO
-          ? findOptimalVideoLayers(track, targetResolution)
+          ? findOptimalVideoLayers(track, targetResolution, preferredBitrate)
           : trackType === TrackType.SCREEN_SHARE
             ? findOptimalScreenSharingLayers(
                 track,
-                opts.screenShareSettings,
+                screenShareSettings,
                 screenShareBitrate,
               )
             : undefined;
-
-      let preferredCodec = opts.preferredCodec;
-      if (!preferredCodec && trackType === TrackType.VIDEO && isReactNative()) {
-        const osName = getOSInfo()?.name.toLowerCase();
-        if (osName === 'ipados') {
-          // in ipads it was noticed that if vp8 codec is used
-          // then the bytes sent is 0 in the outbound-rtp
-          // so we are forcing h264 codec for ipads
-          preferredCodec = 'H264';
-        } else if (osName === 'android') {
-          preferredCodec = 'VP8';
-        }
-      }
 
       // listen for 'ended' event on the track as it might be ended abruptly
       // by an external factor as permission revokes, device disconnected, etc.
@@ -306,9 +293,14 @@ export class Publisher {
       this.transceiverRegistry[trackType] = transceiver;
       this.publishOptionsPerTrackType.set(trackType, opts);
 
+      const codec =
+        isReactNative() && trackType === TrackType.VIDEO && !preferredCodec
+          ? getRNOptimalCodec()
+          : preferredCodec;
+
       const codecPreferences =
         'setCodecPreferences' in transceiver
-          ? this.getCodecPreferences(trackType, preferredCodec)
+          ? this.getCodecPreferences(trackType, codec)
           : undefined;
       if (codecPreferences) {
         this.logger(
@@ -721,7 +713,11 @@ export class Publisher {
           const publishOpts = this.publishOptionsPerTrackType.get(trackType);
           optimalLayers =
             trackType === TrackType.VIDEO
-              ? findOptimalVideoLayers(track, targetResolution)
+              ? findOptimalVideoLayers(
+                  track,
+                  targetResolution,
+                  publishOpts?.preferredBitrate,
+                )
               : trackType === TrackType.SCREEN_SHARE
                 ? findOptimalScreenSharingLayers(
                     track,

--- a/packages/client/src/rtc/__tests__/videoLayers.test.ts
+++ b/packages/client/src/rtc/__tests__/videoLayers.test.ts
@@ -138,7 +138,12 @@ describe('videoLayers', () => {
   describe('getComputedMaxBitrate', () => {
     it('should scale target bitrate down if resolution is smaller than target resolution', () => {
       const targetResolution = { width: 1920, height: 1080, bitrate: 3000000 };
-      const scaledBitrate = getComputedMaxBitrate(targetResolution, 1280, 720);
+      const scaledBitrate = getComputedMaxBitrate(
+        targetResolution,
+        1280,
+        720,
+        undefined,
+      );
       expect(scaledBitrate).toBe(1333333);
     });
 
@@ -148,7 +153,12 @@ describe('videoLayers', () => {
       const targetBitrates = ['f', 'h', 'q'].map((rid) => {
         const width = targetResolution.width / downscaleFactor;
         const height = targetResolution.height / downscaleFactor;
-        const bitrate = getComputedMaxBitrate(targetResolution, width, height);
+        const bitrate = getComputedMaxBitrate(
+          targetResolution,
+          width,
+          height,
+          undefined,
+        );
         downscaleFactor *= 2;
         return {
           rid,
@@ -166,25 +176,45 @@ describe('videoLayers', () => {
 
     it('should not scale target bitrate if resolution is larger than target resolution', () => {
       const targetResolution = { width: 1280, height: 720, bitrate: 1000000 };
-      const scaledBitrate = getComputedMaxBitrate(targetResolution, 2560, 1440);
+      const scaledBitrate = getComputedMaxBitrate(
+        targetResolution,
+        2560,
+        1440,
+        undefined,
+      );
       expect(scaledBitrate).toBe(1000000);
     });
 
     it('should not scale target bitrate if resolution is equal to target resolution', () => {
       const targetResolution = { width: 1280, height: 720, bitrate: 1000000 };
-      const scaledBitrate = getComputedMaxBitrate(targetResolution, 1280, 720);
+      const scaledBitrate = getComputedMaxBitrate(
+        targetResolution,
+        1280,
+        720,
+        undefined,
+      );
       expect(scaledBitrate).toBe(1000000);
     });
 
     it('should handle 0 width and height', () => {
       const targetResolution = { width: 1280, height: 720, bitrate: 1000000 };
-      const scaledBitrate = getComputedMaxBitrate(targetResolution, 0, 0);
+      const scaledBitrate = getComputedMaxBitrate(
+        targetResolution,
+        0,
+        0,
+        undefined,
+      );
       expect(scaledBitrate).toBe(0);
     });
 
     it('should handle 4k target resolution', () => {
       const targetResolution = { width: 3840, height: 2160, bitrate: 15000000 };
-      const scaledBitrate = getComputedMaxBitrate(targetResolution, 1280, 720);
+      const scaledBitrate = getComputedMaxBitrate(
+        targetResolution,
+        1280,
+        720,
+        undefined,
+      );
       expect(scaledBitrate).toBe(1666667);
     });
   });

--- a/packages/client/src/rtc/codecs.ts
+++ b/packages/client/src/rtc/codecs.ts
@@ -1,3 +1,5 @@
+import { getOSInfo } from '../client-details';
+
 /**
  * Returns back a list of sorted codecs, with the preferred codec first.
  *
@@ -87,4 +89,17 @@ export const getGenericSdp = async (direction: RTCRtpTransceiverDirection) => {
   });
   tempPc.close();
   return sdp;
+};
+
+/**
+ * Returns the optimal codec for RN.
+ */
+export const getRNOptimalCodec = () => {
+  const osName = getOSInfo()?.name.toLowerCase();
+  // in ipads it was noticed that if vp8 codec is used
+  // then the bytes sent is 0 in the outbound-rtp
+  // so we are forcing h264 codec for ipads
+  if (osName === 'ipados') return 'h264';
+  if (osName === 'android') return 'vp8';
+  return undefined;
 };

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -148,6 +148,7 @@ export type SubscriptionChanges = {
 
 export type PublishOptions = {
   preferredCodec?: string | null;
+  preferredBitrate?: number;
   screenShareSettings?: ScreenShareSettings;
 };
 

--- a/sample-apps/react/react-dogfood/helpers/bitrateLookup.ts
+++ b/sample-apps/react/react-dogfood/helpers/bitrateLookup.ts
@@ -1,0 +1,24 @@
+const lookup: Record<string, Record<number, number> | undefined> = {
+  h264: {
+    1080: 2_750_000,
+    720: 1_250_000,
+    540: 750_000,
+    360: 400_000,
+  },
+  vp8: {
+    1080: 2_000_000,
+    720: 1_000_000,
+    540: 600_000,
+    360: 350_000,
+  },
+};
+
+export const getPreferredBitrate = (
+  codec: string,
+  frameHeight: number,
+): number | undefined => {
+  const codecLookup = lookup[codec.toLowerCase()];
+  if (!codecLookup) return;
+
+  return codecLookup[frameHeight];
+};

--- a/sample-apps/react/react-dogfood/pages/join/[callId].tsx
+++ b/sample-apps/react/react-dogfood/pages/join/[callId].tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import {
   BackgroundFiltersProvider,
-  Browsers,
   Call,
   CallingState,
   CallRequest,
@@ -26,7 +25,6 @@ import { useSettings } from '../../context/SettingsContext';
 import {
   useAppEnvironment,
   useIsDemoEnvironment,
-  useIsProntoEnvironment,
 } from '../../context/AppEnvironmentContext';
 import { TourProvider } from '../../context/TourContext';
 import appTranslations from '../../translations';
@@ -53,7 +51,6 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
   // support for connecting to any application using an API key and user token
   const apiKeyOverride = !!router.query['api_key'];
 
-  const isProntoEnvironment = useIsProntoEnvironment();
   const isDemoEnvironment = useIsDemoEnvironment();
   useEffect(() => {
     if (!isDemoEnvironment) return;
@@ -155,10 +152,6 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
   useEffect(() => {
     if (!client) return;
     const _call = client.call(callType, callId);
-    if (isProntoEnvironment && Browsers.isSafari()) {
-      console.log('Setting preferred codec to h264');
-      _call.camera.setPreferredCodec('h264');
-    }
     setCall(_call);
 
     // @ts-ignore - for debugging
@@ -172,7 +165,7 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
         window.call = undefined;
       }
     };
-  }, [callId, callType, client, isProntoEnvironment]);
+  }, [callId, callType, client]);
 
   useEffect(() => {
     if (!call) return;


### PR DESCRIPTION
### Overview

Introduces a new internal API that allows overriding of the target bitrate used for encoding video tracks.

Also, it enables h264 by default in our internal environments. We need to dogfood this codec more.