### PR TITLE
fix: expose useDeviceList

### DIFF
--- a/packages/react-sdk/index.ts
+++ b/packages/react-sdk/index.ts
@@ -13,6 +13,7 @@ export {
   useVerticalScrollPosition,
   useRequestPermission,
   usePersistedDevicePreferences,
+  useDeviceList,
 } from './src/hooks';
 
 const [major, minor, patch] = (


### PR DESCRIPTION
🚂 #1701 

This PR exposes `useDeviceList` which we forgot to export.