### PR TITLE
fix:  foreground service cannot be started in background exception

### DIFF
--- a/packages/react-native-sdk/src/utils/hooks/usePrevious.ts
+++ b/packages/react-native-sdk/src/utils/hooks/usePrevious.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-export const usePrevious = (value: any) => {
+export const usePrevious = <T>(value: T) => {
   const valueRef = useRef(value);
 
   useEffect(() => {


### PR DESCRIPTION
Lokal reported this crash from an edgecase — Android

Easily reproducible, steps below

1. Create an Outgoing call
2. Put app to background 
3. Make callee accept the call 
4. Crash on caller: cant create foreground service from background 

solution: create the service as soon as outgoing call state arrives