### PR TITLE
feat: align SDK version reporting, use higher-entropy user agent data for stats

### DIFF
--- a/packages/client/rollup.config.mjs
+++ b/packages/client/rollup.config.mjs
@@ -31,7 +31,7 @@ const browserConfig = {
   input: 'index.ts',
   output: {
     file: 'dist/index.browser.es.js',
-    format: 'es',
+    format: 'esm',
     sourcemap: true,
   },
   external: external.filter((dep) => !browserIgnoredModules.includes(dep)),
@@ -39,34 +39,38 @@ const browserConfig = {
     replace({
       preventAssignment: true,
       'process.env.PKG_VERSION': JSON.stringify(pkg.version),
+      'process.env.CLIENT_BUNDLE': JSON.stringify('browser-esm'),
     }),
     browserIgnorePlugin,
     typescript(),
   ],
 };
 
-const nodeConfig = {
+/**
+ * @return {import('rollup').RollupOptions}
+ */
+const createNodeConfig = (outputFile, format) => ({
   input: 'index.ts',
-  output: [
-    {
-      file: 'dist/index.cjs.js',
-      format: 'cjs',
-      sourcemap: true,
-    },
-    {
-      file: 'dist/index.es.js',
-      format: 'es',
-      sourcemap: true,
-    },
-  ],
+  output: {
+    file: outputFile,
+    format: format,
+    sourcemap: true,
+  },
   external,
   plugins: [
     replace({
       preventAssignment: true,
       'process.env.PKG_VERSION': JSON.stringify(pkg.version),
+      'process.env.CLIENT_BUNDLE': JSON.stringify(`node-${format}`),
     }),
     typescript(),
   ],
-};
+});
 
-export default [browserConfig, nodeConfig];
+const rollupConfig = [
+  browserConfig,
+  createNodeConfig('dist/index.cjs.js', 'cjs'),
+  createNodeConfig('dist/index.es.js', 'esm'),
+];
+
+export default rollupConfig;

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -866,7 +866,7 @@ export class Call {
     this.sfuClient = sfuClient;
     this.dynascaleManager.setSfuClient(sfuClient);
 
-    const clientDetails = getClientDetails();
+    const clientDetails = await getClientDetails();
     // we don't need to send JoinRequest if we are re-using an existing healthy SFU client
     if (previousSfuClient !== sfuClient) {
       // prepare a generic SDP and send it to the SFU.
@@ -2308,8 +2308,9 @@ export class Call {
       custom,
     }: Pick<CollectUserFeedbackRequest, 'reason' | 'custom'> = {},
   ): Promise<CollectUserFeedbackResponse> => {
-    const { sdkName, sdkVersion, ...platform } =
-      getSdkSignature(getClientDetails());
+    const { sdkName, sdkVersion, ...platform } = getSdkSignature(
+      await getClientDetails(),
+    );
     return this.streamClient.post<
       CollectUserFeedbackResponse,
       CollectUserFeedbackRequest

--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -38,6 +38,7 @@ import {
   CreateGuestResponse,
 } from '../../gen/coordinator';
 import { makeSafePromise, type SafePromise } from '../../helpers/promise';
+import { getLogLevel } from '../../logger';
 
 export class StreamClient {
   _user?: UserWithId;
@@ -61,7 +62,7 @@ export class StreamClient {
   setUserPromise: ConnectAPIResponse | null;
   tokenManager: TokenManager;
   user?: UserWithId;
-  userAgent?: string;
+  private cachedUserAgent?: string;
   userID?: string;
   wsBaseURL?: string;
   wsConnection: StableWSConnection | null;
@@ -218,10 +219,7 @@ export class StreamClient {
       );
     }
 
-    if (
-      (this._isUsingServerAuth() || this.node) &&
-      !this.options.allowServerSideConnect
-    ) {
+    if ((this.secret || this.node) && !this.options.allowServerSideConnect) {
       this.logger(
         'warn',
         'Please do not use connectUser server side. Use our @stream-io/node-sdk instead: https://getstream.io/video/docs/api/',
@@ -326,7 +324,7 @@ export class StreamClient {
       return;
     }
 
-    await this._setupConnectionIdPromise();
+    this._setupConnectionIdPromise();
 
     this.clientID = `${this.userID}--${randomId()}`;
     const newWsPromise = this.connect();
@@ -382,7 +380,7 @@ export class StreamClient {
     tokenOrProvider: TokenOrProvider,
   ) => {
     addConnectionEventListeners(this.updateNetworkConnectionStatus);
-    await this._setupConnectionIdPromise();
+    this._setupConnectionIdPromise();
 
     this.anonymous = true;
     await this._setToken(user, tokenOrProvider, this.anonymous);
@@ -469,6 +467,7 @@ export class StreamClient {
       config?: AxiosRequestConfig & { maxBodyLength?: number };
     },
   ) => {
+    if (getLogLevel() !== 'trace') return;
     this.logger('trace', `client: ${type} - Request - ${url}`, {
       payload: data,
       config,
@@ -480,6 +479,7 @@ export class StreamClient {
     url: string,
     response: AxiosResponse<T>,
   ) => {
+    if (getLogLevel() !== 'trace') return;
     this.logger(
       'trace',
       `client:${type} - Response - url: ${url} > status ${response.status}`,
@@ -666,24 +666,31 @@ export class StreamClient {
     return await this.wsConnection.connect(this.defaultWSTimeout);
   };
 
-  getUserAgent = () => {
-    const version = process.env.PKG_VERSION || '0.0.0-development';
-    return (
-      this.userAgent ||
-      `stream-video-javascript-client-${
-        this.node ? 'node' : 'browser'
-      }-${version}`
-    );
-  };
+  getUserAgent = (): string => {
+    if (this.cachedUserAgent) return this.cachedUserAgent;
 
-  setUserAgent = (userAgent: string) => {
-    this.userAgent = userAgent;
-  };
+    const bundleType =
+      process.env.CLIENT_BUNDLE || (this.node ? 'node' : 'browser');
 
-  /**
-   * _isUsingServerAuth - Returns true if we're using server side auth
-   */
-  _isUsingServerAuth = () => !!this.secret;
+    const { clientAppIdentifier } = this.options;
+    if (!clientAppIdentifier) {
+      const version = process.env.PKG_VERSION || '0.0.0-development';
+      return `stream-video-plain_javascript-v${version}|client_bundle=${bundleType}`;
+    }
+
+    const { sdkName, uiSdkVersion, ...rest } = clientAppIdentifier;
+    const baseIdentifier = `stream-video-${sdkName}-v${uiSdkVersion}`;
+    const extras = Object.entries(rest)
+      .concat([['client_bundle', bundleType]])
+      .map(([key, value]) => `${key}=${value}`)
+      .join('|');
+
+    this.cachedUserAgent = extras
+      ? `${baseIdentifier}|${extras}`
+      : baseIdentifier;
+
+    return this.cachedUserAgent;
+  };
 
   _enrichAxiosOptions = (
     options: AxiosRequestConfig & { config?: AxiosRequestConfig } & {

--- a/packages/client/src/coordinator/connection/connection.ts
+++ b/packages/client/src/coordinator/connection/connection.ts
@@ -329,7 +329,7 @@ export class StableWSConnection {
         return response;
       }
     } catch (err) {
-      await this.client._setupConnectionIdPromise();
+      this.client._setupConnectionIdPromise();
       this.isConnecting = false;
       // @ts-ignore
       this._log(`_connect() - Error - `, err);

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -152,6 +152,21 @@ export type StreamClientOptions = Partial<AxiosRequestConfig> & {
    * timer throttling issues in inactive browser tabs.
    */
   enableTimerWorker?: boolean;
+
+  /**
+   * The client app identifier.
+   */
+  clientAppIdentifier?: ClientAppIdentifier;
+};
+
+export type ClientAppIdentifier = {
+  sdkName?: 'react' | 'react-native' | 'plain-js' | (string & {});
+  uiSdkVersion?: string;
+  app?: string;
+  app_version?: string;
+  os?: string;
+  os_version?: string;
+  device_model?: string;
 };
 
 export type TokenProvider = () => Promise<string>;

--- a/packages/client/src/helpers/__tests__/clientUtils.test.ts
+++ b/packages/client/src/helpers/__tests__/clientUtils.test.ts
@@ -46,10 +46,25 @@ describe('clientUtils', () => {
 
   describe('createCoordinatorClient', () => {
     it('should create a coordinator client', () => {
-      const client = createCoordinatorClient('apiKey', { timeout: 1000 });
+      const client = createCoordinatorClient('apiKey', {
+        timeout: 1000,
+        clientAppIdentifier: {
+          app: 'vitest',
+          app_version: '1.0.0',
+          device_model: 'iPhone',
+          os: 'iOS',
+          os_version: '18.4',
+        },
+      });
       expect(client).toBeDefined();
-      expect(client.userAgent).toBe(
-        'stream-video-javascript-client-node-0.0.0-development-video-plain_javascript-sdk-0.0.0',
+      expect(client.getUserAgent()).toBe(
+        'stream-video-plain_javascript-v0.0.0' +
+          '|app=vitest' +
+          '|app_version=1.0.0' +
+          '|device_model=iPhone' +
+          '|os=iOS' +
+          '|os_version=18.4' +
+          '|client_bundle=node',
       );
       expect(client.logger).toBeDefined();
       expect(client.options.persistUserOnConnectionFailure).toBe(true);

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -4,12 +4,9 @@ import { OwnCapability, StatsOptions } from '../gen/coordinator';
 import { getLogger } from '../logger';
 import { Publisher, Subscriber } from '../rtc';
 import { flatten, getSdkName, getSdkVersion } from './utils';
+import { getDeviceState, getWebRTCInfo } from '../helpers/client-details';
 import {
-  getDeviceState,
-  getWebRTCInfo,
-  LocalClientDetailsType,
-} from '../helpers/client-details';
-import {
+  ClientDetails,
   InputDevices,
   WebsocketReconnectStrategy,
 } from '../gen/video/sfu/models/models';
@@ -20,7 +17,7 @@ import { Telemetry } from '../gen/video/sfu/signal_rpc/signal';
 
 export type SfuStatsReporterOptions = {
   options: StatsOptions;
-  clientDetails: LocalClientDetailsType;
+  clientDetails: ClientDetails;
   subscriber: Subscriber;
   publisher?: Publisher;
   microphone: MicrophoneManager;

--- a/packages/client/src/stats/utils.ts
+++ b/packages/client/src/stats/utils.ts
@@ -1,5 +1,4 @@
-import { type LocalClientDetailsType } from '../helpers/client-details';
-import { Sdk, SdkType } from '../gen/video/sfu/models/models';
+import { ClientDetails, Sdk, SdkType } from '../gen/video/sfu/models/models';
 
 /**
  * Flatten the stats report into an array of stats objects.
@@ -14,7 +13,7 @@ export const flatten = (report: RTCStatsReport) => {
   return stats;
 };
 
-export const getSdkSignature = (clientDetails: LocalClientDetailsType) => {
+export const getSdkSignature = (clientDetails: ClientDetails) => {
   const { sdk, ...platform } = clientDetails;
   const sdkName = getSdkName(sdk);
   const sdkVersion = getSdkVersion(sdk);


### PR DESCRIPTION
### Overview

Aligns the value of the `X-Stream-Client` header with the other SDKs, as specified here:
- https://www.notion.so/stream-wiki/X-Stream-Client-values-17b6a5d7f9f6804987bbdfec570698c6

Also, uses the experimental `userAgentData` API (where available) to retrieve higher-entropy user agent data, which eventually will show up on our call stats page.
- https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues



