### PR TITLE
fix: call controls on ipad landscape positioning

### DIFF
--- a/sample-apps/react-native/dogfood/src/theme.ts
+++ b/sample-apps/react-native/dogfood/src/theme.ts
@@ -49,7 +49,7 @@ export const useCustomTheme = (mode: ThemeMode): DeepPartial<Theme> => {
   };
 
   const callContent: DeepPartial<Theme['callContent']> = {
-    container: { paddingTop: 0, paddingBottom: 0 },
+    container: { paddingTop: 0, paddingBottom: 0, flexDirection: 'column' },
   };
 
   const { height, width } = Dimensions.get('window');


### PR DESCRIPTION
Fixes the positioning of the call controls in the dogfood app for tablets in landscape orientation. 