### PR TITLE
chore: update sample apps to webrtc-125.2.0

### DIFF
--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -121,7 +121,7 @@
     "@react-native-firebase/app": "^21.13.0",
     "@react-native-firebase/messaging": "^21.13.0",
     "@react-native/babel-preset": "^0.76.9",
-    "@stream-io/react-native-webrtc": "^125.0.8",
+    "@stream-io/react-native-webrtc": "^125.1.0",
     "@stream-io/video-filters-react-native": "workspace:^",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^12.9.0",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -121,7 +121,7 @@
     "@react-native-firebase/app": "^21.13.0",
     "@react-native-firebase/messaging": "^21.13.0",
     "@react-native/babel-preset": "^0.76.9",
-    "@stream-io/react-native-webrtc": "^125.1.0",
+    "@stream-io/react-native-webrtc": "^125.2.0",
     "@stream-io/video-filters-react-native": "workspace:^",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^12.9.0",

--- a/packages/video-filters-react-native/package.json
+++ b/packages/video-filters-react-native/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/GetStream/stream-video-js#readme",
   "devDependencies": {
-    "@stream-io/react-native-webrtc": "^125.1.0",
+    "@stream-io/react-native-webrtc": "^125.2.0",
     "react-native": "^0.76.9",
     "react-native-builder-bob": "^0.37.0",
     "rimraf": "^6.0.1",

--- a/packages/video-filters-react-native/package.json
+++ b/packages/video-filters-react-native/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/GetStream/stream-video-js#readme",
   "devDependencies": {
-    "@stream-io/react-native-webrtc": "^125.0.8",
+    "@stream-io/react-native-webrtc": "^125.1.0",
     "react-native": "^0.76.9",
     "react-native-builder-bob": "^0.37.0",
     "rimraf": "^6.0.1",

--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -2075,10 +2075,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - stream-react-native-webrtc
     - Yoga
-  - stream-react-native-webrtc (125.0.8):
+  - stream-react-native-webrtc (125.1.0):
     - React-Core
-    - WebRTC-SDK (~> 125.6422.07)
-  - stream-video-react-native (1.11.0):
+    - StreamWebRTC (~> 125.6422.070)
+  - stream-video-react-native (1.11.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2100,7 +2100,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - stream-react-native-webrtc
     - Yoga
-  - WebRTC-SDK (125.6422.07)
+  - StreamWebRTC (125.6422.070)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2198,7 +2198,7 @@ SPEC REPOS:
   trunk:
     - React-Codegen
     - SocketRocket
-    - WebRTC-SDK
+    - StreamWebRTC
 
 EXTERNAL SOURCES:
   boost:
@@ -2464,9 +2464,9 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   stream-chat-react-native: 8e135bcf2be7bc458b1dc297acc2dce74da452b4
   stream-io-video-filters-react-native: b34b88d6c1d1b0dfaceee70343bd1280691b50e9
-  stream-react-native-webrtc: 6bae0dbc939c1cbd98cc4bd94a049ca655bcac03
-  stream-video-react-native: 1d55f9fb4470afb5ae0dceac7e688d4039615708
-  WebRTC-SDK: dff00a3892bc570b6014e046297782084071657e
+  stream-react-native-webrtc: 34a415d328f280c4e6914a51a39f01385c1a7e2c
+  stream-video-react-native: 4a012b29c4560f1cb270a7ae165a248762828c24
+  StreamWebRTC: a50ebd8beba4def8f4e378b4895824c3520f9889
   Yoga: 1259c7a8cbaccf7b4c3ddf8ee36ca11be9dee407
 
 PODFILE CHECKSUM: 22e502ced1a8b5a5e637f60837d3de140b3387b8

--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -2075,7 +2075,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - stream-react-native-webrtc
     - Yoga
-  - stream-react-native-webrtc (125.1.0):
+  - stream-react-native-webrtc (125.2.0):
     - React-Core
     - StreamWebRTC (~> 125.6422.070)
   - stream-video-react-native (1.11.6):
@@ -2464,7 +2464,7 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   stream-chat-react-native: 8e135bcf2be7bc458b1dc297acc2dce74da452b4
   stream-io-video-filters-react-native: b34b88d6c1d1b0dfaceee70343bd1280691b50e9
-  stream-react-native-webrtc: 34a415d328f280c4e6914a51a39f01385c1a7e2c
+  stream-react-native-webrtc: 76a23186152346a16a7ee6f26d59f5edd5742de3
   stream-video-react-native: 4a012b29c4560f1cb270a7ae165a248762828c24
   StreamWebRTC: a50ebd8beba4def8f4e378b4895824c3520f9889
   Yoga: 1259c7a8cbaccf7b4c3ddf8ee36ca11be9dee407

--- a/sample-apps/react-native/dogfood/package.json
+++ b/sample-apps/react-native/dogfood/package.json
@@ -20,7 +20,7 @@
     "@react-native-firebase/messaging": "^21.13.0",
     "@react-navigation/native": "^7.0",
     "@react-navigation/native-stack": "^7.1",
-    "@stream-io/react-native-webrtc": "^125.0.8",
+    "@stream-io/react-native-webrtc": "^125.1.0",
     "@stream-io/video-filters-react-native": "workspace:^",
     "@stream-io/video-react-native-sdk": "workspace:^",
     "axios": "^1.8.1",

--- a/sample-apps/react-native/dogfood/package.json
+++ b/sample-apps/react-native/dogfood/package.json
@@ -20,7 +20,7 @@
     "@react-native-firebase/messaging": "^21.13.0",
     "@react-navigation/native": "^7.0",
     "@react-navigation/native-stack": "^7.1",
-    "@stream-io/react-native-webrtc": "^125.1.0",
+    "@stream-io/react-native-webrtc": "^125.2.0",
     "@stream-io/video-filters-react-native": "workspace:^",
     "@stream-io/video-react-native-sdk": "workspace:^",
     "axios": "^1.8.1",

--- a/sample-apps/react-native/expo-video-sample/package.json
+++ b/sample-apps/react-native/expo-video-sample/package.json
@@ -17,7 +17,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-firebase/app": "^21.13.0",
     "@react-native-firebase/messaging": "^21.13.0",
-    "@stream-io/react-native-webrtc": "^125.1.0",
+    "@stream-io/react-native-webrtc": "^125.2.0",
     "@stream-io/video-react-native-sdk": "workspace:^",
     "expo": "~52.0.44",
     "expo-build-properties": "~0.13.2",

--- a/sample-apps/react-native/expo-video-sample/package.json
+++ b/sample-apps/react-native/expo-video-sample/package.json
@@ -17,7 +17,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-firebase/app": "^21.13.0",
     "@react-native-firebase/messaging": "^21.13.0",
-    "@stream-io/react-native-webrtc": "^125.0.8",
+    "@stream-io/react-native-webrtc": "^125.1.0",
     "@stream-io/video-react-native-sdk": "workspace:^",
     "expo": "~52.0.44",
     "expo-build-properties": "~0.13.2",

--- a/sample-apps/react-native/ringing-tutorial/package.json
+++ b/sample-apps/react-native/ringing-tutorial/package.json
@@ -23,7 +23,7 @@
     "@react-native-firebase/messaging": "^21.13.0",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
-    "@stream-io/react-native-webrtc": "^125.0.8",
+    "@stream-io/react-native-webrtc": "^125.1.0",
     "@stream-io/video-react-native-sdk": "workspace:^",
     "expo": "~52.0.44",
     "expo-blur": "~14.0.3",

--- a/sample-apps/react-native/ringing-tutorial/package.json
+++ b/sample-apps/react-native/ringing-tutorial/package.json
@@ -23,7 +23,7 @@
     "@react-native-firebase/messaging": "^21.13.0",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
-    "@stream-io/react-native-webrtc": "^125.1.0",
+    "@stream-io/react-native-webrtc": "^125.2.0",
     "@stream-io/video-react-native-sdk": "workspace:^",
     "expo": "~52.0.44",
     "expo-blur": "~14.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6534,7 +6534,7 @@ __metadata:
     "@react-native-firebase/messaging": "npm:^21.13.0"
     "@rnx-kit/metro-config": "npm:^1.3.17"
     "@rnx-kit/metro-resolver-symlinks": "npm:^0.1.36"
-    "@stream-io/react-native-webrtc": "npm:^125.1.0"
+    "@stream-io/react-native-webrtc": "npm:^125.2.0"
     "@stream-io/video-react-native-sdk": "workspace:^"
     "@types/react": "npm:~18.3.12"
     "@types/react-native-incall-manager": "npm:^4.0.3"
@@ -6625,16 +6625,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stream-io/react-native-webrtc@npm:^125.1.0":
-  version: 125.1.0
-  resolution: "@stream-io/react-native-webrtc@npm:125.1.0"
+"@stream-io/react-native-webrtc@npm:^125.2.0":
+  version: 125.2.0
+  resolution: "@stream-io/react-native-webrtc@npm:125.2.0"
   dependencies:
     base64-js: "npm:1.5.1"
     debug: "npm:4.3.4"
     event-target-shim: "npm:6.0.2"
   peerDependencies:
     react-native: ">=0.60.0"
-  checksum: 10/d4eff8238b9140696e1fdc12067e010e77ec878fdacd403757576175d0397db305127a5919802e44184a06855e2112fda1068e1d8353977bd7205119e903a998
+  checksum: 10/e2fcdf743ae9932178d5a544a82cbae15da763de5758abd137f8d33e927d15edf66171b53199cc574b8f05a2b2715078d8a0099be65bc5daa685c9f1fae083ac
   languageName: node
   linkType: hard
 
@@ -6710,7 +6710,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stream-io/video-filters-react-native@workspace:packages/video-filters-react-native"
   dependencies:
-    "@stream-io/react-native-webrtc": "npm:^125.1.0"
+    "@stream-io/react-native-webrtc": "npm:^125.2.0"
     react-native: "npm:^0.76.9"
     react-native-builder-bob: "npm:^0.37.0"
     rimraf: "npm:^6.0.1"
@@ -6845,7 +6845,7 @@ __metadata:
     "@react-navigation/native-stack": "npm:^7.1"
     "@rnx-kit/metro-config": "npm:^1.3.17"
     "@rnx-kit/metro-resolver-symlinks": "npm:^0.1.36"
-    "@stream-io/react-native-webrtc": "npm:^125.1.0"
+    "@stream-io/react-native-webrtc": "npm:^125.2.0"
     "@stream-io/video-filters-react-native": "workspace:^"
     "@stream-io/video-react-native-sdk": "workspace:^"
     "@types/react": "npm:^18.3.2"
@@ -6897,7 +6897,7 @@ __metadata:
     "@react-navigation/native": "npm:^7.0.14"
     "@rnx-kit/metro-config": "npm:^1.3.17"
     "@rnx-kit/metro-resolver-symlinks": "npm:^0.1.36"
-    "@stream-io/react-native-webrtc": "npm:^125.1.0"
+    "@stream-io/react-native-webrtc": "npm:^125.2.0"
     "@stream-io/video-react-native-sdk": "workspace:^"
     "@types/react": "npm:~18.3.12"
     expo: "npm:~52.0.44"
@@ -6944,7 +6944,7 @@ __metadata:
     "@react-native-firebase/app": "npm:^21.13.0"
     "@react-native-firebase/messaging": "npm:^21.13.0"
     "@react-native/babel-preset": "npm:^0.76.9"
-    "@stream-io/react-native-webrtc": "npm:^125.1.0"
+    "@stream-io/react-native-webrtc": "npm:^125.2.0"
     "@stream-io/video-client": "workspace:*"
     "@stream-io/video-filters-react-native": "workspace:^"
     "@stream-io/video-react-bindings": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,17 +3115,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.0.0, @floating-ui/dom@npm:^1.6.3":
-  version: 1.6.11
-  resolution: "@floating-ui/dom@npm:1.6.11"
-  dependencies:
-    "@floating-ui/core": "npm:^1.6.0"
-    "@floating-ui/utils": "npm:^0.2.8"
-  checksum: 10/8579392ad10151474869e7640af169b0d7fc2df48d4da27b6dcb1a57202329147ed986b2972787d4b8cd550c87897271b2d9c4633c2ec7d0b3ad37ce1da636f1
-  languageName: node
-  linkType: hard
-
-"@floating-ui/dom@npm:^1.6.13":
+"@floating-ui/dom@npm:^1.0.0, @floating-ui/dom@npm:^1.6.13, @floating-ui/dom@npm:^1.6.3":
   version: 1.6.13
   resolution: "@floating-ui/dom@npm:1.6.13"
   dependencies:
@@ -3161,14 +3151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/utils@npm:^0.2.4, @floating-ui/utils@npm:^0.2.8":
-  version: 0.2.8
-  resolution: "@floating-ui/utils@npm:0.2.8"
-  checksum: 10/3e3ea3b2de06badc4baebdf358b3dbd77ccd9474a257a6ef237277895943db2acbae756477ec64de65a2a1436d94aea3107129a1feeef6370675bf2b161c1abc
-  languageName: node
-  linkType: hard
-
-"@floating-ui/utils@npm:^0.2.9":
+"@floating-ui/utils@npm:^0.2.4, @floating-ui/utils@npm:^0.2.9":
   version: 0.2.9
   resolution: "@floating-ui/utils@npm:0.2.9"
   checksum: 10/0ca786347db3dd8d9034b86d1449fabb96642788e5900cc5f2aee433cd7b243efbcd7a165bead50b004ee3f20a90ddebb6a35296fc41d43cfd361b6f01b69ffb
@@ -6551,7 +6534,7 @@ __metadata:
     "@react-native-firebase/messaging": "npm:^21.13.0"
     "@rnx-kit/metro-config": "npm:^1.3.17"
     "@rnx-kit/metro-resolver-symlinks": "npm:^0.1.36"
-    "@stream-io/react-native-webrtc": "npm:^125.0.8"
+    "@stream-io/react-native-webrtc": "npm:^125.1.0"
     "@stream-io/video-react-native-sdk": "workspace:^"
     "@types/react": "npm:~18.3.12"
     "@types/react-native-incall-manager": "npm:^4.0.3"
@@ -6642,16 +6625,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stream-io/react-native-webrtc@npm:^125.0.8":
-  version: 125.0.8
-  resolution: "@stream-io/react-native-webrtc@npm:125.0.8"
+"@stream-io/react-native-webrtc@npm:^125.1.0":
+  version: 125.1.0
+  resolution: "@stream-io/react-native-webrtc@npm:125.1.0"
   dependencies:
     base64-js: "npm:1.5.1"
     debug: "npm:4.3.4"
     event-target-shim: "npm:6.0.2"
   peerDependencies:
     react-native: ">=0.60.0"
-  checksum: 10/0b590e0f53535d612acf42aaa2cd0824a027e3de66bfb184dad0baffeb7eb2a9925a3f6f6f9c6c7641afd3abd5850430b97af7058b88176fdf764bd52e8e2610
+  checksum: 10/d4eff8238b9140696e1fdc12067e010e77ec878fdacd403757576175d0397db305127a5919802e44184a06855e2112fda1068e1d8353977bd7205119e903a998
   languageName: node
   linkType: hard
 
@@ -6727,7 +6710,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stream-io/video-filters-react-native@workspace:packages/video-filters-react-native"
   dependencies:
-    "@stream-io/react-native-webrtc": "npm:^125.0.8"
+    "@stream-io/react-native-webrtc": "npm:^125.1.0"
     react-native: "npm:^0.76.9"
     react-native-builder-bob: "npm:^0.37.0"
     rimraf: "npm:^6.0.1"
@@ -6862,7 +6845,7 @@ __metadata:
     "@react-navigation/native-stack": "npm:^7.1"
     "@rnx-kit/metro-config": "npm:^1.3.17"
     "@rnx-kit/metro-resolver-symlinks": "npm:^0.1.36"
-    "@stream-io/react-native-webrtc": "npm:^125.0.8"
+    "@stream-io/react-native-webrtc": "npm:^125.1.0"
     "@stream-io/video-filters-react-native": "workspace:^"
     "@stream-io/video-react-native-sdk": "workspace:^"
     "@types/react": "npm:^18.3.2"
@@ -6914,7 +6897,7 @@ __metadata:
     "@react-navigation/native": "npm:^7.0.14"
     "@rnx-kit/metro-config": "npm:^1.3.17"
     "@rnx-kit/metro-resolver-symlinks": "npm:^0.1.36"
-    "@stream-io/react-native-webrtc": "npm:^125.0.8"
+    "@stream-io/react-native-webrtc": "npm:^125.1.0"
     "@stream-io/video-react-native-sdk": "workspace:^"
     "@types/react": "npm:~18.3.12"
     expo: "npm:~52.0.44"
@@ -6961,7 +6944,7 @@ __metadata:
     "@react-native-firebase/app": "npm:^21.13.0"
     "@react-native-firebase/messaging": "npm:^21.13.0"
     "@react-native/babel-preset": "npm:^0.76.9"
-    "@stream-io/react-native-webrtc": "npm:^125.0.8"
+    "@stream-io/react-native-webrtc": "npm:^125.1.0"
     "@stream-io/video-client": "workspace:*"
     "@stream-io/video-filters-react-native": "workspace:^"
     "@stream-io/video-react-bindings": "workspace:*"


### PR DESCRIPTION
### 💡 Overview

Bumps `@stream-io/react-native-webrtc` to the latest stable version.