### PR TITLE
fix: prevent extra unnecessary reconnect after offline to online

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -849,10 +849,8 @@ export class Call {
         if (!avoidRestoreState) {
           // restore the previous call state if the join-flow fails
           this.state.setCallingState(callingState);
-          throw error;
         }
-        // NOTE: we don't throw the error for offline state
-        // as the reconnection flow for offline->online state is handled on "network.changed" event
+        throw error;
       }
     }
 
@@ -1324,6 +1322,7 @@ export class Call {
           this.reconnectStrategy = WebsocketReconnectStrategy.REJOIN;
         }
       } while (
+        this.state.callingState !== CallingState.OFFLINE &&
         this.state.callingState !== CallingState.JOINED &&
         this.state.callingState !== CallingState.RECONNECTING_FAILED &&
         this.state.callingState !== CallingState.LEFT

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -844,14 +844,15 @@ export class Call {
       } catch (error) {
         // prevent triggering reconnect flow if the state is OFFLINE
         const avoidRestoreState =
-          this.state.callingState === CallingState.OFFLINE &&
-          callingState === CallingState.RECONNECTING;
+          this.state.callingState === CallingState.OFFLINE;
 
         if (!avoidRestoreState) {
           // restore the previous call state if the join-flow fails
           this.state.setCallingState(callingState);
+          throw error;
         }
-        throw error;
+        // NOTE: we don't throw the error for offline state
+        // as the reconnection flow for offline->online state is handled on "network.changed" event
       }
     }
 

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1304,6 +1304,13 @@ export class Call {
           }
           break; // do-while loop, reconnection worked, exit the loop
         } catch (error) {
+          if (this.state.callingState === CallingState.OFFLINE) {
+            this.logger(
+              'trace',
+              `[Reconnect] Can't reconnect while offline, stopping reconnection attempts`,
+            );
+            break;
+          }
           if (error instanceof ErrorFromResponse && error.unrecoverable) {
             this.logger(
               'warn',
@@ -1322,7 +1329,6 @@ export class Call {
           this.reconnectStrategy = WebsocketReconnectStrategy.REJOIN;
         }
       } while (
-        this.state.callingState !== CallingState.OFFLINE &&
         this.state.callingState !== CallingState.JOINED &&
         this.state.callingState !== CallingState.RECONNECTING_FAILED &&
         this.state.callingState !== CallingState.LEFT

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1310,6 +1310,8 @@ export class Call {
               `[Reconnect] Can't reconnect while offline, stopping reconnection attempts`,
             );
             break;
+            // we don't need to handle the error if the call is offline
+            // network change event will trigger the reconnection
           }
           if (error instanceof ErrorFromResponse && error.unrecoverable) {
             this.logger(


### PR DESCRIPTION
currently, two reconnects after going offline->online is performed

1. one after join axios error catch
2. from network.changed event

This PR keeps only the 2nd one