### PR TITLE
fix: ignore camera direction for desktop devices

### DIFF
--- a/packages/client/src/compatibility.ts
+++ b/packages/client/src/compatibility.ts
@@ -1,0 +1,7 @@
+/**
+ * Checks if the current platform is a mobile device.
+ *
+ * See:
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
+ */
+export const isMobile = () => /Mobi/i.test(navigator.userAgent);

--- a/packages/client/src/devices/__tests__/CameraManager.test.ts
+++ b/packages/client/src/devices/__tests__/CameraManager.test.ts
@@ -36,6 +36,13 @@ vi.mock('../../Call.ts', () => {
   };
 });
 
+vi.mock('../../compatibility.ts', () => {
+  console.log('MOCKING mobile device');
+  return {
+    isMobile: () => true,
+  };
+});
+
 describe('CameraManager', () => {
   let manager: CameraManager;
 


### PR DESCRIPTION
Our default call types include a default setting for camera direction (user-facing). Having this setting applied by default is useful for mobile devices, but on desktop devices where camera direction reporting is not reliable it leads to confusion, because it can cause a device other than the system default to be used by default.