### PR TITLE
fix: reset the call state value when "live" ends

### DIFF
--- a/packages/client/src/events/__tests__/internal.test.ts
+++ b/packages/client/src/events/__tests__/internal.test.ts
@@ -67,10 +67,15 @@ describe('internal events', () => {
 
   it('handles liveEnded', () => {
     const dispatcher = new Dispatcher();
+
+    const state = new CallState();
+    state.setBackstage(false);
+
     const call = {
       permissionsContext: { hasPermission: () => false },
       leave: vi.fn().mockResolvedValue(undefined),
       logger: vi.fn(),
+      state,
     } as unknown as Call;
 
     watchLiveEnded(dispatcher, call);
@@ -83,6 +88,7 @@ describe('internal events', () => {
       },
     });
     expect(call.leave).toHaveBeenCalled();
+    expect(call.state.backstage).toBe(true);
   });
 
   it('handles liveEnded when user has permission to stay in backstage', () => {

--- a/packages/client/src/events/internal.ts
+++ b/packages/client/src/events/internal.ts
@@ -53,6 +53,7 @@ export const watchLiveEnded = (dispatcher: Dispatcher, call: Call) => {
   return dispatcher.on('error', (e) => {
     if (e.error && e.error.code !== ErrorCode.LIVE_ENDED) return;
 
+    call.state.setBackstage(true);
     if (!call.permissionsContext.hasPermission(OwnCapability.JOIN_BACKSTAGE)) {
       call.leave({ reason: 'live ended' }).catch((err) => {
         call.logger('error', 'Failed to leave call after live ended', err);

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -996,8 +996,8 @@ export class CallState {
             trackType === 'videoTrack'
               ? 'videoDimension'
               : trackType === 'screenShareTrack'
-              ? 'screenShareDimension'
-              : undefined;
+                ? 'screenShareDimension'
+                : undefined;
           if (prop) {
             acc[sessionId] = {
               [prop]: change.dimension,

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -734,6 +734,14 @@ export class CallState {
   }
 
   /**
+   * Sets the backstage state.
+   * @param backstage the backstage state.
+   */
+  setBackstage = (backstage: Patch<boolean>) => {
+    return this.setCurrentValue(this.backstageSubject, backstage);
+  };
+
+  /**
    * Will provide the list of blocked user IDs.
    */
   get blockedUserIds() {
@@ -988,8 +996,8 @@ export class CallState {
             trackType === 'videoTrack'
               ? 'videoDimension'
               : trackType === 'screenShareTrack'
-                ? 'screenShareDimension'
-                : undefined;
+              ? 'screenShareDimension'
+              : undefined;
           if (prop) {
             acc[sessionId] = {
               [prop]: change.dimension,
@@ -1116,7 +1124,7 @@ export class CallState {
    * @param call the call response from the server.
    */
   updateFromCallResponse = (call: CallResponse) => {
-    this.setCurrentValue(this.backstageSubject, call.backstage);
+    this.setBackstage(call.backstage);
     this.setCurrentValue(this.blockedUserIdsSubject, call.blocked_user_ids);
     this.setCurrentValue(this.createdAtSubject, new Date(call.created_at));
     this.setCurrentValue(this.updatedAtSubject, new Date(call.updated_at));


### PR DESCRIPTION
### Overview

When the user is kicked-out of the call with a `LIVE_ENDED` reason, we now update the `backstage` call state too.
Without this change, the state says that the call is still "live" when that isn't the case.

ref: https://linear.app/stream/issue/REACT-339/