### PR TITLE
fix: move useToggleCallRecording to react-bindings

### DIFF
--- a/packages/react-bindings/src/hooks/callUtilHooks.ts
+++ b/packages/react-bindings/src/hooks/callUtilHooks.ts
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
 
+/**
+ * Custom hook for toggling call recording in a video call.
+ *
+ * This hook provides functionality to start and stop call recording,
+ * along with state management for tracking the recording status
+ * and the loading indicator while awaiting a response.
+ */
 export const useToggleCallRecording = () => {
   const call = useCall();
   const { useIsCallRecordingInProgress } = useCallStateHooks();

--- a/packages/react-bindings/src/hooks/index.ts
+++ b/packages/react-bindings/src/hooks/index.ts
@@ -1,6 +1,7 @@
 import * as CallStateHooks from './callStateHooks';
 
 export * from './store';
+export * from './callUtilHooks';
 
 /**
  * A hook-alike function that exposes all call state hooks.

--- a/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
@@ -11,7 +11,7 @@ import {
   useMenuContext,
 } from '../Menu';
 import { LoadingIndicator } from '../LoadingIndicator';
-import { useToggleCallRecording } from '../../hooks';
+import { useToggleCallRecording } from '@stream-io/video-react-bindings';
 import { WithTooltip } from '../Tooltip';
 
 export type RecordCallButtonProps = {

--- a/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/RecordCallButton.tsx
@@ -1,7 +1,11 @@
 import { forwardRef } from 'react';
 
 import { OwnCapability } from '@stream-io/video-client';
-import { Restricted, useI18n } from '@stream-io/video-react-bindings';
+import {
+  Restricted,
+  useI18n,
+  useToggleCallRecording,
+} from '@stream-io/video-react-bindings';
 import { CompositeButton } from '../Button/';
 import { Icon } from '../Icon';
 import {
@@ -11,7 +15,6 @@ import {
   useMenuContext,
 } from '../Menu';
 import { LoadingIndicator } from '../LoadingIndicator';
-import { useToggleCallRecording } from '@stream-io/video-react-bindings';
 import { WithTooltip } from '../Tooltip';
 
 export type RecordCallButtonProps = {

--- a/packages/react-sdk/src/components/Notification/RecordingInProgressNotification.tsx
+++ b/packages/react-sdk/src/components/Notification/RecordingInProgressNotification.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useEffect, useState } from 'react';
 import { useI18n } from '@stream-io/video-react-bindings';
-import { useToggleCallRecording } from '../../hooks';
+import { useToggleCallRecording } from '@stream-io/video-react-bindings';
 import { Notification } from './Notification';
 
 export type RecordingInProgressNotificationProps = {

--- a/packages/react-sdk/src/components/Notification/RecordingInProgressNotification.tsx
+++ b/packages/react-sdk/src/components/Notification/RecordingInProgressNotification.tsx
@@ -1,6 +1,8 @@
 import { PropsWithChildren, useEffect, useState } from 'react';
-import { useI18n } from '@stream-io/video-react-bindings';
-import { useToggleCallRecording } from '@stream-io/video-react-bindings';
+import {
+  useI18n,
+  useToggleCallRecording,
+} from '@stream-io/video-react-bindings';
 import { Notification } from './Notification';
 
 export type RecordingInProgressNotificationProps = {

--- a/packages/react-sdk/src/hooks/index.ts
+++ b/packages/react-sdk/src/hooks/index.ts
@@ -1,5 +1,4 @@
 export * from './useFloatingUIPreset';
 export * from './usePersistedDevicePreferences';
 export * from './useScrollPosition';
-export * from './useToggleCallRecording';
 export * from './useRequestPermission';


### PR DESCRIPTION
Moves the `useToggleCallRecording` hook to `react-bindings` package so it can be used in react-native as well.