### PR TITLE
fix: race condition on Expo iOS when processing incoming voip push notification

### DIFF
--- a/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
@@ -221,18 +221,20 @@ function addAudioSessionMethods(contents: string) {
 
 function addDidReceiveIncomingPushCallback(contents: string) {
   const onIncomingPush = `
-  // send event to JS
-  [RNVoipPushNotificationManager didReceiveIncomingPushWithPayload:payload forType:(NSString *)type];
-
-  // process the payload
+  // process the payload and store it in the native module's cache
   NSDictionary *stream = payload.dictionaryPayload[@"stream"];
   NSString *uuid = [[NSUUID UUID] UUIDString];
   NSString *createdCallerName = stream[@"created_by_display_name"];
   NSString *cid = stream[@"call_cid"];
 
+  // store the call cid and uuid in the native module's cache
   [StreamVideoReactNative registerIncomingCall:cid uuid:uuid];
 
+  // set the completion handler - this one is called by the JS SDK
   [RNVoipPushNotificationManager addCompletionHandler:uuid completionHandler:completion];
+
+  // send event to JS - the JS SDK will handle the rest and call the 'completionHandler'
+  [RNVoipPushNotificationManager didReceiveIncomingPushWithPayload:payload forType:(NSString *)type];
 
   // display the incoming call notification
   [RNCallKeep reportNewIncomingCall: uuid

--- a/sample-apps/react-native/dogfood/ios/StreamReactNativeVideoSDKSample/AppDelegate.mm
+++ b/sample-apps/react-native/dogfood/ios/StreamReactNativeVideoSDKSample/AppDelegate.mm
@@ -70,22 +70,20 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 
 // --- Handle incoming pushes
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(PKPushType)type withCompletionHandler:(void (^)(void))completion {
-  
-  
   NSDictionary *stream = payload.dictionaryPayload[@"stream"];
 
   NSString *uuid = [[NSUUID UUID] UUIDString];
   NSString *createdCallerName = stream[@"created_by_display_name"];
   NSString *cid = stream[@"call_cid"];
-  
+
   [StreamVideoReactNative registerIncomingCall:cid uuid:uuid];
-  
+
   // required if you want to call `completion()` on the js side
   [RNVoipPushNotificationManager addCompletionHandler:uuid completionHandler:completion];
-  
+
   // Process the received push // fire 'notification' event to JS
   [RNVoipPushNotificationManager didReceiveIncomingPushWithPayload:payload forType:(NSString *)type];
-  
+
   [RNCallKeep reportNewIncomingCall: uuid
                              handle: createdCallerName
                          handleType: @"generic"
@@ -123,22 +121,22 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
     @"supportsVideo": @YES,
     @"includesCallsInRecents": @NO,
   }];
-  
+
   [RNVoipPushNotificationManager voipRegistration];
-  
+
   self.moduleName = @"StreamReactNativeVideoSDKSample";
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
-  
+
   UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
   center.delegate = self;
-  
+
   WebRTCModuleOptions *options = [WebRTCModuleOptions sharedInstance];
   options.enableMultitaskingCameraAccess = YES;
 //  uncomment below to see native webrtc logs
 //  options.loggingSeverity = RTCLoggingSeverityInfo;
-  
+
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
@@ -146,7 +144,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 {
   return [self bundleURL];
 }
- 
+
 - (NSURL *)bundleURL
 {
 #if DEBUG


### PR DESCRIPTION
### 💡 Overview

Our built-in expo plugin creates a possible race condition that makes some voip notifications on iOS to remain unprocessed.
This PR fixes that and aligns the implementation of that plugin with the implementation we have in our dogfooding app.

🎫 Ticket: https://linear.app/stream/issue/RN-190/
📑 Docs: https://github.com/GetStream/docs-content/pull/287
