### PR TITLE
fix(client): invoke call.reject only when reject param specified 

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -515,8 +515,7 @@ export class Call {
         };
         await waitUntilCallJoined();
       }
-
-      if (this.ringing) {
+      if (reject && this.ringing) {
         // I'm the one who started the call, so I should cancel it.
         const hasOtherParticipants = this.state.remoteParticipants.length > 0;
         if (
@@ -527,7 +526,7 @@ export class Call {
           // Signals other users that I have cancelled my call to them
           // before they accepted it.
           await this.reject();
-        } else if (reject && callingState === CallingState.RINGING) {
+        } else if (callingState === CallingState.RINGING) {
           // Signals other users that I have rejected the incoming call.
           await this.reject();
         }

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -515,6 +515,7 @@ export class Call {
         };
         await waitUntilCallJoined();
       }
+
       if (reject && this.ringing) {
         // I'm the one who started the call, so I should cancel it.
         const hasOtherParticipants = this.state.remoteParticipants.length > 0;

--- a/packages/client/src/events/__tests__/call.test.ts
+++ b/packages/client/src/events/__tests__/call.test.ts
@@ -310,6 +310,36 @@ describe('Call ringing events', () => {
       expect(call.leave).not.toHaveBeenCalled();
     });
   });
+
+  describe('call.leave', () => {
+    it('should not call reject when leaving under specific conditions', async () => {
+      const call = fakeCall();
+      call.state.setCallingState(CallingState.JOINED);
+      const rejectSpy = vi
+        .spyOn(call, 'reject')
+        .mockImplementation(async () => {
+          console.log('TEST: reject() called');
+        });
+
+      await call.leave({ reject: false });
+
+      expect(rejectSpy).not.toHaveBeenCalled();
+    });
+
+    it('should call reject when leaving while ringing and reject is true', async () => {
+      const call = fakeCall();
+      call.state.setCallingState(CallingState.RINGING);
+      const rejectSpy = vi
+        .spyOn(call, 'reject')
+        .mockImplementation(async () => {
+          console.log('TEST: reject() called');
+        });
+
+      await call.leave({ reject: true });
+
+      expect(rejectSpy).toHaveBeenCalled();
+    });
+  });
 });
 
 const fakeCall = ({ ring = true, currentUserId = 'test-user-id' } = {}) => {


### PR DESCRIPTION
### Issue
Rejecting a call which has already been ended results in 400 error from backend. To prevent this error we should not allow `call.reject()` to be called on `call.ended` event.

### Fix
This PR updates the `call.leave` method to make sure that `reject()` can be invoked inside `leave()` only if the reject input param is set to `true`.
```ts
  leave = async ({
    reject = false,  // <-- only if this param is explicitly sent with value true
    reason = 'user is leaving the call',
  }: CallLeaveOptions = {}) => {
```