### PR TITLE
fix: do not stop incall manager on change of audio settings

### DIFF
--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -85,9 +85,10 @@ export type CallContentProps = Pick<
      */
     disablePictureInPicture?: boolean;
     /**
-     * Props to set the audio mode for the InCallManager
-     * If media type is video, audio is routed by default to speaker otherwise it is routed to earpiece
-     * Changing the mode on the fly is not supported. Manually invoke `InCallManager.start({ media })` to achieve this.
+     * Props to set the audio mode for the InCallManager.
+     * If media type is video, audio is routed by default to speaker, otherwise it is routed to earpiece.
+     * Changing the mode on the fly is not supported.
+     * Manually invoke `InCallManager.start({ media })` to achieve this.
      * @default 'video'
      */
     inCallManagerAudioMode?: 'video' | 'audio';

--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -91,7 +91,7 @@ export type CallContentProps = Pick<
      * Manually invoke `InCallManager.start({ media })` to achieve this.
      * @default 'video'
      */
-    inCallManagerAudioMode?: 'video' | 'audio';
+    initialInCallManagerAudioMode?: 'video' | 'audio';
   };
 
 export const CallContent = ({
@@ -111,7 +111,7 @@ export const CallContent = ({
   supportedReactions,
   iOSPiPIncludeLocalParticipantVideo,
   disablePictureInPicture,
-  inCallManagerAudioMode = 'video',
+  initialInCallManagerAudioMode = 'video',
 }: CallContentProps) => {
   const [
     showRemoteParticipantInFloatingView,
@@ -129,7 +129,7 @@ export const CallContent = ({
 
   useAutoEnterPiPEffect(disablePictureInPicture);
 
-  const incallManagerModeRef = useRef(inCallManagerAudioMode);
+  const incallManagerModeRef = useRef(initialInCallManagerAudioMode);
 
   const _remoteParticipants = useRemoteParticipants();
   const remoteParticipants = useDebouncedValue(_remoteParticipants, 300); // we debounce the remote participants to avoid unnecessary rerenders that happen when participant tracks are all subscribed simultaneously


### PR DESCRIPTION
If call settings are changed on the fly when a call is already joined, then incall manager is started and stopped again. 

InCallmanger mode with "audio" is almost never used by our integrators. Speaker is the default preferred output in any scenario. We should not route to earpiece in video disabled calls by default too. I do not know why this was added.
 
This behaviour also aligns with other SDKs and also fixes the bug on iOS that audio is lost after start->stop->start

