### PR TITLE
fix: XCode 16 compatibility

### DIFF
--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -1108,15 +1108,15 @@ PODS:
   - RNGoogleSignin (11.0.0):
     - GoogleSignIn (~> 7.0)
     - React-Core
-  - RNImageCropPicker (0.40.0):
+  - RNImageCropPicker (0.41.2):
     - React-Core
     - React-RCTImage
-    - RNImageCropPicker/QBImagePickerController (= 0.40.0)
-    - TOCropViewController
-  - RNImageCropPicker/QBImagePickerController (0.40.0):
+    - RNImageCropPicker/QBImagePickerController (= 0.41.2)
+    - TOCropViewController (~> 2.7.4)
+  - RNImageCropPicker/QBImagePickerController (0.41.2):
     - React-Core
     - React-RCTImage
-    - TOCropViewController
+    - TOCropViewController (~> 2.7.4)
   - RNNotifee (7.8.0):
     - React-Core
     - RNNotifee/NotifeeCore (= 7.8.0)
@@ -1148,7 +1148,7 @@ PODS:
   - stream-react-native-webrtc (118.1.0):
     - JitsiWebRTC (~> 118.0.0)
     - React-Core
-  - stream-video-react-native (1.0.5):
+  - stream-video-react-native (1.0.10):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1468,7 +1468,7 @@ SPEC CHECKSUMS:
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: a51b249f3c779e38a5d9ec45cb107d8780b39fb2
   RNGoogleSignin: fc408799f1990a12497a32f64280c0fe353ffcc1
-  RNImageCropPicker: 486e2f7e2b0461ce24321f751410dce1b3b49e6d
+  RNImageCropPicker: 771e2ca319d2cf92e04ebf334ece892ee9a6728f
   RNNotifee: f3c01b391dd8e98e67f539f9a35a9cbcd3bae744
   RNPermissions: 4d64d2c763b20e5db08dfb8f1ef541f95c0d28c1
   RNReactNativeHapticFeedback: afa5bf2794aecbb2dba2525329253da0d66656df
@@ -1479,7 +1479,7 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   stream-io-video-filters-react-native: 8c345e6adf5164646696d45f9962c4199b2fe3b9
   stream-react-native-webrtc: 4ccf61161f77c57b9aa45f78cb7f69b7d91f3e9f
-  stream-video-react-native: a8220f05e0a89902a62f5f42017d64adfe4d7550
+  stream-video-react-native: 4731ac81060b8b432e57f9a923769ffa851880a8
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 

--- a/sample-apps/react-native/dogfood/package.json
+++ b/sample-apps/react-native/dogfood/package.json
@@ -40,7 +40,7 @@
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^2.15.0",
     "react-native-haptic-feedback": "^2.0.3",
-    "react-native-image-crop-picker": "^0.40.0",
+    "react-native-image-crop-picker": "^0.41.2",
     "react-native-image-resizer": "^1.4.5",
     "react-native-incall-manager": "4.2.0",
     "react-native-mmkv": "2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7476,7 +7476,7 @@ __metadata:
     react-native-fs: ^2.20.0
     react-native-gesture-handler: ^2.15.0
     react-native-haptic-feedback: ^2.0.3
-    react-native-image-crop-picker: ^0.40.0
+    react-native-image-crop-picker: ^0.41.2
     react-native-image-resizer: ^1.4.5
     react-native-incall-manager: 4.2.0
     react-native-mmkv: 2.8.0
@@ -22004,12 +22004,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-image-crop-picker@npm:^0.40.0":
-  version: 0.40.0
-  resolution: "react-native-image-crop-picker@npm:0.40.0"
+"react-native-image-crop-picker@npm:^0.41.2":
+  version: 0.41.2
+  resolution: "react-native-image-crop-picker@npm:0.41.2"
   peerDependencies:
     react-native: ">=0.40.0"
-  checksum: f2f2a4ea8ae1dd8c242361f391dc694ef93a651314efe538ecb5e382911f82595cd0f2337ac5cd5225acd740899a90a1d65a8d9e1f02a66232ac5273c33fd550
+  checksum: c1333b3b761e948bd0bc856773f68dcc859c7ce39dda3e14d2c32c17d55927735bfc5cbbb7ac5e8bac21feda87c93399f2a596aca7d5b0611cc1e8203d97ad2e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Overview

It makes it possible to run our dogfood application from XCode 16.
Ref: https://github.com/ivpusic/react-native-image-crop-picker/pull/2068