### PR TITLE
fix: add explicit default device option to device selectors

### DIFF
--- a/packages/react-sdk/src/components/DeviceSettings/DeviceSelector.tsx
+++ b/packages/react-sdk/src/components/DeviceSettings/DeviceSelector.tsx
@@ -100,7 +100,7 @@ const DeviceSelectorDropdown = (props: {
   icon: string;
 }) => {
   const { devices = [], selectedDeviceId, title, onChange, icon } = props;
-  const { deviceList, selectedDevice, selectedIndex } = useDeviceList(
+  const { deviceList, selectedDeviceInfo, selectedIndex } = useDeviceList(
     devices,
     selectedDeviceId,
   );
@@ -123,7 +123,7 @@ const DeviceSelectorDropdown = (props: {
       <DropDownSelect
         icon={icon}
         defaultSelectedIndex={selectedIndex}
-        defaultSelectedLabel={selectedDevice.label}
+        defaultSelectedLabel={selectedDeviceInfo.label}
         handleSelect={handleSelect}
       >
         {deviceList.map((device) => (

--- a/packages/react-sdk/src/components/DeviceSettings/DeviceSelector.tsx
+++ b/packages/react-sdk/src/components/DeviceSettings/DeviceSelector.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import { ChangeEventHandler, useCallback } from 'react';
 
+import { useDeviceList } from '../../hooks/useDeviceList';
 import { DropDownSelect, DropDownSelectOption } from '../DropdownSelect';
 import { useMenuContext } from '../Menu';
-import { useDeviceListWithDefault } from './useDeviceListWithDefault';
 
 type DeviceSelectorOptionProps = {
   id: string;
@@ -60,7 +60,7 @@ const DeviceSelectorList = (props: {
 }) => {
   const { devices = [], selectedDeviceId, title, type, onChange } = props;
   const { close } = useMenuContext();
-  const { deviceList } = useDeviceListWithDefault(devices, selectedDeviceId);
+  const { deviceList } = useDeviceList(devices, selectedDeviceId);
 
   return (
     <div className="str-video__device-settings__device-kind">
@@ -100,8 +100,10 @@ const DeviceSelectorDropdown = (props: {
   icon: string;
 }) => {
   const { devices = [], selectedDeviceId, title, onChange, icon } = props;
-  const { deviceList, selectedDevice, selectedIndex } =
-    useDeviceListWithDefault(devices, selectedDeviceId);
+  const { deviceList, selectedDevice, selectedIndex } = useDeviceList(
+    devices,
+    selectedDeviceId,
+  );
 
   const handleSelect = useCallback(
     (index: number) => {

--- a/packages/react-sdk/src/components/DeviceSettings/useDeviceListWithDefault.tsx
+++ b/packages/react-sdk/src/components/DeviceSettings/useDeviceListWithDefault.tsx
@@ -1,0 +1,50 @@
+import { useI18n } from '@stream-io/video-react-bindings';
+import { useMemo } from 'react';
+
+export interface DeviceListItem {
+  deviceId: string;
+  label: string;
+  isSelected: boolean;
+}
+
+export function useDeviceListWithDefault(
+  devices: MediaDeviceInfo[],
+  selectedDeviceId: string | undefined,
+): {
+  deviceList: DeviceListItem[];
+  selectedDevice: DeviceListItem;
+  selectedIndex: number;
+} {
+  const { t } = useI18n();
+
+  return useMemo(() => {
+    let selectedDevice: DeviceListItem | null = null;
+    let selectedIndex: number | null = null;
+
+    const deviceList: DeviceListItem[] = devices.map((d, i) => {
+      const isSelected = d.deviceId === selectedDeviceId;
+      const device = { deviceId: d.deviceId, label: d.label, isSelected };
+
+      if (isSelected) {
+        selectedDevice = device;
+        selectedIndex = i;
+      }
+
+      return device;
+    });
+
+    if (selectedDevice === null || selectedIndex === null) {
+      const defaultDevice = {
+        deviceId: 'default',
+        label: t('Default'),
+        isSelected: true,
+      };
+
+      selectedDevice = defaultDevice;
+      selectedIndex = 0;
+      deviceList.unshift(defaultDevice);
+    }
+
+    return { deviceList, selectedDevice, selectedIndex };
+  }, [devices, selectedDeviceId, t]);
+}

--- a/packages/react-sdk/src/hooks/index.ts
+++ b/packages/react-sdk/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useFloatingUIPreset';
 export * from './usePersistedDevicePreferences';
 export * from './useScrollPosition';
 export * from './useRequestPermission';
+export * from './useDeviceList';

--- a/packages/react-sdk/src/hooks/useDeviceList.tsx
+++ b/packages/react-sdk/src/hooks/useDeviceList.tsx
@@ -9,7 +9,7 @@ export interface DeviceListItem {
 
 /**
  * Utility hook that helps render a list of devices or implement a device selector.
- * Compared someting like `useCameraState().devices`, it has some handy features:
+ * Compared to someting like `useCameraState().devices`, it has some handy features:
  * 1. Adds the "Default" device to the list if applicable (either the user did not
  * select a device, or a previously selected device is no longer available).
  * 2. Maps the device list to a format more suitable for rendering.

--- a/packages/react-sdk/src/hooks/useDeviceList.tsx
+++ b/packages/react-sdk/src/hooks/useDeviceList.tsx
@@ -7,7 +7,14 @@ export interface DeviceListItem {
   isSelected: boolean;
 }
 
-export function useDeviceListWithDefault(
+/**
+ * Utility hook that helps render a list of devices or implement a device selector.
+ * Compared someting like `useCameraState().devices`, it has some handy features:
+ * 1. Adds the "Default" device to the list if applicable (either the user did not
+ * select a device, or a previously selected device is no longer available).
+ * 2. Maps the device list to a format more suitable for rendering.
+ */
+export function useDeviceList(
   devices: MediaDeviceInfo[],
   selectedDeviceId: string | undefined,
 ): {

--- a/packages/react-sdk/src/hooks/useDeviceList.tsx
+++ b/packages/react-sdk/src/hooks/useDeviceList.tsx
@@ -19,13 +19,13 @@ export function useDeviceList(
   selectedDeviceId: string | undefined,
 ): {
   deviceList: DeviceListItem[];
-  selectedDevice: DeviceListItem;
+  selectedDeviceInfo: DeviceListItem;
   selectedIndex: number;
 } {
   const { t } = useI18n();
 
   return useMemo(() => {
-    let selectedDevice: DeviceListItem | null = null;
+    let selectedDeviceInfo: DeviceListItem | null = null;
     let selectedIndex: number | null = null;
 
     const deviceList: DeviceListItem[] = devices.map((d, i) => {
@@ -33,25 +33,25 @@ export function useDeviceList(
       const device = { deviceId: d.deviceId, label: d.label, isSelected };
 
       if (isSelected) {
-        selectedDevice = device;
+        selectedDeviceInfo = device;
         selectedIndex = i;
       }
 
       return device;
     });
 
-    if (selectedDevice === null || selectedIndex === null) {
+    if (selectedDeviceInfo === null || selectedIndex === null) {
       const defaultDevice = {
         deviceId: 'default',
         label: t('Default'),
         isSelected: true,
       };
 
-      selectedDevice = defaultDevice;
+      selectedDeviceInfo = defaultDevice;
       selectedIndex = 0;
       deviceList.unshift(defaultDevice);
     }
 
-    return { deviceList, selectedDevice, selectedIndex };
+    return { deviceList, selectedDeviceInfo, selectedIndex };
   }, [devices, selectedDeviceId, t]);
 }


### PR DESCRIPTION
### Overview

As far as we know, there's no reliable way to determine the system's default camera and microphone devices without querying them first-and we shouldn't query the user's media devices unless they're enabled. So we have no way of knowing which camera or microphone device is being used by the browser under the following conditions

1. No device has been explicitly selected by the user (or the previously selected device is no longer available).
2. No device was previously enabled by the user

Previously, in this case, we simply rendered a list of devices with no device selected. This was confusing and looked "broken".

Now we add an explicit "Default" option to the list instead. This option is purely cosmetic: if it's present, it's always selected, so selecting it does nothing; and if a different device is selected, this option disappears.

![Screenshot 2025-02-26 at 16 26 02](https://github.com/user-attachments/assets/dae2d549-4f5e-4616-8b34-e01acd26e0de)

![Screenshot 2025-02-26 at 16 25 29](https://github.com/user-attachments/assets/3d47a33a-cd79-4fa6-9279-af925e0281c9)

### Implementation notes

This is implemented on the React SDK level, and the new `useDeviceList` hook is applied to device lists in all device selectors.

This hook is public API, documented here: https://github.com/GetStream/docs-content/pull/206