### PR TITLE
fix: pick correct device for speaking while muted detection

### DIFF
--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -250,7 +250,7 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
       } else {
         // Need to start a new stream that's not connected to publisher
         const stream = await this.getStream({
-          deviceId,
+          deviceId: { exact: deviceId },
         });
         this.soundDetectorCleanup = createSoundDetector(stream, (event) => {
           this.state.setSpeakingWhileMuted(event.isSoundDetected);


### PR DESCRIPTION
### Overview

Incorrect device could sometimes be picked up for "speaking while muted" detection. E.g. you could have built-in mic selected, but external mic was used when muted.

### Implementation notes

This is follow-up to #1538: since selecting device without `exact` basically means nothing in modern Chrome (always leads to Chrome's default device being used), we must get device with `exact` for "speaking while muted" detection.