### PR TITLE
fix: pre-built timer worker

### DIFF
--- a/packages/client/generate-timer-worker.sh
+++ b/packages/client/generate-timer-worker.sh
@@ -4,6 +4,7 @@ npx tsc src/timers/worker.ts \
   --skipLibCheck \
   --removeComments \
   --module preserve \
+  --target ES2020 \
   --lib ES2020,WebWorker \
   --outDir worker-dist
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "start": "rollup -w -c",
-    "build": "yarn clean && ./generate-timer-worker.sh && rollup -c",
+    "build": "yarn clean && rollup -c",
     "test": "vitest",
     "clean:docs": "rimraf generated-docs",
     "test-ci": "vitest --coverage",

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -89,12 +89,11 @@ export class StreamVideoClient {
     if (typeof apiKeyOrArgs === 'string') {
       logLevel = opts?.logLevel || logLevel;
       logger = opts?.logger || logger;
-      if (opts?.expertimental_enableTimerWorker) enableTimerWorker();
+      if (opts?.enableTimerWorker) enableTimerWorker();
     } else {
       logLevel = apiKeyOrArgs.options?.logLevel || logLevel;
       logger = apiKeyOrArgs.options?.logger || logger;
-      if (apiKeyOrArgs.options?.expertimental_enableTimerWorker)
-        enableTimerWorker();
+      if (apiKeyOrArgs.options?.enableTimerWorker) enableTimerWorker();
     }
 
     setLogger(logger, logLevel);

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -151,7 +151,7 @@ export type StreamClientOptions = Partial<AxiosRequestConfig> & {
    * Create Web Worker to initiate timer events like health checks. Can possibly prevent
    * timer throttling issues in inactive browser tabs.
    */
-  expertimental_enableTimerWorker?: boolean;
+  enableTimerWorker?: boolean;
 };
 
 export type TokenProvider = () => Promise<string>;

--- a/packages/client/src/timers/worker.build.ts
+++ b/packages/client/src/timers/worker.build.ts
@@ -1,9 +1,28 @@
-// Do not modify this file manually. You can edit worker.ts if necessary
+// Do not modify this file manually. Instead, edit worker.ts
 // and the run ./generate-timer-worker.sh
 export const timerWorker = {
-  get src(): string {
-    throw new Error(
-      'Timer worker source missing. Did you forget to run generate-timer-worker.sh?',
-    );
-  },
+  src: `const timerIdMapping = new Map();
+self.addEventListener('message', (event) => {
+    const request = event.data;
+    switch (request.type) {
+        case 'setTimeout':
+        case 'setInterval':
+            timerIdMapping.set(request.id, (request.type === 'setTimeout' ? setTimeout : setInterval)(() => {
+                tick(request.id);
+                if (request.type === 'setTimeout') {
+                    timerIdMapping.delete(request.id);
+                }
+            }, request.timeout));
+            break;
+        case 'clearTimeout':
+        case 'clearInterval':
+            (request.type === 'clearTimeout' ? clearTimeout : clearInterval)(timerIdMapping.get(request.id));
+            timerIdMapping.delete(request.id);
+            break;
+    }
+});
+function tick(id) {
+    const message = { type: 'tick', id };
+    self.postMessage(message);
+}`,
 };


### PR DESCRIPTION
Dropping the `experimental_` prefix since this feature was confirmed working.

Since the timer worker (introduced in #1557) is not going to be updated too often, we can skip an additional built step and just check in the prebuilt worker.

The "source" file `worker.ts` and the script to generate worker are still there, but they are not used during build.