### PR TITLE
fix: ensure negotiation runs sequentially

### DIFF
--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -8,7 +8,7 @@ import { createSafeAsyncSubscription } from '../store/rxUtils';
 import { PeerType } from '../gen/video/sfu/models/models';
 import { StreamSfuClient } from '../StreamSfuClient';
 import { AllSfuEvents, Dispatcher } from './Dispatcher';
-import { withCancellation, withoutConcurrency } from '../helpers/concurrency';
+import { withoutConcurrency } from '../helpers/concurrency';
 
 export type BasePeerConnectionOpts = {
   sfuClient: StreamSfuClient;
@@ -85,7 +85,7 @@ export abstract class BasePeerConnection {
   /**
    * Detaches the event handlers from the `RTCPeerConnection`.
    */
-  protected detachEventHandlers() {
+  detachEventHandlers() {
     this.pc.removeEventListener('icecandidate', this.onIceCandidate);
     this.pc.removeEventListener('icecandidateerror', this.onIceCandidateError);
     this.pc.removeEventListener('signalingstatechange', this.onSignalingChange);
@@ -93,8 +93,6 @@ export abstract class BasePeerConnection {
       'iceconnectionstatechange',
       this.onIceConnectionStateChange,
     );
-    // cancel any ongoing ICE restart process
-    withCancellation('onIceConnectionStateChange', () => Promise.resolve());
     this.pc.removeEventListener(
       'icegatheringstatechange',
       this.onIceGatherChange,

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -18,7 +18,7 @@ import {
 import { isSvcCodec } from './codecs';
 import { isAudioTrackType } from './helpers/tracks';
 import { extractMid } from './helpers/sdp';
-import { withCancellation } from '../helpers/concurrency';
+import { withoutConcurrency } from '../helpers/concurrency';
 import { isReactNative } from '../helpers/platforms';
 
 export type PublisherConstructorOpts = BasePeerConnectionOpts & {
@@ -41,7 +41,6 @@ export class Publisher extends BasePeerConnection {
   constructor({ publishOptions, ...baseOptions }: PublisherConstructorOpts) {
     super(PeerType.PUBLISHER_UNSPECIFIED, baseOptions);
     this.publishOptions = publishOptions;
-    this.pc.addEventListener('negotiationneeded', this.onNegotiationNeeded);
 
     this.on('iceRestart', (iceRestart) => {
       if (iceRestart.peerType !== PeerType.PUBLISHER_UNSPECIFIED) return;
@@ -61,18 +60,6 @@ export class Publisher extends BasePeerConnection {
       this.publishOptions = event.publishOptions;
       return this.syncPublishOptions();
     });
-  }
-
-  /**
-   * Detaches the event handlers from the `RTCPeerConnection`.
-   * This is useful when we want to replace the `RTCPeerConnection`
-   * instance with a new one (in case of migration).
-   */
-  detachEventHandlers() {
-    super.detachEventHandlers();
-    this.pc.removeEventListener('negotiationneeded', this.onNegotiationNeeded);
-    // abort any ongoing negotiation
-    withCancellation('publisher.negotiate', () => Promise.resolve());
   }
 
   /**
@@ -107,7 +94,7 @@ export class Publisher extends BasePeerConnection {
 
       const transceiver = this.transceiverCache.get(publishOption);
       if (!transceiver) {
-        this.addTransceiver(trackToPublish, publishOption);
+        await this.addTransceiver(trackToPublish, publishOption);
       } else {
         const previousTrack = transceiver.sender.track;
         await transceiver.sender.replaceTrack(trackToPublish);
@@ -121,7 +108,7 @@ export class Publisher extends BasePeerConnection {
   /**
    * Adds a new transceiver carrying the given track to the peer connection.
    */
-  private addTransceiver = (
+  private addTransceiver = async (
     track: MediaStreamTrack,
     publishOption: PublishOption,
   ) => {
@@ -137,6 +124,8 @@ export class Publisher extends BasePeerConnection {
     const trackType = publishOption.trackType;
     this.logger('debug', `Added ${TrackType[trackType]} transceiver`);
     this.transceiverCache.add(publishOption, transceiver);
+
+    await this.negotiate();
   };
 
   /**
@@ -159,7 +148,7 @@ export class Publisher extends BasePeerConnection {
       // take the track from the existing transceiver for the same track type,
       // clone it and publish it with the new publish options
       const track = this.cloneTrack(item.transceiver.sender.track!);
-      this.addTransceiver(track, publishOption);
+      await this.addTransceiver(track, publishOption);
     }
 
     // stop publishing with options not required anymore -> [vp9]
@@ -237,10 +226,12 @@ export class Publisher extends BasePeerConnection {
     const tag = 'Update publish quality:';
     this.logger('info', `${tag} requested layers by SFU:`, enabledLayers);
 
-    const sender = this.transceiverCache.getWith(
-      trackType,
-      publishOptionId,
-    )?.sender;
+    const transceiverId = this.transceiverCache.find(
+      (t) =>
+        t.publishOption.id === publishOptionId &&
+        t.publishOption.trackType === trackType,
+    );
+    const sender = transceiverId?.transceiver.sender;
     if (!sender) {
       return this.logger('warn', `${tag} no video sender found.`);
     }
@@ -250,8 +241,8 @@ export class Publisher extends BasePeerConnection {
       return this.logger('warn', `${tag} there are no encodings set.`);
     }
 
-    const [codecInUse] = params.codecs;
-    const usesSvcCodec = codecInUse && isSvcCodec(codecInUse.mimeType);
+    const codecInUse = transceiverId?.publishOption.codec?.name;
+    const usesSvcCodec = codecInUse && isSvcCodec(codecInUse);
 
     let changed = false;
     for (const encoder of params.encodings) {
@@ -313,7 +304,7 @@ export class Publisher extends BasePeerConnection {
   /**
    * Restarts the ICE connection and renegotiates with the SFU.
    */
-  restartIce = async () => {
+  restartIce = async (): Promise<void> => {
     this.logger('debug', 'Restarting ICE connection');
     const signalingState = this.pc.signalingState;
     if (this.isIceRestarting || signalingState === 'have-local-offer') {
@@ -323,44 +314,33 @@ export class Publisher extends BasePeerConnection {
     await this.negotiate({ iceRestart: true });
   };
 
-  private onNegotiationNeeded = () => {
-    withCancellation('publisher.negotiate', (signal) =>
-      this.negotiate().catch((err) => {
-        if (signal.aborted) return;
-        this.logger('error', `Negotiation failed.`, err);
-        this.onUnrecoverableError?.();
-      }),
-    );
-  };
-
   /**
    * Initiates a new offer/answer exchange with the currently connected SFU.
    *
    * @param options the optional offer options to use.
    */
-  private negotiate = async (options?: RTCOfferOptions) => {
-    const offer = await this.pc.createOffer(options);
-    const trackInfos = this.getAnnouncedTracks(offer.sdp);
-    if (trackInfos.length === 0) {
-      throw new Error(`Can't negotiate without announcing any tracks`);
-    }
+  private negotiate = async (options?: RTCOfferOptions): Promise<void> => {
+    return withoutConcurrency('publisher.negotiate', async () => {
+      const offer = await this.pc.createOffer(options);
+      const tracks = this.getAnnouncedTracks(offer.sdp);
+      if (!tracks.length) throw new Error(`Can't negotiate without any tracks`);
 
-    try {
-      this.isIceRestarting = options?.iceRestart ?? false;
-      await this.pc.setLocalDescription(offer);
+      try {
+        this.isIceRestarting = options?.iceRestart ?? false;
+        await this.pc.setLocalDescription(offer);
 
-      const { response } = await this.sfuClient.setPublisher({
-        sdp: offer.sdp || '',
-        tracks: trackInfos,
-      });
+        const { sdp = '' } = offer;
+        const { response } = await this.sfuClient.setPublisher({ sdp, tracks });
+        if (response.error) throw new Error(response.error.message);
 
-      if (response.error) throw new Error(response.error.message);
-      await this.pc.setRemoteDescription({ type: 'answer', sdp: response.sdp });
-    } finally {
-      this.isIceRestarting = false;
-    }
+        const { sdp: answerSdp } = response;
+        await this.pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
+      } finally {
+        this.isIceRestarting = false;
+      }
 
-    this.addTrickledIceCandidates();
+      this.addTrickledIceCandidates();
+    });
   };
 
   /**

--- a/packages/client/src/rtc/TransceiverCache.ts
+++ b/packages/client/src/rtc/TransceiverCache.ts
@@ -1,4 +1,4 @@
-import { PublishOption, TrackType } from '../gen/video/sfu/models/models';
+import { PublishOption } from '../gen/video/sfu/models/models';
 import { OptimalVideoLayer } from './videoLayers';
 
 type TransceiverId = {
@@ -34,13 +34,6 @@ export class TransceiverCache {
    */
   get = (publishOption: PublishOption): RTCRtpTransceiver | undefined => {
     return this.findTransceiver(publishOption)?.transceiver;
-  };
-
-  /**
-   * Gets the last transceiver for the given track type and publish option id.
-   */
-  getWith = (trackType: TrackType, id: number) => {
-    return this.findTransceiver({ trackType, id })?.transceiver;
   };
 
   /**

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -98,6 +98,8 @@ describe('Publisher', () => {
       const track = new MediaStreamTrack();
       const clone = new MediaStreamTrack();
       vi.spyOn(track, 'clone').mockReturnValue(clone);
+      // @ts-expect-error - private method
+      const negotiateSpy = vi.spyOn(publisher, 'negotiate').mockResolvedValue();
 
       await publisher.publish(track, TrackType.VIDEO);
 
@@ -117,6 +119,7 @@ describe('Publisher', () => {
         ],
       });
       expect(publisher['clonedTracks'].size).toBe(1);
+      expect(negotiateSpy).toHaveBeenCalled();
     });
 
     it('should update an existing transceiver for a new track', async () => {
@@ -506,6 +509,8 @@ describe('Publisher', () => {
       vi.spyOn(track, 'clone').mockReturnValue(track);
       // @ts-expect-error private method
       vi.spyOn(publisher, 'addTransceiver');
+      // @ts-expect-error private method
+      vi.spyOn(publisher, 'negotiate').mockResolvedValue();
 
       publisher['publishOptions'] = [
         // @ts-expect-error incomplete data
@@ -544,6 +549,7 @@ describe('Publisher', () => {
           codec: { name: 'vp9' },
         }),
       );
+      expect(publisher['negotiate']).toHaveBeenCalledTimes(2);
     });
 
     it('disables extra transceivers', async () => {
@@ -671,12 +677,6 @@ describe('Publisher', () => {
       });
     });
 
-    it('onNegotiationNeeded delegates to negotiate', () => {
-      publisher['negotiate'] = vi.fn().mockResolvedValue(void 0);
-      publisher['onNegotiationNeeded']();
-      expect(publisher['negotiate']).toHaveBeenCalled();
-    });
-
     it('getPublishedTracks returns the published tracks', () => {
       const tracks = publisher.getPublishedTracks();
       expect(tracks).toHaveLength(2);
@@ -712,7 +712,7 @@ describe('Publisher', () => {
     });
 
     it('stopTracks should stop tracks', () => {
-      const track = cache['cache'][0].transceiver.sender.track;
+      const track = cache['cache'][0].transceiver.sender.track!;
       vi.spyOn(track, 'stop');
       expect(publisher['clonedTracks'].size).toBe(3);
       publisher.stopTracks(TrackType.VIDEO);
@@ -721,7 +721,7 @@ describe('Publisher', () => {
     });
 
     it('stopAllTracks should stop all tracks', () => {
-      const track = cache['cache'][0].transceiver.sender.track;
+      const track = cache['cache'][0].transceiver.sender.track!;
       vi.spyOn(track, 'stop');
       expect(publisher['clonedTracks'].size).toBe(3);
       publisher.stopAllTracks();


### PR DESCRIPTION
### Overview

When negotiating, we shouldn't run two SetPublisher requests in parallel as they can arrive in non-deterministic order on our server.
Sometimes it used to happen that we ran two SetPublisher requests:
1. Audio
2. Audio + Video

When 2. arrives first, then 1 will overwrite the announced video track and will lead to issues where participant A can't see the video of participant B.

This PR aims to fix that by ensuring that we wait for Req-1 to finish before we run Req-2.

Ticket: https://linear.app/stream/issue/REACT-310/ensure-sequential-negotiation

### Implementation notes
- We guard `negotiate()` with a concurrency lock that's shared between both, ICE restarts, and regular negotiations
- We don't use `negotiationneeded` event anymore - we explicitly control the negotiation process that enables better exception handling, as we can now bubble up the negotiation errors to the original initiator