### PR TITLE
chore: fix the expo sample app pip mode

### DIFF
--- a/sample-apps/react-native/expo-video-sample/app.json
+++ b/sample-apps/react-native/expo-video-sample/app.json
@@ -50,7 +50,8 @@
             "showWhenLockedAndroid": true
           },
           "enableNonRingingPushNotifications": true,
-          "androidPictureInPicture": true
+          "androidPictureInPicture": true,
+          "iOSEnableMultitaskingCameraAccess": true
         }
       ],
       "@config-plugins/react-native-callkeep",

--- a/sample-apps/react-native/expo-video-sample/components/MeetingUI.tsx
+++ b/sample-apps/react-native/expo-video-sample/components/MeetingUI.tsx
@@ -24,7 +24,7 @@ export const MeetingUI = () => {
         call.leave();
       }
     };
-  }, []);
+  }, [call]);
 
   if (callingState === CallingState.IDLE) {
     return <Lobby />;
@@ -33,7 +33,10 @@ export const MeetingUI = () => {
   }
   return (
     <SafeAreaView style={styles.container}>
-      <CallContent CallControls={CallControlsComponent} />
+      <CallContent
+        CallControls={CallControlsComponent}
+        iOSPiPIncludeLocalParticipantVideo={true}
+      />
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
### 💡 Overview

This PR fixes pip issues in the expo sample app. when the app goes in pip mode only black screen was presented instead of the participant video.

### 📝 Implementation notes

Adds missing pip configuration in the `app.json` and missing prop in the `CallContent` component 

🎫 Ticket: https://linear.app/stream/issue/RN-193/picture-in-picture-fix-for-expo-sample-app
