### PR TITLE
fix: add pending browser permission state

### DIFF
--- a/packages/client/src/devices/InputMediaDeviceManagerState.ts
+++ b/packages/client/src/devices/InputMediaDeviceManagerState.ts
@@ -68,6 +68,12 @@ export abstract class InputMediaDeviceManagerState<C = MediaTrackConstraints> {
   hasBrowserPermission$: Observable<boolean>;
 
   /**
+   * An observable that emits `true` when SDK is prompting for browser permission
+   * (i.e. browser's UI for allowing or disallowing device access is visible)
+   */
+  isPromptingPermission$: Observable<boolean>;
+
+  /**
    * Constructs new InputMediaDeviceManagerState instance.
    *
    * @param disableMode the disable mode to use.
@@ -81,6 +87,10 @@ export abstract class InputMediaDeviceManagerState<C = MediaTrackConstraints> {
     this.hasBrowserPermission$ = permission
       ? permission.asObservable().pipe(shareReplay(1))
       : of(true);
+
+    this.isPromptingPermission$ = permission
+      ? permission.getIsPromptingObservable().pipe(shareReplay(1))
+      : of(false);
   }
 
   /**

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -221,4 +221,5 @@ export const emitDeviceIds = (values: MediaDeviceInfo[]) => {
 
 export const mockBrowserPermission = {
   asObservable: () => of(true),
+  getIsPromptingObservable: () => of(false),
 } as BrowserPermission;

--- a/packages/client/src/helpers/concurrency.ts
+++ b/packages/client/src/helpers/concurrency.ts
@@ -48,7 +48,10 @@ export function hasPending(tag: string | symbol) {
 }
 
 export async function settled(tag: string | symbol) {
-  await pendingPromises.get(tag)?.promise;
+  let pending: PendingPromise | undefined;
+  while ((pending = pendingPromises.get(tag))) {
+    await pending.promise;
+  }
 }
 
 /**

--- a/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
@@ -30,8 +30,12 @@ export const ToggleAudioPreviewButton = (
   const { caption, onMenuToggle, ...restCompositeButtonProps } = props;
   const { t } = useI18n();
   const { useMicrophoneState } = useCallStateHooks();
-  const { microphone, optimisticIsMute, hasBrowserPermission } =
-    useMicrophoneState();
+  const {
+    microphone,
+    optimisticIsMute,
+    hasBrowserPermission,
+    isPromptingPermission,
+  } = useMicrophoneState();
   const [tooltipDisabled, setTooltipDisabled] = useState(false);
   const handleClick = createCallControlHandler(props, () =>
     microphone.toggle(),
@@ -74,6 +78,13 @@ export const ToggleAudioPreviewButton = (
             children="!"
           />
         )}
+        {isPromptingPermission && (
+          <span
+            className="str-video__pending-permission"
+            title={t('Waiting for permission')}
+            children="?"
+          />
+        )}
       </CompositeButton>
     </WithTooltip>
   );
@@ -102,8 +113,12 @@ export const ToggleAudioPublishingButton = (
     useRequestPermission(OwnCapability.SEND_AUDIO);
 
   const { useMicrophoneState } = useCallStateHooks();
-  const { microphone, optimisticIsMute, hasBrowserPermission } =
-    useMicrophoneState();
+  const {
+    microphone,
+    optimisticIsMute,
+    hasBrowserPermission,
+    isPromptingPermission,
+  } = useMicrophoneState();
   const [tooltipDisabled, setTooltipDisabled] = useState(false);
   const handleClick = createCallControlHandler(props, async () => {
     if (!hasPermission) {
@@ -153,6 +168,14 @@ export const ToggleAudioPublishingButton = (
             <Icon icon={optimisticIsMute ? 'mic-off' : 'mic'} />
             {(!hasBrowserPermission || !hasPermission) && (
               <span className="str-video__no-media-permission">!</span>
+            )}
+            {isPromptingPermission && (
+              <span
+                className="str-video__pending-permission"
+                title={t('Waiting for permission')}
+              >
+                ?
+              </span>
             )}
           </CompositeButton>
         </WithTooltip>

--- a/packages/react-sdk/src/components/CallControls/ToggleVideoButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleVideoButton.tsx
@@ -36,7 +36,12 @@ export const ToggleVideoPreviewButton = (
   } = props;
   const { t } = useI18n();
   const { useCameraState } = useCallStateHooks();
-  const { camera, optimisticIsMute, hasBrowserPermission } = useCameraState();
+  const {
+    camera,
+    optimisticIsMute,
+    hasBrowserPermission,
+    isPromptingPermission,
+  } = useCameraState();
   const [tooltipDisabled, setTooltipDisabled] = useState(false);
   const handleClick = createCallControlHandler(props, () => camera.toggle());
 
@@ -79,6 +84,13 @@ export const ToggleVideoPreviewButton = (
             children="!"
           />
         )}
+        {isPromptingPermission && (
+          <span
+            className="str-video__pending-permission"
+            title={t('Waiting for permission')}
+            children="?"
+          />
+        )}
       </CompositeButton>
     </WithTooltip>
   );
@@ -107,7 +119,12 @@ export const ToggleVideoPublishingButton = (
     useRequestPermission(OwnCapability.SEND_VIDEO);
 
   const { useCameraState, useCallSettings } = useCallStateHooks();
-  const { camera, optimisticIsMute, hasBrowserPermission } = useCameraState();
+  const {
+    camera,
+    optimisticIsMute,
+    hasBrowserPermission,
+    isPromptingPermission,
+  } = useCameraState();
   const callSettings = useCallSettings();
   const isPublishingVideoAllowed = callSettings?.video.enabled;
   const [tooltipDisabled, setTooltipDisabled] = useState(false);
@@ -169,6 +186,14 @@ export const ToggleVideoPublishingButton = (
               !hasPermission ||
               !isPublishingVideoAllowed) && (
               <span className="str-video__no-media-permission">!</span>
+            )}
+            {isPromptingPermission && (
+              <span
+                className="str-video__pending-permission"
+                title={t('Waiting for permission')}
+              >
+                ?
+              </span>
             )}
           </CompositeButton>
         </WithTooltip>


### PR DESCRIPTION
### Overview

Previously there was no way to track if the SDK is currently prompting browser for a device permission. For example:

1. Call has camera enabled by default. User visits the call page for the first time. Browser permission prompt is displayed, but in the meanwhile camera toggle is showing that camera is enabled (because `hasBrowserPermission` is true for `prompt` state, and `optimisticStatus` is `enabled`).
2. Permissions have been reset, and user tries to enable camera. Once again, browser permission prompt is displayed, but in the meanwhile camera toggle is showing that camera is enabled.

We now introduce another permission state apart from `prompt`, `granted` and `denied`: **`prompting`**. This state is in effect while browser prompt is visible, i.e. when permission state is `prompt` and `getUserMedia` promise is pending.

### Implementation notes

New browser permission state `prompting` is added to `BrowserPermission` class.

This state is exposed via the `isPermissionPending$` observable in input media device manager state.

State hooks for camera and microphone state also return this flag.

Default device toggles support this flag and display the new "?" badge while permission is pending:

![Screenshot 2025-03-12 at 13 03 37](https://github.com/user-attachments/assets/4966c66e-f9f2-4ed4-8b9f-3513f3bd67d7)

Docs are to follow.

---

There are also two other minor changes in this PR.

The `settled()` check in concurrency.ts is fixed to prevent possible race conditions. Previously, it was possible to check for `settled()`, then add more promises to the queue, and `settled()` will resolve _before_ these newly added promises are resolved.

`isTogglePending` flag is returned from device-related call state hooks. It can be used to display a loader while camera/microphone are enabled/disabled. It's not used by our default toggle buttons, but it's nice to have.