### PR TITLE
fix: ios compilation error on old arch

### DIFF
--- a/packages/react-native-sdk/ios/StreamVideoReactNative.m
+++ b/packages/react-native-sdk/ios/StreamVideoReactNative.m
@@ -245,7 +245,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)reactTag
 #else
     [self.bridge.uiManager
      addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        UIView *view = [uiManager viewForReactTag:viewRef];
+        UIView *view = [uiManager viewForReactTag:reactTag];
 #endif
 
         if (!view) {


### PR DESCRIPTION
### 💡 Overview

Compiler skips the else clause in the pragma in our dogfood and expo since we use new arch. So we missed this. 
