### PR TITLE
fix: do not reconnect when device is offline

### DIFF
--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -206,6 +206,7 @@ export abstract class BasePeerConnection {
     const state = this.pc.iceConnectionState;
     this.logger('debug', `ICE connection state changed`, state);
 
+    if (this.state.callingState === CallingState.OFFLINE) return;
     if (this.state.callingState === CallingState.RECONNECTING) return;
 
     // do nothing when ICE is restarting


### PR DESCRIPTION
### Overview

Fixes this issue:
- A call's B , B answers the call and joins the call
- then A goes offline (lost internet completely), then the calling state of A transitions like this -->   reconnecting  -> joining  -> offline  -> reconnecting

The fix is: **do not Attempt to restart ICE when the device is offline**. When going back to online, the calling state can go back to reconnecting. 

