### PR TITLE
fix: fast reconnect should be followed up with full rejoining on network switch

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1309,7 +1309,7 @@ export class Call {
     )
       return;
     // normal close, no need to reconnect
-    if (sfuClient.isLeaving) return;
+    if (sfuClient.isLeaving || sfuClient.isClosing) return;
     this.reconnect(WebsocketReconnectStrategy.REJOIN, reason).catch((err) => {
       this.logger('warn', '[Reconnect] Error reconnecting', err);
     });
@@ -1583,9 +1583,10 @@ export class Call {
       },
     );
 
-    this.leaveCallHooks.add(unregisterGoAway);
-    this.leaveCallHooks.add(unregisterOnError);
-    this.leaveCallHooks.add(unregisterNetworkChanged);
+    this.leaveCallHooks
+      .add(unregisterGoAway)
+      .add(unregisterOnError)
+      .add(unregisterNetworkChanged);
   };
 
   /**

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -118,6 +118,11 @@ export class StreamSfuClient {
    */
   isLeaving = false;
 
+  /**
+   * Flag to indicate if the client is in the process of closing the connection.
+   */
+  isClosing = false;
+
   private readonly rpc: SignalServerClient;
   private keepAliveInterval?: number;
   private connectionCheckTimeout?: NodeJS.Timeout;
@@ -288,6 +293,7 @@ export class StreamSfuClient {
   };
 
   close = (code: number = StreamSfuClient.NORMAL_CLOSURE, reason?: string) => {
+    this.isClosing = true;
     if (this.signalWs.readyState === WebSocket.OPEN) {
       this.logger('debug', `Closing SFU WS connection: ${code} - ${reason}`);
       this.signalWs.close(code, `js-client: ${reason}`);


### PR DESCRIPTION
### 💡 Overview

We weren't properly handling the Fast reconnects on the network switch. Every fast reconnect was later followed up with a full rejoin due to the `previousSfuClient` not being correctly flagged as disposed of.
This behavior wasn't an issue that had a destructive impact on end users but it did create multiple timelines in our dashboard stats (due to the `session_id` change) and made it more difficult for us to investigate call issues and assign call scores.

🎫 Ticket: https://linear.app/stream/issue/REACT-354