### PR TITLE
fix: fully reset token manager on user disconnect

### DIFF
--- a/packages/client/src/__tests__/StreamVideoClient.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.test.ts
@@ -100,6 +100,15 @@ describe('StreamVideoClient', () => {
     expect(response.calls).toBeDefined();
   });
 
+  it('should clear token on disconnect', async () => {
+    const user = { id: 'jane' };
+    const tp = vi.fn(tokenProvider(user.id));
+    await client.connectUser(user, tp);
+    await client.disconnectUser();
+    await client.connectUser({ type: 'anonymous' });
+    expect(tp).toBeCalledTimes(1);
+  });
+
   afterEach(() => {
     client.disconnectUser();
   });

--- a/packages/client/src/coordinator/connection/token_manager.ts
+++ b/packages/client/src/coordinator/connection/token_manager.ts
@@ -63,6 +63,8 @@ export class TokenManager {
    */
   reset = () => {
     this.token = undefined;
+    this.tokenProvider = undefined;
+    this.type = 'static';
     this.user = undefined;
     this.loadTokenPromise = null;
   };


### PR DESCRIPTION
`TokenManager` state was not fully reset on user disconnect: token provider and token type were not reset. For example:

```ts
await client.connectUser({ id: 'jane' }, tokenProvider);
await client.disconnectUser();
await client.connectUser({ type: 'anonymous' });
```

When connecting an anonymous user, token provider from the first connection was still used.

This PR fixes that by fully resetting `TokenManager` on user disconnect.

Fixes #1573.