### PR TITLE
fix: access device list lazily from call state hook

### DIFF
--- a/packages/react-bindings/src/hooks/callStateHooks.ts
+++ b/packages/react-bindings/src/hooks/callStateHooks.ts
@@ -21,7 +21,9 @@ import { isReactNative } from '../helpers/platforms';
 import { useObservableValue } from './useObservableValue';
 
 // kind-of memoized, used as a default value
-const EMPTY_DEVICES_ARRAY = Object.freeze<MediaDeviceInfo[]>([]);
+const EMPTY_DEVICES_ARRAY = Object.freeze<MediaDeviceInfo[]>(
+  [],
+) as MediaDeviceInfo[];
 
 /**
  * Utility hook, which provides the current call's state.

--- a/packages/react-bindings/src/hooks/callStateHooks.ts
+++ b/packages/react-bindings/src/hooks/callStateHooks.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import {
   Call,
   CallClosedCaption,
@@ -15,12 +14,14 @@ import {
   StreamVideoParticipant,
   UserResponse,
 } from '@stream-io/video-client';
+import { useMemo, useState } from 'react';
+import { Observable, of } from 'rxjs';
 import { useCall } from '../contexts';
-import { useObservableValue } from './useObservableValue';
 import { isReactNative } from '../helpers/platforms';
+import { useObservableValue } from './useObservableValue';
 
 // kind-of memoized, used as a default value
-const EMPTY_DEVICES_ARRAY = Object.freeze([]) as unknown as MediaDeviceInfo[];
+const EMPTY_DEVICES_ARRAY = Object.freeze<MediaDeviceInfo[]>([]);
 
 /**
  * Utility hook, which provides the current call's state.
@@ -355,13 +356,11 @@ export const useCameraState = () => {
   const call = useCall();
   const { camera } = call as Call;
 
-  const devices$ = useMemo(() => camera.listDevices(), [camera]);
-
   const { state } = camera;
   const direction = useObservableValue(state.direction$);
   const mediaStream = useObservableValue(state.mediaStream$);
   const selectedDevice = useObservableValue(state.selectedDevice$);
-  const devices = useObservableValue(devices$, EMPTY_DEVICES_ARRAY);
+  const { getDevices } = useLazyDeviceList(camera);
   const hasBrowserPermission = useObservableValue(state.hasBrowserPermission$);
   const isPromptingPermission = useObservableValue(
     state.isPromptingPermission$,
@@ -371,7 +370,9 @@ export const useCameraState = () => {
     camera,
     direction,
     mediaStream,
-    devices,
+    get devices() {
+      return getDevices();
+    },
     hasBrowserPermission,
     isPromptingPermission,
     selectedDevice,
@@ -391,12 +392,10 @@ export const useMicrophoneState = () => {
   const call = useCall();
   const { microphone } = call as Call;
 
-  const devices$ = useMemo(() => microphone.listDevices(), [microphone]);
-
   const { state } = microphone;
   const mediaStream = useObservableValue(state.mediaStream$);
   const selectedDevice = useObservableValue(state.selectedDevice$);
-  const devices = useObservableValue(devices$, EMPTY_DEVICES_ARRAY);
+  const { getDevices } = useLazyDeviceList(microphone);
   const hasBrowserPermission = useObservableValue(state.hasBrowserPermission$);
   const isPromptingPermission = useObservableValue(
     state.isPromptingPermission$,
@@ -406,7 +405,9 @@ export const useMicrophoneState = () => {
   return {
     microphone,
     mediaStream,
-    devices,
+    get devices() {
+      return getDevices();
+    },
     selectedDevice,
     hasBrowserPermission,
     isPromptingPermission,
@@ -432,13 +433,14 @@ export const useSpeakerState = () => {
   const call = useCall();
   const { speaker } = call as Call;
 
-  const devices$ = useMemo(() => speaker.listDevices(), [speaker]);
-  const devices = useObservableValue(devices$, EMPTY_DEVICES_ARRAY);
+  const { getDevices } = useLazyDeviceList(speaker);
   const selectedDevice = useObservableValue(speaker.state.selectedDevice$);
 
   return {
     speaker,
-    devices,
+    get devices() {
+      return getDevices();
+    },
     selectedDevice,
     isDeviceSelectionSupported: speaker.state.isDeviceSelectionSupported,
   };
@@ -503,4 +505,24 @@ function getComputedStatus(
     optimisticIsMute: optimisticStatus !== 'enabled',
     isTogglePending: optimisticStatus !== status,
   };
+}
+
+interface DeviceManagerLike {
+  listDevices(): Observable<MediaDeviceInfo[]>;
+}
+
+function useLazyDeviceList(manager: DeviceManagerLike) {
+  const placeholderDevices$ = useMemo(() => of(EMPTY_DEVICES_ARRAY), []);
+  const [devices$, setDevices$] = useState(placeholderDevices$);
+  const devices = useObservableValue(devices$, EMPTY_DEVICES_ARRAY);
+
+  const getDevices = () => {
+    if (devices$ === placeholderDevices$) {
+      setDevices$(manager.listDevices());
+    }
+
+    return devices;
+  };
+
+  return { getDevices };
 }

--- a/packages/react-sdk/src/hooks/usePersistedDevicePreferences.ts
+++ b/packages/react-sdk/src/hooks/usePersistedDevicePreferences.ts
@@ -20,7 +20,7 @@ type DeviceState<K extends DeviceKey> = {
   [ManagerKey in K]: DeviceManagerLike;
 } & {
   isMute?: boolean;
-  devices: MediaDeviceInfo[];
+  devices: readonly MediaDeviceInfo[];
   selectedDevice: string | undefined;
 };
 
@@ -183,7 +183,7 @@ const patchLocalDevicePreference = (
 const applyLocalDevicePreference = async (
   manager: DeviceManagerLike,
   preference: LocalDevicePreference[],
-  devices: MediaDeviceInfo[],
+  devices: readonly MediaDeviceInfo[],
 ): Promise<void> => {
   let muted: boolean | undefined;
 
@@ -211,7 +211,7 @@ const applyLocalDevicePreference = async (
 };
 
 const getSelectedDevicePreference = (
-  devices: MediaDeviceInfo[],
+  devices: readonly MediaDeviceInfo[],
   selectedDevice: string | undefined,
 ): Pick<LocalDevicePreference, 'selectedDeviceId' | 'selectedDeviceLabel'> => ({
   selectedDeviceId: selectedDevice || defaultDevice,

--- a/packages/react-sdk/src/hooks/usePersistedDevicePreferences.ts
+++ b/packages/react-sdk/src/hooks/usePersistedDevicePreferences.ts
@@ -20,7 +20,7 @@ type DeviceState<K extends DeviceKey> = {
   [ManagerKey in K]: DeviceManagerLike;
 } & {
   isMute?: boolean;
-  devices: readonly MediaDeviceInfo[];
+  devices: MediaDeviceInfo[];
   selectedDevice: string | undefined;
 };
 
@@ -183,7 +183,7 @@ const patchLocalDevicePreference = (
 const applyLocalDevicePreference = async (
   manager: DeviceManagerLike,
   preference: LocalDevicePreference[],
-  devices: readonly MediaDeviceInfo[],
+  devices: MediaDeviceInfo[],
 ): Promise<void> => {
   let muted: boolean | undefined;
 
@@ -211,7 +211,7 @@ const applyLocalDevicePreference = async (
 };
 
 const getSelectedDevicePreference = (
-  devices: readonly MediaDeviceInfo[],
+  devices: MediaDeviceInfo[],
   selectedDevice: string | undefined,
 ): Pick<LocalDevicePreference, 'selectedDeviceId' | 'selectedDeviceLabel'> => ({
   selectedDeviceId: selectedDevice || defaultDevice,

--- a/packages/styling/src/CallLayout/PipLayout-layout.scss
+++ b/packages/styling/src/CallLayout/PipLayout-layout.scss
@@ -8,3 +8,16 @@
   padding-inline: 1rem;
   height: 100%;
 }
+
+.str-video__pip-screen-share-local {
+  display: flex;
+  gap: var(--str-video__spacing-sm);
+  border-radius: var(--str-video__border-radius-sm);
+  padding: var(--str-video__spacing-md);
+  font-size: var(--str-video__font-size-sm);
+
+  .str-video__icon {
+    width: 1rem;
+    height: 1rem;
+  }
+}

--- a/packages/styling/src/CallLayout/PipLayout-theme.scss
+++ b/packages/styling/src/CallLayout/PipLayout-theme.scss
@@ -1,0 +1,3 @@
+.str-video__pip-screen-share-local {
+  background: var(--str-video__background-color5);
+}

--- a/packages/styling/src/CallLayout/index.scss
+++ b/packages/styling/src/CallLayout/index.scss
@@ -2,3 +2,4 @@
 @import './PaginatedGridLayout-layout';
 @import './SpeakerLayout-layout';
 @import './PipLayout-layout.scss';
+@import './PipLayout-theme.scss';


### PR DESCRIPTION
### 💡 Overview

Previously, rendering call state hooks like `useCameraState` and `useMicrophoneState` triggered permission prompt. That happened because these hooks access device list.

Some customers rightly find this confusing: rendering `useCameraState` doesn't necessarily mean you are going to access device list.

Now, device list is accessed only when the `devices` property returned by the hook is really read. If it is not read, no permission prompt will be triggered by the hook.

### 📝 Implementation notes

The `devices` property is now a getter that forces component update when accessed for the first time. Most of the times it will happen during render, which is OK.

> **Note**
> 
> There's one edge case when updating state from getter will not work: that is, if you save hook value to a variable (`const state = useCameraState()`) and then pass it to another component (`<SomeComponent state={state} />`), and then this component accessed device list (`function SomeComponent(props) { props.state.devices }`).
> 
> It's safe to assume nobody will every do that.

Of course this means double-rendering component when the device list is first accessed. But at least it happens synchronously, without a paint in between.