### PR TITLE
fix: force single codec preference in the SDP

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -459,9 +459,14 @@ export class Publisher {
   private getCodecPreferences = (
     trackType: TrackType,
     preferredCodec?: string,
+    codecPreferencesSource?: 'sender' | 'receiver',
   ) => {
     if (trackType === TrackType.VIDEO) {
-      return getPreferredCodecs('video', preferredCodec || 'vp8');
+      return getPreferredCodecs(
+        'video',
+        preferredCodec || 'vp8',
+        codecPreferencesSource,
+      );
     }
     if (trackType === TrackType.AUDIO) {
       const defaultAudioCodec = this.isRedEnabled ? 'red' : 'opus';
@@ -575,8 +580,8 @@ export class Publisher {
     const opts = this.publishOptsForTrack.get(trackType);
     if (!opts || !opts.forceSingleCodec) return sdp;
 
-    const codec = opts.forceCodec || opts.preferredCodec;
-    const orderedCodecs = this.getCodecPreferences(trackType, codec);
+    const codec = opts.forceCodec || getOptimalVideoCodec(opts.preferredCodec);
+    const orderedCodecs = this.getCodecPreferences(trackType, codec, 'sender');
     if (!orderedCodecs || orderedCodecs.length === 0) return sdp;
 
     const transceiver = this.transceiverCache.get(trackType);

--- a/packages/client/src/rtc/codecs.ts
+++ b/packages/client/src/rtc/codecs.ts
@@ -9,15 +9,19 @@ import type { PreferredCodec } from '../types';
  * @param kind the kind of codec to get.
  * @param preferredCodec the codec to prioritize (vp8, h264, vp9, av1...).
  * @param codecToRemove the codec to exclude from the list.
+ * @param codecPreferencesSource the source of the codec preferences.
  */
 export const getPreferredCodecs = (
   kind: 'audio' | 'video',
   preferredCodec: string,
   codecToRemove?: string,
-): RTCRtpCodecCapability[] | undefined => {
-  if (!('getCapabilities' in RTCRtpReceiver)) return;
+  codecPreferencesSource: 'sender' | 'receiver' = 'receiver',
+): RTCRtpCodec[] | undefined => {
+  const source =
+    codecPreferencesSource === 'receiver' ? RTCRtpReceiver : RTCRtpSender;
+  if (!('getCapabilities' in source)) return;
 
-  const capabilities = RTCRtpReceiver.getCapabilities(kind);
+  const capabilities = source.getCapabilities(kind);
   if (!capabilities) return;
 
   const preferred: RTCRtpCodecCapability[] = [];


### PR DESCRIPTION
### Overview

Continuation of #1581. Reads the available codec info from the RTCRtpSender.