### PR TITLE
fix: use scoped locking for PeerConnection events

### DIFF
--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -43,6 +43,7 @@ export abstract class BasePeerConnection {
   readonly stats: StatsTracer;
   private readonly subscriptions: (() => void)[] = [];
   private unsubscribeIceTrickle?: () => void;
+  protected readonly lock = Math.random().toString(36).slice(2);
 
   /**
    * Constructs a new `BasePeerConnection` instance.
@@ -138,7 +139,8 @@ export abstract class BasePeerConnection {
   ): void => {
     this.subscriptions.push(
       this.dispatcher.on(event, (e) => {
-        withoutConcurrency(`pc.${event}`, async () => fn(e)).catch((err) => {
+        const lockKey = `pc.${this.lock}.${event}`;
+        withoutConcurrency(lockKey, async () => fn(e)).catch((err) => {
           if (this.isDisposed) return;
           this.logger('warn', `Error handling ${event}`, err);
         });

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -323,7 +323,7 @@ export class Publisher extends BasePeerConnection {
    * @param options the optional offer options to use.
    */
   private negotiate = async (options?: RTCOfferOptions): Promise<void> => {
-    return withoutConcurrency('publisher.negotiate', async () => {
+    return withoutConcurrency(`publisher.negotiate.${this.lock}`, async () => {
       const offer = await this.pc.createOffer(options);
       const tracks = this.getAnnouncedTracks(offer.sdp);
       if (!tracks.length) throw new Error(`Can't negotiate without any tracks`);


### PR DESCRIPTION
### 💡 Overview

We have locks to ensure sequential processing of certain Peer Connection-related events.

While this works well in the happy path, it sometimes fails when there are multiple `call` instances running in parallel.
e.g., processing an event for Call A halts the processing of the events meant for Call B.
The real problem happens when Call A halts completely and causes a complete stop of processing events for any other Call instance. This is because we keep a global Promise chain that isn't scoped.

This bug affects only the few `withoutConcurency(string)` usages we have throughout the SDK; .symbols are unaffected.

### 📝 Implementation notes
- Add a random chain identifier for the PeerConnection implementation
- We don't use `call.cid` as there could be multiple `call` instances for the same `cid` too

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

