### PR TITLE
fix: use more granular permission state for stats reporter

### DIFF
--- a/packages/client/src/devices/BrowserPermission.ts
+++ b/packages/client/src/devices/BrowserPermission.ts
@@ -139,6 +139,10 @@ export class BrowserPermission {
     );
   }
 
+  asStateObservable() {
+    return this.getStateObservable();
+  }
+
   getIsPromptingObservable() {
     return this.getStateObservable().pipe(
       map((state) => state === 'prompting'),

--- a/packages/client/src/devices/InputMediaDeviceManagerState.ts
+++ b/packages/client/src/devices/InputMediaDeviceManagerState.ts
@@ -6,7 +6,7 @@ import {
   shareReplay,
 } from 'rxjs';
 import { RxUtils } from '../store';
-import { BrowserPermission } from './BrowserPermission';
+import { BrowserPermission, BrowserPermissionState } from './BrowserPermission';
 
 export type InputDeviceStatus = 'enabled' | 'disabled' | undefined;
 export type TrackDisableMode = 'stop-tracks' | 'disable-tracks';
@@ -63,9 +63,15 @@ export abstract class InputMediaDeviceManagerState<C = MediaTrackConstraints> {
 
   /**
    * An observable that will emit `true` if browser/system permission
-   * is granted, `false` otherwise.
+   * is granted (or at least hasn't been denied), `false` otherwise.
    */
   hasBrowserPermission$: Observable<boolean>;
+
+  /**
+   * An observable that emits with browser permission state changes.
+   * Gives more granular visiblity than hasBrowserPermission$.
+   */
+  browserPermissionState$: Observable<BrowserPermissionState>;
 
   /**
    * An observable that emits `true` when SDK is prompting for browser permission
@@ -87,6 +93,10 @@ export abstract class InputMediaDeviceManagerState<C = MediaTrackConstraints> {
     this.hasBrowserPermission$ = permission
       ? permission.asObservable().pipe(shareReplay(1))
       : of(true);
+
+    this.browserPermissionState$ = permission
+      ? permission.asStateObservable().pipe(shareReplay(1))
+      : of('prompt');
 
     this.isPromptingPermission$ = permission
       ? permission.getIsPromptingObservable().pipe(shareReplay(1))

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -221,5 +221,6 @@ export const emitDeviceIds = (values: MediaDeviceInfo[]) => {
 
 export const mockBrowserPermission = {
   asObservable: () => of(true),
+  asStateObservable: () => of('prompt'),
   getIsPromptingObservable: () => of(false),
 } as BrowserPermission;

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -83,11 +83,11 @@ export class SfuStatsReporter {
     device: CameraManager | MicrophoneManager,
     kind: 'mic' | 'camera',
   ) => {
-    const { hasBrowserPermission$ } = device.state;
+    const { browserPermissionState$ } = device.state;
     this.unsubscribeDevicePermissionsSubscription?.();
     this.unsubscribeDevicePermissionsSubscription = createSubscription(
-      combineLatest([hasBrowserPermission$, this.state.ownCapabilities$]),
-      ([hasPermission, ownCapabilities]) => {
+      combineLatest([browserPermissionState$, this.state.ownCapabilities$]),
+      ([browserPermissionState, ownCapabilities]) => {
         // cleanup the previous listDevices() subscription in case
         // permissions or capabilities have changed.
         // we will subscribe again if everything is in order.
@@ -96,7 +96,7 @@ export class SfuStatsReporter {
           kind === 'mic'
             ? ownCapabilities.includes(OwnCapability.SEND_AUDIO)
             : ownCapabilities.includes(OwnCapability.SEND_VIDEO);
-        if (!hasPermission || !hasCapability) {
+        if (browserPermissionState !== 'granted' || !hasCapability) {
           this.inputDevices.set(kind, {
             currentDevice: '',
             availableDevices: [],


### PR DESCRIPTION
### 💡 Overview

Some time ago we introduced device reporting in call stats (https://github.com/GetStream/stream-video-js/pull/1533).

The unexpected side effect of this is that stats reporter now tries to list available devices every time the call is joined, even if camera and mic are off by default, causing permission prompt to appear.

This PR fixes that: stats reporter will never cause a permission prompt to appear.

### 📝 Implementation notes

The condition for listing devices was:
1. User has capability to send audio or video
2. Device permission was not explicitly denied (this condition comes from the `hasBrowserPermission$` observable, which is only false if permission state is `denied`)

This PR adds `browserPermissionState$` observable to input device manager, which provides more granular visibility into current permission state. Most importantly, it has different values for `prompt` and `granted` states.

Then we can rely on `browserPermissionState$` in stats reporter, and only report devices when permission is already granted, avoiding prompts.

📑 Docs: https://github.com/GetStream/docs-content/pull/311