### PR TITLE
fix: race condition with unrecoverable error handling 

### DIFF
--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -31,7 +31,7 @@ export abstract class BasePeerConnection {
   protected readonly dispatcher: Dispatcher;
   protected sfuClient: StreamSfuClient;
 
-  private isDisposed = false;
+  protected isDisposed = false;
 
   protected readonly onUnrecoverableError?: () => void;
   protected isIceRestarting = false;
@@ -143,7 +143,9 @@ export abstract class BasePeerConnection {
       observable,
       async (candidate) => {
         return this.pc.addIceCandidate(candidate).catch((e) => {
-          this.logger('warn', `ICE candidate error`, e, candidate);
+          if (!this.isDisposed) {
+            this.logger('warn', `ICE candidate error`, e, candidate);
+          }
         });
       },
     );

--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -31,6 +31,8 @@ export abstract class BasePeerConnection {
   protected readonly dispatcher: Dispatcher;
   protected sfuClient: StreamSfuClient;
 
+  private isDisposed = false;
+
   protected readonly onUnrecoverableError?: () => void;
   protected isIceRestarting = false;
 
@@ -55,7 +57,11 @@ export abstract class BasePeerConnection {
     this.sfuClient = sfuClient;
     this.state = state;
     this.dispatcher = dispatcher;
-    this.onUnrecoverableError = onUnrecoverableError;
+    this.onUnrecoverableError = () => {
+      if (!this.isDisposed) {
+        onUnrecoverableError?.();
+      }
+    };
     this.logger = getLogger([
       peerType === PeerType.SUBSCRIBER ? 'Subscriber' : 'Publisher',
       logTag,
@@ -76,6 +82,7 @@ export abstract class BasePeerConnection {
    * Disposes the `RTCPeerConnection` instance.
    */
   dispose = () => {
+    this.isDisposed = true;
     this.detachEventHandlers();
     this.pc.close();
   };

--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -119,6 +119,7 @@ export abstract class BasePeerConnection {
     this.subscriptions.push(
       this.dispatcher.on(event, (e) => {
         withoutConcurrency(`pc.${event}`, async () => fn(e)).catch((err) => {
+          if (this.isDisposed) return;
           this.logger('warn', `Error handling ${event}`, err);
         });
       }),
@@ -140,6 +141,7 @@ export abstract class BasePeerConnection {
       observable,
       async (candidate) => {
         return this.pc.addIceCandidate(candidate).catch((e) => {
+          if (this.isDisposed) return;
           this.logger('warn', `ICE candidate error`, e, candidate);
         });
       },
@@ -177,7 +179,10 @@ export abstract class BasePeerConnection {
     const iceCandidate = this.toJSON(candidate);
     this.sfuClient
       .iceTrickle({ peerType: this.peerType, iceCandidate })
-      .catch((err) => this.logger('warn', `ICETrickle failed`, err));
+      .catch((err) => {
+        if (this.isDisposed) return;
+        this.logger('warn', `ICETrickle failed`, err);
+      });
   };
 
   /**

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -301,6 +301,9 @@ export class Publisher extends BasePeerConnection {
         this.onUnrecoverableError?.();
       },
     );
+        if (!this.isDisposed) {
+          this.logger('error', `Negotiation failed.`, err);
+        }
   };
 
   /**

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -297,13 +297,12 @@ export class Publisher extends BasePeerConnection {
   private onNegotiationNeeded = () => {
     withoutConcurrency('publisher.negotiate', () => this.negotiate()).catch(
       (err) => {
-        this.logger('error', `Negotiation failed.`, err);
-        this.onUnrecoverableError?.();
-      },
-    );
         if (!this.isDisposed) {
           this.logger('error', `Negotiation failed.`, err);
         }
+        this.onUnrecoverableError?.();
+      },
+    );
   };
 
   /**

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -18,7 +18,7 @@ import {
 import { isSvcCodec } from './codecs';
 import { isAudioTrackType } from './helpers/tracks';
 import { extractMid } from './helpers/sdp';
-import { withCancellation, withoutConcurrency } from '../helpers/concurrency';
+import { withCancellation } from '../helpers/concurrency';
 
 export type PublisherConstructorOpts = BasePeerConnectionOpts & {
   publishOptions: PublishOption[];

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -297,9 +297,7 @@ export class Publisher extends BasePeerConnection {
   private onNegotiationNeeded = () => {
     withoutConcurrency('publisher.negotiate', () => this.negotiate()).catch(
       (err) => {
-        if (!this.isDisposed) {
-          this.logger('error', `Negotiation failed.`, err);
-        }
+        this.logger('error', `Negotiation failed.`, err);
         this.onUnrecoverableError?.();
       },
     );


### PR DESCRIPTION
A peer connection may be disposed but a event maybe still being handled..

for example.. say onNegotationNeeded is going on, but leave is called after that is invoked and onNegotationNeeded is not finished, now unrecoverable error function is invoked, which causes a rejoin

this is primarily caused only in RN I think as the peer condition awaits are executing in native thread and not JS thread 

This PR aims to not invoke unrecoverable error callback in peer connections when it is already disposed

additionally removes error logging when peer connection is disposed

fixes #1649 #1618 

## Reproduction

Join and immediately leave call, thank you @kristian-mkd 

![image](https://github.com/user-attachments/assets/4876290a-955c-4424-8fcf-19ef413234ed)

![image](https://github.com/user-attachments/assets/fb9ec110-2036-42e1-bdfb-f8afb49411c5)

![image](https://github.com/user-attachments/assets/15dd65df-b562-4fea-a8eb-e3d696378792)

