### PR TITLE
fix: edge case with participant bar rendering

### DIFF
--- a/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
@@ -42,7 +42,7 @@ export type SpeakerLayoutProps = {
    */
   excludeLocalParticipant?: boolean;
   /**
-   * When set to `false` disables mirroring of the local partipant's video.
+   * When set to `false` disables mirroring of the local participant's video.
    * @default true
    */
   mirrorLocalParticipantVideo?: boolean;
@@ -127,6 +127,9 @@ export const SpeakerLayout = ({
 
   if (!call) return null;
 
+  const renderParticipantsBar =
+    participantsBarPosition &&
+    (participantsWithAppliedLimit.length > 0 || isSpeakerScreenSharing);
   return (
     <div className="str-video__speaker-layout__wrapper">
       <ParticipantsAudio participants={remoteParticipants} />
@@ -151,7 +154,7 @@ export const SpeakerLayout = ({
             />
           )}
         </div>
-        {participantsWithAppliedLimit.length > 0 && participantsBarPosition && (
+        {renderParticipantsBar && (
           <div
             ref={setButtonsWrapperElement}
             className="str-video__speaker-layout__participants-bar-buttons-wrapper"


### PR DESCRIPTION
### Overview

Under special circumstances - `excludeLocalParticipant = true` and the screen sharer is the only participant in the call, the participant bar didn't render, which led to an exclusion of the screen sharer's video track.

Context: https://getstream.slack.com/archives/C07KX5D7MFX/p1727981915684569