### PR TITLE
fix: guard against null fenceSync

### DIFF
--- a/packages/video-filters-web/src/helpers/webglHelper.ts
+++ b/packages/video-filters-web/src/helpers/webglHelper.ts
@@ -111,8 +111,10 @@ async function getBufferSubDataAsync(
   dstOffset?: number,
   length?: number,
 ) {
-  const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0)!;
+  const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
   gl.flush();
+  if (!sync) return;
+
   const res = await clientWaitAsync(gl, sync);
   gl.deleteSync(sync);
 


### PR DESCRIPTION
### Overview

Adds a `null` guard for the `fenceSync` GL object.