### PR TITLE
fix: implement retry logic for call joining process

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -828,6 +828,7 @@ export class Call {
 
     this.state.setCallingState(CallingState.JOINING);
 
+    maxJoinRetries = Math.max(maxJoinRetries, 1);
     for (let attempt = 0; attempt < maxJoinRetries; attempt++) {
       try {
         this.logger('trace', `Joining call (${attempt})`, this.cid);

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1270,13 +1270,18 @@ export class Call {
    */
   private handleSfuSignalClose = (sfuClient: StreamSfuClient) => {
     this.logger('debug', '[Reconnect] SFU signal connection closed');
-    // SFU WS closed before we finished current join, no need to schedule reconnect
-    // because join operation will fail
-    if (this.state.callingState === CallingState.JOINING) return;
-    // SFU WS closed as a result of unsuccessful join, and no further retries need to be made
+    const { callingState } = this.state;
     if (
-      this.state.callingState === CallingState.IDLE ||
-      this.state.callingState === CallingState.LEFT
+      // SFU WS closed before we finished current join,
+      // no need to schedule reconnecting
+      callingState === CallingState.JOINING ||
+      // we are already in the process of reconnecting,
+      // no need to schedule another one
+      callingState === CallingState.RECONNECTING ||
+      // SFU WS closed as a result of unsuccessful join,
+      // and no further retries need to be made
+      callingState === CallingState.IDLE ||
+      callingState === CallingState.LEFT
     )
       return;
     // normal close, no need to reconnect

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -263,7 +263,7 @@ export class StreamSfuClient {
   get isHealthy() {
     return (
       this.signalWs.readyState === WebSocket.OPEN &&
-      this.joinResponseTask.isResolved
+      this.joinResponseTask.isResolved()
     );
   }
 
@@ -415,7 +415,10 @@ export class StreamSfuClient {
   ): Promise<JoinResponse> => {
     // wait for the signal web socket to be ready before sending "joinRequest"
     await this.signalReady();
-    if (this.joinResponseTask.isResolved || this.joinResponseTask.isRejected) {
+    if (
+      this.joinResponseTask.isResolved() ||
+      this.joinResponseTask.isRejected()
+    ) {
       // we need to lock the RPC requests until we receive a JoinResponse.
       // that's why we have this primitive lock mechanism.
       // the client starts with already initialized joinResponseTask,

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -261,7 +261,10 @@ export class StreamSfuClient {
   };
 
   get isHealthy() {
-    return this.signalWs.readyState === WebSocket.OPEN;
+    return (
+      this.signalWs.readyState === WebSocket.OPEN &&
+      this.joinResponseTask.isResolved
+    );
   }
 
   get joinTask() {

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -259,11 +259,10 @@ export class StreamVideoClient {
       this.connectionConcurrencyTag,
       async () => {
         const client = this.streamClient;
-        const {
-          maxConnectUserRetries = 5,
-          onConnectUserError,
-          persistUserOnConnectionFailure,
-        } = client.options;
+        const { onConnectUserError, persistUserOnConnectionFailure } =
+          client.options;
+        let { maxConnectUserRetries = 5 } = client.options;
+        maxConnectUserRetries = Math.max(maxConnectUserRetries, 1);
 
         const errorQueue: Error[] = [];
         for (let attempt = 0; attempt < maxConnectUserRetries; attempt++) {

--- a/packages/client/src/helpers/promise.ts
+++ b/packages/client/src/helpers/promise.ts
@@ -50,8 +50,8 @@ export type PromiseWithResolvers<T> = {
   promise: Promise<T>;
   resolve: (value: T | PromiseLike<T>) => void;
   reject: (reason: any) => void;
-  isResolved: boolean;
-  isRejected: boolean;
+  isResolved: () => boolean;
+  isRejected: () => boolean;
 };
 
 /**
@@ -85,7 +85,7 @@ export const promiseWithResolvers = <T = void>(): PromiseWithResolvers<T> => {
     promise,
     resolve: resolver,
     reject: rejecter,
-    isResolved,
-    isRejected,
+    isResolved: () => isResolved,
+    isRejected: () => isRejected,
   };
 };


### PR DESCRIPTION
### Overview

Previously, only a single attempt to join the call has been made, and the `join()` method threw immediately if it failed.

This PR adds retry logic for call joining. Be default, we retry 3 times, and then throw.

### Implementation notes

This PR basically moves previous logic from `join` to `doJoin`, and `join` implements retry logic.

We also add some more safeguards around SFU WS handling:

1. SFU WS is not considered healthy unless `joinResponse` has been received from it. That means if `sfuClient.join()` request fails, the whole client will be recreated next time.
2. We close SFU WS client from client if it the `joinResponse` failed. That prevents us from having an open SFU WS after `call.join()` threw and no longer retries.

This PR also fixed a bug in `promiseWithResolver` implementation, where `isResolved` and `isRejected` flags were returned as values, and thus were never updated.