### PR TITLE
fix: call cancellation not reliably seen on killed state RN-198

### DIFF
--- a/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
+++ b/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
@@ -104,10 +104,6 @@ let isSetForegroundServiceRan = false;
  * Additionally: also responsible for cancelling any notifee displayed notification when the call has transitioned out of ringing
  */
 export const useAndroidKeepCallAliveEffect = () => {
-  if (!isSetForegroundServiceRan) {
-    isSetForegroundServiceRan = true;
-    setForegroundService();
-  }
   const foregroundServiceStartedRef = useRef(false);
 
   const call = useCall();
@@ -133,6 +129,10 @@ export const useAndroidKeepCallAliveEffect = () => {
       const run = async () => {
         if (foregroundServiceStartedRef.current) {
           return;
+        }
+        if (!isSetForegroundServiceRan) {
+          isSetForegroundServiceRan = true;
+          setForegroundService();
         }
         const notifee = notifeeLib.default;
         const displayedNotifications =

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -211,11 +211,6 @@ export const firebaseDataHandler = async (
           // check if service needs to be closed if accept/decline event was done on another device
           const unsubscribe = callFromPush.on('all', (event) => {
             const _canListenToWS = canListenToWS();
-            getLogger(['firebaseMessagingOnMessageHandler'])(
-              'debug',
-              `Got event inside fg service callCid: ${call_cid} canListenToWS: ${_canListenToWS}`,
-              { event },
-            );
             if (!_canListenToWS) {
               getLogger(['firebaseMessagingOnMessageHandler'])(
                 'debug',

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -211,6 +211,11 @@ export const firebaseDataHandler = async (
           // check if service needs to be closed if accept/decline event was done on another device
           const unsubscribe = callFromPush.on('all', (event) => {
             const _canListenToWS = canListenToWS();
+            getLogger(['firebaseMessagingOnMessageHandler'])(
+              'debug',
+              `Got event inside fg service callCid: ${call_cid} canListenToWS: ${_canListenToWS}`,
+              { event },
+            );
             if (!_canListenToWS) {
               getLogger(['firebaseMessagingOnMessageHandler'])(
                 'debug',
@@ -239,6 +244,10 @@ export const firebaseDataHandler = async (
                 callingState === CallingState.IDLE ||
                 callingState === CallingState.LEFT
               ) {
+                getLogger(['firebaseMessagingOnMessageHandler'])(
+                  'debug',
+                  `Closing fg service from callingState callCid: ${call_cid} callingState: ${callingState}`,
+                );
                 unsubscribeFunctions.forEach((fn) => fn());
                 notifee.stopForegroundService();
               }


### PR DESCRIPTION
### 💡 Overview

Sometimes this happens

```
 when A initiates a call to B and then A cancels the call but the notification has already reached B and the notification is not cleared at B’s side.
```

Technically, this happens when StreamCall is mounted after Foreground service for incoming call. This overwrites the foreground service responsible for listening to call cancellation.

### 📝 Implementation notes

In this PR, we delay the foreground service setting for keep call alive only when call is joined so that we dont overwrite the foreground service.

🎫 Ticket: https://linear.app/stream/issue/RN-198/notification-not-cleared-on-call-cancellation-sometimes-android

📑 Docs: NA
