### PR TITLE
fix: disable join call button to prevent multiple call joins

### DIFF
--- a/packages/react-native-sdk/src/components/Call/Lobby/JoinCallButton.tsx
+++ b/packages/react-native-sdk/src/components/Call/Lobby/JoinCallButton.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { LobbyProps } from './Lobby';
 import { Pressable, StyleSheet, Text } from 'react-native';
 import { useCall, useI18n } from '@stream-io/video-react-bindings';
@@ -23,10 +23,12 @@ export const JoinCallButton = ({
     theme: { colors, typefaces, joinCallButton },
   } = useTheme();
   const styles = useStyles();
+  const [isLoading, setIsLoading] = useState(false);
   const { t } = useI18n();
   const call = useCall();
 
   const onPress = async () => {
+    setIsLoading(true);
     if (onPressHandler) {
       onPressHandler();
       return;
@@ -39,17 +41,20 @@ export const JoinCallButton = ({
     } catch (error) {
       const logger = getLogger(['JoinCallButton']);
       logger('error', 'Error joining call:', error);
+    } finally {
+      setIsLoading(false);
     }
   };
 
+  const backgroundColor = isLoading
+    ? colors.buttonDisabled
+    : colors.buttonPrimary;
+
   return (
     <Pressable
-      style={[
-        styles.container,
-        { backgroundColor: colors.buttonPrimary },
-        joinCallButton.container,
-      ]}
+      style={[styles.container, { backgroundColor }, joinCallButton.container]}
       onPress={onPress}
+      disabled={isLoading}
     >
       <Text
         style={[
@@ -59,7 +64,7 @@ export const JoinCallButton = ({
           joinCallButton.label,
         ]}
       >
-        {t('Join')}
+        {isLoading ? t('Joining...') : t('Join')}
       </Text>
     </Pressable>
   );

--- a/packages/react-native-sdk/src/translations/en.json
+++ b/packages/react-native-sdk/src/translations/en.json
@@ -4,6 +4,7 @@
   "Mute All": "Mute All",
   "Invite": "Invite",
   "Join": "Join",
+  "Joining...": "Joining...",
   "You": "You",
   "Reconnecting...": "Reconnecting...",
   "Loading...": "Loading...",

--- a/sample-apps/react-native/dogfood/src/components/AuthenticatingProgress.tsx
+++ b/sample-apps/react-native/dogfood/src/components/AuthenticatingProgress.tsx
@@ -1,16 +1,26 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ActivityIndicator, SafeAreaView, StyleSheet } from 'react-native';
-import { appTheme } from '../theme';
+import { useTheme } from '@stream-io/video-react-native-sdk';
 
-export const AuthenticationProgress = () => (
-  <SafeAreaView style={styles.container}>
-    <ActivityIndicator size={'large'} style={StyleSheet.absoluteFill} />
-  </SafeAreaView>
-);
+export const AuthenticationProgress = () => {
+  const styles = useStyles();
+  return (
+    <SafeAreaView style={styles.container}>
+      <ActivityIndicator size={'large'} style={StyleSheet.absoluteFill} />
+    </SafeAreaView>
+  );
+};
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: appTheme.colors.static_grey,
-  },
-});
+const useStyles = () => {
+  const { theme } = useTheme();
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: theme.colors.sheetPrimary,
+        },
+      }),
+    [theme],
+  );
+};


### PR DESCRIPTION
The problem:
- multiple call join press events on the button caused this error on call join:
<img src="https://github.com/user-attachments/assets/a42e7b6d-12bf-443a-b947-312d8270a1e4" alt="ios" width="200" height="440"/>

Solution:
- after the initial press, Join button is dissabeld showing `'Joining...'` message and prevent subsequent press events on it. 
<img src="https://github.com/user-attachments/assets/3cd251d9-e839-49f7-8e9f-ba0eaa23cefc" alt="ios" width="200" height="440"/>

*This PR also contains fix for the general loading screen background colour. 