### PR TITLE
fix: do not show callTopControls on PiP mode for android

### DIFF
--- a/sample-apps/react-native/dogfood/src/components/ActiveCall.tsx
+++ b/sample-apps/react-native/dogfood/src/components/ActiveCall.tsx
@@ -3,6 +3,7 @@ import {
   useCall,
   CallContent,
   useTheme,
+  useIsInPiPMode,
 } from '@stream-io/video-react-native-sdk';
 import { ActivityIndicator, StatusBar, StyleSheet, View } from 'react-native';
 import { ParticipantsInfoList } from './ParticipantsInfoList';
@@ -34,6 +35,7 @@ export const ActiveCall = ({
   const styles = useStyles();
   const { selectedLayout } = useLayout();
   const themeMode = useAppGlobalStoreValue((store) => store.themeMode);
+  const isInPiPMode = useIsInPiPMode(false);
 
   const onOpenCallParticipantsInfo = useCallback(() => {
     setIsCallParticipantsVisible(true);
@@ -87,7 +89,7 @@ export const ActiveCall = ({
       <StatusBar
         barStyle={themeMode === 'light' ? 'dark-content' : 'light-content'}
       />
-      <CustomTopControls />
+      {!isInPiPMode && <CustomTopControls />}
       <CallContent
         onHangupCallHandler={onHangupCallHandler}
         CallControls={CustomBottomControls}


### PR DESCRIPTION
Fixes the PiP mode on Android.

Before:
![Screenshot at Nov 26 15-53-42](https://github.com/user-attachments/assets/455c0eda-3cbf-4a3b-b996-7c7c397e6459)
After:
![Screenshot at Nov 26 15-53-51](https://github.com/user-attachments/assets/69da354f-cb1a-4467-871c-e5b24a8382f0)
