### PR TITLE
fix(rn-expo): fixes error/warning when the call is left in expo [skip ci]

### DIFF
--- a/sample-apps/react-native/expo-video-sample/app/meeting.tsx
+++ b/sample-apps/react-native/expo-video-sample/app/meeting.tsx
@@ -1,14 +1,20 @@
 import { StreamCall, useCalls } from '@stream-io/video-react-native-sdk';
 import { router } from 'expo-router';
 import { MeetingUI } from '../components/MeetingUI';
+import { useEffect } from 'react';
 
 export default function JoinMeetingScreen() {
   const calls = useCalls().filter((c) => !c.ringing);
 
   const firstCall = calls[0];
 
+  useEffect(() => {
+    if (!firstCall) {
+      router.back();
+    }
+  }, [firstCall]);
+
   if (!firstCall) {
-    router.back();
     return null;
   }
 


### PR DESCRIPTION
## Overview 
Fixes the error/warning generated when user is leaving a call in our sample expo app. 

```
 ERROR  Warning: Cannot update a component (ForwardRef(BaseNavigationContainer)) while rendering a different component (JoinMeetingScreen). To locate the bad setState() call inside JoinMeetingScreen, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
```

The issue was in our JoinMeetingScreen component - it's trying to update state during render.

**Solution**: Move the navigation logic into an effect:


