### PR TITLE
docs: ongoing calls header wording update

### DIFF
--- a/packages/client/docusaurus/docs/javascript/02-guides/06-querying-calls.mdx
+++ b/packages/client/docusaurus/docs/javascript/02-guides/06-querying-calls.mdx
@@ -89,7 +89,7 @@ const { calls } = await client.queryCalls({
 });
 ```
 
-### Calls that live / currently have participants
+### Calls that are ongoing / currently have participants
 
 ```typescript
 import { StreamVideoClient } from '@stream-io/video-client';

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/06-querying-calls.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/03-core/06-querying-calls.mdx
@@ -89,7 +89,7 @@ const { calls } = await client.queryCalls({
 });
 ```
 
-### Calls that live / currently have participants
+### Calls that are ongoing / currently have participants
 
 ```typescript
 import { StreamVideoClient } from '@stream-io/video-react-native-sdk';

--- a/packages/react-sdk/docusaurus/docs/React/02-guides/06-querying-calls.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/02-guides/06-querying-calls.mdx
@@ -89,7 +89,7 @@ const { calls } = await client.queryCalls({
 });
 ```
 
-### Calls that live / currently have participants
+### Calls that are ongoing / currently have participants
 
 ```typescript
 import { StreamVideoClient } from '@stream-io/video-react-sdk';


### PR DESCRIPTION
Wording fix based on this request in -> [Docs gaps page](https://www.notion.so/stream-wiki/Docs-gaps-4515af280e024c3ab33eb81828bde019?pvs=4#8805b230d1ff4da8820a5be0ef8febd0) 

Changes the header from `Calls that live` to `Calls that are ongoing`.