### PR TITLE
fix(LivestreamPlayer): don't render any component until `call` is ready

### DIFF
--- a/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
+++ b/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
@@ -41,6 +41,8 @@ export const LivestreamPlayer = (props: LivestreamPlayerProps) => {
     };
   }, [callId, callType, client]);
 
+  if (!call) return null;
+
   return (
     <StreamCall call={call}>
       <LivestreamLayout {...layoutProps} />


### PR DESCRIPTION
### Overview

More context: https://linear.app/stream/issue/MAR-238/running-livestream-react-tutorial-causes-error

Fixes:
```
You are using useCallState() outside a Call context. Please wrap your component in <StreamCall /> and provide a "call" instance. Error Component Stack
    at LivestreamLayout (@stream-io_video-react-sdk.js?v=757bf647:35805:16)
    at StreamCallProvider (@stream-io_video-react-sdk.js?v=757bf647:26471:11)
    at LivestreamPlayer (@stream-io_video-react-sdk.js?v=757bf647:36019:11)
    at StreamI18nProvider (@stream-io_video-react-sdk.js?v=757bf647:26552:29)
    at StreamVideoProvider (@stream-io_video-react-sdk.js?v=757bf647:26579:30)
    at StreamVideo (<anonymous>)
    at App (<anonymous>)
    at div (<anonymous>)
    at StreamTheme (@stream-io_video-react-sdk.js?v=757bf647:35523:26)
```