### PR TITLE
fix: ios ipad crash in incoming call component

### DIFF
--- a/packages/react-native-sdk/src/components/Call/RingingCallContent/IncomingCall.tsx
+++ b/packages/react-native-sdk/src/components/Call/RingingCallContent/IncomingCall.tsx
@@ -109,7 +109,6 @@ const Background: React.FunctionComponent<{
   if (avatarsToShow.length) {
     return (
       <ImageBackground
-        blurRadius={10}
         source={{
           uri: avatarsToShow[0],
         }}


### PR DESCRIPTION
### Overview

This crash happens only on iPads. Atleast in my test. Almost 50% of the time i receive incoming calls. 

Upon deepdive, It is  because the blur is done on background thread always, and when blur starts at a time when push notification is shown, the app goes into a native crash.  Possibly the iOS doesn't allow background thread opening at that point. 

Just removing the action of blur fixes the issue
