### PR TITLE
fix: open fg service only on a successful join

### DIFF
--- a/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
+++ b/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
@@ -7,7 +7,6 @@ import {
   getNotifeeLibNoThrowForKeepCallAlive,
   getKeepCallAliveForegroundServiceTypes,
 } from '../utils/push/libs/notifee';
-import { usePrevious } from '../utils/hooks';
 
 const notifeeLib = getNotifeeLibNoThrowForKeepCallAlive();
 
@@ -86,23 +85,12 @@ export const useAndroidKeepCallAliveEffect = () => {
   const { useCallCallingState } = useCallStateHooks();
   const callingState = useCallCallingState();
 
-  const prevCallingState = usePrevious(callingState);
-
-  const isStartingToJoin =
-    prevCallingState === CallingState.IDLE &&
-    callingState === CallingState.JOINING;
-  const isStartingToJoinFromRinging =
-    prevCallingState === CallingState.RINGING &&
-    callingState === CallingState.JOINING;
   const isOutgoingCall =
     callingState === CallingState.RINGING && call?.isCreatedByMe;
   const isCallJoined = callingState === CallingState.JOINED;
 
   const shouldStartForegroundService =
-    isStartingToJoin ||
-    isStartingToJoinFromRinging ||
-    isOutgoingCall ||
-    isCallJoined;
+    !foregroundServiceStartedRef.current && (isOutgoingCall || isCallJoined);
 
   useEffect((): (() => void) | undefined => {
     if (Platform.OS === 'ios' || !activeCallCid) {


### PR DESCRIPTION
Joining can fail due to permission errors, so open FG service only on successful join