### PR TITLE
feat: [VID-561] add getCallReport method

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -36,6 +36,7 @@ import type {
   DeleteCallRequest,
   DeleteCallResponse,
   EndCallResponse,
+  GetCallReportResponse,
   GetCallResponse,
   GetCallStatsResponse,
   GetOrCreateCallRequest,
@@ -2394,10 +2395,26 @@ export class Call {
    *
    * @param callSessionID the call session ID to retrieve statistics for.
    * @returns The call stats.
+   * @deprecated use `call.getCallReport` instead.
+   * @internal
    */
   getCallStats = async (callSessionID: string) => {
     const endpoint = `${this.streamClientBasePath}/stats/${callSessionID}`;
     return this.streamClient.get<GetCallStatsResponse>(endpoint);
+  };
+
+  /**
+   * Retrieve call report. If the `callSessionID` is not specified, then the
+   * report for the latest call session is retrieved. If it is specified, then
+   * the report for that particular session is retrieved if it exists.
+   *
+   * @param callSessionID the optional call session ID to retrieve statistics for
+   * @returns the call report
+   */
+  getCallReport = async (callSessionID: string = '') => {
+    const endpoint = `${this.streamClientBasePath}/report`;
+    const params = callSessionID !== '' ? { session_id: callSessionID } : {};
+    return this.streamClient.get<GetCallReportResponse>(endpoint, params);
   };
 
   /**


### PR DESCRIPTION
### 💡 Overview
Introduce `getCallReport` method and deprecate the old `getCallStats` method.

Deprecated getCallStats for several reasons
* It is purpose built for the dashboard
* It mixes call level and participant level stats
* It doesn't scale well with lots of participants because of the previous point

### 📝 Implementation notes
* deprecate old `getCallStats` method
* implement new `getCallReport` method

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
