### PR TITLE
fix: pip race condition

### DIFF
--- a/packages/react-native-sdk/src/hooks/internal/useCallMediaStreamCleanup.ts
+++ b/packages/react-native-sdk/src/hooks/internal/useCallMediaStreamCleanup.ts
@@ -1,5 +1,9 @@
 import { MediaStream } from '@stream-io/react-native-webrtc';
-import { CallingState, disposeOfMediaStream } from '@stream-io/video-client';
+import {
+  CallingState,
+  disposeOfMediaStream,
+  getLogger,
+} from '@stream-io/video-client';
 import { useCall } from '@stream-io/video-react-bindings';
 import { useEffect, useRef } from 'react';
 
@@ -25,6 +29,10 @@ export const useCallMediaStreamCleanup = () => {
           callRef.current?.state.callingState === CallingState.JOINING
         )
       ) {
+        getLogger(['useCallMediaStreamCleanup'])(
+          'debug',
+          'Cleaning up camera media stream'
+        );
         // we cleanup media stream only if call is not joined or joining
         // @ts-ignore Due to DOM typing incompatible with RN
         disposeOfMediaStream(mediaStream);

--- a/packages/react-native-sdk/src/providers/StreamCall/AppStateListener.tsx
+++ b/packages/react-native-sdk/src/providers/StreamCall/AppStateListener.tsx
@@ -89,10 +89,7 @@ export const AppStateListener = () => {
           if (cameraDisabledByAppState.current) {
             call?.camera?.resume();
             cameraDisabledByAppState.current = false;
-            logger(
-              'debug',
-              'Disable and reenable camera as app came to foreground'
-            );
+            logger('debug', 'Resume camera as app came to foreground');
           }
         }
         appState.current = nextAppState;


### PR DESCRIPTION
### Overview

In expo dev builds, app weirdly (albiet rarely not all the time) starts with background state when app opens from push notification and then there is no event listener callback when it moves to active again. 

We rely on the initial app start for initial pip mode. This causes a bug in expo where pip mode did not reset to true. 

### Implementation notes

This PR will fix this bug by simply asking the native module if pip mode is true initially on component mount.

### Extra

Added debug logs for camera disabling