### PR TITLE
fix: proper non ringing only push support without ringing libs

### DIFF
--- a/packages/react-native-sdk/src/hooks/push/useInitAndroidTokenAndRest.ts
+++ b/packages/react-native-sdk/src/hooks/push/useInitAndroidTokenAndRest.ts
@@ -5,6 +5,7 @@ import {
 import { useEffect } from 'react';
 import { StreamVideoRN } from '../../utils';
 import { initAndroidPushToken } from '../../utils/push/android';
+import { getLogger } from '@stream-io/video-client';
 
 /**
  * This hook is used to initialize the push token for Android.
@@ -21,6 +22,12 @@ export const useInitAndroidTokenAndRest = () => {
     let unsubscribe = () => {};
     initAndroidPushToken(client, pushConfig, (unsubscribeListener) => {
       unsubscribe = unsubscribeListener;
+    }).catch((error) => {
+      getLogger(['useInitAndroidTokenAndRest'])(
+        'warn',
+        'Error in initializing android push token',
+        error
+      );
     });
     return () => {
       unsubscribe();

--- a/packages/react-native-sdk/src/hooks/push/useIosCallkeepWithCallingStateEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useIosCallkeepWithCallingStateEffect.ts
@@ -59,9 +59,18 @@ export const useIosCallkeepWithCallingStateEffect = () => {
   useEffect(() => {
     return () => {
       const pushConfig = StreamVideoRN.getConfig().push;
-      if (Platform.OS !== 'ios' || !pushConfig) {
+      if (
+        Platform.OS !== 'ios' ||
+        !pushConfig ||
+        !pushConfig.ios?.pushProviderName
+      ) {
         return;
       }
+      if (!pushConfig.android.incomingCallChannel) {
+        // TODO: remove this check and find a better way once we have telecom integration for android
+        return;
+      }
+
       const callkeep = getCallKeepLib();
       // if the component is unmounted and the callID was not reported to callkeep, then report it now
       if (acceptedForegroundCallkeepMap) {
@@ -80,7 +89,16 @@ export const useIosCallkeepWithCallingStateEffect = () => {
   useEffect(() => {
     return () => {
       const pushConfig = StreamVideoRN.getConfig().push;
-      if (Platform.OS !== 'ios' || !pushConfig || !activeCallCid) {
+      if (
+        Platform.OS !== 'ios' ||
+        !pushConfig ||
+        !pushConfig.ios?.pushProviderName ||
+        !activeCallCid
+      ) {
+        return;
+      }
+      if (!pushConfig.android.incomingCallChannel) {
+        // TODO: remove this check and find a better way once we have telecom integration for android
         return;
       }
       const nativeDialerAcceptedCallMap = RxUtils.getCurrentValue(
@@ -111,7 +129,16 @@ export const useIosCallkeepWithCallingStateEffect = () => {
   }, [activeCallCid]);
 
   const pushConfig = StreamVideoRN.getConfig().push;
-  if (Platform.OS !== 'ios' || !pushConfig || !activeCallCid) {
+  if (
+    Platform.OS !== 'ios' ||
+    !pushConfig ||
+    !pushConfig.ios.pushProviderName ||
+    !activeCallCid
+  ) {
+    return;
+  }
+  if (!pushConfig.android.incomingCallChannel) {
+    // TODO: remove this check and find a better way once we have telecom integration for android
     return;
   }
 

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
@@ -39,8 +39,8 @@ export type StreamVideoConfig = {
        */
       smallIcon?: string;
       /**
-       * The name for the alias of push provider used for Android
-       * Pass undefined if you will not be using stream's push notifications but still want to use the functionality of the SDK
+       * The name for the alias of push provider used for Android.
+       * Pass undefined if you will not be using stream's push notifications but still want to use the functionality of the SDK.
        * @example "production-fcm-video" or "staging-fcm-video" based on the environment
        */
       pushProviderName?: string;

--- a/packages/react-native-sdk/src/utils/push/libs/expoNotifications.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/expoNotifications.ts
@@ -1,5 +1,6 @@
 export type ExpoNotificationsLib = typeof import('expo-notifications');
 
+import { getLogger } from '@stream-io/video-client';
 import type { Notification } from 'expo-notifications';
 
 export type ExpoNotification = Notification;
@@ -13,7 +14,17 @@ try {
 export function getExpoNotificationsLib() {
   if (!expoNotificationsLib) {
     throw Error(
-      'expo-notifications library is not installed. Please see https://docs.expo.dev/versions/latest/sdk/notifications/ for installation instructions'
+      'expo-notifications library is not installed. Please see https://docs.expo.dev/versions/latest/sdk/notifications/ for installation instructions. It is required for non ringing push notifications.'
+    );
+  }
+  return expoNotificationsLib;
+}
+
+export function getExpoNotificationsLibNoThrow() {
+  if (!expoNotificationsLib) {
+    getLogger(['getExpoNotificationsLibNoThrow'])(
+      'debug',
+      'expo-notifications library is not installed. It is required for non ringing push notifications and not for ringing'
     );
   }
   return expoNotificationsLib;

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
@@ -21,7 +21,7 @@ export function getFirebaseMessagingLibNoThrow(isExpo: boolean) {
   if (!lib) {
     const logger = getLogger(['getFirebaseMessagingLibNoThrow']);
     logger(
-      'warn',
+      'debug',
       `${
         isExpo
           ? 'In Expo, @react-native-firebase/messaging library is required to receive ringing notifications in app killed state for Android.'

--- a/packages/react-native-sdk/src/utils/push/setupIosCallKeepEvents.ts
+++ b/packages/react-native-sdk/src/utils/push/setupIosCallKeepEvents.ts
@@ -27,6 +27,14 @@ export function setupIosCallKeepEvents(
   if (Platform.OS !== 'ios' || !pushConfig.ios.pushProviderName) {
     return;
   }
+  if (!pushConfig.android.incomingCallChannel) {
+    // TODO: remove this check and find a better way once we have telecom integration for android
+    getLogger(['setupIosCallKeepEvents'])(
+      'debug',
+      'android incomingCallChannel is not defined, so skipping the setupIosCallKeepEvents'
+    );
+    return;
+  }
   const logger = getLogger(['setupIosCallKeepEvents']);
   const callkeep = getCallKeepLib();
 

--- a/packages/react-native-sdk/src/utils/push/setupIosVoipPushEvents.ts
+++ b/packages/react-native-sdk/src/utils/push/setupIosVoipPushEvents.ts
@@ -13,6 +13,14 @@ export function setupIosVoipPushEvents(
     return;
   }
   const logger = getLogger(['setupIosVoipPushEvents']);
+  if (!pushConfig.android.incomingCallChannel) {
+    // TODO: remove this check and find a better way once we have telecom integration for android
+    logger(
+      'debug',
+      'android incomingCallChannel is not defined, so skipping the setupIosVoipPushEvents'
+    );
+    return;
+  }
   const voipPushNotification = getVoipPushNotificationLib();
 
   logger('debug', 'notification event listener added');


### PR DESCRIPTION
### Overview

Currently when only non ringing push is configured and ringing is not. We still check for ringing push deps. This is fixed in this PR. 

Also, on expo when only ringing was configured we still checked for expo-notifications presence. This should not be the case. Also fixed in this PR.


Extra: some logs added for debugging purposes