### PR TITLE
fix: watched calls should auto-subscribe for state updates

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -315,7 +315,12 @@ export class Call {
     this.dynascaleManager = new DynascaleManager(this.state, this.speaker);
   }
 
-  private setup = async () => {
+  /**
+   * Set's up the call instance.
+   *
+   * @internal an internal method and should not be used outside the SDK.
+   */
+  setup = async () => {
     await withoutConcurrency(this.joinLeaveConcurrencyTag, async () => {
       if (this.initialized) return;
 

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -316,7 +316,7 @@ export class Call {
   }
 
   /**
-   * Set's up the call instance.
+   * Sets up the call instance.
    *
    * @internal an internal method and should not be used outside the SDK.
    */

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -406,6 +406,7 @@ export class StreamVideoClient {
       call.state.updateFromCallResponse(c.call);
       await call.applyDeviceConfig(c.call.settings, false);
       if (data.watch) {
+        await call.setup();
         this.writeableStateStore.registerCall(call);
       }
       calls.push(call);


### PR DESCRIPTION
### 💡 Overview

We introduced a bug in #1433 that prevented `call` instances returned by `client.queryCalls` from automatically updating their `state` when the `watch: true` flag is provided.

The event handler for `all` events was moved outside the Call's constructor, causing this bug.

### 📝 Implementation notes
- Marks the `call.setup()` as an `@internal` method
- Every `call` instance is automatically set when `watch` mode is set to `true`

🎫 Ticket: https://linear.app/stream/issue/REACT-358/
