### PR TITLE
fix: use timeout reason when auto-dropping calls (instead of decline)

### DIFF
--- a/packages/client/src/__tests__/Call.autodrop.test.ts
+++ b/packages/client/src/__tests__/Call.autodrop.test.ts
@@ -1,0 +1,101 @@
+import '../rtc/__tests__/mocks/webrtc.mocks';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Call } from '../Call';
+import { StreamClient } from '../coordinator/connection/client';
+import { generateUUIDv4 } from '../coordinator/connection/utils';
+import { CallingState, StreamVideoWriteableStateStore } from '../store';
+
+describe('Auto drop ringing calls', () => {
+  let call: Call;
+  const userId = 'jane';
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+
+    const clientStore = new StreamVideoWriteableStateStore();
+    call = new Call({
+      type: 'test',
+      id: generateUUIDv4(),
+      streamClient: new StreamClient('abc'),
+      clientStore: clientStore,
+    });
+
+    // @ts-expect-error mocking only what we need for the test
+    clientStore.connectedUserSubject.next({
+      id: userId,
+    });
+
+    call.state['callingStateSubject'].next(CallingState.RINGING);
+
+    vi.spyOn(call, 'leave').mockImplementation(async () => {
+      console.log(`TEST: leave() called`);
+    });
+  });
+
+  it('caller should drop ringing calls after a timeout if no one accepted', async () => {
+    call.state['settingsSubject'].next({
+      // @ts-expect-error mocking only what we need for the test, we use fake timers, so undefined for timeout works
+      ring: {},
+      // @ts-expect-error mocking only what we need for the test
+      screensharing: {
+        enabled: false,
+        target_resolution: {
+          width: 100,
+          height: 100,
+        },
+      },
+    });
+
+    // @ts-expect-error mocking only what we need for the test
+    call.state['createdBySubject'].next({
+      id: userId,
+    });
+
+    // black-box test, calling private method
+    call['scheduleAutoDrop']();
+
+    await vi.runAllTimersAsync();
+
+    expect(call.leave).toHaveBeenCalledWith({
+      reject: true,
+      reason: 'timeout',
+      message: `ringing timeout - no one accepted`,
+    });
+  });
+
+  it(`callee should drop ringing calls after a timeout if user didn't interact with incoming call screen`, async () => {
+    call.state['settingsSubject'].next({
+      // @ts-expect-error mocking only what we need for the test, we use fake timers, so undefined for timeout works
+      ring: {},
+      // @ts-expect-error mocking only what we need for the test
+      screensharing: {
+        enabled: false,
+        target_resolution: {
+          width: 100,
+          height: 100,
+        },
+      },
+    });
+
+    // @ts-expect-error mocking only what we need for the test
+    call.state['createdBySubject'].next({
+      id: 'not-' + userId,
+    });
+
+    // black-box test, calling private method
+    call['scheduleAutoDrop']();
+
+    await vi.runAllTimersAsync();
+
+    expect(call.leave).toHaveBeenCalledWith({
+      reject: true,
+      reason: 'timeout',
+      message: `ringing timeout - user didn't interact with incoming call screen`,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+});

--- a/packages/client/src/events/__tests__/call.test.ts
+++ b/packages/client/src/events/__tests__/call.test.ts
@@ -114,7 +114,11 @@ describe('Call ringing events', () => {
           },
         },
       });
-      expect(call.leave).toHaveBeenCalled();
+      expect(call.leave).toHaveBeenCalledWith({
+        reject: true,
+        reason: 'cancel',
+        message: 'ring: everyone rejected',
+      });
     });
 
     it(`caller will not leave the call if only one callee rejects`, async () => {

--- a/packages/client/src/events/call.ts
+++ b/packages/client/src/events/call.ts
@@ -58,12 +58,16 @@ export const watchCallRejected = (call: Call) => {
         .every((m) => rejectedBy[m.user_id]);
       if (everyoneElseRejected) {
         call.logger('info', 'everyone rejected, leaving the call');
-        await call.leave({ reason: 'ring: everyone rejected' });
+        await call.leave({
+          reject: true,
+          reason: 'cancel',
+          message: 'ring: everyone rejected',
+        });
       }
     } else {
       if (rejectedBy[eventCall.created_by.id]) {
         call.logger('info', 'call creator rejected, leaving call');
-        await call.leave({ reason: 'ring: creator rejected' });
+        await call.leave({ message: 'ring: creator rejected' });
       }
     }
   };
@@ -80,7 +84,7 @@ export const watchCallEnded = (call: Call) => {
       callingState !== CallingState.LEFT
     ) {
       call
-        .leave({ reason: 'call.ended event received', reject: false })
+        .leave({ message: 'call.ended event received', reject: false })
         .catch((err) => {
           call.logger('error', 'Failed to leave call after call.ended ', err);
         });
@@ -100,7 +104,7 @@ export const watchSfuCallEnded = (call: Call) => {
       // update the call state to reflect the call has ended.
       call.state.setEndedAt(new Date());
       const reason = CallEndedReason[e.reason];
-      await call.leave({ reason: `callEnded received: ${reason}` });
+      await call.leave({ message: `callEnded received: ${reason}` });
     } catch (err) {
       call.logger(
         'error',

--- a/packages/client/src/events/internal.ts
+++ b/packages/client/src/events/internal.ts
@@ -55,7 +55,7 @@ export const watchLiveEnded = (dispatcher: Dispatcher, call: Call) => {
 
     call.state.setBackstage(true);
     if (!call.permissionsContext.hasPermission(OwnCapability.JOIN_BACKSTAGE)) {
-      call.leave({ reason: 'live ended' }).catch((err) => {
+      call.leave({ message: 'live ended' }).catch((err) => {
         call.logger('error', 'Failed to leave call after live ended', err);
       });
     }

--- a/packages/client/src/store/stateStore.ts
+++ b/packages/client/src/store/stateStore.ts
@@ -29,7 +29,7 @@ export class StreamVideoWriteableStateStore {
 
           logger('info', `User disconnected, leaving call: ${call.cid}`);
           await call
-            .leave({ reason: 'client.disconnectUser() called' })
+            .leave({ message: 'client.disconnectUser() called' })
             .catch((err) => {
               logger('error', `Error leaving call: ${call.cid}`, err);
             });

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -12,6 +12,7 @@ import type { StreamClient } from './coordinator/connection/client';
 import type { Comparator } from './sorting';
 import type { StreamVideoWriteableStateStore } from './store';
 import { AxiosError } from 'axios';
+import { RejectReason } from './coordinator/connection/types';
 
 export type StreamReaction = Pick<
   ReactionResponse,
@@ -225,9 +226,14 @@ export type CallLeaveOptions = {
 
   /**
    * The reason for leaving the call.
-   * This will be sent to the backend and will be visible in the logs.
+   * This will be sent as the `reason` field in the `call.rejected` event.
    */
-  reason?: string;
+  reason?: RejectReason;
+
+  /**
+   * You can provide extra information about why the call is being left and/or rejected, used for logging purposes.
+   */
+  message?: string;
 };
 
 /**


### PR DESCRIPTION
### 💡 Overview

When auto dropping calls the client sent `decline` instead of `timeout` reason

### 📝 Implementation notes

The `reason` field previously was misused, instead of sending it coordinator, we sent it as a log message to SFU. Now `reason` is sent to coordinator, and a new field is introduced - `message` - to send to SFU.

I checked and all UI SDKs use the `reason` field correctly - so no changes were required there.

🎫 Ticket: https://linear.app/stream/issue/REACT-363/fix-call-rejection-reasons-in-js-client-for-timeout-scenarios

📑 Docs: N/A
