### PR TITLE
fix: use foreground service to keep call alive

### DIFF
--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidManifest.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidManifest.test.ts
@@ -41,6 +41,7 @@ const props: ConfigProps = {
   androidPictureInPicture: {
     enableAutomaticEnter: true,
   },
+  androidKeepCallAlive: true,
 };
 
 describe('withStreamVideoReactNativeSDKManifest', () => {

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidPermissions.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidPermissions.test.ts
@@ -15,6 +15,7 @@ describe('withStreamVideoReactNativeSDKAndroidPermissions', () => {
     const props: ConfigProps = {
       enableScreenshare: true,
       ringingPushNotifications: { disableVideoIos: false },
+      androidKeepCallAlive: true,
     };
 
     const updatedConfig = withStreamVideoReactNativeSDKAndroidPermissions(
@@ -31,6 +32,10 @@ describe('withStreamVideoReactNativeSDKAndroidPermissions', () => {
         'android.permission.BLUETOOTH',
         'android.permission.BLUETOOTH_CONNECT',
         'android.permission.BLUETOOTH_ADMIN',
+        'android.permission.FOREGROUND_SERVICE_CAMERA',
+        'android.permission.FOREGROUND_SERVICE_MICROPHONE',
+        'android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE',
+        'android.permission.FOREGROUND_SERVICE_DATA_SYNC',
       ])
     );
   });

--- a/packages/react-native-sdk/expo-config-plugin/src/common/types.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/common/types.ts
@@ -13,6 +13,7 @@ export type ConfigProps =
       ringingPushNotifications?: RingingPushNotifications;
       enableNonRingingPushNotifications?: boolean;
       androidPictureInPicture?: AndroidPictureInPicture;
+      androidKeepCallAlive?: boolean;
       enableScreenshare?: boolean;
       appleTeamId?: string;
     }

--- a/packages/react-native-sdk/expo-config-plugin/src/withAndroidPermissions.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAndroidPermissions.ts
@@ -20,6 +20,14 @@ const withStreamVideoReactNativeSDKAndroidPermissions: ConfigPlugin<
       );
     }
   }
+  if (props?.androidKeepCallAlive) {
+    permissions.push(
+      'android.permission.FOREGROUND_SERVICE_CAMERA',
+      'android.permission.FOREGROUND_SERVICE_MICROPHONE',
+      'android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE',
+      'android.permission.FOREGROUND_SERVICE_DATA_SYNC'
+    );
+  }
   if (props?.ringingPushNotifications?.showWhenLockedAndroid) {
     permissions.push('android.permission.USE_FULL_SCREEN_INTENT');
   }

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -55,7 +55,7 @@
     "text-encoding-polyfill": "0.6.7"
   },
   "peerDependencies": {
-    "@notifee/react-native": ">=7.8.0",
+    "@notifee/react-native": ">=9.0.0",
     "@react-native-community/netinfo": ">=9.0.0",
     "@react-native-community/push-notification-ios": ">=1.11.0",
     "@react-native-firebase/app": ">=17.5.0",
@@ -115,7 +115,7 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.24.7",
     "@expo/config-plugins": "~7.8.4",
-    "@notifee/react-native": "7.8.0",
+    "@notifee/react-native": "9.1.2",
     "@react-native-community/netinfo": "9.3.9",
     "@react-native-community/push-notification-ios": "1.11.0",
     "@react-native-firebase/app": "19.2.2",

--- a/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
+++ b/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
@@ -3,14 +3,14 @@ import { useEffect, useRef } from 'react';
 import { StreamVideoRN } from '../utils';
 import { Platform } from 'react-native';
 import { CallingState, getLogger } from '@stream-io/video-client';
-import { getNotifeeLibNoThrowForKeepCallAlive } from '../utils/push/libs/notifee';
-
-const isAndroid7OrBelow = Platform.OS === 'android' && Platform.Version < 26;
+import {
+  getNotifeeLibNoThrowForKeepCallAlive,
+  getKeepCallAliveForegroundServiceTypes,
+} from '../utils/push/libs/notifee';
 
 const notifeeLib = getNotifeeLibNoThrowForKeepCallAlive();
 
 function setForegroundService() {
-  if (!isAndroid7OrBelow) return;
   notifeeLib?.default.registerForegroundService(() => {
     return new Promise(() => {
       const logger = getLogger(['setForegroundService method']);
@@ -20,7 +20,6 @@ function setForegroundService() {
 }
 
 async function startForegroundService(call_cid: string) {
-  if (!isAndroid7OrBelow) return;
   const foregroundServiceConfig = StreamVideoRN.getConfig().foregroundService;
   const { title, body } = foregroundServiceConfig.android.notificationTexts;
 
@@ -37,12 +36,18 @@ async function startForegroundService(call_cid: string) {
     );
     return;
   }
-  // channel id is not required for notifee as its only used on android 7 and below here
+  const channelId = foregroundServiceConfig.android.channel.id;
+  await notifeeLib.default.createChannel(
+    foregroundServiceConfig.android.channel
+  );
+  const foregroundServiceTypes = await getKeepCallAliveForegroundServiceTypes();
   await notifeeLib.default.displayNotification({
     id: call_cid,
     title,
     body,
     android: {
+      channelId,
+      foregroundServiceTypes,
       asForegroundService: true,
       ongoing: true, // user cannot dismiss the notification
       colorized: true,
@@ -61,10 +66,10 @@ let isSetForegroundServiceRan = false;
  * This hook is used to keep the call alive in the background for Android.
  * It starts a foreground service to keep the call alive as soon as the call is joined
  * and stops the foreground Service when the call is left.
- * Additonally: also responsible for cancelling any notifee displayed notification when the call has transitioned out of ringing
+ * Additionally: also responsible for cancelling any notifee displayed notification when the call has transitioned out of ringing
  */
 export const useAndroidKeepCallAliveEffect = () => {
-  if (!isSetForegroundServiceRan && isAndroid7OrBelow) {
+  if (!isSetForegroundServiceRan) {
     isSetForegroundServiceRan = true;
     setForegroundService();
   }
@@ -75,10 +80,10 @@ export const useAndroidKeepCallAliveEffect = () => {
   const callingState = useCallCallingState();
 
   useEffect((): (() => void) | undefined => {
-    if (!notifeeLib) return;
     if (Platform.OS === 'ios' || !activeCallCid) {
       return;
     }
+    if (!notifeeLib) return;
 
     // start foreground service as soon as the call is joined
     if (callingState === CallingState.JOINED) {

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
@@ -7,6 +7,13 @@ import newNotificationCallbacks, {
 const DEFAULT_STREAM_VIDEO_CONFIG: StreamVideoConfig = {
   foregroundService: {
     android: {
+      channel: {
+        id: 'stream_call_foreground_service',
+        name: 'To keep calls alive',
+        lights: false,
+        vibration: false,
+        importance: 3,
+      },
       notificationTexts: {
         title: 'Call in progress',
         body: 'Tap to return to the call',

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
@@ -122,9 +122,11 @@ export type StreamVideoConfig = {
   foregroundService: {
     android: {
       /**
+       * The notification channel to keep call alive in the background for Android using a foreground service.
+       */
+      channel: AndroidChannel;
+      /**
        * The texts shown in the notification to keep call alive in the background
-       * for Android 24 and 25 platforms using a foreground service.
-       * On Android 26 and above, Picture in Picture mode is used to keep the call alive.
        */
       notificationTexts: {
         title: string;

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -1,5 +1,6 @@
 import {
   Call,
+  CallingState,
   RxUtils,
   StreamVideoClient,
   getLogger,
@@ -15,6 +16,7 @@ import {
   getNotifeeLibThrowIfNotInstalledForPush,
   NotifeeLib,
   FirebaseMessagingTypes,
+  getIncomingCallForegroundServiceTypes,
 } from './libs';
 import {
   pushAcceptedIncomingCallCId$,
@@ -133,14 +135,14 @@ export const firebaseDataHandler = async (
     const created_by_id = data.created_by_id as string;
     const receiver_id = data.receiver_id as string;
 
-    function shouldCallBeClosed(callToCheck: Call) {
+    const shouldCallBeClosed = (callToCheck: Call) => {
       const { mustEndCall } = shouldCallBeEnded(
         callToCheck,
         created_by_id,
         receiver_id
       );
       return mustEndCall;
-    }
+    };
 
     const canListenToWS = () =>
       canAddPushWSSubscriptionsRef.current &&
@@ -165,17 +167,33 @@ export const firebaseDataHandler = async (
             notifee.stopForegroundService();
             return;
           }
+          const unsubscribeFunctions: Array<() => void> = [];
+          // check if service needs to be closed if accept/decline event was done on another device
           const unsubscribe = callFromPush.on('all', () => {
             if (!canListenToWS() || shouldCallBeClosed(callFromPush)) {
-              unsubscribe();
+              unsubscribeFunctions.forEach((fn) => fn());
               notifee.stopForegroundService();
             }
           });
+          // check if service needs to be closed if call was left
+          const subscription = callFromPush.state.callingState$.subscribe(
+            (callingState) => {
+              if (
+                callingState === CallingState.IDLE ||
+                callingState === CallingState.LEFT
+              ) {
+                unsubscribeFunctions.forEach((fn) => fn());
+                notifee.stopForegroundService();
+              }
+            }
+          );
+          unsubscribeFunctions.push(unsubscribe);
+          unsubscribeFunctions.push(() => subscription.unsubscribe());
           const unsubscriptionCallbacks =
             RxUtils.getCurrentValue(pushUnsubscriptionCallbacks$) ?? [];
           pushUnsubscriptionCallbacks$.next([
             ...unsubscriptionCallbacks,
-            unsubscribe,
+            ...unsubscribeFunctions,
           ]);
         });
       });
@@ -211,6 +229,7 @@ export const firebaseDataHandler = async (
       data,
       android: {
         channelId,
+        foregroundServiceTypes: getIncomingCallForegroundServiceTypes(),
         asForegroundService,
         sound: incomingCallChannel.sound,
         vibrationPattern: incomingCallChannel.vibrationPattern,

--- a/packages/react-native-sdk/src/utils/push/libs/notifee.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/notifee.ts
@@ -1,5 +1,5 @@
+import { getLogger } from '@stream-io/video-client';
 import { PermissionsAndroid } from 'react-native';
-import { getLogger } from '../../..';
 
 export type NotifeeLib = typeof import('@notifee/react-native');
 

--- a/sample-apps/react-native/dogfood/android/app/src/main/AndroidManifest.xml
+++ b/sample-apps/react-native/dogfood/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.CALL_PHONE" />
@@ -69,11 +73,10 @@
                 <data android:pathPrefix="/video/demos/join" />
             </intent-filter>
         </activity>
-
         <service
             android:name="app.notifee.core.ForegroundService"
             tools:replace="android:foregroundServiceType"
-            android:foregroundServiceType="shortService"
-            android:stopWithTask="true" />
+            android:stopWithTask="true"
+            android:foregroundServiceType="shortService|dataSync|camera|microphone|connectedDevice" />
     </application>
 </manifest>

--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -1116,10 +1116,10 @@ PODS:
     - React-Core
     - React-RCTImage
     - TOCropViewController (~> 2.7.4)
-  - RNNotifee (7.8.0):
+  - RNNotifee (9.1.2):
     - React-Core
-    - RNNotifee/NotifeeCore (= 7.8.0)
-  - RNNotifee/NotifeeCore (7.8.0):
+    - RNNotifee/NotifeeCore (= 9.1.2)
+  - RNNotifee/NotifeeCore (9.1.2):
     - React-Core
   - RNPermissions (4.1.1):
     - React-Core
@@ -1148,7 +1148,7 @@ PODS:
   - stream-react-native-webrtc (125.0.0-rc.1):
     - React-Core
     - WebRTC-SDK (~> 125.6422.05)
-  - stream-video-react-native (1.2.14):
+  - stream-video-react-native (1.3.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1465,7 +1465,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: a51b249f3c779e38a5d9ec45cb107d8780b39fb2
   RNGoogleSignin: fc408799f1990a12497a32f64280c0fe353ffcc1
   RNImageCropPicker: 771e2ca319d2cf92e04ebf334ece892ee9a6728f
-  RNNotifee: f3c01b391dd8e98e67f539f9a35a9cbcd3bae744
+  RNNotifee: bc20a5e3d581f629db988075944fdd944d363dfe
   RNPermissions: 4d64d2c763b20e5db08dfb8f1ef541f95c0d28c1
   RNReactNativeHapticFeedback: afa5bf2794aecbb2dba2525329253da0d66656df
   RNReanimated: 8cd12e58bbedca2b0b62a3c3872d3629fc2e1583
@@ -1475,7 +1475,7 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   stream-io-video-filters-react-native: 8c345e6adf5164646696d45f9962c4199b2fe3b9
   stream-react-native-webrtc: 976646e6e3643d331fc4da20e4be04ea16af295b
-  stream-video-react-native: 99eb88b52009b0687c3e9d8600e924ba789490dd
+  stream-video-react-native: 4c85bd9c26933254bfcab689c7db5751110f67e5
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   WebRTC-SDK: 1990a1a595bd0b59c17485ce13ff17f575732c12
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312

--- a/sample-apps/react-native/dogfood/package.json
+++ b/sample-apps/react-native/dogfood/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^4.6.1",
-    "@notifee/react-native": "^7.8.0",
+    "@notifee/react-native": "9.1.2",
     "@react-native-camera-roll/camera-roll": "^5.6.0",
     "@react-native-clipboard/clipboard": "^1.11.1",
     "@react-native-community/netinfo": "11.3.0",

--- a/sample-apps/react-native/expo-video-sample/android/app/src/main/AndroidManifest.xml
+++ b/sample-apps/react-native/expo-video-sample/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,10 @@
   <uses-permission android:name="android.permission.CALL_PHONE"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
@@ -37,7 +41,11 @@
         <action android:name="android.telecom.ConnectionService"/>
       </intent-filter>
     </service>
-    <service android:name="app.notifee.core.ForegroundService" android:stopWithTask="true" android:foregroundServiceType="shortService" tools:replace="android:foregroundServiceType"/>
+    <service
+        android:name="app.notifee.core.ForegroundService"
+        tools:replace="android:foregroundServiceType"
+        android:stopWithTask="true"
+        android:foregroundServiceType="shortService|dataSync|camera|microphone|connectedDevice" />
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|smallestScreenSize" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait" android:supportsPictureInPicture="true" android:showWhenLocked="true" android:turnScreenOn="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/sample-apps/react-native/expo-video-sample/app.json
+++ b/sample-apps/react-native/expo-video-sample/app.json
@@ -12,9 +12,7 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
       "bitcode": false,
@@ -26,6 +24,11 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
+      "permissions": [
+        "android.permission.FOREGROUND_SERVICE_CAMERA",
+        "android.permission.FOREGROUND_SERVICE_MICROPHONE",
+        "android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"
+      ],
       "googleServicesFile": "./google-services.json",
       "package": "io.getstream.expovideosample"
     },
@@ -35,6 +38,7 @@
         "@stream-io/video-react-native-sdk",
         {
           "enableScreenshare": true,
+          "androidKeepCallAlive": true,
           "appleTeamId": "EHV7XZLAHA",
           "ringingPushNotifications": {
             "disableVideoIos": false,

--- a/sample-apps/react-native/expo-video-sample/app.json
+++ b/sample-apps/react-native/expo-video-sample/app.json
@@ -24,11 +24,6 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "permissions": [
-        "android.permission.FOREGROUND_SERVICE_CAMERA",
-        "android.permission.FOREGROUND_SERVICE_MICROPHONE",
-        "android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"
-      ],
       "googleServicesFile": "./google-services.json",
       "package": "io.getstream.expovideosample"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4211,12 +4211,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@notifee/react-native@npm:7.8.0, @notifee/react-native@npm:^7.8.0":
-  version: 7.8.0
-  resolution: "@notifee/react-native@npm:7.8.0"
+"@notifee/react-native@npm:9.1.2":
+  version: 9.1.2
+  resolution: "@notifee/react-native@npm:9.1.2"
   peerDependencies:
     react-native: "*"
-  checksum: 800233c9505195046e918ee42a4b11d8e84cf1846ea4a0b52599e1a40181b2bbfcab09c64b445b5a7eed98c38556c97550bce32ed24a51ce05ccd8b65047548d
+  checksum: 1cf39654ed9679992f098e7df1586d47a65239297903ab57c76ca5834641d9171f8d2d3a337c8453950c9f6ee2cea1b5388093e1a386e7a89eceb96bf27ef374
   languageName: node
   linkType: hard
 
@@ -7914,7 +7914,7 @@ __metadata:
     "@babel/preset-env": ^7.25.4
     "@babel/runtime": ^7.25.6
     "@gorhom/bottom-sheet": ^4.6.1
-    "@notifee/react-native": ^7.8.0
+    "@notifee/react-native": 9.1.2
     "@react-native-camera-roll/camera-roll": ^5.6.0
     "@react-native-clipboard/clipboard": ^1.11.1
     "@react-native-community/netinfo": 11.3.0
@@ -7977,7 +7977,7 @@ __metadata:
   dependencies:
     "@babel/preset-typescript": ^7.24.7
     "@expo/config-plugins": ~7.8.4
-    "@notifee/react-native": 7.8.0
+    "@notifee/react-native": 9.1.2
     "@react-native-community/netinfo": 9.3.9
     "@react-native-community/push-notification-ios": 1.11.0
     "@react-native-firebase/app": 19.2.2
@@ -8020,7 +8020,7 @@ __metadata:
     ts-node: ^10.9.2
     typescript: ^5.5.2
   peerDependencies:
-    "@notifee/react-native": ">=7.8.0"
+    "@notifee/react-native": ">=9.0.0"
     "@react-native-community/netinfo": ">=9.0.0"
     "@react-native-community/push-notification-ios": ">=1.11.0"
     "@react-native-firebase/app": ">=17.5.0"


### PR DESCRIPTION
In Android PiP mode, even though app is in foreground mode. The websockets die and reconnect. Then 10-15 secs after die and reconnect after. This goes on. Its a weird state with seemingly no workaround. The only way is to keep a foreground service in all android platforms.

docs: https://github.com/GetStream/docs-content/pull/22