### PR TITLE
chore(pronto): enter full screen on double-click

### DIFF
--- a/sample-apps/react/react-dogfood/components/Debug/DebugParticipantViewUI.tsx
+++ b/sample-apps/react/react-dogfood/components/Debug/DebugParticipantViewUI.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import {
   DefaultParticipantViewUI,
@@ -25,12 +25,24 @@ export const DebugParticipantViewUI = () => {
   const call = useCall();
   const {
     participant: { sessionId, userId },
+    participantViewElement,
   } = useParticipantViewContext();
 
   const isDemoEnvironment = useIsDemoEnvironment();
   const participantContextMenuActions = isDemoEnvironment
     ? CustomParticipantActionsContextMenu
     : ParticipantActionsContextMenu;
+
+  const fullscreenModeOn = !!document.fullscreenElement;
+  const enterFullScreen = useCallback(() => {
+    if (!participantViewElement) return;
+    if (typeof participantViewElement.requestFullscreen === 'undefined') return;
+
+    if (!fullscreenModeOn) {
+      return participantViewElement.requestFullscreen().catch(console.error);
+    }
+    document.exitFullscreen().catch(console.error);
+  }, [fullscreenModeOn, participantViewElement]);
 
   const isDebug = useIsDebugMode();
   if (!isDebug) {
@@ -40,6 +52,7 @@ export const DebugParticipantViewUI = () => {
           'rd__debug__participant-view',
           isDemoEnvironment && 'rd__debug__participant-view--hide-elements',
         )}
+        onDoubleClick={enterFullScreen}
       >
         <DefaultParticipantViewUI
           ParticipantActionsContextMenu={participantContextMenuActions}

--- a/sample-apps/react/react-dogfood/package.json
+++ b/sample-apps/react/react-dogfood/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "clean": "rimraf .next",
     "dev": "next dev",
+    "dev:https": "next dev --experimental-https",
     "build": "next build",
     "start": "next start"
   },


### PR DESCRIPTION
### 💡 Overview

When a ParticipantView is double-clicked (in Pronto), it automatically enters full-screen mode.
The behavior of the SDK remains the same to prevent breaking changes.