### PR TITLE
fix: enable chore releases

### DIFF
--- a/packages/audio-filters-web/project.json
+++ b/packages/audio-filters-web/project.json
@@ -10,19 +10,19 @@
           "name": "conventionalcommits",
           "preMajor": true,
           "types": [
-            {"type": "feat", "section": "Features"},
-            {"type": "fix", "section": "Bug Fixes"},
-            {"type": "chore", "hidden": true},
-            {"type": "docs", "hidden": true},
-            {"type": "style", "hidden": true},
-            {"type": "refactor", "hidden": true},
-            {"type": "perf", "section": "Features"},
-            {"type": "test", "hidden": true}
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "chore", "hidden": true },
+            { "type": "docs", "hidden": true },
+            { "type": "style", "hidden": true },
+            { "type": "refactor", "hidden": true },
+            { "type": "perf", "section": "Features" },
+            { "type": "test", "hidden": true }
           ]
         },
         "trackDeps": true,
         "push": true,
-        "skipCommitTypes": ["chore", "ci", "refactor", "test", "docs"],
+        "skipCommitTypes": ["ci", "refactor", "test", "docs"],
         "postTargets": [
           "@stream-io/audio-filters-web:update-version",
           "@stream-io/audio-filters-web:github",

--- a/packages/client/project.json
+++ b/packages/client/project.json
@@ -11,18 +11,18 @@
           "name": "conventionalcommits",
           "preMajor": false,
           "types": [
-            {"type": "feat", "section": "Features"},
-            {"type": "fix", "section": "Bug Fixes"},
-            {"type": "chore", "hidden": false},
-            {"type": "docs", "hidden": true},
-            {"type": "style", "hidden": true},
-            {"type": "refactor", "hidden": true},
-            {"type": "perf", "section": "Features"},
-            {"type": "test", "hidden": true}
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "chore", "hidden": false },
+            { "type": "docs", "hidden": true },
+            { "type": "style", "hidden": true },
+            { "type": "refactor", "hidden": true },
+            { "type": "perf", "section": "Features" },
+            { "type": "test", "hidden": true }
           ]
         },
         "push": true,
-        "skipCommitTypes": ["chore", "ci", "refactor", "test", "docs"],
+        "skipCommitTypes": ["ci", "refactor", "test", "docs"],
         "postTargets": [
           "@stream-io/video-client:update-version",
           "@stream-io/video-client:github",

--- a/packages/react-bindings/project.json
+++ b/packages/react-bindings/project.json
@@ -23,7 +23,7 @@
         },
         "trackDeps": true,
         "push": true,
-        "skipCommitTypes": ["chore", "ci", "refactor", "test", "docs"],
+        "skipCommitTypes": ["ci", "refactor", "test", "docs"],
         "postTargets": [
           "@stream-io/video-react-bindings:github",
           "@stream-io/video-react-bindings:publish"

--- a/packages/react-native-sdk/project.json
+++ b/packages/react-native-sdk/project.json
@@ -23,7 +23,7 @@
         },
         "trackDeps": true,
         "push": true,
-        "skipCommitTypes": ["chore", "ci", "docs"],
+        "skipCommitTypes": ["ci", "docs"],
         "postTargets": [
           "@stream-io/video-react-native-sdk:update-version",
           "@stream-io/video-react-native-sdk:github",

--- a/packages/react-sdk/project.json
+++ b/packages/react-sdk/project.json
@@ -11,19 +11,19 @@
           "name": "conventionalcommits",
           "preMajor": false,
           "types": [
-            {"type": "feat", "section": "Features"},
-            {"type": "fix", "section": "Bug Fixes"},
-            {"type": "chore", "hidden": false},
-            {"type": "docs", "hidden": true},
-            {"type": "style", "hidden": true},
-            {"type": "refactor", "hidden": true},
-            {"type": "perf", "section": "Features"},
-            {"type": "test", "hidden": true}
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "chore", "hidden": false },
+            { "type": "docs", "hidden": true },
+            { "type": "style", "hidden": true },
+            { "type": "refactor", "hidden": true },
+            { "type": "perf", "section": "Features" },
+            { "type": "test", "hidden": true }
           ]
         },
         "trackDeps": true,
         "push": true,
-        "skipCommitTypes": ["chore", "ci", "refactor", "test", "docs"],
+        "skipCommitTypes": ["ci", "refactor", "test", "docs"],
         "postTargets": [
           "@stream-io/video-react-sdk:update-version",
           "@stream-io/video-react-sdk:github",

--- a/packages/styling/project.json
+++ b/packages/styling/project.json
@@ -22,7 +22,7 @@
         },
         "trackDeps": true,
         "push": true,
-        "skipCommitTypes": ["chore", "ci", "refactor", "test"],
+        "skipCommitTypes": ["ci", "refactor", "test"],
         "postTargets": [
           "@stream-io/video-styling:github",
           "@stream-io/video-styling:publish"

--- a/packages/video-filters-react-native/project.json
+++ b/packages/video-filters-react-native/project.json
@@ -22,7 +22,7 @@
         },
         "trackDeps": true,
         "push": true,
-        "skipCommitTypes": ["chore", "ci", "docs"],
+        "skipCommitTypes": ["ci", "docs"],
         "postTargets": [
           "@stream-io/video-filters-react-native:build",
           "@stream-io/video-filters-react-native:github",

--- a/packages/video-filters-web/project.json
+++ b/packages/video-filters-web/project.json
@@ -10,19 +10,19 @@
           "name": "conventionalcommits",
           "preMajor": true,
           "types": [
-            {"type": "feat", "section": "Features"},
-            {"type": "fix", "section": "Bug Fixes"},
-            {"type": "chore", "hidden": true},
-            {"type": "docs", "hidden": true},
-            {"type": "style", "hidden": true},
-            {"type": "refactor", "hidden": true},
-            {"type": "perf", "section": "Features"},
-            {"type": "test", "hidden": true}
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "chore", "hidden": true },
+            { "type": "docs", "hidden": true },
+            { "type": "style", "hidden": true },
+            { "type": "refactor", "hidden": true },
+            { "type": "perf", "section": "Features" },
+            { "type": "test", "hidden": true }
           ]
         },
         "trackDeps": true,
         "push": true,
-        "skipCommitTypes": ["chore", "ci", "refactor", "test", "docs"],
+        "skipCommitTypes": ["ci", "refactor", "test", "docs"],
         "postTargets": [
           "@stream-io/video-filters-web:update-version",
           "@stream-io/video-filters-web:github",


### PR DESCRIPTION
### 💡 Overview

Allows `chore` releases to perform version bump of the SDK packages.
