### PR TITLE
fix: fixes an edge case where tracks weren't restored after a reconnect

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1013,7 +1013,7 @@ export class Call {
       );
     }
 
-    if (performingRejoin) {
+    if (performingRejoin && isWsHealthy) {
       const strategy = WebsocketReconnectStrategy[this.reconnectStrategy];
       await previousSfuClient?.leaveAndClose(
         `Closing previous WS after reconnect with strategy: ${strategy}`,
@@ -1338,16 +1338,12 @@ export class Call {
   ): Promise<void> => {
     if (
       this.state.callingState === CallingState.RECONNECTING ||
+      this.state.callingState === CallingState.MIGRATING ||
       this.state.callingState === CallingState.RECONNECTING_FAILED
     )
       return;
 
     return withoutConcurrency(this.reconnectConcurrencyTag, async () => {
-      this.logger(
-        'info',
-        `[Reconnect] Reconnecting with strategy ${WebsocketReconnectStrategy[strategy]}`,
-      );
-
       const reconnectStartTime = Date.now();
       this.reconnectStrategy = strategy;
       this.reconnectReason = reason;
@@ -1374,6 +1370,12 @@ export class Call {
         try {
           // wait until the network is available
           await this.networkAvailableTask?.promise;
+
+          this.logger(
+            'info',
+            `[Reconnect] Reconnecting with strategy ${WebsocketReconnectStrategy[this.reconnectStrategy]}`,
+          );
+
           switch (this.reconnectStrategy) {
             case WebsocketReconnectStrategy.UNSPECIFIED:
             case WebsocketReconnectStrategy.DISCONNECT:
@@ -1428,6 +1430,7 @@ export class Call {
         this.state.callingState !== CallingState.RECONNECTING_FAILED &&
         this.state.callingState !== CallingState.LEFT
       );
+      this.logger('info', '[Reconnect] Reconnection flow finished');
     });
   };
 


### PR DESCRIPTION
### 💡 Overview

Sometimes when the WS was abruptly closed, the local track state wasn't restored properly until the user toggled the mic/camera.
The reason for this was improper handling of sending the `LeaveRequest` to the broken SFU. 
The `doJoin()` method never returned, as it was awaiting the "broken client" to reconnect, which obviously won't happen.
This led to a situation where `restorePublishedTracks()` and `restorePublishedTracks()` never ran, and kept the UI state inconsistent.

### 📝 Implementation notes
- Skip sending the `LeaveRequest` if the previous WS connection is not healthy

