### PR TITLE
feat: add media inspector bookmarklet

### DIFF
--- a/sample-apps/react/react-dogfood/components/Inspector/Inspector.tsx
+++ b/sample-apps/react/react-dogfood/components/Inspector/Inspector.tsx
@@ -4,6 +4,7 @@ import { CodecDash } from './CodecDash';
 import { ConnectivityDash } from './ConnectivityDash';
 import { DevicesDash } from './DevicesDash';
 import { InspectorCall } from './InspectorCall';
+import { MediaInspectorBookmarkletDash } from './MediaInspectorBookmarkletDash';
 
 export interface InspectorProps {
   autoJoinDemoCall?: boolean;
@@ -20,6 +21,7 @@ export default function Inspector(props: InspectorProps) {
             {call && <ConnectivityDash />}
             {call && <CodecDash />}
             {call && <CallStatsDash />}
+            <MediaInspectorBookmarkletDash />
           </div>
         )}
       </InspectorCall>

--- a/sample-apps/react/react-dogfood/components/Inspector/MediaInspectorBookmarkletDash.tsx
+++ b/sample-apps/react/react-dogfood/components/Inspector/MediaInspectorBookmarkletDash.tsx
@@ -1,0 +1,77 @@
+export function MediaInspectorBookmarkletDash() {
+  return (
+    <div className="rd__inspector-dash rd__inspector-dash_wide">
+      <h3>Media Inspector Bookmarklet</h3>
+      <section>
+        Drag and drop this link to your bookmark bar:{' '}
+        <a
+          className="rd__inspector-bookmarklet"
+          href={`javascript:${encodeURIComponent(`(${mediaInspectorBookmarklet.toString()})()`)}`}
+        >
+          Media Inspector ⤴️
+        </a>
+        .
+      </section>
+      <section>
+        <small>
+          Running this bookmarklet makes _inspectMedia global variable availble.
+          It can give you some hints why camera or microphone devices are is
+          use.
+        </small>
+      </section>
+    </div>
+  );
+}
+
+type MediaInspectorRecord = readonly [
+  ms: MediaStream,
+  contraints: MediaStreamConstraints,
+  err: Error,
+];
+
+function mediaInspectorBookmarklet() {
+  if ('__inspectMedia' in window) {
+    console.log('[media inspector] Already installed');
+  }
+
+  const registry: MediaInspectorRecord[] = [];
+  const md = navigator.mediaDevices;
+  const gum = md.getUserMedia;
+  navigator.mediaDevices.getUserMedia = async (constraints) => {
+    const ms = await gum.call(md, constraints);
+    const err = new Error('[media inspector] Inspect stack trace');
+    const record = [ms, constraints ?? {}, err] as const;
+    registry.push(record);
+    ms.getTracks().forEach((t) => {
+      t.addEventListener('ended', () => {
+        console.log(
+          '[media inspector]',
+          `Track "${t.kind}" ended`,
+          formatRecord(record),
+        );
+      });
+      const stop = t.stop;
+      t.stop = () => {
+        console.log(
+          '[media inspector]',
+          `Track "${t.kind}" stopped`,
+          formatRecord(record),
+        );
+        return stop.call(t);
+      };
+    });
+    return ms;
+  };
+  const formatRecord = (r: MediaInspectorRecord) => {
+    const record: Array<any> & { trace?: () => void } = [
+      r[0],
+      r[1],
+      r[0].active ? 'live' : 'ended',
+    ];
+    record.trace = () => {
+      throw r[2];
+    };
+    return record;
+  };
+  window._inspectMedia = () => registry.map(formatRecord);
+}

--- a/sample-apps/react/react-dogfood/components/Inspector/MediaInspectorBookmarkletDash.tsx
+++ b/sample-apps/react/react-dogfood/components/Inspector/MediaInspectorBookmarkletDash.tsx
@@ -14,7 +14,7 @@ export function MediaInspectorBookmarkletDash() {
       </section>
       <section>
         <small>
-          Running this bookmarklet makes _inspectMedia global variable availble.
+          Running this bookmarklet makes _inspectMedia global function availble.
           It can give you some hints why camera or microphone devices are is
           use.
         </small>

--- a/sample-apps/react/react-dogfood/components/Inspector/MediaInspectorBookmarkletDash.tsx
+++ b/sample-apps/react/react-dogfood/components/Inspector/MediaInspectorBookmarkletDash.tsx
@@ -15,7 +15,7 @@ export function MediaInspectorBookmarkletDash() {
       <section>
         <small>
           Running this bookmarklet makes _inspectMedia global function availble.
-          It can give you some hints why camera or microphone devices are is
+          It can give you some hints why camera or microphone devices are in
           use.
         </small>
       </section>

--- a/sample-apps/react/react-dogfood/style/Inspector.scss
+++ b/sample-apps/react/react-dogfood/style/Inspector.scss
@@ -32,7 +32,8 @@
   }
 }
 
-.rd__inspector button {
+.rd__inspector button,
+.rd__inspector-bookmarklet {
   font: inherit;
   padding: 5px 10px;
   border-radius: 4px;
@@ -379,4 +380,8 @@ button.rd__copy-button {
 .rd__inspector-pre {
   font-size: 13px;
   color: var(--str-video__text-color2);
+}
+
+.rd__inspector-bookmarklet {
+  text-decoration: none;
 }


### PR DESCRIPTION
Since monkey-patching `getUserMedia` is out favorite way of debugging anyway, adding a bookmarklet we can share with customers to help them debug why camera or microphone are in use.

<img width="977" alt="image" src="https://github.com/user-attachments/assets/dc3c7355-ba58-4624-9f0b-5a511e80ec54" />

## How to use

Running bookmarklet adds global `_inspectMedia` function, and starts tracking `getUserMedia()` calls.

At any point, call `_inspectMedia()` to get a list of media streams returned by `getUserMedia()`. Each stream is marked live (which means device is in use) or ended.

Every record in `_inspectMedia()` output has a `trace()` method. Call it to get a stack trace showing where the origin `getUserMedia()` call originated.
