### PR TITLE
fix: screenshare_layout is not injected in egress app

### DIFF
--- a/sample-apps/react/egress-composite/src/components/UIDispatcher.tsx
+++ b/sample-apps/react/egress-composite/src/components/UIDispatcher.tsx
@@ -9,15 +9,15 @@ import {
 import { Spotlight } from './layouts/Spotlight';
 
 export const UIDispatcher = () => {
-  const {
-    layout = DEFAULT_LAYOUT,
-    screenshare_layout = DEFAULT_SCREENSHARE_LAYOUT,
-  } = useConfigurationContext();
+  const { layout, screenshare_layout } = useConfigurationContext();
   const { useHasOngoingScreenShare } = useCallStateHooks();
   const hasScreenShare = useHasOngoingScreenShare();
 
-  const DefaultView = layoutMap[layout]?.[0] ?? Spotlight;
-  const ScreenShareView = layoutMap[screenshare_layout]?.[1] ?? Spotlight;
+  const DefaultView = layoutMap[layout ?? DEFAULT_LAYOUT]?.[0] ?? Spotlight;
+  const ScreenShareView =
+    layoutMap[
+      screenshare_layout ?? layout ?? DEFAULT_SCREENSHARE_LAYOUT
+    ]?.[1] ?? Spotlight;
 
   return hasScreenShare ? <ScreenShareView /> : <DefaultView />;
 };


### PR DESCRIPTION
### 💡 Overview

The `screenshare_layout` option (that supposedly controls which layout is used for recording calls with ongoing screen shares) is not injected into egress app.

We now fallback to `layout` when `screenshare_layout` is missing, instead of Spotlight layout.

### 📝 Implementation notes

In general, seems like `screenshare_layout` option is not needed, because all layouts implement default view and screenshare view.
