### PR TITLE
fix: make device selection by device id exact

### DIFF
--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -308,7 +308,7 @@ export abstract class InputMediaDeviceManager<
       const defaultConstraints = this.state.defaultConstraints;
       const constraints: MediaTrackConstraints = {
         ...defaultConstraints,
-        deviceId: this.state.selectedDevice,
+        deviceId: { exact: this.state.selectedDevice },
       };
 
       /**

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -206,11 +206,17 @@ export abstract class InputMediaDeviceManager<
         'This method is not supported in React Native. Please visit https://getstream.io/video/docs/reactnative/core/camera-and-microphone/#speaker-management for reference.',
       );
     }
-    if (deviceId === this.state.selectedDevice) {
+    const prevDeviceId = this.state.selectedDevice;
+    if (deviceId === prevDeviceId) {
       return;
     }
-    this.state.setDevice(deviceId);
-    await this.applySettingsToStream();
+    try {
+      this.state.setDevice(deviceId);
+      await this.applySettingsToStream();
+    } catch (error) {
+      this.state.setDevice(prevDeviceId);
+      throw error;
+    }
   }
 
   /**

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -314,7 +314,9 @@ export abstract class InputMediaDeviceManager<
       const defaultConstraints = this.state.defaultConstraints;
       const constraints: MediaTrackConstraints = {
         ...defaultConstraints,
-        deviceId: { exact: this.state.selectedDevice },
+        deviceId: this.state.selectedDevice
+          ? { exact: this.state.selectedDevice }
+          : undefined,
       };
 
       /**

--- a/packages/client/src/devices/__tests__/CameraManager.test.ts
+++ b/packages/client/src/devices/__tests__/CameraManager.test.ts
@@ -157,7 +157,7 @@ describe('CameraManager', () => {
     await manager.select(deviceId);
 
     expect((getVideoStream as Mock).mock.lastCall[0]).toEqual({
-      deviceId,
+      deviceId: { exact: deviceId },
       width: 1280,
       height: 720,
     });
@@ -182,7 +182,7 @@ describe('CameraManager', () => {
     await manager.selectTargetResolution({ width: 640, height: 480 });
 
     expect((getVideoStream as Mock).mock.lastCall[0]).toEqual({
-      deviceId: mockVideoDevices[0].deviceId,
+      deviceId: { exact: mockVideoDevices[0].deviceId },
       width: 640,
       height: 480,
     });

--- a/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
+++ b/packages/client/src/devices/__tests__/InputMediaDeviceManager.test.ts
@@ -181,7 +181,7 @@ describe('InputMediaDeviceManager.test', () => {
 
     expect(manager.stopPublishStream).toHaveBeenCalledWith(true);
     expect(manager.getStream).toHaveBeenCalledWith({
-      deviceId,
+      deviceId: { exact: deviceId },
     });
     expect(manager.publishStream).toHaveBeenCalled();
   });

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -212,7 +212,7 @@ export const getVideoStream = async (
       throwOnNotAllowed: true,
       forcePrompt: true,
     });
-    return getStream(constraints);
+    return await getStream(constraints);
   } catch (e) {
     getLogger(['devices'])('error', 'Failed to get video stream', {
       error: e,


### PR DESCRIPTION
Somewhere around Chrome v126 a new behavior was introduced, and the `deviceId: string` constraint when querying `getUserMedia` was no longer respected. The default device was always returned instead.

Using the `deviceId: { exact: string }` constraint seems to solve the issue. However, it also can cause the `OvercontrainedError` exception when device id is not valid. We handle it by falling back to default device in this case.