### PR TITLE
fix: rn-174 call hang up fixes

### DIFF
--- a/packages/react-native-sdk/src/components/Call/RingingCallContent/RingingCallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/RingingCallContent/RingingCallContent.tsx
@@ -23,7 +23,6 @@ import {
   type CallPreparingIndicatorProps,
 } from './CallPreparingIndicator';
 import { useTheme } from '../../../contexts';
-import { getLogger } from '@stream-io/video-client';
 
 /**
  * Props for the RingingCallContent component
@@ -76,18 +75,6 @@ const RingingCallPanel = ({
   const { useCallCallingState } = useCallStateHooks();
   const callingState = useCallCallingState();
 
-  const onHangupCallHandler = async () => {
-    try {
-      if (callingState === CallingState.LEFT) {
-        return;
-      }
-      await call?.endCall();
-    } catch (error) {
-      const logger = getLogger(['RingingCallContent']);
-      logger('error', 'Error ending Call', error);
-    }
-  };
-
   switch (callingState) {
     case CallingState.RINGING:
       return isCallCreatedByMe
@@ -104,14 +91,7 @@ const RingingCallPanel = ({
         )
       );
     default:
-      return (
-        CallContent && (
-          <CallContent
-            landscape={landscape}
-            onHangupCallHandler={onHangupCallHandler}
-          />
-        )
-      );
+      return CallContent && <CallContent landscape={landscape} />;
   }
 };
 

--- a/packages/react-native-sdk/src/components/Call/RingingCallContent/RingingCallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/RingingCallContent/RingingCallContent.tsx
@@ -23,6 +23,7 @@ import {
   type CallPreparingIndicatorProps,
 } from './CallPreparingIndicator';
 import { useTheme } from '../../../contexts';
+import { getLogger } from '@stream-io/video-client';
 
 /**
  * Props for the RingingCallContent component
@@ -75,6 +76,18 @@ const RingingCallPanel = ({
   const { useCallCallingState } = useCallStateHooks();
   const callingState = useCallCallingState();
 
+  const onHangupCallHandler = async () => {
+    try {
+      if (callingState === CallingState.LEFT) {
+        return;
+      }
+      await call?.endCall();
+    } catch (error) {
+      const logger = getLogger(['RingingCallContent']);
+      logger('error', 'Error ending Call', error);
+    }
+  };
+
   switch (callingState) {
     case CallingState.RINGING:
       return isCallCreatedByMe
@@ -91,7 +104,14 @@ const RingingCallPanel = ({
         )
       );
     default:
-      return CallContent && <CallContent landscape={landscape} />;
+      return (
+        CallContent && (
+          <CallContent
+            landscape={landscape}
+            onHangupCallHandler={onHangupCallHandler}
+          />
+        )
+      );
   }
 };
 

--- a/packages/react-native-sdk/src/utils/push/internal/utils.ts
+++ b/packages/react-native-sdk/src/utils/push/internal/utils.ts
@@ -130,7 +130,7 @@ export const processCallFromPush = async (
       if (canReject) {
         await callFromPush.leave({ reject: canReject, reason: 'decline' });
       } else {
-        await callFromPush.endCall();
+        await callFromPush.leave();
       }
     }
   } catch (e) {

--- a/packages/react-native-sdk/src/utils/push/internal/utils.ts
+++ b/packages/react-native-sdk/src/utils/push/internal/utils.ts
@@ -127,7 +127,11 @@ export const processCallFromPush = async (
         'debug',
         `declining call from push notification with callCid: ${callFromPush.cid} reject: ${canReject}`,
       );
-      await callFromPush.leave({ reject: canReject, reason: 'decline' });
+      if (canReject) {
+        await callFromPush.leave({ reject: canReject, reason: 'decline' });
+      } else {
+        await callFromPush.endCall();
+      }
     }
   } catch (e) {
     const logger = getLogger(['processCallFromPush']);


### PR DESCRIPTION
### Overview

https://linear.app/stream/issue/RN-174/call-hang-up-does-not-update-the-call-that-user-left

The issue: After joining a ringing call, if one of the call members hangs up, the call is not updated that user left on the other side.

### Implementation notes

If the call state is not in Ringing mode (call already accepted) execute plain `call.leave()` action. 

