### PR TITLE
fix: retryable client.connectUser()

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -277,13 +277,13 @@ export class StreamVideoClient {
               throw err;
             }
 
-            await sleep(retryInterval(attempt));
-
             // we need to force to disconnect the user if the client is
             // configured to persist the user on connection failure
             if (persistUserOnConnectionFailure) {
               await client.disconnectUser();
             }
+
+            await sleep(retryInterval(attempt));
           }
         }
       },

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -255,7 +255,7 @@ export class StreamVideoClient {
     let connectUserResponse: ConnectedEvent | void | undefined = undefined;
 
     const client = this.streamClient;
-    const { maxUserConnectRetries = 5, onUserConnectError } = client.options;
+    const { maxUserConnectRetries = 5, onConnectUserError } = client.options;
     for (
       let attempt = 0, errorQueue: Error[] = [];
       !connectUserResponse && attempt < maxUserConnectRetries;
@@ -279,7 +279,7 @@ export class StreamVideoClient {
         this.logger('warn', `Failed to connect a user (${attempt})`, err);
         errorQueue.push(err as Error);
         if (attempt === maxUserConnectRetries - 1) {
-          onUserConnectError?.(err as Error, errorQueue);
+          onConnectUserError?.(err as Error, errorQueue);
           throw err;
         }
 

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -255,10 +255,10 @@ export class StreamVideoClient {
     let connectUserResponse: ConnectedEvent | void | undefined = undefined;
 
     const client = this.streamClient;
-    const { maxUserConnectRetries = 5, onConnectUserError } = client.options;
+    const { maxConnectUserRetries = 5, onConnectUserError } = client.options;
     for (
       let attempt = 0, errorQueue: Error[] = [];
-      !connectUserResponse && attempt < maxUserConnectRetries;
+      !connectUserResponse && attempt < maxConnectUserRetries;
       attempt++
     ) {
       try {
@@ -278,7 +278,7 @@ export class StreamVideoClient {
       } catch (err) {
         this.logger('warn', `Failed to connect a user (${attempt})`, err);
         errorQueue.push(err as Error);
-        if (attempt === maxUserConnectRetries - 1) {
+        if (attempt === maxConnectUserRetries - 1) {
           onConnectUserError?.(err as Error, errorQueue);
           throw err;
         }

--- a/packages/client/src/__tests__/StreamVideoClient.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.test.ts
@@ -205,7 +205,7 @@ describe('StreamVideoClient.connectUser retries', () => {
     const client = new StreamVideoClient(apiKey, {
       // tests run in node, so we have to fake being in browser env
       browser: true,
-      maxUserConnectRetries: 2,
+      maxConnectUserRetries: 2,
     });
     client.streamClient.connectUser = vi
       .fn()
@@ -224,7 +224,7 @@ describe('StreamVideoClient.connectUser retries', () => {
     const client = new StreamVideoClient(apiKey, {
       // tests run in node, so we have to fake being in browser env
       browser: true,
-      maxUserConnectRetries: 3,
+      maxConnectUserRetries: 3,
       onConnectUserError,
     });
 

--- a/packages/client/src/__tests__/StreamVideoClient.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.test.ts
@@ -157,12 +157,12 @@ describe('StreamVideoClient', () => {
       const instance1 = StreamVideoClient.getOrCreateInstance({
         apiKey,
         user: { id: 'jane' },
-        token: 'abc',
+        token: serverClient.generateUserToken({ user_id: 'jane' }),
       });
       const instance2 = StreamVideoClient.getOrCreateInstance({
         apiKey,
         user: { id: 'jane' },
-        token: 'abc',
+        token: serverClient.generateUserToken({ user_id: 'jane' }),
       });
       expect(instance1).toBe(instance2);
     });
@@ -171,12 +171,12 @@ describe('StreamVideoClient', () => {
       const instance1 = StreamVideoClient.getOrCreateInstance({
         apiKey,
         user: { id: 'jane' },
-        token: 'abc',
+        token: serverClient.generateUserToken({ user_id: 'jane' }),
       });
       const instance2 = StreamVideoClient.getOrCreateInstance({
         apiKey,
         user: { id: 'john' },
-        token: 'abc',
+        token: serverClient.generateUserToken({ user_id: 'jane' }),
       });
       expect(instance1).not.toBe(instance2);
     });
@@ -185,14 +185,14 @@ describe('StreamVideoClient', () => {
       const instance1 = StreamVideoClient.getOrCreateInstance({
         apiKey,
         user: { id: 'jane' },
-        token: 'abc',
+        token: serverClient.generateUserToken({ user_id: 'jane' }),
       });
       await instance1.disconnectUser();
 
       const instance2 = StreamVideoClient.getOrCreateInstance({
         apiKey,
         user: { id: 'jane' },
-        token: 'abc',
+        token: serverClient.generateUserToken({ user_id: 'jane' }),
       });
 
       expect(instance1).not.toBe(instance2);

--- a/packages/client/src/__tests__/StreamVideoClient.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.test.ts
@@ -220,12 +220,12 @@ describe('StreamVideoClient.connectUser retries', () => {
   });
 
   it('should propagate error if max retries reached', async () => {
-    const onUserConnectError = vi.fn();
+    const onConnectUserError = vi.fn();
     const client = new StreamVideoClient(apiKey, {
       // tests run in node, so we have to fake being in browser env
       browser: true,
       maxUserConnectRetries: 3,
-      onUserConnectError: onUserConnectError,
+      onConnectUserError,
     });
 
     client.streamClient.connectUser = vi
@@ -238,9 +238,9 @@ describe('StreamVideoClient.connectUser retries', () => {
       await client.connectUser(user, token);
     }).rejects.toThrowError('something happened');
 
-    expect(onUserConnectError).toBeCalledTimes(1);
+    expect(onConnectUserError).toBeCalledTimes(1);
 
-    const invocation = onUserConnectError.mock.calls[0];
+    const invocation = onConnectUserError.mock.calls[0];
     const [lastError, allErrors] = invocation;
     expect(lastError.message).toBe('something happened');
     expect(allErrors.length).toBe(3);
@@ -252,11 +252,11 @@ describe('StreamVideoClient.connectUser retries', () => {
   });
 
   it('should connect the user if all is good', async () => {
-    const onUserConnectError = vi.fn();
+    const onConnectUserError = vi.fn();
     const client = new StreamVideoClient(apiKey, {
       // tests run in node, so we have to fake being in browser env
       browser: true,
-      onUserConnectError: onUserConnectError,
+      onConnectUserError,
     });
 
     const user = { id: 'jane' };
@@ -268,7 +268,7 @@ describe('StreamVideoClient.connectUser retries', () => {
     const token = serverClient.generateUserToken({ user_id: user.id });
     await client.connectUser(user, token);
 
-    expect(onUserConnectError).not.toBeCalled();
+    expect(onConnectUserError).not.toBeCalled();
     expect(client.state.connectedUser?.id).toBe(user.id);
 
     await client.disconnectUser();

--- a/packages/client/src/coordinator/connection/token_manager.ts
+++ b/packages/client/src/coordinator/connection/token_manager.ts
@@ -8,8 +8,8 @@ import type { TokenOrProvider, UserWithId } from './types';
  * Handles all the operations around user token.
  */
 export class TokenManager {
-  private loadTokenPromise: Promise<string> | null;
-  private type: 'static' | 'provider';
+  private loadTokenPromise: Promise<string> | null = null;
+  private type: 'static' | 'provider' = 'static';
   private readonly secret?: string;
   private token?: string;
   private tokenProvider?: TokenOrProvider;
@@ -17,9 +17,7 @@ export class TokenManager {
   private isAnonymous?: boolean;
 
   constructor(secret?: string) {
-    this.loadTokenPromise = null;
     this.secret = secret;
-    this.type = 'static';
   }
 
   /**
@@ -74,11 +72,7 @@ export class TokenManager {
       throw new Error('User token can not be empty');
     }
 
-    if (
-      tokenOrProvider &&
-      typeof tokenOrProvider !== 'string' &&
-      !isFunction(tokenOrProvider)
-    ) {
+    if (typeof tokenOrProvider !== 'string' && !isFunction(tokenOrProvider)) {
       throw new Error('User token should either be a string or a function');
     }
 

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -157,6 +157,23 @@ export type StreamClientOptions = Partial<AxiosRequestConfig> & {
    * The client app identifier.
    */
   clientAppIdentifier?: ClientAppIdentifier;
+
+  /**
+   * The default timeout for WebSocket connections.
+   */
+  defaultWsTimeout?: number;
+
+  /**
+   * The maximum number of retries to connect a user.
+   */
+  maxUserConnectRetries?: number;
+
+  /**
+   * A callback to be called one the maxUserConnectRetries is exhausted.
+   * @param error the last error
+   * @param errors all errors
+   */
+  onUserConnectError?: (error: Error, errors: Error[]) => void;
 };
 
 export type ClientAppIdentifier = {

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -170,10 +170,10 @@ export type StreamClientOptions = Partial<AxiosRequestConfig> & {
 
   /**
    * A callback to be called one the maxUserConnectRetries is exhausted.
-   * @param error the last error
-   * @param errors all errors
+   * @param lastError the last error.
+   * @param allErrors all errors.
    */
-  onUserConnectError?: (error: Error, errors: Error[]) => void;
+  onConnectUserError?: (lastError: Error, allErrors: Error[]) => void;
 };
 
 export type ClientAppIdentifier = {

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -166,7 +166,7 @@ export type StreamClientOptions = Partial<AxiosRequestConfig> & {
   /**
    * The maximum number of retries to connect a user.
    */
-  maxUserConnectRetries?: number;
+  maxConnectUserRetries?: number;
 
   /**
    * A callback to be called one the maxUserConnectRetries is exhausted.

--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -40,10 +40,9 @@ export class CameraManager extends InputMediaDeviceManager<CameraManagerState> {
           this.logger('warn', 'No video track found to do direction selection');
           return;
         }
-        const constraints = {
+        await videoTrack.applyConstraints({
           facingMode: direction === 'front' ? 'user' : 'environment',
-        };
-        await videoTrack.applyConstraints(constraints);
+        });
         this.state.setDirection(direction);
         this.state.setDevice(undefined);
       } else {

--- a/sample-apps/client/ts-quickstart/src/main.ts
+++ b/sample-apps/client/ts-quickstart/src/main.ts
@@ -13,9 +13,21 @@ import { ClosedCaptionManager } from './closed-captions';
 
 const ENVIRONMENT = 'demo';
 const userId = 'luke';
-const credentials = (await fetch(
-  `https://pronto.getstream.io/api/auth/create-token?environment=${ENVIRONMENT}&user_id=${userId}`,
-).then((res) => res.json())) as { apiKey: string; token: string };
+
+const fetchCredentials = async (): Promise<{
+  apiKey: string;
+  token: string;
+}> => {
+  const params = new URLSearchParams({
+    environment: ENVIRONMENT,
+    user_id: userId,
+  });
+  return fetch(
+    `https://pronto.getstream.io/api/auth/create-token?${params.toString()}`,
+  ).then((res) => res.json());
+};
+
+const credentials = await fetchCredentials();
 
 const searchParams = new URLSearchParams(window.location.search);
 const callId =
@@ -26,6 +38,10 @@ const callId =
 const client = new StreamVideoClient({
   apiKey: credentials.apiKey,
   token: credentials.token,
+  tokenProvider: async () => {
+    const { token } = await fetchCredentials();
+    return token;
+  },
   user: { id: userId, name: 'Luke' },
   options: { logLevel: 'debug' },
 });


### PR DESCRIPTION
### Overview

Adds a retry mechanism for the `client.connectUser()` API.
By default, the SDK will now attempt to establish the initial WebSocket connection up to 5 times.
Once all attempts are exhausted, and are unsuccessful, the `connectUser()` will reject with the last captured error as a rejection reason.

### Implementation notes
Connection flow can happen in the `StreamVideoClient` constructor, but due to its non-async nature, integrators can't catch and handle these errors. This is a flaw that we introduced early in the development of the SDK and fixing it is a huge breaking change. We need to consider fixing this when we start planning for the v2 release of the SDK.
Until then, a new `onUserConnectError` callback can be provided in the constructor's options that will be invoked once the SDK gives up from retrying. This callback will get the `lastError` and the `allErrors`.

```ts
const client = new StreamVideoClient(apiKey, {
  defaultWsTimeout: 5000,
  maxConnectUserRetries: 3,
  onConnectUserError: (lastError: Error, allErrors: Error[]) => {
    // handle connect errors
  },
});

// alternatively
const client = StreamVideoClient.getOrCreateInstance({
  apiKey,
  user,
  options: {
    defaultWsTimeout: 5000,
    maxConnectUserRetries: 3,
    onConnectUserError: (lastError: Error, allErrors: Error[]) => {
      // handle connect errors
    },
  },
});
```