### PR TITLE
fix: React v17 compatibility

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -40,8 +40,8 @@
     "react-chartjs-2": "^5.2.0"
   },
   "peerDependencies": {
-    "react": "^18 || ^19",
-    "react-dom": "^18 || ^19"
+    "react": "^17 || ^18 || ^19",
+    "react-dom": "^17 || ^18 || ^19"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7616,8 +7616,8 @@ __metadata:
     rollup: ^4.22.0
     typescript: ^5.5.2
   peerDependencies:
-    react: ^18 || ^19
-    react-dom: ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Overview

Add React v17 to the list of supported peer dependencies.