### PR TITLE
feat: [VID-315] allow filtering participants using filter object

### DIFF
--- a/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
@@ -77,6 +77,21 @@ export type PaginatedGridLayoutProps = {
 
   /**
    * Predicate to filter call participants or a filter object.
+   * @example
+   * // With a predicate:
+   * <PaginatedGridLayout
+   *   filterParticipants={p => p.roles.includes('student')}
+   * />
+   * @example
+   * // With a filter object:
+   * <PaginatedGridLayout
+   *   filterParticipants={{
+   *     $or: [
+   *       { roles: { $contains: 'student' } },
+   *       { isPinned: true },
+   *     ],
+   *   }}
+   * />
    */
   filterParticipants?: ParticipantPredicate | ParticipantFilter;
 

--- a/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
@@ -76,7 +76,7 @@ export type PaginatedGridLayoutProps = {
   excludeLocalParticipant?: boolean;
 
   /**
-   * Predicate to filter call participants.
+   * Predicate to filter call participants or a filter object.
    */
   filterParticipants?: ParticipantPredicate | ParticipantFilter;
 

--- a/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
@@ -11,7 +11,12 @@ import {
 import { ParticipantsAudio } from '../Audio';
 import { IconButton } from '../../../components';
 import { chunk } from '../../../utilities';
-import { useFilteredParticipants, usePaginatedLayoutSortPreset } from './hooks';
+import {
+  ParticipantFilter,
+  ParticipantPredicate,
+  useFilteredParticipants,
+  usePaginatedLayoutSortPreset,
+} from './hooks';
 
 const GROUP_SIZE = 16;
 
@@ -73,7 +78,7 @@ export type PaginatedGridLayoutProps = {
   /**
    * Predicate to filter call participants.
    */
-  filterParticipants?: (participant: StreamVideoParticipant) => boolean;
+  filterParticipants?: ParticipantPredicate | ParticipantFilter;
 
   /**
    * When set to `false` disables mirroring of the local partipant's video.

--- a/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState } from 'react';
 import clsx from 'clsx';
-import {
-  hasScreenShare,
-  StreamVideoParticipant,
-} from '@stream-io/video-client';
+import { hasScreenShare } from '@stream-io/video-client';
 import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
 
 import {
@@ -16,7 +13,12 @@ import {
   useHorizontalScrollPosition,
   useVerticalScrollPosition,
 } from '../../../hooks';
-import { useFilteredParticipants, useSpeakerLayoutSortPreset } from './hooks';
+import {
+  ParticipantFilter,
+  ParticipantPredicate,
+  useFilteredParticipants,
+  useSpeakerLayoutSortPreset,
+} from './hooks';
 import { useCalculateHardLimit } from '../../hooks/useCalculateHardLimit';
 import { ParticipantsAudio } from '../Audio';
 
@@ -47,7 +49,7 @@ export type SpeakerLayoutProps = {
   /**
    * Predicate to filter call participants.
    */
-  filterParticipants?: (participant: StreamVideoParticipant) => boolean;
+  filterParticipants?: ParticipantPredicate | ParticipantFilter;
   /**
    * When set to `false` disables mirroring of the local participant's video.
    * @default true

--- a/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
@@ -48,6 +48,21 @@ export type SpeakerLayoutProps = {
   excludeLocalParticipant?: boolean;
   /**
    * Predicate to filter call participants or a filter object.
+   * @example
+   * // With a predicate:
+   * <SpeakerLayout
+   *   filterParticipants={p => p.roles.includes('student')}
+   * />
+   * @example
+   * // With a filter object:
+   * <SpeakerLayout
+   *   filterParticipants={{
+   *     $or: [
+   *       { roles: { $contains: 'student' } },
+   *       { isPinned: true },
+   *     ],
+   *   }}
+   * />
    */
   filterParticipants?: ParticipantPredicate | ParticipantFilter;
   /**

--- a/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
@@ -47,7 +47,7 @@ export type SpeakerLayoutProps = {
    */
   excludeLocalParticipant?: boolean;
   /**
-   * Predicate to filter call participants.
+   * Predicate to filter call participants or a filter object.
    */
   filterParticipants?: ParticipantPredicate | ParticipantFilter;
   /**

--- a/packages/react-sdk/src/core/components/CallLayout/hooks.ts
+++ b/packages/react-sdk/src/core/components/CallLayout/hooks.ts
@@ -39,33 +39,38 @@ export const useFilteredParticipants = ({
       ? remoteParticipants
       : allParticipants;
 
-    if (!filterParticipants) {
-      return unfilteredParticipants;
-    }
-
-    const filterCallback =
-      typeof filterParticipants === 'function'
-        ? filterParticipants
-        : (participant: StreamVideoParticipant) =>
-            applyFilter(
-              {
-                userId: participant.userId,
-                isSpeaking: participant.isSpeaking,
-                isDominantSpeaker: participant.isDominantSpeaker,
-                name: participant.name,
-                roles: participant.roles,
-                isPinned: isPinned(participant),
-              },
-              filterParticipants,
-            );
-
-    return unfilteredParticipants.filter(filterCallback);
+    return filterParticipants
+      ? applyParticipantsFilter(unfilteredParticipants, filterParticipants)
+      : unfilteredParticipants;
   }, [
     allParticipants,
     remoteParticipants,
     excludeLocalParticipant,
     filterParticipants,
   ]);
+};
+
+export const applyParticipantsFilter = (
+  participants: StreamVideoParticipant[],
+  filter: ParticipantPredicate | ParticipantFilter,
+) => {
+  const filterCallback =
+    typeof filter === 'function'
+      ? filter
+      : (participant: StreamVideoParticipant) =>
+          applyFilter(
+            {
+              userId: participant.userId,
+              isSpeaking: participant.isSpeaking,
+              isDominantSpeaker: participant.isDominantSpeaker,
+              name: participant.name,
+              roles: participant.roles,
+              isPinned: isPinned(participant),
+            },
+            filter,
+          );
+
+  return participants.filter(filterCallback);
 };
 
 export const usePaginatedLayoutSortPreset = (call: Call | undefined) => {

--- a/packages/react-sdk/src/core/components/CallLayout/index.ts
+++ b/packages/react-sdk/src/core/components/CallLayout/index.ts
@@ -1,3 +1,8 @@
 export * from './LivestreamLayout';
 export * from './PaginatedGridLayout';
 export * from './SpeakerLayout';
+export type {
+  FilterableParticipant,
+  ParticipantFilter,
+  ParticipantPredicate,
+} from './hooks';

--- a/packages/react-sdk/src/core/components/CallLayout/partcipantFilter.test.ts
+++ b/packages/react-sdk/src/core/components/CallLayout/partcipantFilter.test.ts
@@ -1,0 +1,65 @@
+import { StreamVideoParticipant } from '@stream-io/video-client';
+import { test, type TestContext } from 'node:test';
+import { applyParticipantsFilter } from './hooks';
+
+const participants = [
+  {
+    userId: 'host-id',
+    isSpeaking: true,
+    isDominantSpeaker: true,
+    name: 'Host',
+    roles: ['host', 'admin'],
+  },
+  {
+    userId: 'listener-id-1',
+    isSpeaking: false,
+    isDominantSpeaker: false,
+    name: 'Listener 1',
+    roles: ['listener', 'user'],
+    pin: { pinnedAt: new Date() },
+  },
+  {
+    userId: 'listener-id-2',
+    isSpeaking: false,
+    isDominantSpeaker: false,
+    name: 'Listener 2',
+    roles: ['listener', 'user'],
+  },
+] as StreamVideoParticipant[];
+
+test('applies predicate filter', (t: TestContext) => {
+  const filtered = applyParticipantsFilter(participants, (p) =>
+    p.roles.includes('listener'),
+  );
+
+  t.assert.strictEqual(filtered.length, 2);
+  t.assert.deepStrictEqual(
+    filtered.map((p) => p.userId),
+    ['listener-id-1', 'listener-id-2'],
+  );
+});
+
+test('applies filter object', (t: TestContext) => {
+  const filtered = applyParticipantsFilter(participants, {
+    $and: [
+      { roles: { $contains: 'listener' } },
+      { $not: { roles: { $contains: 'host' } } },
+    ],
+  });
+
+  t.assert.strictEqual(filtered.length, 2);
+  t.assert.deepStrictEqual(
+    filtered.map((p) => p.userId),
+    ['listener-id-1', 'listener-id-2'],
+  );
+});
+
+test('filter object supports boolean pin property', (t: TestContext) => {
+  const filtered = applyParticipantsFilter(participants, {
+    roles: { $contains: 'listener' },
+    isPinned: true,
+  });
+
+  t.assert.strictEqual(filtered.length, 1);
+  t.assert.strictEqual(filtered[0].userId, 'listener-id-1');
+});

--- a/packages/react-sdk/src/utilities/filter.test.ts
+++ b/packages/react-sdk/src/utilities/filter.test.ts
@@ -1,0 +1,119 @@
+import { test, type TestContext } from 'node:test';
+import { applyFilter } from './filter';
+
+const obj = {
+  num: 42,
+  str: 'hello, world',
+  array: ['apples', 'bananas'],
+};
+
+test('checks single $eq condition', (t: TestContext) => {
+  t.assert.ok(applyFilter(obj, { num: { $eq: 42 } }));
+  t.assert.ok(!applyFilter(obj, { num: { $eq: 43 } }));
+});
+
+test('checks single $neq condition', (t: TestContext) => {
+  t.assert.ok(applyFilter(obj, { num: { $neq: 43 } }));
+  t.assert.ok(!applyFilter(obj, { num: { $neq: 42 } }));
+});
+
+test('checks single $in condition', (t: TestContext) => {
+  t.assert.ok(applyFilter(obj, { num: { $in: [41, 42, 43] } }));
+  t.assert.ok(!applyFilter(obj, { num: { $in: [1, 2, 3] } }));
+});
+
+test('checks single $contains condition', (t: TestContext) => {
+  t.assert.ok(applyFilter(obj, { array: { $contains: 'apples' } }));
+  t.assert.ok(!applyFilter(obj, { array: { $contains: 'cherries' } }));
+});
+
+test('fails $contains condition if value is not array', (t: TestContext) => {
+  // This case is not permitted by types, but can still happen in runtime
+  t.assert.ok(!applyFilter(obj as any, { str: { $contains: 'apples' } }));
+});
+
+test('conditions without operator are treated as $eq', (t: TestContext) => {
+  t.assert.ok(applyFilter(obj, { num: 42 }));
+  t.assert.ok(!applyFilter(obj, { num: 43 }));
+});
+
+test('checks multiple conditions', (t: TestContext) => {
+  t.assert.ok(applyFilter(obj, { num: 42, array: { $contains: 'bananas' } }));
+  t.assert.ok(!applyFilter(obj, { num: 42, array: { $contains: 'cherries' } }));
+});
+
+test('applies $and filter', (t: TestContext) => {
+  t.assert.ok(
+    applyFilter(obj, {
+      $and: [
+        { num: 42, array: { $contains: 'bananas' } },
+        { str: 'hello, world', array: { $contains: 'apples' } },
+      ],
+    }),
+  );
+
+  t.assert.ok(
+    !applyFilter(obj, {
+      $and: [
+        { num: 42, array: { $contains: 'bananas' } },
+        { str: 'hello, world', array: { $contains: 'cherries' } },
+      ],
+    }),
+  );
+});
+
+test('applies $or filter', (t: TestContext) => {
+  t.assert.ok(
+    applyFilter(obj, {
+      $or: [
+        { str: 'hello, world', array: { $contains: 'cherries' } },
+        { num: 42, array: { $contains: 'bananas' } },
+      ],
+    }),
+  );
+
+  t.assert.ok(
+    !applyFilter(obj, {
+      $or: [
+        { str: 'hello, world', array: { $contains: 'cherries' } },
+        { num: 43, array: { $contains: 'bananas' } },
+      ],
+    }),
+  );
+});
+
+test('applies $not filter', (t: TestContext) => {
+  t.assert.ok(
+    applyFilter(obj, {
+      $not: { str: 'hello, world', array: { $contains: 'cherries' } },
+    }),
+  );
+});
+
+test('applies nested filters', (t: TestContext) => {
+  t.assert.ok(
+    applyFilter(obj, {
+      $or: [
+        { str: 'hello, world', array: { $contains: 'cherries' } },
+        { $and: [{ num: 42 }, { array: { $contains: 'bananas' } }] },
+      ],
+    }),
+  );
+
+  t.assert.ok(
+    applyFilter(obj, {
+      $not: {
+        $or: [
+          { str: 'hello, world', array: { $contains: 'cherries' } },
+          {
+            $and: [
+              { num: 42 },
+              { array: { $contains: 'bananas' } },
+              { str: 'bye, world' },
+            ],
+          },
+        ],
+      },
+    }),
+  );
+});

--- a/packages/react-sdk/src/utilities/filter.ts
+++ b/packages/react-sdk/src/utilities/filter.ts
@@ -1,0 +1,79 @@
+export type Filter<T> =
+  | { $and: Array<Filter<T>> }
+  | { $or: Array<Filter<T>> }
+  | { $not: Filter<T> }
+  | Conditions<T>;
+
+type Conditions<T> = {
+  [K in keyof T]?: T[K] extends Array<infer E>
+    ? ArrayOperator<E>
+    : ScalarOperator<T[K]>;
+};
+
+export type ScalarOperator<T> =
+  | EqOperator<T>
+  | NeqOperator<T>
+  | InOperator<T>
+  | T;
+
+export type ArrayOperator<T> = ContainsOperator<T>;
+
+export type EqOperator<T> = { $eq: T };
+export type NeqOperator<T> = { $neq: T };
+export type InOperator<T> = { $in: Array<T> };
+export type ContainsOperator<T> = { $contains: T };
+
+export function applyFilter<T>(obj: T, filter: Filter<T>): boolean {
+  if ('$and' in filter) {
+    return filter.$and.every((f) => applyFilter(obj, f));
+  }
+
+  if ('$or' in filter) {
+    return filter.$or.some((f) => applyFilter(obj, f));
+  }
+
+  if ('$not' in filter) {
+    return !applyFilter(obj, filter.$not);
+  }
+
+  return checkConditions(obj, filter);
+}
+
+function checkConditions<T>(obj: T, conditions: Conditions<T>): boolean {
+  let match = true;
+
+  for (const key of Object.keys(conditions) as Array<keyof T>) {
+    const operator = conditions[key];
+    const maybeOperator = operator && typeof operator === 'object';
+    let value = obj[key];
+
+    if (maybeOperator && '$eq' in operator) {
+      const eqOperator = operator as EqOperator<typeof value>;
+      match &&= eqOperator.$eq === value;
+    } else if (maybeOperator && '$neq' in operator) {
+      const neqOperator = operator as NeqOperator<typeof value>;
+      match &&= neqOperator.$neq !== value;
+    } else if (maybeOperator && '$in' in operator) {
+      const inOperator = operator as InOperator<typeof value>;
+      match &&= inOperator.$in.includes(value);
+    } else if (maybeOperator && '$contains' in operator) {
+      if (Array.isArray(value)) {
+        const containsOperator = operator as ContainsOperator<
+          (typeof value)[number]
+        >;
+        match &&= value.includes(containsOperator.$contains);
+      } else {
+        match = false;
+      }
+    } else {
+      const eqValue = operator as typeof value;
+      match &&= eqValue === value;
+    }
+
+    if (!match) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/sample-apps/react/egress-composite/src/ConfigurationContext.tsx
+++ b/sample-apps/react/egress-composite/src/ConfigurationContext.tsx
@@ -1,6 +1,10 @@
 import { createContext, useContext } from 'react';
 import { decode } from 'js-base64';
-import { LogLevel, StreamVideoParticipant } from '@stream-io/video-react-sdk';
+import {
+  LogLevel,
+  ParticipantFilter,
+  StreamVideoParticipant,
+} from '@stream-io/video-react-sdk';
 
 import { Layout, ScreenshareLayout } from './components/layouts';
 
@@ -81,6 +85,7 @@ export type ConfigurationValue = {
     'participant.outline_width'?: string;
     'participant.border_radius'?: string | number;
     'participant.placeholder_background_color'?: string;
+    'participant.filter'?: ParticipantFilter;
 
     // ✅
     'participant_label.display'?: boolean;

--- a/sample-apps/react/egress-composite/src/components/layouts/PaginatedGrid/PaginatedGrid.tsx
+++ b/sample-apps/react/egress-composite/src/components/layouts/PaginatedGrid/PaginatedGrid.tsx
@@ -8,7 +8,10 @@ import './PaginatedGrid.scss';
 
 export const PaginatedGrid = () => {
   const {
-    options: { 'layout.grid.page_size': pageSize = 20 },
+    options: {
+      'layout.grid.page_size': pageSize = 20,
+      'participant.filter': filterParticipants,
+    },
   } = useConfigurationContext();
 
   return (
@@ -21,6 +24,7 @@ export const PaginatedGrid = () => {
           />
         }
         excludeLocalParticipant
+        filterParticipants={filterParticipants}
         pageArrowsVisible={false}
         groupSize={pageSize}
       />

--- a/sample-apps/react/egress-composite/src/components/layouts/Spotlight/Spotlight.tsx
+++ b/sample-apps/react/egress-composite/src/components/layouts/Spotlight/Spotlight.tsx
@@ -11,6 +11,7 @@ export const Spotlight = () => {
     options: {
       'layout.spotlight.participants_bar_position': position = 'bottom',
       'layout.spotlight.participants_bar_limit': limit = 'dynamic',
+      'participant.filter': filterParticipants,
     },
   } = useConfigurationContext();
 
@@ -20,6 +21,7 @@ export const Spotlight = () => {
         participantsBarPosition={position}
         participantsBarLimit={limit}
         excludeLocalParticipant
+        filterParticipants={filterParticipants}
         pageArrowsVisible={false}
         ParticipantViewUIBar={
           <DefaultParticipantViewUI


### PR DESCRIPTION
This PR adds support for filtering participants using a filter object instead of a predicate. Filter object looks something like this:

```js
// Render video only from pinned participants
// or participants with the role "presenter"
{
  $or: [
    { isPinned: true },
    { roles: { $contains: 'presenter' } },
  ],
}
```

(For more examples of what kinds of operators we allow, see `filters.test.ts`.)

Filtering is supported for a subset of participant properties:
- userId: string
- isSpeaking: boolean
- isDominantSpeaker: boolean
- name: string
- roles: string[]
- isPinned: boolean

`SpeakerLayout` and `PaginatedGridLayout` now accept filter objects in their `filterParticipants` prop:

```jsx
<SpeakerLayout
  filterParticipants={{
    $or: [
      { roles: { $contains: 'student' } },
      { isPinned: true },
    ],
  }}
/>
```

This is particularly useful for the composite app, because a filter object (unlike a predicate) can be passed in configuration. So the new optional configuration option is added to the composite app: `participant.filter`. It is supported by built-in layouts.