### PR TITLE
fix: avoid call.get in all call.ring events

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -263,7 +263,6 @@ export class StreamVideoClient {
           );
           return;
         }
-
         this.logger('info', `New call created and registered: ${call.cid}`);
         const newCall = new Call({
           streamClient: this.streamClient,
@@ -287,25 +286,24 @@ export class StreamVideoClient {
           );
           return;
         }
-
-        // The call might already be tracked by the client,
         // if `call.created` was received before `call.ring`.
-        // In that case, we cleanup the already tracked call.
-        const prevCall = this.writeableStateStore.findCall(call.type, call.id);
-        await prevCall?.leave({ reason: 'cleaning-up in call.ring' });
-        // we create a new call
-        const theCall = new Call({
-          streamClient: this.streamClient,
-          type: call.type,
-          id: call.id,
-          members,
-          clientStore: this.writeableStateStore,
-          ringing: true,
-        });
-        theCall.state.updateFromCallResponse(call);
-        // we fetch the latest metadata for the call from the server
-        await theCall.get();
-        this.writeableStateStore.registerCall(theCall);
+        // the client already has the call instance and we just need to update the state
+        const theCall = this.writeableStateStore.findCall(call.type, call.id);
+        if (theCall) {
+          await theCall.updateFromRingingEvent(event);
+        } else {
+          // if client doesn't have the call instance, create the instance and fetch the latest state
+          // Note: related - we also have onRingingCall method to handle this case from push notifications
+          const newCallInstance = new Call({
+            streamClient: this.streamClient,
+            type: call.type,
+            id: call.id,
+            members,
+            clientStore: this.writeableStateStore,
+            ringing: true,
+          });
+          await newCallInstance.get();
+        }
       }),
     );
 


### PR DESCRIPTION
As per spec

```
When the event is received, you need to ensure there is a WS connection open. If the connection needs to be opened, you also need to call call.get to fetch the latest state of the call object
```

Avoids confusion on support where users logging callingstate inform that they get left before ringing state