### PR TITLE
fix: do not remove voip listeners for wrong user

### DIFF
--- a/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
@@ -102,6 +102,10 @@ export class StreamVideoRN {
     return Promise.resolve();
   }
 
+  static clearPushLogoutCallbacks() {
+    pushLogoutCallbacks.current = [];
+  }
+
   /**
    * This function is used to add a callback to be called when a new call notification is received.
    * @param callback


### PR DESCRIPTION
### Overview

Consider this scenario where user A logs out and then user B logs in

1. User B logs in, new event listeners are attached
2. StreamVideo useEffect for A unmounts listeners are removed
3. Now there is no more event listeners

This is fixed by this PR

Additionally: also added a method for clearing logout callbacks 
