### PR TITLE
fix(rn-sdk): allow prop component ParticipantVideoFallback in FloatingParticipantView

### DIFF
--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -214,6 +214,7 @@ export const CallContent = ({
                 onPressHandler={handleFloatingViewParticipantSwitch}
                 supportedReactions={supportedReactions}
                 {...participantViewProps}
+                ParticipantVideoFallback={customParticipantVideoFallback}
               />
             )}
           </View>

--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -214,7 +214,6 @@ export const CallContent = ({
                 onPressHandler={handleFloatingViewParticipantSwitch}
                 supportedReactions={supportedReactions}
                 {...participantViewProps}
-                ParticipantVideoFallback={customParticipantVideoFallback}
               />
             )}
           </View>

--- a/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
+++ b/packages/react-native-sdk/src/components/Participant/FloatingParticipantView/index.tsx
@@ -60,7 +60,7 @@ export type FloatingParticipantViewProps = ParticipantViewComponentProps &
     onPressHandler?: () => void;
   };
 
-const CustomLocalParticipantViewVideoFallback = () => {
+const DefaultLocalParticipantViewVideoFallback = () => {
   const {
     theme: {
       colors,
@@ -96,6 +96,7 @@ export const FloatingParticipantView = ({
   draggableContainerStyle,
   ParticipantView = DefaultParticipantView,
   ParticipantNetworkQualityIndicator,
+  ParticipantVideoFallback = DefaultLocalParticipantViewVideoFallback,
   ParticipantReaction,
   VideoRenderer,
   supportedReactions,
@@ -125,7 +126,7 @@ export const FloatingParticipantView = ({
     ParticipantLabel: null,
     ParticipantNetworkQualityIndicator,
     ParticipantReaction,
-    ParticipantVideoFallback: CustomLocalParticipantViewVideoFallback,
+    ParticipantVideoFallback,
     VideoRenderer,
   };
 


### PR DESCRIPTION
Fixes the customisation option in the `FloatingParticipantView` for a `ParticipantVideoFallback` component. 

```typescript
  const customParticipantVideoFallback = () => {
    return (
      <View
        style={[
          {
            ...
            backgroundColor: 'orange',
          },
        ]}
      >
        <View style={{ height: 30, width: 30 }}>
          <VideoSlash color={'green'} size={30} />
        </View>
      </View>
    );
  };

<FloatingParticipantView
  ParticipantVideoFallback={customParticipantVideoFallback}
/>
```
<img src="https://github.com/user-attachments/assets/d4c3dd5e-f324-4e03-9e5c-1a2be08dc5fb" alt="ios-after" width="200" height="440"/>
