### PR TITLE
chore: disable the automated release process

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -4,11 +4,12 @@ env:
   STREAM_SECRET: ${{ secrets.CLIENT_TEST_SECRET }}
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/**'
+# Disable the automatic release trigger
+#  push:
+#    branches:
+#      - main
+#    paths:
+#      - 'packages/**'
 
   workflow_dispatch:
 


### PR DESCRIPTION
### Overview

Disables the automatic release process that run after every push to `main`.
We now switch to a more controlled and manual release process. 

**The original criteria remain, every merged PR is considered releasable at any time!**
