### PR TITLE
fix: add callkit audio methods for expo

### DIFF
--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withAppDelegate.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withAppDelegate.test.ts
@@ -95,6 +95,17 @@ describe('withStreamVideoReactNativeSDKAppDelegate', () => {
     );
     expect(updatedConfig.modResults.contents).toMatch(/reportNewIncomingCall/);
 
+    expect(updatedConfig.modResults.contents).toMatch(
+      /#import <WebRTC\/RTCAudioSession.h>/
+    );
+
+    expect(updatedConfig.modResults.contents).toMatch(
+      /audioSessionDidActivate/
+    );
+    expect(updatedConfig.modResults.contents).toMatch(
+      /audioSessionDidDeactivate/
+    );
+
     modifiedConfig = updatedConfig;
   });
 

--- a/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
@@ -181,7 +181,7 @@ function addAudioSessionMethods(contents: string) {
     );
     if (!codeblock) {
       contents = addNewLinesToAppDelegate(contents, [
-        '- (void) provider:(CXProvider *) provider didActivateAudioSession:(AVAudioSession *) audioSession',
+        '- (void) provider:(CXProvider *) provider didActivateAudioSession:(AVAudioSession *) audioSession {',
         '  ' /* indentation */ + audioSessionDidActivateMethod,
         '}',
       ]);
@@ -197,14 +197,14 @@ function addAudioSessionMethods(contents: string) {
   const audioSessionDidDeactivateMethod =
     '[[RTCAudioSession sharedInstance] audioSessionDidDeactivate:[AVAudioSession sharedInstance]];';
 
-  if (!audioSessionDidDeactivateMethod) {
+  if (!contents.includes(audioSessionDidDeactivateMethod)) {
     const codeblock = findObjcFunctionCodeBlock(
       contents,
       DID_DEACTIVATE_AUDIO_SESSION
     );
     if (!codeblock) {
       contents = addNewLinesToAppDelegate(contents, [
-        '- (void) provider:(CXProvider *) provider didDeactivateAudioSession:(AVAudioSession *) audioSession',
+        '- (void) provider:(CXProvider *) provider didDeactivateAudioSession:(AVAudioSession *) audioSession {',
         '  ' /* indentation */ + audioSessionDidDeactivateMethod,
         '}',
       ]);

--- a/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
@@ -17,12 +17,8 @@ const DID_UPDATE_PUSH_CREDENTIALS =
   'pushRegistry:didUpdatePushCredentials:forType:';
 const DID_RECEIVE_INCOMING_PUSH =
   'pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:';
-
-// - (void) provider:(CXProvider *) provider didActivateAudioSession:(AVAudioSession *) audioSession {
 const DID_ACTIVATE_AUDIO_SESSION =
   'provider:didActivateAudioSession:audioSession';
-
-// - (void) provider:(CXProvider *) provider didDeactivateAudioSession:(AVAudioSession *) audioSession {
 const DID_DEACTIVATE_AUDIO_SESSION =
   'provider:didDeactivateAudioSession:audioSession';
 


### PR DESCRIPTION
added the new callkit integration methods in [webrtc](https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/iOSInstallation.md#callkit) for expo config plugin