### PR TITLE
fix: respect codec overrides when computing the layers

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -652,7 +652,8 @@ export class Publisher {
       settings?.screensharing.target_resolution?.bitrate;
 
     const publishOpts = opts || this.publishOptsForTrack.get(trackType);
-    const codecInUse = getOptimalVideoCodec(publishOpts?.preferredCodec);
+    const codecInUse =
+      opts?.forceCodec || getOptimalVideoCodec(opts?.preferredCodec);
     return trackType === TrackType.VIDEO
       ? findOptimalVideoLayers(track, targetResolution, codecInUse, publishOpts)
       : trackType === TrackType.SCREEN_SHARE


### PR DESCRIPTION
### Overview

Fixes an issue where `max_simulcast_layers` was not correctly respected when combined with `preferredCodec`.