### PR TITLE
fix: callControls styling issue

### DIFF
--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -13,7 +13,7 @@ import {
   HangUpCallButtonProps,
 } from '../CallControls';
 import { useCallStateHooks } from '@stream-io/video-react-bindings';
-import { CallingState, StreamReaction } from '@stream-io/video-client';
+import { StreamReaction } from '@stream-io/video-client';
 
 import { Z_INDEX } from '../../../constants';
 import { useDebouncedValue } from '../../../utils/hooks';
@@ -117,12 +117,10 @@ export const CallContent = ({
     useHasOngoingScreenShare,
     useRemoteParticipants,
     useLocalParticipant,
-    useCallCallingState,
   } = useCallStateHooks();
 
   useAutoEnterPiPEffect(disablePictureInPicture);
 
-  const callingState = useCallCallingState();
   const callSettings = useCallSettings();
   const isVideoEnabledInCall = callSettings?.video.enabled;
 
@@ -150,12 +148,8 @@ export const CallContent = ({
   useEffect(() => {
     InCallManager.start({ media: isVideoEnabledInCall ? 'video' : 'audio' });
 
-    return () => {
-      if (callingState === CallingState.LEFT) {
-        return InCallManager.stop();
-      }
-    };
-  }, [isVideoEnabledInCall, callingState]);
+    return () => InCallManager.stop();
+  }, [isVideoEnabledInCall]);
 
   const handleFloatingViewParticipantSwitch = () => {
     if (remoteParticipants.length !== 1) {

--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -13,7 +13,7 @@ import {
   HangUpCallButtonProps,
 } from '../CallControls';
 import { useCallStateHooks } from '@stream-io/video-react-bindings';
-import { StreamReaction } from '@stream-io/video-client';
+import { CallingState, StreamReaction } from '@stream-io/video-client';
 
 import { Z_INDEX } from '../../../constants';
 import { useDebouncedValue } from '../../../utils/hooks';
@@ -117,10 +117,12 @@ export const CallContent = ({
     useHasOngoingScreenShare,
     useRemoteParticipants,
     useLocalParticipant,
+    useCallCallingState,
   } = useCallStateHooks();
 
   useAutoEnterPiPEffect(disablePictureInPicture);
 
+  const callingState = useCallCallingState();
   const callSettings = useCallSettings();
   const isVideoEnabledInCall = callSettings?.video.enabled;
 
@@ -148,8 +150,12 @@ export const CallContent = ({
   useEffect(() => {
     InCallManager.start({ media: isVideoEnabledInCall ? 'video' : 'audio' });
 
-    return () => InCallManager.stop();
-  }, [isVideoEnabledInCall]);
+    return () => {
+      if (callingState === CallingState.LEFT) {
+        return InCallManager.stop();
+      }
+    };
+  }, [isVideoEnabledInCall, callingState]);
 
   const handleFloatingViewParticipantSwitch = () => {
     if (remoteParticipants.length !== 1) {

--- a/packages/react-native-sdk/src/components/Call/CallControls/CallControls.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallControls/CallControls.tsx
@@ -32,7 +32,7 @@ export const CallControls = ({
     theme: { colors, callControls },
   } = useTheme();
   const landscapeStyles: ViewStyle = {
-    flexDirection: landscape ? 'column-reverse' : 'row',
+    flexDirection: 'row',
     paddingHorizontal: landscape ? 12 : 0,
     paddingVertical: landscape ? 0 : 12,
   };


### PR DESCRIPTION
### Overview
`CallControlls` styling issue for landscape mode where the buttons are not properly positioned. 

Before:
<img src="https://github.com/user-attachments/assets/facd83ce-e8e4-438a-bd3e-9fad4c653003" alt="ios-after" width="440" height="200"/>

After:
<img src="https://github.com/user-attachments/assets/81c6129a-5e03-43d3-9b6b-69dcd5bc1da3" alt="ios-after" width="440" height="200"/>


