### PR TITLE
chore(rn-dogfood): watch ringing calls on all screens

### DIFF
--- a/sample-apps/react-native/dogfood/App.tsx
+++ b/sample-apps/react-native/dogfood/App.tsx
@@ -32,7 +32,7 @@ import { setPushConfig } from './src/utils/setPushConfig';
 import { useSyncPermissions } from './src/hooks/useSyncPermissions';
 import { NavigationHeader } from './src/components/NavigationHeader';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { LogBox } from 'react-native';
+import { Alert, LogBox } from 'react-native';
 import { LiveStream } from './src/navigators/Livestream';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import {
@@ -40,6 +40,7 @@ import {
   isPushNotificationiOSStreamVideoEvent,
   onPushNotificationiOSStreamVideoEvent,
   StreamTheme,
+  useCalls,
 } from '@stream-io/video-react-native-sdk';
 import { appTheme } from './src/theme';
 
@@ -170,12 +171,47 @@ const StackNavigator = () => {
   return (
     <GestureHandlerRootView style={containerStyle}>
       <VideoWrapper>
+        <RingingWatcher />
         <ChatWrapper>
           <Stack.Navigator>{mode}</Stack.Navigator>
         </ChatWrapper>
       </VideoWrapper>
     </GestureHandlerRootView>
   );
+};
+
+/**
+ * This component is used to watch for incoming calls and set the app mode to 'Call'
+ */
+const RingingWatcher = () => {
+  const setState = useAppGlobalStoreSetState();
+  const calls = useCalls().filter((c) => c.ringing);
+
+  const handleMoreCalls = React.useCallback(async () => {
+    const lastCallCreatedBy = calls[1]?.state.createdBy;
+    Alert.alert(
+      `Incoming call from ${
+        lastCallCreatedBy?.name ?? lastCallCreatedBy?.id
+      }, only 1 call at a time is supported`,
+    );
+  }, [calls]);
+
+  // Reset the state of the show variable when there are no calls.
+  useEffect(() => {
+    if (calls.length > 1) {
+      handleMoreCalls();
+    }
+  }, [calls.length, handleMoreCalls]);
+
+  const firstCall = calls[0];
+
+  useEffect(() => {
+    if (firstCall) {
+      setState({ appMode: 'Call' });
+    }
+  }, [firstCall, setState]);
+
+  return null;
 };
 
 export default function App() {

--- a/sample-apps/react-native/dogfood/App.tsx
+++ b/sample-apps/react-native/dogfood/App.tsx
@@ -189,7 +189,7 @@ const RingingWatcher = () => {
 
   useEffect(() => {
     if (calls.length > 1) {
-      const lastCallCreatedBy = calls[1]?.state.createdBy;
+      const lastCallCreatedBy = calls.at(-1)?.state.createdBy;
       Alert.alert(
         `Incoming call from ${
           lastCallCreatedBy?.name ?? lastCallCreatedBy?.id

--- a/sample-apps/react-native/dogfood/App.tsx
+++ b/sample-apps/react-native/dogfood/App.tsx
@@ -187,21 +187,16 @@ const RingingWatcher = () => {
   const setState = useAppGlobalStoreSetState();
   const calls = useCalls().filter((c) => c.ringing);
 
-  const handleMoreCalls = React.useCallback(async () => {
-    const lastCallCreatedBy = calls[1]?.state.createdBy;
-    Alert.alert(
-      `Incoming call from ${
-        lastCallCreatedBy?.name ?? lastCallCreatedBy?.id
-      }, only 1 call at a time is supported`,
-    );
-  }, [calls]);
-
-  // Reset the state of the show variable when there are no calls.
   useEffect(() => {
     if (calls.length > 1) {
-      handleMoreCalls();
+      const lastCallCreatedBy = calls[1]?.state.createdBy;
+      Alert.alert(
+        `Incoming call from ${
+          lastCallCreatedBy?.name ?? lastCallCreatedBy?.id
+        }, only 1 call at a time is supported`,
+      );
     }
-  }, [calls.length, handleMoreCalls]);
+  }, [calls]);
 
   const firstCall = calls[0];
 

--- a/sample-apps/react-native/dogfood/src/navigators/Call.tsx
+++ b/sample-apps/react-native/dogfood/src/navigators/Call.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import JoinCallScreen from '../screens/Call/JoinCallScreen';
 
 import {
@@ -8,7 +8,7 @@ import {
   StreamCall,
   useCalls,
 } from '@stream-io/video-react-native-sdk';
-import { Alert, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { CallStackParamList } from '../../types';
 import { NavigationHeader } from '../components/NavigationHeader';
@@ -24,22 +24,6 @@ const Calls = () => {
   const calls = useCalls().filter((c) => c.ringing);
   const { top } = useSafeAreaInsets();
   const orientation = useOrientation();
-
-  const handleMoreCalls = useCallback(async () => {
-    const lastCallCreatedBy = calls[1]?.state.createdBy;
-    Alert.alert(
-      `Incoming call from ${
-        lastCallCreatedBy?.name ?? lastCallCreatedBy?.id
-      }, only 1 call at a time is supported`,
-    );
-  }, [calls]);
-
-  // Reset the state of the show variable when there are no calls.
-  useEffect(() => {
-    if (calls.length > 1) {
-      handleMoreCalls();
-    }
-  }, [calls.length, handleMoreCalls]);
 
   const firstCall = calls[0];
 
@@ -64,7 +48,7 @@ const CallLeaveOnUnmount = ({ call }: { call: StreamCallType }) => {
         call.leave();
       }
     };
-  }, []);
+  }, [call]);
   return null;
 };
 


### PR DESCRIPTION
### 💡 Overview

In df app, we watched ringing calls only when the app mode was set to calling. With this change, we also watch whatever mode it is. 

So that even when df app is killed off, it navigates properly even if meeting was used before.
