### PR TITLE
fix: race condition in `applySettingsToStream`

### DIFF
--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -227,6 +227,7 @@ export abstract class InputMediaDeviceManager<
       if (this.enabled) {
         await this.muteStream();
         await this.unmuteStream();
+      }
     });
   }
 

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -223,7 +223,7 @@ export abstract class InputMediaDeviceManager<
   };
 
   protected async applySettingsToStream() {
-    withCancellation(this.statusChangeConcurrencyTag, async () => {
+    await withCancellation(this.statusChangeConcurrencyTag, async () => {
       if (this.enabled) {
         await this.muteStream();
         await this.unmuteStream();

--- a/sample-apps/react/react-dogfood/components/MeetingUI.tsx
+++ b/sample-apps/react/react-dogfood/components/MeetingUI.tsx
@@ -114,10 +114,7 @@ export const MeetingUI = ({ chatClient, mode }: MeetingUIProps) => {
 
   useEffect(() => {
     const handlePageLeave = async () => {
-      if (
-        call &&
-        [CallingState.JOINING, CallingState.JOINED].includes(callState)
-      ) {
+      if (call) {
         await call.leave();
       }
     };


### PR DESCRIPTION
User case:

1. Have a button to leave a call that navigates to a different page
2. Have filters enabled and `BackgroundFiltersProvider` rendered
3. Pressing the "leave" button invokes `call.leave()` which disables devices; it also causes navigation to happen
4. Navigation unmounts `BackgroundFiltersProvider`, which unregisters the current filter, which calls `camera.applySettingsToStream()`
5. Depending on the conditions, `camera.applySettingsToStream()` may re-enable camera

The user ends up with a camera still in use after leaving the call.

Solution: "synchronize" `applySettingsToStream` with enable/disable methods. This way, either the camera will be disabled first, and `applySettingsToStream` does nothing; or `applySettingsToStream` finishes first, but the camera is then safely disabled.