### PR TITLE
fix: overridable bitrate and bitrate downscale factor

### DIFF
--- a/packages/client/src/devices/__tests__/CameraManager.test.ts
+++ b/packages/client/src/devices/__tests__/CameraManager.test.ts
@@ -82,9 +82,7 @@ describe('CameraManager', () => {
 
     expect(manager['call'].publishVideoStream).toHaveBeenCalledWith(
       manager.state.mediaStream,
-      {
-        preferredCodec: undefined,
-      },
+      undefined,
     );
   });
 

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -259,16 +259,11 @@ export class Publisher {
       const screenShareBitrate =
         settings?.screensharing.target_resolution?.bitrate;
 
-      const { preferredBitrate, preferredCodec, screenShareSettings } = opts;
       const videoEncodings =
         trackType === TrackType.VIDEO
-          ? findOptimalVideoLayers(track, targetResolution, preferredBitrate)
+          ? findOptimalVideoLayers(track, targetResolution, opts)
           : trackType === TrackType.SCREEN_SHARE
-            ? findOptimalScreenSharingLayers(
-                track,
-                screenShareSettings,
-                screenShareBitrate,
-              )
+            ? findOptimalScreenSharingLayers(track, opts, screenShareBitrate)
             : undefined;
 
       // listen for 'ended' event on the track as it might be ended abruptly
@@ -293,6 +288,7 @@ export class Publisher {
       this.transceiverRegistry[trackType] = transceiver;
       this.publishOptionsPerTrackType.set(trackType, opts);
 
+      const { preferredCodec } = opts;
       const codec =
         isReactNative() && trackType === TrackType.VIDEO && !preferredCodec
           ? getRNOptimalCodec()
@@ -713,16 +709,9 @@ export class Publisher {
           const publishOpts = this.publishOptionsPerTrackType.get(trackType);
           optimalLayers =
             trackType === TrackType.VIDEO
-              ? findOptimalVideoLayers(
-                  track,
-                  targetResolution,
-                  publishOpts?.preferredBitrate,
-                )
+              ? findOptimalVideoLayers(track, targetResolution, publishOpts)
               : trackType === TrackType.SCREEN_SHARE
-                ? findOptimalScreenSharingLayers(
-                    track,
-                    publishOpts?.screenShareSettings,
-                  )
+                ? findOptimalScreenSharingLayers(track, publishOpts)
                 : [];
           this.trackLayersCache[trackType] = optimalLayers;
         } else {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -146,9 +146,16 @@ export type SubscriptionChanges = {
   [sessionId: string]: SubscriptionChange;
 };
 
+/**
+ * A preferred codec to use when publishing a video track.
+ * @internal
+ */
+export type PreferredCodec = 'vp8' | 'h264' | string;
+
 export type PublishOptions = {
-  preferredCodec?: string | null;
+  preferredCodec?: PreferredCodec | null;
   preferredBitrate?: number;
+  bitrateDownscaleFactor?: number;
   screenShareSettings?: ScreenShareSettings;
 };
 

--- a/sample-apps/react/react-dogfood/components/DevMenu.tsx
+++ b/sample-apps/react/react-dogfood/components/DevMenu.tsx
@@ -1,8 +1,8 @@
-import Link from 'next/link';
 import { Icon, useCall, useCallStateHooks } from '@stream-io/video-react-sdk';
 import { decodeBase64 } from 'stream-chat';
 
 export const DevMenu = () => {
+  const call = useCall();
   return (
     <ul className="rd__dev-menu">
       <li className="rd__dev-menu__item">
@@ -57,7 +57,7 @@ export const DevMenu = () => {
         </a>
       </li>
       <li className="rd__dev-menu__item">
-        <Link
+        <a
           className="rd__link rd__link--faux-button rd__link--align-left"
           href={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/call-recordings`}
           target="_blank"
@@ -65,8 +65,24 @@ export const DevMenu = () => {
         >
           <Icon className="rd__link__icon" icon="film-roll" />
           Recordings
-        </Link>
+        </a>
       </li>
+
+      <li className="rd__dev-menu__item rd__dev-menu__item--divider" />
+      <a
+        className="rd__link rd__link--faux-button rd__link--align-left"
+        href={`https://pronto-staging.getstream.io/join/${call?.id}?type=${call?.type}`}
+        rel="noreferrer"
+      >
+        Switch to Pronto Staging
+      </a>
+      <a
+        className="rd__link rd__link--faux-button rd__link--align-left"
+        href={`https://pronto.getstream.io/join/${call?.id}?type=${call?.type}`}
+        rel="noreferrer"
+      >
+        Switch to Pronto
+      </a>
     </ul>
   );
 };
@@ -138,61 +154,6 @@ const GoOrStopLive = () => {
     </button>
   );
 };
-
-// const MigrateToNewSfu = () => {
-//   const call = useCall();
-//   return (
-//     <button className="rd__button rd__button--align-left"
-//       hidden
-//       onClick={() => {
-//         if (!call) return;
-//         call['dispatcher'].dispatch({
-//           eventPayload: {
-//             oneofKind: 'goAway',
-//             goAway: {
-//               reason: SfuModels.GoAwayReason.REBALANCE,
-//             },
-//           },
-//         });
-//       }}
-//     >
-//       <ListItemIcon>
-//         <SwitchAccessShortcutIcon
-//           fontSize="small"
-//           sx={{
-//             transform: 'rotate(90deg)',
-//           }}
-//         />
-//       </ListItemIcon>
-//       <ListItemText>Migrate to a new SFU</ListItemText>
-//     </button>
-//   );
-// };
-//
-
-// const EmulateSFUShuttingDown = () => {
-//   const call = useCall();
-//   return (
-//     <button className="rd__button rd__button--align-left"
-//       onClick={() => {
-//         if (!call) return;
-//         call['dispatcher'].dispatch({
-//           eventPayload: {
-//             oneofKind: 'error',
-//             error: {
-//               code: SfuModels.ErrorCode.SFU_SHUTTING_DOWN,
-//             },
-//           },
-//         });
-//       }}
-//     >
-//       <ListItemIcon>
-//         <PowerSettingsNewIcon fontSize="small" />
-//       </ListItemIcon>
-//       <ListItemText>Emulate SFU shutdown</ListItemText>
-//     </button>
-//   );
-// };
 
 const ConnectToLocalSfu = (props: { port?: number; sfuId?: string }) => {
   const { port = 3031, sfuId = 'SFU-1' } = props;

--- a/sample-apps/react/react-dogfood/components/MeetingUI.tsx
+++ b/sample-apps/react/react-dogfood/components/MeetingUI.tsx
@@ -64,7 +64,7 @@ export const MeetingUI = ({ chatClient, mode }: MeetingUIProps) => {
 
         const videoSettings = call.state.settings?.video;
         const frameHeight =
-          call.camera.getCaptureResolution()?.width ??
+          call.camera.getCaptureResolution()?.height ??
           videoSettings?.target_resolution.height ??
           1080;
 


### PR DESCRIPTION
### Overview

Adds experimental APIs for overriding codec, bitrate, and bitrate downscale factor.
Currently, we keep this API internal and undocumented until we get more feedback and more insights from our testing.

In Pronto, these parameters can be overriden via a query parameter:

`?video_codec=h264&bitrate=1200000&bitrate_factor=3` 
- will use h264, with 1.2mbps bitrate, and every lower layer will use 3 times less bitrate than the previous one.