### PR TITLE
fix: allow specifying publish options in PN config

### DIFF
--- a/packages/react-native-sdk/src/hooks/push/useProcessPushCallEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useProcessPushCallEffect.ts
@@ -1,8 +1,8 @@
 import {
   pushAcceptedIncomingCallCId$,
+  pushAndroidBackgroundDeliveredIncomingCallCId$,
   pushRejectedIncomingCallCId$,
   pushTappedIncomingCallCId$,
-  pushAndroidBackgroundDeliveredIncomingCallCId$,
 } from '../../utils/push/rxSubjects';
 import { useEffect } from 'react';
 import { StreamVideoRN } from '../../utils';
@@ -91,7 +91,7 @@ const createCallSubscription = (
   return behaviourSubjectWithCallCid
     .pipe(filter(cidIsNotUndefined))
     .subscribe(async (callCId) => {
-      await processCallFromPush(client, callCId, action);
+      await processCallFromPush(client, callCId, action, pushConfig);
       if (action === 'accept') {
         pushConfig.navigateAcceptCall();
       } else if (action === 'pressed' || action === 'backgroundDelivered') {

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
@@ -1,4 +1,4 @@
-import { StreamVideoClient } from '@stream-io/video-client';
+import { PublishOptions, StreamVideoClient } from '@stream-io/video-client';
 import type { AndroidChannel } from '@notifee/react-native';
 
 export type NonRingingPushEvent = 'call.live_started' | 'call.notification';
@@ -11,6 +11,12 @@ export type StreamVideoConfig = {
    */
   push?: {
     isExpo?: boolean;
+    /**
+     * The publish options to be used when joining a call from a push notification.
+     *
+     * @internal
+     */
+    publishOptions?: PublishOptions;
     ios: {
       /**
        * The name for the alias of push provider used for iOS

--- a/packages/react-native-sdk/src/utils/push/utils.ts
+++ b/packages/react-native-sdk/src/utils/push/utils.ts
@@ -1,8 +1,8 @@
 import {
   Call,
+  getLogger,
   RxUtils,
   StreamVideoClient,
-  getLogger,
 } from '@stream-io/video-client';
 import type {
   NonRingingPushEvent,
@@ -80,7 +80,7 @@ export const processCallFromPushInBackground = async (
     logger('error', 'failed to create video client', e);
     return;
   }
-  await processCallFromPush(videoClient, call_cid, action);
+  await processCallFromPush(videoClient, call_cid, action, pushConfig);
 };
 
 /**
@@ -93,7 +93,8 @@ export const processCallFromPushInBackground = async (
 export const processCallFromPush = async (
   client: StreamVideoClient,
   call_cid: string,
-  action: 'accept' | 'decline' | 'pressed' | 'backgroundDelivered'
+  action: 'accept' | 'decline' | 'pressed' | 'backgroundDelivered',
+  pushConfig: PushConfig
 ) => {
   let callFromPush: Call;
   try {
@@ -106,6 +107,9 @@ export const processCallFromPush = async (
   // note: when action was pressed or delivered, we dont need to do anything as the only thing is to do is to get the call which adds it to the client
   try {
     if (action === 'accept') {
+      if (pushConfig.publishOptions) {
+        callFromPush.updatePublishOptions(pushConfig.publishOptions);
+      }
       await callFromPush.join();
     } else if (action === 'decline') {
       await callFromPush.leave({ reject: true });


### PR DESCRIPTION
### Overview

Follow-up to #1434. Allows specifying publish options for calls accepted through Push Notifications config.