### PR TITLE
fix: send device token when switching user

### DIFF
--- a/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
@@ -103,14 +103,6 @@ export const useIosVoipPushEventsSetupEffect = () => {
       );
       return;
     }
-    if (!pushConfig.android.incomingCallChannel) {
-      // TODO: remove this check and find a better way once we have telecom integration for android
-      logger(
-        'debug',
-        'android incomingCallChannel is not defined, so skipping the useIosVoipPushEventsSetupEffect',
-      );
-      return;
-    }
 
     const voipPushNotification = getVoipPushNotificationLib();
 

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -63,6 +63,10 @@ export async function initAndroidPushToken(
   const logger = getLogger(['initAndroidPushToken']);
   const setDeviceToken = async (token: string) => {
     const userId = client.streamClient._user?.id ?? '';
+    if (client.streamClient.anonymous) {
+      logger('debug', 'Skipped sending voip token for anonymous user');
+      return;
+    }
     if (
       lastFirebaseToken.token === token &&
       lastFirebaseToken.userId === userId

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -64,7 +64,7 @@ export async function initAndroidPushToken(
   const setDeviceToken = async (token: string) => {
     const userId = client.streamClient._user?.id ?? '';
     if (client.streamClient.anonymous) {
-      logger('debug', 'Skipped sending voip token for anonymous user');
+      logger('debug', 'Skipped sending firebase token for anonymous user');
       return;
     }
     if (
@@ -88,7 +88,7 @@ export async function initAndroidPushToken(
       }
     });
     const push_provider_name = pushConfig.android.pushProviderName;
-    logger('debug', `sending token from firebase: ${token}`);
+    logger('debug', `sending firebase token: ${token} for userId: ${userId}`);
     await client.addDevice(token, 'firebase', push_provider_name);
   };
   if (pushConfig.isExpo) {


### PR DESCRIPTION
### Overview

When switching a `user` by reusing the same `client` instance, we should also send the existing device token to our backend as otherwise, the device remains registered to the old `user` until the new one restarts the app.

This PR also fixes another issue - we shouldn't send device tokens to anonymous users.

Ref: https://linear.app/stream/issue/RN-189/video-update-device-token-when-switching-a-user
