### PR TITLE
fix: add track release for react-native whenever track stop is called

### DIFF
--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -279,7 +279,14 @@ export abstract class InputMediaDeviceManager<
 
   private stopTracks() {
     this.getTracks().forEach((track) => {
-      if (track.readyState === 'live') track.stop();
+      if (track.readyState === 'live') {
+        track.stop();
+        // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the track
+        if (typeof track.release === 'function') {
+          // @ts-expect-error
+          track.release();
+        }
+      }
     });
   }
 

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -277,6 +277,11 @@ export const disposeOfMediaStream = (stream: MediaStream) => {
   stream.getTracks().forEach((track) => {
     track.stop();
     stream.removeTrack(track);
+    // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the track
+    if (typeof track.release === 'function') {
+      // @ts-expect-error
+      track.release();
+    }
   });
   // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the stream
   if (typeof stream.release === 'function') {

--- a/packages/client/src/helpers/RNSpeechDetector.ts
+++ b/packages/client/src/helpers/RNSpeechDetector.ts
@@ -106,7 +106,14 @@ export class RNSpeechDetector {
     if (!this.audioStream) {
       return;
     }
-    this.audioStream.getTracks().forEach((track) => track.stop());
+    this.audioStream.getTracks().forEach((track) => {
+      track.stop();
+      // @ts-expect-error release() is present in react-native-webrtc and must be called to dispose the track
+      if (typeof track.release === 'function') {
+        // @ts-expect-error
+        track.release();
+      }
+    });
     if (
       // @ts-expect-error release() is present in react-native-webrtc
       typeof this.audioStream.release === 'function'


### PR DESCRIPTION
track release does the garbage collection of track natively