### PR TITLE
fix: update call reject reasons

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -566,7 +566,7 @@ export class Call {
 
       if (callingState === CallingState.RINGING && reject !== false) {
         if (reject) {
-          await this.reject(reason);
+          await this.reject('decline');
         } else {
           // if reject was undefined, we still have to cancel the call automatically
           // when I am the creator and everyone else left the call
@@ -602,6 +602,7 @@ export class Call {
       this.initialized = false;
       this.hasJoinedOnce = false;
       this.ringingSubject.next(false);
+      this.cancelAutoDrop();
       this.clientStore.unregisterCall(this);
 
       this.camera.dispose();
@@ -798,7 +799,9 @@ export class Call {
    *
    * @param reason the reason for rejecting the call.
    */
-  reject = async (reason?: RejectReason): Promise<RejectCallResponse> => {
+  reject = async (
+    reason: RejectReason = 'decline',
+  ): Promise<RejectCallResponse> => {
     return this.streamClient.post<RejectCallResponse, RejectCallRequest>(
       `${this.streamClientBasePath}/reject`,
       { reason: reason },

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -188,5 +188,5 @@ export type ClientAppIdentifier = {
 export type TokenProvider = () => Promise<string>;
 export type TokenOrProvider = null | string | TokenProvider | undefined;
 
-export type BuiltInRejectReason = 'busy' | 'decline' | 'cancel';
-export type RejectReason = BuiltInRejectReason | string;
+export type BuiltInRejectReason = 'busy' | 'decline' | 'cancel' | 'timeout';
+export type RejectReason = BuiltInRejectReason | (string & {});


### PR DESCRIPTION
### Overview

Adds the missing `timeout` reject reason to the type definitions. Cancels the automatic dropTimeouts on `call.leave()`

Ref: https://getstream.slack.com/archives/C06LKRKGZGQ/p1742477187822799