### PR TITLE
fix: ensure tracks are stopped when disposing a Publisher

### DIFF
--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -75,12 +75,12 @@ export abstract class BasePeerConnection {
   /**
    * Disposes the `RTCPeerConnection` instance.
    */
-  dispose = () => {
+  dispose() {
     this.onUnrecoverableError = undefined;
     this.isDisposed = true;
     this.detachEventHandlers();
     this.pc.close();
-  };
+  }
 
   /**
    * Detaches the event handlers from the `RTCPeerConnection`.

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -74,6 +74,14 @@ export class Publisher extends BasePeerConnection {
   }
 
   /**
+   * Disposes this Publisher instance.
+   */
+  dispose() {
+    super.dispose();
+    this.stopAllTracks();
+  }
+
+  /**
    * Starts publishing the given track of the given media stream.
    *
    * Consecutive calls to this method will replace the stream.
@@ -98,7 +106,9 @@ export class Publisher extends BasePeerConnection {
       if (!transceiver) {
         this.addTransceiver(trackToPublish, publishOption);
       } else {
+        const previousTrack = transceiver.sender.track;
         await transceiver.sender.replaceTrack(trackToPublish);
+        previousTrack?.stop();
       }
     }
   };
@@ -199,6 +209,15 @@ export class Publisher extends BasePeerConnection {
     for (const item of this.transceiverCache.items()) {
       const { publishOption, transceiver } = item;
       if (!trackTypes.includes(publishOption.trackType)) continue;
+      transceiver.sender.track?.stop();
+    }
+  };
+
+  /**
+   * Stops all the cloned tracks that are being published to the SFU.
+   */
+  stopAllTracks = () => {
+    for (const { transceiver } of this.transceiverCache.items()) {
       transceiver.sender.track?.stop();
     }
   };

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -124,6 +124,8 @@ describe('Publisher', () => {
       vi.spyOn(track, 'clone').mockReturnValue(clone);
 
       const transceiver = new RTCRtpTransceiver();
+      // @ts-ignore test setup
+      transceiver.sender.track = track;
       publisher['transceiverCache'].add(
         publisher['publishOptions'][0],
         transceiver,
@@ -134,6 +136,7 @@ describe('Publisher', () => {
       expect(track.clone).toHaveBeenCalled();
       expect(publisher['pc'].addTransceiver).not.toHaveBeenCalled();
       expect(transceiver.sender.replaceTrack).toHaveBeenCalledWith(clone);
+      expect(track.stop).toHaveBeenCalled();
     });
   });
 
@@ -699,6 +702,13 @@ describe('Publisher', () => {
       const track = cache['cache'][0].transceiver.sender.track;
       vi.spyOn(track, 'stop');
       publisher.stopTracks(TrackType.VIDEO);
+      expect(track!.stop).toHaveBeenCalled();
+    });
+
+    it('stopAllTracks should stop all tracks', () => {
+      const track = cache['cache'][0].transceiver.sender.track;
+      vi.spyOn(track, 'stop');
+      publisher.stopAllTracks();
       expect(track!.stop).toHaveBeenCalled();
     });
   });

--- a/packages/client/src/rtc/__tests__/mocks/webrtc.mocks.ts
+++ b/packages/client/src/rtc/__tests__/mocks/webrtc.mocks.ts
@@ -6,7 +6,7 @@ const RTCPeerConnectionMock = vi.fn((): Partial<RTCPeerConnection> => {
     addIceCandidate: vi.fn(),
     removeEventListener: vi.fn(),
     getTransceivers: vi.fn(),
-    addTransceiver: vi.fn(),
+    addTransceiver: vi.fn().mockReturnValue(new RTCRtpTransceiverMock()),
     getConfiguration: vi.fn(),
     setConfiguration: vi.fn(),
     createOffer: vi.fn().mockResolvedValue({}),

--- a/sample-apps/client/ts-quickstart/package.json
+++ b/sample-apps/client/ts-quickstart/package.json
@@ -9,8 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@stream-io/video-client": "workspace:^",
-    "js-base64": "^3.7.5"
+    "@stream-io/video-client": "workspace:^"
   },
   "devDependencies": {
     "@vitejs/plugin-basic-ssl": "^1.0.1",

--- a/sample-apps/client/ts-quickstart/src/controls.ts
+++ b/sample-apps/client/ts-quickstart/src/controls.ts
@@ -1,4 +1,4 @@
-import { Call } from '@stream-io/video-client';
+import { Call, CallingState } from '@stream-io/video-client';
 
 const renderAudioButton = (call: Call) => {
   const audioButton = document.createElement('button');
@@ -59,6 +59,26 @@ const renderFlipButton = (call: Call) => {
 
   return flipButton;
 };
+const renderLeaveJoinButton = (call: Call) => {
+  const btn = document.createElement('button');
+  btn.addEventListener('click', () => {
+    if (call.state.callingState === CallingState.LEFT) {
+      call.join();
+    } else {
+      call.leave();
+    }
+  });
+
+  call.state.callingState$.subscribe((s) => {
+    if (s !== CallingState.JOINED) {
+      btn.innerText = 'Join';
+    } else {
+      btn.innerText = 'Leave';
+    }
+  });
+
+  return btn;
+};
 
 export const renderControls = (call: Call) => {
   return {
@@ -66,5 +86,6 @@ export const renderControls = (call: Call) => {
     videoButton: renderVideoButton(call),
     screenShareButton: renderScreenShareButton(call),
     flipButton: renderFlipButton(call),
+    leaveJoinCallButton: renderLeaveJoinButton(call),
   };
 };

--- a/sample-apps/client/ts-quickstart/vite.config.ts
+++ b/sample-apps/client/ts-quickstart/vite.config.ts
@@ -2,4 +2,7 @@ import basicSsl from '@vitejs/plugin-basic-ssl';
 
 export default {
   plugins: [basicSsl()],
+  build: {
+    target: 'esnext',
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8212,7 +8212,6 @@ __metadata:
   dependencies:
     "@stream-io/video-client": "workspace:^"
     "@vitejs/plugin-basic-ssl": ^1.0.1
-    js-base64: ^3.7.5
     typescript: ^5.5.2
     vite: ^5.4.6
   languageName: unknown


### PR DESCRIPTION
### Overview

In some circumstances, we were dangling track clones. No data flowed to the SFU, but the browser kept the camera/mic indicators on as there were MediaStreamTrack instances that weren't stopped properly.

### Implementation notes

Upon disposing of a `Publisher`, we now iterate through all transceivers and we explicitly stop the assigned track.
This PR also fixes another issue that could lead to dangling, unstopped tracks when replacing a track on an existing transceiver.