### PR TITLE
docs: fix overview doc pages for react and react native

### DIFF
--- a/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/01-overview.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/01-overview.mdx
@@ -16,7 +16,7 @@ export const CookbookCard = ({ title, link, img }) => (
     <h4 style={{ margin: '0px' }}>{title}</h4>
     <a href={link}>
       <p style={{ margin: '0', padding: '0' }}>
-        {img && <img src={img} alt={title} />}
+        <img src={img} alt={title} />
       </p>
     </a>
   </div>

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/01-overview.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/01-overview.mdx
@@ -16,7 +16,7 @@ export const CookbookCard = ({ title, link, img }) => (
     <h4 style={{ margin: '0px' }}>{title}</h4>
     <a href={link}>
       <p style={{ margin: '0', padding: '0' }}>
-        <img src={img} alt={title} />
+        {img && <img src={img} alt={title} />}
       </p>
     </a>
   </div>

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/01-overview.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/01-overview.mdx
@@ -72,11 +72,6 @@ This UI Cookbook will walk you through how to customize each component in your v
     img={Lobby}
   ></CookbookCard>
   <CookbookCard
-    title="Network Quality Indicator"
-    link="../../ui-cookbook/network-quality-indicator"
-    img={NetworkQualityIndicator}
-  ></CookbookCard>
-  <CookbookCard
     title="Video Fallback"
     link="../../ui-cookbook/video-fallback"
     img={VideoFallback}
@@ -92,8 +87,46 @@ This UI Cookbook will walk you through how to customize each component in your v
     img={Reaction}
   ></CookbookCard>
   <CookbookCard
+    title="Network Quality Indicator"
+    link="../../ui-cookbook/network-quality-indicator"
+    img={NetworkQualityIndicator}
+  ></CookbookCard>
+  <CookbookCard
     title="Runtime Layout Switching"
     link="../../ui-cookbook/runtime-layout-switching"
     img={RuntimeLayoutSwitching}
+  ></CookbookCard>
+  <CookbookCard
+    title="Landscape mode"
+    link="../../ui-cookbook/landscape-mode"
+  ></CookbookCard>
+  <CookbookCard
+    title="Hosting a livestream"
+    link="../../ui-cookbook/hosting-a-livestream"
+  ></CookbookCard>
+  <CookbookCard
+    title="Watching a livestream"
+    link="../../ui-cookbook/watching-a-livestream"
+  ></CookbookCard>
+  <CookbookCard
+    title="Speaking while muted"
+    link="../../ui-cookbook/speaking-while-muted"
+  ></CookbookCard>
+  <CookbookCard
+    title="Transcriptions"
+    link="../../ui-cookbook/transcriptions"
+  ></CookbookCard>
+  <CookbookCard
+    title="Session timers"
+    link="../../ui-cookbook/session-timers"
+    img={SessionTimer}
+  ></CookbookCard>
+  <CookbookCard
+    title="Manual video quality selection"
+    link="../../ui-cookbook/manual-video-quality-selection"
+  ></CookbookCard>
+  <CookbookCard
+    title="Call quality rating"
+    link="../../ui-cookbook/call-quality-rating"
   ></CookbookCard>
 </div>

--- a/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/01-overview.mdx
+++ b/packages/react-native-sdk/docusaurus/docs/reactnative/05-ui-cookbook/01-overview.mdx
@@ -119,7 +119,6 @@ This UI Cookbook will walk you through how to customize each component in your v
   <CookbookCard
     title="Session timers"
     link="../../ui-cookbook/session-timers"
-    img={SessionTimer}
   ></CookbookCard>
   <CookbookCard
     title="Manual video quality selection"

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/01-overview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/01-overview.mdx
@@ -16,7 +16,7 @@ export const CookbookCard = ({ title, link, img }) => (
     <h4 style={{ margin: '0px' }}>{title}</h4>
     <a href={link}>
       <p style={{ margin: '0', padding: '0' }}>
-        <img alt={title} src={img} />
+        {img && <img src={img} alt={title} />}
       </p>
     </a>
   </div>

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/01-overview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/01-overview.mdx
@@ -16,7 +16,7 @@ export const CookbookCard = ({ title, link, img }) => (
     <h4 style={{ margin: '0px' }}>{title}</h4>
     <a href={link}>
       <p style={{ margin: '0', padding: '0' }}>
-        {img && <img src={img} alt={title} />}
+        <img alt={title} src={img} />
       </p>
     </a>
   </div>

--- a/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/01-overview.mdx
+++ b/packages/react-sdk/docusaurus/docs/React/06-ui-cookbook/01-overview.mdx
@@ -30,10 +30,13 @@ import LobbyPreview from '../assets/lobby-preview.png';
 import VideoFallback from '../assets/no-video-fallback-avatar.png';
 import PermissionRequests from '../assets/03-ui-components/permission-requests/permission-requests-list.png';
 import VolumeIndicator from '../assets/06-ui-cookbook/09-audio-volume-indicator/audio-volume-indicator.png';
-import ConnectionQuality from '../assets/weak-connection.png';
 import SpeakingWhileMuted from '../assets/speaking-while-muted.png';
 import ConnectionWarning from '../assets/connection-warning.png';
 import Participant from '../assets/06-ui-cookbook/14-participant-view-customizations/participant-view-ui.png';
+import NetworkIndicator from '../assets/06-ui-cookbook/10-network-quality-indicator/quality-indicators.png';
+import CallQualityRating from '../assets/06-ui-cookbook/16-call-quality-rating/rating-form.png';
+import SessionTimer from '../assets/06-ui-cookbook/19-session-timers/session-timer.png';
+import ManualVideoQuality from '../assets/06-ui-cookbook/20-manual-video-quality-selection/video-quality-ui.png';
 
 Stream UI components are highly customizable and allow you to fully customize styles to your taste. This UI Cookbook will walk you through how to customize each component in your video call.
 
@@ -41,24 +44,19 @@ Stream UI components are highly customizable and allow you to fully customize st
   style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '1.2rem' }}
 >
   <CookbookCard
-    title="Video layout"
-    link="../../ui-cookbook/video-layout"
-    img={VideoLayout}
-  ></CookbookCard>
-  <CookbookCard
     title="Call controls"
     link="../../ui-cookbook/replacing-call-controls"
     img={CallControls}
   ></CookbookCard>
   <CookbookCard
-    title="Participant view"
-    link="../../ui-cookbook/participant-view-customizations"
-    img={Participant}
+    title="Participant label"
+    link="../../ui-cookbook/custom-label"
+    img={Label}
   ></CookbookCard>
   <CookbookCard
-    title="Lobby preview"
-    link="../../ui-cookbook/lobby-preview"
-    img={LobbyPreview}
+    title="Video layout"
+    link="../../ui-cookbook/video-layout"
+    img={VideoLayout}
   ></CookbookCard>
   <CookbookCard
     title="Ringing call"
@@ -66,14 +64,14 @@ Stream UI components are highly customizable and allow you to fully customize st
     img={RingingCall}
   ></CookbookCard>
   <CookbookCard
+    title="Lobby preview"
+    link="../../ui-cookbook/lobby-preview"
+    img={LobbyPreview}
+  ></CookbookCard>
+  <CookbookCard
     title="Video placeholder"
     link="../../ui-cookbook/video-placeholder"
     img={VideoFallback}
-  ></CookbookCard>
-  <CookbookCard
-    title="Participant label"
-    link="../../ui-cookbook/custom-label"
-    img={Label}
   ></CookbookCard>
   <CookbookCard
     title="Permission requests"
@@ -86,18 +84,62 @@ Stream UI components are highly customizable and allow you to fully customize st
     img={VolumeIndicator}
   ></CookbookCard>
   <CookbookCard
-    title="Speaking while muted notifiaction"
-    link="../../ui-cookbook/speaking-while-muted"
-    img={SpeakingWhileMuted}
+    title="Network quality indicator"
+    link="../../ui-cookbook/network-quality-indicator"
+    img={NetworkIndicator}
   ></CookbookCard>
   <CookbookCard
-    title="Connection quality indicator"
-    link="../../ui-cookbook/connection-quality-indicator"
-    img={ConnectionQuality}
+    title="Call preview thumbnail"
+    link="../../ui-cookbook/call-preview-thumbnail"
+  ></CookbookCard>
+  <CookbookCard
+    title="Speaking while muted notification"
+    link="../../ui-cookbook/speaking-while-muted"
+    img={SpeakingWhileMuted}
   ></CookbookCard>
   <CookbookCard
     title="Connection unstable"
     link="../../ui-cookbook/connection-unstable"
     img={ConnectionWarning}
+  ></CookbookCard>
+  <CookbookCard
+    title="Participant view"
+    link="../../ui-cookbook/participant-view-customizations"
+    img={Participant}
+  ></CookbookCard>
+  <CookbookCard
+    title="Fullscreen mode"
+    link="../../ui-cookbook/fullscreen-mode"
+  ></CookbookCard>
+  <CookbookCard
+    title="Runtime layout switching"
+    link="../../ui-cookbook/runtime-layout-switching"
+  ></CookbookCard>
+  <CookbookCard
+    title="Watching a livestream"
+    link="../../ui-cookbook/watching-a-livestream"
+  ></CookbookCard>
+  <CookbookCard
+    title="Call quality rating"
+    link="../../ui-cookbook/call-quality-rating"
+    img={CallQualityRating}
+  ></CookbookCard>
+  <CookbookCard
+    title="Transcriptions"
+    link="../../ui-cookbook/transcriptions"
+  ></CookbookCard>
+  <CookbookCard
+    title="Participant notification sound"
+    link="../../ui-cookbook/participant-notification-sound"
+  ></CookbookCard>
+  <CookbookCard
+    title="Session timers"
+    link="../../ui-cookbook/session-timers"
+    img={SessionTimer}
+  ></CookbookCard>
+  <CookbookCard
+    title="Manual video quality selection"
+    link="../../ui-cookbook/manual-video-quality-selection"
+    img={ManualVideoQuality}
   ></CookbookCard>
 </div>


### PR DESCRIPTION
Adds the missing list entries in the overview pages for React and RN so that in these overview pages all cookbooks are properly in order referenced. 