### PR TITLE
fix(rn): break cyclic dependencies issue

### DIFF
--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/SpeechIndicator.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/SpeechIndicator.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { View, Animated, StyleSheet } from 'react-native';
-import { useTheme } from '../../..';
+import { useTheme } from '../../../contexts';
 
 /**
  * Props for the SpeechIndicator component.


### PR DESCRIPTION
Fixes the imports in the `SpeechIndicator` to break the cyclic imports. 