### PR TITLE
fix: metro commonjs issues with optional libs

### DIFF
--- a/packages/react-native-sdk/.gitignore
+++ b/packages/react-native-sdk/.gitignore
@@ -59,6 +59,7 @@ buck-out/
 
 # Bundle artifact
 *.jsbundle
+*.tgz
 
 # Ruby / CocoaPods
 /ios/Pods/

--- a/packages/react-native-sdk/src/utils/push/ios.ts
+++ b/packages/react-native-sdk/src/utils/push/ios.ts
@@ -4,12 +4,13 @@ import { pushNonRingingCallData$ } from './internal/rxSubjects';
 import {
   ExpoNotification,
   getExpoNotificationsLib,
+  getNotifeeLibThrowIfNotInstalledForPush,
   getPushNotificationIosLib,
   PushNotificationiOSType,
 } from './libs';
 import { StreamVideoClient, getLogger } from '@stream-io/video-client';
 import { setPushLogoutCallback } from '../internal/pushLogoutCallback';
-import { EventType, Event } from '@notifee/react-native';
+import type { Event } from '@notifee/react-native';
 import { StreamVideoRN } from '../StreamVideoRN';
 import { StreamPushPayload } from './utils';
 
@@ -51,7 +52,8 @@ export const oniOSNotifeeEvent = ({
   if (Platform.OS !== 'ios') return;
   const pushConfig = StreamVideoRN.getConfig().push;
   const { type, detail } = event;
-  if (pushConfig && type === EventType.PRESS) {
+  const notifeeLib = getNotifeeLibThrowIfNotInstalledForPush();
+  if (pushConfig && type === notifeeLib.EventType.PRESS) {
     const streamPayload = detail.notification?.data?.stream as
       | StreamPushPayload
       | undefined;

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
@@ -1,29 +1,24 @@
 import { getLogger } from '@stream-io/video-client';
+import { Type, lib } from './lib';
 
 export type { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
-export type FirebaseMessagingType =
-  typeof import('@react-native-firebase/messaging').default;
-
-let messaging: FirebaseMessagingType | undefined;
-
-try {
-  messaging = require('@react-native-firebase/messaging').default;
-} catch (_e) {}
+export type FirebaseMessagingType = Type;
 
 const INSTALLATION_INSTRUCTION =
   'Please see https://rnfirebase.io/messaging/usage#installation for installation instructions';
+
 export function getFirebaseMessagingLib() {
-  if (!messaging) {
+  if (!lib) {
     throw Error(
       '@react-native-firebase/messaging is not installed. ' +
         INSTALLATION_INSTRUCTION
     );
   }
-  return messaging;
+  return lib;
 }
 
 export function getFirebaseMessagingLibNoThrow(isExpo: boolean) {
-  if (!messaging) {
+  if (!lib) {
     const logger = getLogger(['getFirebaseMessagingLibNoThrow']);
     logger(
       'warn',
@@ -34,5 +29,5 @@ export function getFirebaseMessagingLibNoThrow(isExpo: boolean) {
       }${INSTALLATION_INSTRUCTION}`
     );
   }
-  return messaging;
+  return lib;
 }

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/lib.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/lib.ts
@@ -1,4 +1,4 @@
-type Type = typeof import('@react-native-firebase/messaging').default;
+export type Type = typeof import('@react-native-firebase/messaging').default;
 
 let lib: Type | undefined;
 
@@ -6,7 +6,7 @@ try {
   lib = require('@react-native-firebase/messaging').default;
 } catch (_e) {}
 
-export { Type, lib };
+export { lib };
 
 /*
     IMPORT: must keep a failing import in a different file

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/lib.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/lib.ts
@@ -9,6 +9,6 @@ try {
 export { lib };
 
 /*
-    IMPORT: must keep a failing import in a different file
+    IMPORTANT: must keep a failing import in a different file
     Else on commonjs, metro doesnt resolve any other modules properly in a file, if one of the module is not installed
 */

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/lib.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/lib.ts
@@ -1,0 +1,14 @@
+type Type = typeof import('@react-native-firebase/messaging').default;
+
+let lib: Type | undefined;
+
+try {
+  lib = require('@react-native-firebase/messaging').default;
+} catch (_e) {}
+
+export { Type, lib };
+
+/*
+    IMPORT: must keep a failing import in a different file
+    Else on commonjs, metro doesnt resolve any other modules properly in a file, if one of the module is not installed
+*/

--- a/packages/react-native-sdk/src/utils/push/libs/index.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/index.ts
@@ -6,6 +6,6 @@ export * from './callkeep';
 export * from './notifee';
 
 /*
-NOTE: must keep each libs in different files
-Else on commonjs, metro doesnt resolve modules properly if one of the module is not installed
+    NOTE: must keep each libs in different files
+    Else on commonjs, metro doesnt resolve modules properly if one of the module is not installed
 */

--- a/packages/react-native-sdk/src/utils/push/libs/notifee/index.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/notifee/index.ts
@@ -1,7 +1,8 @@
 import { getLogger } from '@stream-io/video-client';
 import { PermissionsAndroid } from 'react-native';
+import { Type, lib } from './lib';
 
-export type NotifeeLib = typeof import('@notifee/react-native');
+export type NotifeeLib = Type;
 
 enum AndroidForegroundServiceType {
   FOREGROUND_SERVICE_TYPE_CAMERA = 64,
@@ -21,34 +22,28 @@ enum AndroidForegroundServiceType {
   FOREGROUND_SERVICE_TYPE_MANIFEST = -1,
 }
 
-let notifeeLib: NotifeeLib | undefined;
-
-try {
-  notifeeLib = require('@notifee/react-native');
-} catch (_e) {}
-
 const INSTALLATION_INSTRUCTION =
   'Please see https://notifee.app/react-native/docs/installation for installation instructions';
 
 export function getNotifeeLibThrowIfNotInstalledForPush() {
-  if (!notifeeLib) {
+  if (!lib) {
     throw Error(
       '@notifee/react-native is not installed. It is required for implementing push notifications. ' +
         INSTALLATION_INSTRUCTION
     );
   }
-  return notifeeLib;
+  return lib;
 }
 
 export function getNotifeeLibNoThrowForKeepCallAlive() {
-  if (!notifeeLib) {
+  if (!lib) {
     const logger = getLogger(['getNotifeeLibNoThrow']);
     logger(
       'info',
       `${'@notifee/react-native library not installed. It is required to keep call alive in the background for Android. '}${INSTALLATION_INSTRUCTION}`
     );
   }
-  return notifeeLib;
+  return lib;
 }
 
 export async function getKeepCallAliveForegroundServiceTypes() {

--- a/packages/react-native-sdk/src/utils/push/libs/notifee/lib.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/notifee/lib.ts
@@ -1,0 +1,14 @@
+type Type = typeof import('@notifee/react-native');
+
+let lib: Type | undefined;
+
+try {
+  lib = require('@notifee/react-native');
+} catch (_e) {}
+
+export { Type, lib };
+
+/*
+    IMPORT: must keep a failing import in a different file
+    Else on commonjs, metro doesnt resolve any other modules properly in a file, if one of the module is not installed
+*/

--- a/packages/react-native-sdk/src/utils/push/libs/notifee/lib.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/notifee/lib.ts
@@ -9,6 +9,6 @@ try {
 export { lib };
 
 /*
-    IMPORT: must keep a failing import in a different file
+    IMPORTANT: must keep a failing import in a different file
     Else on commonjs, metro doesnt resolve any other modules properly in a file, if one of the module is not installed
 */

--- a/packages/react-native-sdk/src/utils/push/libs/notifee/lib.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/notifee/lib.ts
@@ -1,4 +1,4 @@
-type Type = typeof import('@notifee/react-native');
+export type Type = typeof import('@notifee/react-native');
 
 let lib: Type | undefined;
 
@@ -6,7 +6,7 @@ try {
   lib = require('@notifee/react-native');
 } catch (_e) {}
 
-export { Type, lib };
+export { lib };
 
 /*
     IMPORT: must keep a failing import in a different file

--- a/packages/react-native-sdk/src/utils/push/utils.ts
+++ b/packages/react-native-sdk/src/utils/push/utils.ts
@@ -1,4 +1,4 @@
-import { Event } from '@notifee/react-native';
+import type { Event } from '@notifee/react-native';
 import { FirebaseMessagingTypes } from './libs/firebaseMessaging';
 import { ExpoNotification } from './libs/expoNotifications';
 import { NonRingingPushEvent } from '../StreamVideoRN/types';


### PR DESCRIPTION
on commonjs, metro's module resolution has unpredicatable behaviour in a single file,if one of the module is not installed

Solution: move modules that may not be installed into its own file

fixes #1620 