### PR TITLE
fix: update mute state only for video track on mobile

### DIFF
--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -3,6 +3,7 @@ import { Call } from '../Call';
 import { CallingState } from '../store';
 import { createSubscription } from '../store/rxUtils';
 import { InputMediaDeviceManagerState } from './InputMediaDeviceManagerState';
+import { isMobile } from '../helpers/compatibility';
 import { isReactNative } from '../helpers/platforms';
 import { Logger } from '../coordinator/connection/types';
 import { getLogger } from '../logger';
@@ -417,6 +418,7 @@ export abstract class InputMediaDeviceManager<
         }
       };
       const createTrackMuteHandler = (muted: boolean) => () => {
+        if (!isMobile() || this.trackType !== TrackType.VIDEO) return;
         this.call.notifyTrackMuteState(muted, this.trackType).catch((err) => {
           this.logger('warn', 'Error while notifying track mute state', err);
         });


### PR DESCRIPTION
### Overview

Fixes a regression introduced with #1527 where aggressive muting of screen share tracks (by browsers, when shared content is still) led to flickering.