### PR TITLE
fix: prevent device list observable from erroring

### DIFF
--- a/packages/client/src/devices/BrowserPermission.ts
+++ b/packages/client/src/devices/BrowserPermission.ts
@@ -63,7 +63,7 @@ export class BrowserPermission {
     forcePrompt = false,
     throwOnNotAllowed = false,
   }: { forcePrompt?: boolean; throwOnNotAllowed?: boolean } = {}) {
-    await withoutConcurrency(
+    return await withoutConcurrency(
       `permission-prompt-${this.permission.queryName}`,
       async () => {
         if (

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -29,8 +29,7 @@ const getDevices = (permission: BrowserPermission, kind: MediaDeviceKind) => {
       const shouldPromptForBrowserPermission = devices.some(
         (device) => device.kind === kind && device.label === '',
       );
-      if (shouldPromptForBrowserPermission) {
-        await permission.prompt({ throwOnNotAllowed: true });
+      if (shouldPromptForBrowserPermission && (await permission.prompt())) {
         devices = await navigator.mediaDevices.enumerateDevices();
       }
       return devices.filter(


### PR DESCRIPTION
Since the `useObservableValue` doesn't re-subscribe to observables after the stream errors, we should avoid erroring in observables unless the error is fatal.

One example is the observable returned by `listDevices()`. Currently, it errors on denied browser permission, and unless you re-subscribe, you won't get updated device list when the permission is granted.

With this change, observable doesn't error and returns an empty list instead.