### PR TITLE
fix: reset background blur level when filter is disabled

### DIFF
--- a/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
+++ b/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
@@ -145,7 +145,7 @@ export const BackgroundFiltersProvider = (
     backgroundImages = [],
     backgroundFilter: bgFilterFromProps = undefined,
     backgroundImage: bgImageFromProps = undefined,
-    backgroundBlurLevel: bgBlurLevelFromProps = 'high',
+    backgroundBlurLevel: bgBlurLevelFromProps = undefined,
     tfFilePath,
     modelFilePath,
     basePath,
@@ -173,7 +173,7 @@ export const BackgroundFiltersProvider = (
   const disableBackgroundFilter = useCallback(() => {
     setBackgroundFilter(undefined);
     setBackgroundImage(undefined);
-    setBackgroundBlurLevel('high');
+    setBackgroundBlurLevel(undefined);
   }, []);
 
   const [isSupported, setIsSupported] = useState(false);


### PR DESCRIPTION
Disabling background filters had an unexpected side-effect of setting background blur level to `high` (since it was our default anyway). To avoid confusion, we now reset background blur level to `undefined`.