### PR TITLE
fix: do not mutate filters array during pipeline setup

### DIFF
--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -173,6 +173,7 @@ export abstract class InputMediaDeviceManager<
     const registered = withoutConcurrency(
       this.filterRegistrationConcurrencyTag,
       async () => {
+        await settled(this.statusChangeConcurrencyTag);
         this.filters.push(entry);
         await this.applySettingsToStream();
       },
@@ -182,6 +183,7 @@ export abstract class InputMediaDeviceManager<
       registered,
       unregister: () =>
         withoutConcurrency(this.filterRegistrationConcurrencyTag, async () => {
+          await settled(this.statusChangeConcurrencyTag);
           entry.stop?.();
           this.filters = this.filters.filter((f) => f !== entry);
           await this.applySettingsToStream();


### PR DESCRIPTION
### 💡 Overview

It's a possible fix for the issue when there's no audio coming out out from the noise cancellation audio context.

### 📝 Implementation notes

Our filter pipeline setup is async, so we should be careful not to mutate anything filter-related while the pipeline is being set up. Even if it's not a root cause of the problem described above, it can still lead to weird consequences.