### PR TITLE
fix(rn-dogfood): more actions bottom drawer pressable issues

### DIFF
--- a/sample-apps/react-native/dogfood/src/components/BottomControlsDrawer.tsx
+++ b/sample-apps/react-native/dogfood/src/components/BottomControlsDrawer.tsx
@@ -216,10 +216,9 @@ export const BottomControlsDrawer: React.FC<DrawerProps> = ({
         <View style={styles.overlay}>
           <SafeAreaView style={styles.safeArea}>
             <Animated.View
-              {...panResponder.panHandlers}
               style={[styles.container, { transform: [{ translateY }] }]}
             >
-              {dragIndicator}
+              <View {...panResponder.panHandlers}>{dragIndicator}</View>
               {!showCallStats && moreActions}
               {showCallStats && <CallStats showCodecInfo />}
             </Animated.View>


### PR DESCRIPTION
### 💡 Overview
The actions inside of the more actions bottom drawer component were not working as expected. On press event on any of them the drawer was closed without firing the expected action. 

### 📝 Implementation notes

The pan responder is only attached to the drag indicator instead of the entire `Animated.View`. This way, the buttons will receive their own touch events.

🎫 Ticket: https://linear.app/stream/issue/RN-207/fix-dogfood-bottom-drawer-component-issue

📑 Docs: 🚫 
