### PR TITLE
fix: experimental option to force single codec preference in the SDP

### DIFF
--- a/packages/client/src/helpers/sdp-munging.ts
+++ b/packages/client/src/helpers/sdp-munging.ts
@@ -130,6 +130,50 @@ export const toggleDtx = (sdp: string, enable: boolean): string => {
 };
 
 /**
+ * Returns and SDP with all the codecs except the given codec removed.
+ */
+export const preserveCodec = (
+  sdp: string,
+  mid: string,
+  codec: RTCRtpCodec,
+): string => {
+  const [kind, codecName] = codec.mimeType.toLowerCase().split('/');
+  const parsedSdp = SDP.parse(sdp);
+  for (const media of parsedSdp.media) {
+    if (media.type !== kind || String(media.mid) !== mid) continue;
+
+    // find the payload id of the desired codec
+    const payloads = new Set<number>();
+    for (const rtp of media.rtp) {
+      if (
+        rtp.codec.toLowerCase() === codecName &&
+        media.fmtp.some(
+          (f) => f.payload === rtp.payload && f.config === codec.sdpFmtpLine,
+        )
+      ) {
+        payloads.add(rtp.payload);
+      }
+    }
+
+    // find the corresponding rtx codec by matching apt=<preserved-codec-payload>
+    for (const fmtp of media.fmtp) {
+      const match = fmtp.config.match(/(apt)=(\d+)/);
+      if (!match) continue;
+      const [, , preservedCodecPayload] = match;
+      if (payloads.has(Number(preservedCodecPayload))) {
+        payloads.add(fmtp.payload);
+      }
+    }
+
+    media.rtp = media.rtp.filter((r) => payloads.has(r.payload));
+    media.fmtp = media.fmtp.filter((f) => payloads.has(f.payload));
+    media.rtcpFb = media.rtcpFb?.filter((f) => payloads.has(f.payload));
+    media.payloads = Array.from(payloads).join(' ');
+  }
+  return SDP.write(parsedSdp);
+};
+
+/**
  * Enables high-quality audio through SDP munging for the given trackMid.
  *
  * @param sdp the SDP to munge.

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -20,6 +20,7 @@ import { PublishOptions } from '../types';
 import {
   enableHighQualityAudio,
   extractMid,
+  preserveCodec,
   toggleDtx,
 } from '../helpers/sdp-munging';
 import { Logger } from '../coordinator/connection/types';
@@ -530,6 +531,12 @@ export class Publisher {
       if (this.isPublishing(TrackType.SCREEN_SHARE_AUDIO)) {
         offer.sdp = this.enableHighQualityAudio(offer.sdp);
       }
+      if (this.isPublishing(TrackType.VIDEO)) {
+        // Hotfix for platforms that don't respect the ordered codec list
+        // (Firefox, Android, Linux, etc...).
+        // We remove all the codecs from the SDP except the one we want to use.
+        offer.sdp = this.removeUnpreferredCodecs(offer.sdp, TrackType.VIDEO);
+      }
     }
 
     const trackInfos = this.getAnnouncedTracks(offer.sdp);
@@ -563,6 +570,23 @@ export class Publisher {
       },
     );
   };
+
+  private removeUnpreferredCodecs(sdp: string, trackType: TrackType) {
+    const opts = this.publishOptsForTrack.get(trackType);
+    if (!opts || !opts.forceSinglePreferredCodec) return sdp;
+
+    const codec = opts.forceCodec || opts.preferredCodec;
+    const orderedCodecs = this.getCodecPreferences(trackType, codec);
+    if (!orderedCodecs || orderedCodecs.length === 0) return sdp;
+
+    const transceiver = this.transceiverCache.get(trackType);
+    if (!transceiver) return sdp;
+
+    const index = this.transceiverInitOrder.indexOf(trackType);
+    const mid = extractMid(transceiver, index, sdp);
+    const [codecToPreserve] = orderedCodecs;
+    return preserveCodec(sdp, mid, codecToPreserve);
+  }
 
   private enableHighQualityAudio = (sdp: string) => {
     const transceiver = this.transceiverCache.get(TrackType.SCREEN_SHARE_AUDIO);

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -168,6 +168,12 @@ export type PublishOptions = {
    */
   forceCodec?: PreferredCodec;
   /**
+   * When using a preferred codec, force the use of a single codec.
+   * Enabling this, it will remove all other supported codecs from the SDP.
+   * Defaults to false.
+   */
+  forceSinglePreferredCodec?: boolean;
+  /**
    * The preferred scalability to use when publishing the video stream.
    * Applicable only for SVC codecs.
    */


### PR DESCRIPTION
### Overview

This is a hotfix for platforms that don't respect the ordered codec list(Firefox, Android, Linux, etc.).
We remove all the codecs from the SDP except the one we want to use. This is an opt-in feature hidden behind a toggle in the call's publish options.
To enable it:
```ts
call.updatePublishOptions({
  preferredCodec: 'vp9',
  forceSinglePreferredCodec: true,
});
```