### PR TITLE
fix: graceful handling of LIVE_ENDED CallEnded reason

### DIFF
--- a/packages/client/src/events/__tests__/call.test.ts
+++ b/packages/client/src/events/__tests__/call.test.ts
@@ -10,6 +10,7 @@ import {
   CallAcceptedEvent,
   CallEndedEvent,
   CallResponse,
+  OwnCapability,
   RejectCallResponse,
 } from '../../gen/coordinator';
 import { Call } from '../../Call';
@@ -294,6 +295,28 @@ describe('Call ringing events', () => {
       call['dispatcher'].dispatch(event);
 
       expect(call.leave).not.toHaveBeenCalled();
+    });
+
+    it('will stay in backstage if live ended and has permission', async () => {
+      const call = fakeCall();
+      call.state.setBackstage(false);
+      call.permissionsContext.setPermissions([OwnCapability.JOIN_BACKSTAGE]);
+      vi.spyOn(call, 'leave').mockImplementation(async () => {
+        console.log(`TEST: leave() called`);
+      });
+
+      watchSfuCallEnded(call);
+      const event: SfuEvent = {
+        eventPayload: {
+          oneofKind: 'callEnded',
+          callEnded: { reason: CallEndedReason.LIVE_ENDED },
+        },
+      };
+      // @ts-expect-error type issue
+      call['dispatcher'].dispatch(event);
+
+      expect(call.leave).not.toHaveBeenCalled();
+      expect(call.state.backstage).toBe(true);
     });
   });
 


### PR DESCRIPTION
### 💡 Overview

When the `callEnded` event was received by the SFU, we weren't properly checking the `reason` field, and we were aggressively leaving the call.
This isn't the expected behavior for hosts who enter backstage and have permission to join the backstage.