### PR TITLE
fix: share screen fix for spotlight layout

### DIFF
--- a/packages/react-native-sdk/src/components/Call/CallLayout/CallParticipantsSpotlight.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallLayout/CallParticipantsSpotlight.tsx
@@ -91,6 +91,11 @@ export const CallParticipantsSpotlight = ({
     marginHorizontal: landscape ? 0 : 8,
   };
 
+  const showShareScreenOverlay =
+    participantInSpotlight?.isLocalParticipant &&
+    isScreenShareOnSpotlight &&
+    ScreenShareOverlay;
+
   return (
     <View
       testID={ComponentTestIds.CALL_PARTICIPANTS_SPOTLIGHT}
@@ -105,7 +110,7 @@ export const CallParticipantsSpotlight = ({
     >
       {participantInSpotlight &&
         ParticipantView &&
-        (participantInSpotlight.isLocalParticipant && ScreenShareOverlay ? (
+        (showShareScreenOverlay ? (
           <ScreenShareOverlay />
         ) : (
           <ParticipantView


### PR DESCRIPTION
Before: 
-  screen share was shown when alone participant on a call in spotlight layout
     <img src="https://github.com/user-attachments/assets/6ee6a1db-a462-4687-af62-008f84bbf45f" alt="ios-after" width="200" height="440"/>

After: 
- screen share overlay condition is updated so that now check whether there is active screen share
<img src="https://github.com/user-attachments/assets/f9699594-f034-4a1b-85c8-b5314a070578" alt="ios-after" width="200" height="440"/>
