### PR TITLE
fix: prevent flickering of participant's video when migrating

### DIFF
--- a/packages/client/src/rtc/__tests__/Subscriber.test.ts
+++ b/packages/client/src/rtc/__tests__/Subscriber.test.ts
@@ -1,12 +1,11 @@
 import './mocks/webrtc.mocks';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { DispatchableMessage, Dispatcher } from '../Dispatcher';
+import { Dispatcher } from '../Dispatcher';
 import { StreamSfuClient } from '../../StreamSfuClient';
 import { Subscriber } from '../Subscriber';
 import { CallState } from '../../store';
-import { SfuEvent } from '../../gen/video/sfu/event/events';
-import { PeerType, TrackType } from '../../gen/video/sfu/models/models';
+import { TrackType } from '../../gen/video/sfu/models/models';
 import { IceTrickleBuffer } from '../IceTrickleBuffer';
 import { StreamClient } from '../../coordinator/connection/client';
 
@@ -59,40 +58,6 @@ describe('Subscriber', () => {
   });
 
   describe('Subscriber ICE restart', () => {
-    it('should perform ICE restart when iceRestart event is received', () => {
-      sfuClient.iceRestart = vi.fn();
-      dispatcher.dispatch(
-        SfuEvent.create({
-          eventPayload: {
-            oneofKind: 'iceRestart',
-            iceRestart: {
-              peerType: PeerType.SUBSCRIBER,
-            },
-          },
-        }) as DispatchableMessage<'iceRestart'>,
-      );
-
-      expect(sfuClient.iceRestart).toHaveBeenCalledWith({
-        peerType: PeerType.SUBSCRIBER,
-      });
-    });
-
-    it('should not perform ICE restart when iceRestart event is received for a different peer type', () => {
-      sfuClient.iceRestart = vi.fn();
-      dispatcher.dispatch(
-        SfuEvent.create({
-          eventPayload: {
-            oneofKind: 'iceRestart',
-            iceRestart: {
-              peerType: PeerType.PUBLISHER_UNSPECIFIED,
-            },
-          },
-        }) as DispatchableMessage<'iceRestart'>,
-      );
-
-      expect(sfuClient.iceRestart).not.toHaveBeenCalled();
-    });
-
     it(`should drop consequent ICE restart requests`, async () => {
       sfuClient.iceRestart = vi.fn();
       // @ts-ignore


### PR DESCRIPTION
### Overview

Improves the "incoming stream update" flow by changing the order of operations.
When a new MediaStream arrives for a participant, we now immediately store it in the CallState, and later we dispose of the old MediaStream.
This prevents participant video flickering caused by the aggressive `track.stop()`.

As part of this PR, the handlers for Subscriber ICE restarts are removed, as they don't make sense anymore. ICE restarts of the subscriber peer connection are initiated by the SFU through the `subscriberOffer` event.