### PR TITLE
fix: early completion call on iOS remote notifications

### DIFF
--- a/packages/react-native-sdk/src/hooks/push/useIosCallKeepEventsSetupEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useIosCallKeepEventsSetupEffect.ts
@@ -4,7 +4,10 @@ import {
   voipPushNotificationCallCId$,
 } from '../../utils/push/internal/rxSubjects';
 import { getLogger, RxUtils } from '@stream-io/video-client';
-import { getCallKeepLib } from '../../utils/push/libs';
+import {
+  getCallKeepLib,
+  getVoipPushNotificationLib,
+} from '../../utils/push/libs';
 import { StreamVideoRN } from '../../utils/StreamVideoRN';
 import type { StreamVideoConfig } from '../../utils/StreamVideoRN/types';
 import {
@@ -52,21 +55,22 @@ export const useIosCallKeepEventsSetupEffect = () => {
     const { remove: removeDisplayIncomingCall } = callkeep.addEventListener(
       'didDisplayIncomingCall',
       ({ callUUID, payload }) => {
+        const voipPushNotification = getVoipPushNotificationLib();
         // you might want to do following things when receiving this event:
         // - Start playing ringback if it is an outgoing call
         // @ts-expect-error
         const call_cid = payload?.call_cid as string | undefined;
-        if (!call_cid) {
-          return;
-        }
         logger(
           'debug',
-          `didDisplayIncomingCall event with call_cid: ${call_cid}`
+          `didDisplayIncomingCall event with callUUID: ${callUUID} call_cid: ${call_cid}`
         );
-        voipCallkeepCallOnForegroundMap$.next({
-          uuid: callUUID,
-          cid: call_cid,
-        });
+        if (call_cid) {
+          voipCallkeepCallOnForegroundMap$.next({
+            uuid: callUUID,
+            cid: call_cid,
+          });
+        }
+        voipPushNotification.onVoipNotificationCompleted(callUUID);
       }
     );
 

--- a/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
@@ -28,7 +28,7 @@ const logger = getLogger(['useIosVoipPushEventsSetupEffect']);
  hence to support login and logout scenario of multiple users we keep of the last count of the listener that was added
  This helps in not removing the listeners when a new user logs in and overrides the last listener
 */
-let lastListenerCount = 0;
+let lastListener = { count: 0 };
 
 function setLogoutCallback(
   client: StreamVideoClient,
@@ -166,12 +166,12 @@ export const useIosVoipPushEventsSetupEffect = () => {
         }
       }
     });
-    lastListenerCount += 1;
-    const currentListenerCount = lastListenerCount;
+    lastListener.count += 1;
+    const currentListenerCount = lastListener.count;
 
     return () => {
       const userId = client.streamClient._user?.id;
-      if (currentListenerCount !== lastListenerCount) {
+      if (currentListenerCount !== lastListener.count) {
         logger(
           'debug',
           'Skipped removing voip event listeners for user: ' + userId

--- a/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
@@ -305,6 +305,4 @@ const onNotificationReceived = async (notification: any) => {
   // send the info to this subject, it is listened by callkeep events
   // callkeep events will then accept/reject the call
   voipPushNotificationCallCId$.next(call_cid);
-  const voipPushNotification = getVoipPushNotificationLib();
-  voipPushNotification.onVoipNotificationCompleted(uuid);
 };

--- a/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
@@ -266,6 +266,8 @@ const onNotificationReceived = async (notification: any) => {
         `callkeep.reportEndCallWithUUID for uuid: ${uuid}, call_cid: ${call_cid}, reason: ${callkeepReason}`
       );
       callkeep.reportEndCallWithUUID(uuid, callkeepReason);
+      const voipPushNotification = getVoipPushNotificationLib();
+      voipPushNotification.onVoipNotificationCompleted(uuid);
       return true;
     }
     return false;


### PR DESCRIPTION
### Overview

rarely didDisplayIncomingCall comes after onNotificationReceived completes, this is problematic as per the voipNotification library. We must complete only at the last after all are processed it seems. 

But I dont know what the problem is though. 

### Test

Just ensure that JS calls the completion function in all three scenarios

1. Foregrounded app
2. Backgrounded app
3. Killed off app 
