### PR TITLE
chore: `preMajor: false` for stable packages

### DIFF
--- a/packages/react-bindings/project.json
+++ b/packages/react-bindings/project.json
@@ -9,16 +9,16 @@
         "baseBranch": "main",
         "preset": {
           "name": "conventionalcommits",
-          "preMajor": true,
+          "preMajor": false,
           "types": [
-            {"type": "feat", "section": "Features"},
-            {"type": "fix", "section": "Bug Fixes"},
-            {"type": "chore", "hidden": false},
-            {"type": "docs", "hidden": true},
-            {"type": "style", "hidden": true},
-            {"type": "refactor", "hidden": true},
-            {"type": "perf", "section": "Features"},
-            {"type": "test", "hidden": true}
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "chore", "hidden": false },
+            { "type": "docs", "hidden": true },
+            { "type": "style", "hidden": true },
+            { "type": "refactor", "hidden": true },
+            { "type": "perf", "section": "Features" },
+            { "type": "test", "hidden": true }
           ]
         },
         "trackDeps": true,

--- a/packages/react-native-sdk/project.json
+++ b/packages/react-native-sdk/project.json
@@ -9,16 +9,16 @@
         "baseBranch": "main",
         "preset": {
           "name": "conventionalcommits",
-          "preMajor": true,
+          "preMajor": false,
           "types": [
-            {"type": "feat", "section": "Features"},
-            {"type": "fix", "section": "Bug Fixes"},
-            {"type": "chore", "hidden": false},
-            {"type": "docs", "hidden": true},
-            {"type": "style", "hidden": true},
-            {"type": "refactor", "hidden": true},
-            {"type": "perf", "section": "Features"},
-            {"type": "test", "hidden": true}
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "chore", "hidden": false },
+            { "type": "docs", "hidden": true },
+            { "type": "style", "hidden": true },
+            { "type": "refactor", "hidden": true },
+            { "type": "perf", "section": "Features" },
+            { "type": "test", "hidden": true }
           ]
         },
         "trackDeps": true,

--- a/packages/styling/project.json
+++ b/packages/styling/project.json
@@ -8,16 +8,16 @@
         "dryRun": false,
         "preset": {
           "name": "conventionalcommits",
-          "preMajor": true,
+          "preMajor": false,
           "types": [
-            {"type": "feat", "section": "Features"},
-            {"type": "fix", "section": "Bug Fixes"},
-            {"type": "chore", "hidden": true},
-            {"type": "docs", "section": "Documentation"},
-            {"type": "style", "hidden": true},
-            {"type": "refactor", "hidden": true},
-            {"type": "perf", "section": "Features"},
-            {"type": "test", "hidden": true}
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "chore", "hidden": true },
+            { "type": "docs", "section": "Documentation" },
+            { "type": "style", "hidden": true },
+            { "type": "refactor", "hidden": true },
+            { "type": "perf", "section": "Features" },
+            { "type": "test", "hidden": true }
           ]
         },
         "trackDeps": true,


### PR DESCRIPTION
### Overview

Enables proper semver version bumps for packages that are stable.