### PR TITLE
fix: closed captions and speaker border bugfixes

### DIFF
--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantView.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantView.tsx
@@ -117,7 +117,6 @@ export const ParticipantView = ({
   const isScreenSharing = trackType === 'screenShareTrack';
   const applySpeakerStyle = isSpeaking && !isScreenSharing;
   const speakerStyle = applySpeakerStyle && [
-    styles.highlightedContainer,
     { borderColor: colors.buttonPrimary },
     participantView.highlightedContainer,
   ];
@@ -181,9 +180,6 @@ const useStyles = () => {
           flexDirection: 'row',
           justifyContent: 'space-between',
           alignItems: 'center',
-        },
-        highlightedContainer: {
-          borderWidth: 2,
         },
         networkIndicatorOnly: { justifyContent: 'flex-end' },
       }),

--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantView.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantView.tsx
@@ -174,6 +174,8 @@ const useStyles = () => {
           overflow: 'hidden',
           justifyContent: 'flex-end',
           borderRadius: theme.variants.borderRadiusSizes.md,
+          borderWidth: 2,
+          borderColor: 'transparent',
         },
         footerContainer: {
           flexDirection: 'row',

--- a/sample-apps/react-native/dogfood/src/components/BottomControlsDrawer.tsx
+++ b/sample-apps/react-native/dogfood/src/components/BottomControlsDrawer.tsx
@@ -59,11 +59,9 @@ export const BottomControlsDrawer: React.FC<DrawerProps> = ({
   ).current;
 
   const SNAP_TOP = offset;
-  const SNAP_BOTTOM = drawerHeight + offset;
-  const SNAP_MIDDLE = drawerHeight * 0.5;
-
+  const SNAP_BOTTOM = (drawerHeight + offset) / 2;
   const getClosestSnapPoint = (y: number) => {
-    const points = [SNAP_TOP, SNAP_MIDDLE, SNAP_BOTTOM];
+    const points = [SNAP_TOP, SNAP_BOTTOM];
     return points.reduce((prev, curr) =>
       Math.abs(curr - y) < Math.abs(prev - y) ? curr : prev,
     );

--- a/sample-apps/react-native/dogfood/src/components/ClosedCaptions.tsx
+++ b/sample-apps/react-native/dogfood/src/components/ClosedCaptions.tsx
@@ -26,17 +26,24 @@ const useStyles = () => {
         rootContainer: {
           backgroundColor: theme.colors.sheetPrimary,
           padding: theme.variants.spacingSizes.md,
-          height: 55,
+          width: '100%',
+          minHeight: 55,
         },
         closedCaptionItem: {
           flexDirection: 'row',
+          flexWrap: 'wrap',
+          flexShrink: 1,
           gap: theme.variants.spacingSizes.xs,
+          alignItems: 'flex-start',
+          marginBottom: 4,
         },
         speakerName: {
           color: theme.colors.textSecondary,
         },
         closedCaption: {
           color: theme.colors.textPrimary,
+          flexShrink: 1,
+          flex: 1,
         },
       }),
     [theme],


### PR DESCRIPTION
## Overview
- adds default transparent border to the speaker, so when speaker is active the blue border does not resize the video of the current speaker which previously led to a lot of unnecessary SFU updateSubscriptions requests 
- fixes the closed captions formatting when there are long messages
- fixes the bottom snap point of the controls drawer in the dogfood app

<img src="https://github.com/user-attachments/assets/076ab375-b861-46db-89d3-2ec749a65676" alt="ios-after" width="200" height="440"/>

