### PR TITLE
fix: participant filter for `single-participant` layout in egress app

### DIFF
--- a/packages/react-sdk/src/core/components/CallLayout/index.ts
+++ b/packages/react-sdk/src/core/components/CallLayout/index.ts
@@ -2,6 +2,7 @@ export * from './LivestreamLayout';
 export * from './PaginatedGridLayout';
 export * from './SpeakerLayout';
 export * from './PipLayout';
+export { useFilteredParticipants } from './hooks';
 export type {
   FilterableParticipant,
   ParticipantFilter,

--- a/sample-apps/react/egress-composite/src/components/layouts/DominantSpeaker/DominantSpeaker.tsx
+++ b/sample-apps/react/egress-composite/src/components/layouts/DominantSpeaker/DominantSpeaker.tsx
@@ -15,8 +15,8 @@ import './DominantSpeaker.scss';
 export const DominantSpeaker = () => {
   const activeCall = useCall();
   const speakerInSpotlight = useSpotlightParticipant();
-  const { useParticipants } = useCallStateHooks();
-  const participants = useParticipants();
+  const { useRemoteParticipants } = useCallStateHooks();
+  const remoteParticipants = useRemoteParticipants();
   const { setVideoElement, setVideoPlaceholderElement } =
     useEgressReadyWhenAnyParticipantMounts(
       speakerInSpotlight!,
@@ -29,7 +29,7 @@ export const DominantSpeaker = () => {
       className="eca__dominant-speaker__container"
       data-testid="single-participant"
     >
-      <ParticipantsAudio participants={participants} />
+      <ParticipantsAudio participants={remoteParticipants} />
       {speakerInSpotlight && (
         <ParticipantView
           participant={speakerInSpotlight}


### PR DESCRIPTION
### 💡 Overview

We didn't expect previously that using participant filter with `single-participant` layout would make sense. Turns out, there's a good use case for this: ensuring that RTMP participant always stays visible in the recording, even if somebody else is speaking.

This PR adds support for `participant.filter` configuration option for `single-participant` layout.

### 📝 Implementation notes

Participant list is now filtered before spotlight participant is determined: see the `useSpotlightParticipant` hook.

This change doesn't affect the layout used for calls with ongoing screenshare: the screensharing participant is always in spotlight in this case.