### PR TITLE
fix: ensures that maxBitrate is an integer

### DIFF
--- a/packages/client/src/rtc/__tests__/videoLayers.test.ts
+++ b/packages/client/src/rtc/__tests__/videoLayers.test.ts
@@ -257,6 +257,23 @@ describe('videoLayers', () => {
     });
   });
 
+  it('should use integer for maxBitrate', () => {
+    const track = new MediaStreamTrack();
+    const layers = computeVideoLayers(track, {
+      bitrate: 2999777,
+      // @ts-expect-error - incomplete data
+      codec: { name: 'vp8' },
+      videoDimension: { width: 1920, height: 1080 },
+      fps: 30,
+    });
+    expect(layers).toBeDefined();
+    for (const layer of layers!) {
+      expect(Number.isInteger(layer.width)).toBe(true);
+      expect(Number.isInteger(layer.height)).toBe(true);
+      expect(Number.isInteger(layer.maxBitrate)).toBe(true);
+    }
+  });
+
   describe('getComputedMaxBitrate', () => {
     it('should scale target bitrate down if resolution is smaller than target resolution', () => {
       const targetResolution = { width: 1920, height: 1080, bitrate: 3000000 };

--- a/packages/client/src/rtc/videoLayers.ts
+++ b/packages/client/src/rtc/videoLayers.ts
@@ -109,7 +109,8 @@ export const computeVideoLayers = (
       rid,
       width: Math.round(width / downscaleFactor),
       height: Math.round(height / downscaleFactor),
-      maxBitrate: maxBitrate / bitrateFactor || defaultBitratePerRid[rid],
+      maxBitrate:
+        Math.round(maxBitrate / bitrateFactor) || defaultBitratePerRid[rid],
       maxFramerate: fps,
     };
     if (svcCodec) {


### PR DESCRIPTION
### Overview

Fixes a regression introduced with #1527. 
We must ensure that the `maxBbitrate` value is an integer as otherwise, floating point numbers fail to be serialized when `sfu.SetPublisher()` RPC is invoked, leading to issues where the other participant couldn't see the affected participant's video.