### PR TITLE
fix: ringing calls not being left when ended

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -123,6 +123,7 @@ import {
   PromiseWithResolvers,
   promiseWithResolvers,
 } from './helpers/withResolvers';
+import { REASON_FOR_LEAVE_ON_CALL_ENDED } from './events/internal';
 
 /**
  * An object representation of a `Call`.
@@ -516,7 +517,10 @@ export class Call {
         await waitUntilCallJoined();
       }
 
-      if (callingState === CallingState.RINGING && !this.state.endedAt) {
+      if (
+        callingState === CallingState.RINGING &&
+        reason !== REASON_FOR_LEAVE_ON_CALL_ENDED
+      ) {
         if (reject) {
           await this.reject(reason);
         } else {

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -123,7 +123,6 @@ import {
   PromiseWithResolvers,
   promiseWithResolvers,
 } from './helpers/withResolvers';
-import { REASON_FOR_LEAVE_ON_CALL_ENDED } from './events/internal';
 
 /**
  * An object representation of a `Call`.
@@ -517,10 +516,7 @@ export class Call {
         await waitUntilCallJoined();
       }
 
-      if (
-        callingState === CallingState.RINGING &&
-        reason !== REASON_FOR_LEAVE_ON_CALL_ENDED
-      ) {
+      if (callingState === CallingState.RINGING && !this.state.endedAt) {
         if (reject) {
           await this.reject(reason);
         } else {

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -516,7 +516,7 @@ export class Call {
         await waitUntilCallJoined();
       }
 
-      if (callingState === CallingState.RINGING) {
+      if (callingState === CallingState.RINGING && !this.state.endedAt) {
         if (reject) {
           await this.reject(reason);
         } else {

--- a/packages/client/src/events/call.ts
+++ b/packages/client/src/events/call.ts
@@ -3,7 +3,6 @@ import { Call } from '../Call';
 import type { CallAcceptedEvent, CallRejectedEvent } from '../gen/coordinator';
 import { CallEnded } from '../gen/video/sfu/event/events';
 import { CallEndedReason } from '../gen/video/sfu/models/models';
-import { REASON_FOR_LEAVE_ON_CALL_ENDED } from './internal';
 
 /**
  * Event handler that watched the delivery of `call.accepted`.
@@ -80,7 +79,7 @@ export const watchCallEnded = (call: Call) => {
       callingState !== CallingState.IDLE &&
       callingState !== CallingState.LEFT
     ) {
-      call.leave({ reason: REASON_FOR_LEAVE_ON_CALL_ENDED }).catch((err) => {
+      call.leave({ reason: 'call.ended event received' }).catch((err) => {
         call.logger('error', 'Failed to leave call after call.ended ', err);
       });
     }

--- a/packages/client/src/events/call.ts
+++ b/packages/client/src/events/call.ts
@@ -79,9 +79,11 @@ export const watchCallEnded = (call: Call) => {
       callingState !== CallingState.IDLE &&
       callingState !== CallingState.LEFT
     ) {
-      call.leave({ reason: 'call.ended event received' }).catch((err) => {
-        call.logger('error', 'Failed to leave call after call.ended ', err);
-      });
+      call
+        .leave({ reason: 'call.ended event received', reject: false })
+        .catch((err) => {
+          call.logger('error', 'Failed to leave call after call.ended ', err);
+        });
     }
   };
 };

--- a/packages/client/src/events/call.ts
+++ b/packages/client/src/events/call.ts
@@ -3,6 +3,7 @@ import { Call } from '../Call';
 import type { CallAcceptedEvent, CallRejectedEvent } from '../gen/coordinator';
 import { CallEnded } from '../gen/video/sfu/event/events';
 import { CallEndedReason } from '../gen/video/sfu/models/models';
+import { REASON_FOR_LEAVE_ON_CALL_ENDED } from './internal';
 
 /**
  * Event handler that watched the delivery of `call.accepted`.
@@ -79,7 +80,7 @@ export const watchCallEnded = (call: Call) => {
       callingState !== CallingState.IDLE &&
       callingState !== CallingState.LEFT
     ) {
-      call.leave({ reason: 'call.ended event received' }).catch((err) => {
+      call.leave({ reason: REASON_FOR_LEAVE_ON_CALL_ENDED }).catch((err) => {
         call.logger('error', 'Failed to leave call after call.ended ', err);
       });
     }

--- a/packages/client/src/events/internal.ts
+++ b/packages/client/src/events/internal.ts
@@ -10,8 +10,6 @@ import {
 } from '../gen/video/sfu/models/models';
 import { OwnCapability } from '../gen/coordinator';
 
-export const REASON_FOR_LEAVE_ON_CALL_ENDED = 'call.ended event received';
-
 export const watchConnectionQualityChanged = (
   dispatcher: Dispatcher,
   state: CallState,

--- a/packages/client/src/events/internal.ts
+++ b/packages/client/src/events/internal.ts
@@ -10,6 +10,8 @@ import {
 } from '../gen/video/sfu/models/models';
 import { OwnCapability } from '../gen/coordinator';
 
+export const REASON_FOR_LEAVE_ON_CALL_ENDED = 'call.ended event received';
+
 export const watchConnectionQualityChanged = (
   dispatcher: Dispatcher,
   state: CallState,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -215,8 +215,6 @@ export type CallLeaveOptions = {
   /**
    * If true, the caller will get a `call.rejected` event.
    * Has an effect only if the call is in the `ringing` state.
-   *
-   * @default `false`.
    */
   reject?: boolean;
 


### PR DESCRIPTION
Currently when a ringing call was ended, the reject API fails and then the call is never left! 

This PR fixes that we dont call reject API if call was already ended