### PR TITLE
fix: check for user capabilities before rendering call control buttons

### DIFF
--- a/packages/react-sdk/src/components/CallControls/CallControls.tsx
+++ b/packages/react-sdk/src/components/CallControls/CallControls.tsx
@@ -1,3 +1,5 @@
+import { OwnCapability } from '@stream-io/video-client';
+import { Restricted } from '@stream-io/video-react-bindings';
 import { SpeakingWhileMutedNotification } from '../Notification';
 import { RecordCallButton } from './RecordCallButton';
 import { ReactionsButton } from './ReactionsButton';
@@ -12,13 +14,28 @@ export type CallControlsProps = {
 
 export const CallControls = ({ onLeave }: CallControlsProps) => (
   <div className="str-video__call-controls">
-    <SpeakingWhileMutedNotification>
-      <ToggleAudioPublishingButton />
-    </SpeakingWhileMutedNotification>
-    <ToggleVideoPublishingButton />
-    <ReactionsButton />
-    <ScreenShareButton />
-    <RecordCallButton />
+    <Restricted requiredGrants={[OwnCapability.SEND_AUDIO]}>
+      <SpeakingWhileMutedNotification>
+        <ToggleAudioPublishingButton />
+      </SpeakingWhileMutedNotification>
+    </Restricted>
+    <Restricted requiredGrants={[OwnCapability.SEND_VIDEO]}>
+      <ToggleVideoPublishingButton />
+    </Restricted>
+    <Restricted requiredGrants={[OwnCapability.CREATE_REACTION]}>
+      <ReactionsButton />
+    </Restricted>
+    <Restricted requiredGrants={[OwnCapability.SCREENSHARE]}>
+      <ScreenShareButton />
+    </Restricted>
+    <Restricted
+      requiredGrants={[
+        OwnCapability.START_RECORD_CALL,
+        OwnCapability.STOP_RECORD_CALL,
+      ]}
+    >
+      <RecordCallButton />
+    </Restricted>
     <CancelCallButton onLeave={onLeave} />
   </div>
 );


### PR DESCRIPTION
## Overview

Adds OwnCapability checks on the Call Control buttons.
They shouldn't be rendered at all when certain user capabilities are not present.

## Fixes
When browser permissions are not granted, and the user doesn't have `send-video` or `send-audio` permissions, the `CallControls` component is still prompting for browser permissions.
The reason for this prompt is - these buttons use `useMicrophoneState()` and `useCameraState()` hooks that trigger these prompts. Fixing this in the buttons component will require a bit of refactoring, so I'm opting for this less ideal and simple fix.