### PR TITLE
fix: pip android crash on activity not enabled

### DIFF
--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/StreamVideoReactNativeModule.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/StreamVideoReactNativeModule.kt
@@ -3,13 +3,11 @@ package com.streamvideo.reactnative
 import android.app.AppOpsManager
 import android.app.PictureInPictureParams
 import android.content.BroadcastReceiver
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
-import android.content.pm.PackageManager.NameNotFoundException
 import android.net.Uri
 import android.os.Build
 import android.os.PowerManager

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/StreamVideoReactNativeModule.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/StreamVideoReactNativeModule.kt
@@ -24,10 +24,11 @@ import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEm
 import com.streamvideo.reactnative.util.RingtoneUtil
 
 
-class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
 
     override fun getName(): String {
-        return NAME;
+        return NAME
     }
 
     private var thermalStatusListener: PowerManager.OnThermalStatusChangedListener? = null
@@ -62,12 +63,15 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
                         // RN pauses rendering in paused mode, so we instruct it to resume here
                         reactApplicationContext?.onHostResume(activity)
                     } catch (e: IllegalStateException) {
-                        Log.d(NAME, "Skipping Picture-in-Picture mode. Its not enabled for activity")
+                        Log.d(
+                            NAME,
+                            "Skipping Picture-in-Picture mode. Its not enabled for activity"
+                        )
                     }
                 }
             }
         }
-        
+
         val filter = IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
         reactApplicationContext.registerReceiver(powerReceiver, filter)
     }
@@ -75,11 +79,14 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
     @ReactMethod
     fun getDefaultRingtoneUrl(promise: Promise) {
         val defaultRingtoneUri: Uri? =
-            RingtoneUtil.getActualDefaultRingtoneUri(reactApplicationContext);
+            RingtoneUtil.getActualDefaultRingtoneUri(reactApplicationContext)
         if (defaultRingtoneUri != null) {
-            promise.resolve(defaultRingtoneUri.toString());
+            promise.resolve(defaultRingtoneUri.toString())
         } else {
-            promise.reject(NAME, "Cannot get default ringtone in Android - check native logs for more info");
+            promise.reject(
+                NAME,
+                "Cannot get default ringtone in Android - check native logs for more info"
+            )
         }
     }
 
@@ -115,9 +122,9 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
         try {
             if (value) {
                 activity.setPictureInPictureParams(getPiPParams().build())
-            // NOTE: for SDK_INT < Build.VERSION_CODES.S
-            // onUserLeaveHint from Activity is used, SDK cant directly use it
-            // onUserLeaveHint will call the PiP listener and we call enterPictureInPictureMode there
+                // NOTE: for SDK_INT < Build.VERSION_CODES.S
+                // onUserLeaveHint from Activity is used, SDK cant directly use it
+                // onUserLeaveHint will call the PiP listener and we call enterPictureInPictureMode there
             } else {
                 val params = PictureInPictureParams.Builder()
                 params.setAutoEnterEnabled(false)
@@ -132,8 +139,9 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
     fun startThermalStatusUpdates(promise: Promise) {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                val powerManager = reactApplicationContext.getSystemService(ReactApplicationContext.POWER_SERVICE) as PowerManager
-                
+                val powerManager =
+                    reactApplicationContext.getSystemService(ReactApplicationContext.POWER_SERVICE) as PowerManager
+
                 val listener = PowerManager.OnThermalStatusChangedListener { status ->
                     val thermalStatus = when (status) {
                         PowerManager.THERMAL_STATUS_NONE -> "NONE"
@@ -145,12 +153,12 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
                         PowerManager.THERMAL_STATUS_SHUTDOWN -> "SHUTDOWN"
                         else -> "UNKNOWN"
                     }
-                    
+
                     reactApplicationContext
                         .getJSModule(RCTDeviceEventEmitter::class.java)
                         .emit("thermalStateDidChange", thermalStatus)
                 }
-                
+
                 thermalStatusListener = listener
                 powerManager.addThermalStatusListener(listener)
                 // Get initial status
@@ -166,7 +174,8 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
     @ReactMethod
     fun stopThermalStatusUpdates() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val powerManager = reactApplicationContext.getSystemService(ReactApplicationContext.POWER_SERVICE) as PowerManager
+            val powerManager =
+                reactApplicationContext.getSystemService(ReactApplicationContext.POWER_SERVICE) as PowerManager
             // Store the current listener in a local val for safe null checking
             val currentListener = thermalStatusListener
             if (currentListener != null) {
@@ -180,7 +189,8 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
     fun currentThermalState(promise: Promise) {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                val powerManager = reactApplicationContext.getSystemService(ReactApplicationContext.POWER_SERVICE) as PowerManager
+                val powerManager =
+                    reactApplicationContext.getSystemService(ReactApplicationContext.POWER_SERVICE) as PowerManager
                 val status = powerManager.currentThermalStatus
                 val thermalStatus = when (status) {
                     PowerManager.THERMAL_STATUS_NONE -> "NONE"
@@ -210,7 +220,8 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
     }
 
     private fun sendPowerModeEvent() {
-        val powerManager = reactApplicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+        val powerManager =
+            reactApplicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
         val isLowPowerMode = powerManager.isPowerSaveMode
         reactApplicationContext
             .getJSModule(RCTDeviceEventEmitter::class.java)
@@ -220,7 +231,8 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
     @ReactMethod
     fun isLowPowerModeEnabled(promise: Promise) {
         try {
-            val powerManager = reactApplicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+            val powerManager =
+                reactApplicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
             promise.resolve(powerManager.isPowerSaveMode)
         } catch (e: Exception) {
             promise.reject("ERROR", e.message)
@@ -228,14 +240,25 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) : Reac
     }
 
     private fun hasPiPSupport(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && reactApplicationContext.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && reactApplicationContext.packageManager.hasSystemFeature(
+                PackageManager.FEATURE_PICTURE_IN_PICTURE
+            )
+        ) {
             val appOps =
                 reactApplicationContext.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
             val packageName = reactApplicationContext.packageName
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                appOps.unsafeCheckOpNoThrow(AppOpsManager.OPSTR_PICTURE_IN_PICTURE, Process.myUid(), packageName) == AppOpsManager.MODE_ALLOWED
+                appOps.unsafeCheckOpNoThrow(
+                    AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
+                    Process.myUid(),
+                    packageName
+                ) == AppOpsManager.MODE_ALLOWED
             } else {
-                appOps.checkOpNoThrow(AppOpsManager.OPSTR_PICTURE_IN_PICTURE, Process.myUid(), packageName) == AppOpsManager.MODE_ALLOWED
+                appOps.checkOpNoThrow(
+                    AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
+                    Process.myUid(),
+                    packageName
+                ) == AppOpsManager.MODE_ALLOWED
             }
         } else {
             false


### PR DESCRIPTION
## Bug

When activity flag is not enabled

![image](https://github.com/user-attachments/assets/879b51c4-3297-45dd-aa1d-b681f88f3763)

## Test

- [x] Without PiP enabled - no crash
- [x] With PiP enabled - PiP should work automatically