### PR TITLE
fix: rpc error tracing

### DIFF
--- a/packages/client/src/rpc/__tests__/createClient.test.ts
+++ b/packages/client/src/rpc/__tests__/createClient.test.ts
@@ -30,9 +30,8 @@ describe('createClient', () => {
 
   it('withRequestLogger should log the request', () => {
     const logger = vi.fn();
-    const level = 'debug';
-    const interceptor = withRequestLogger(logger, level);
-    const next = vi.fn();
+    const interceptor = withRequestLogger(logger, 'debug');
+    const next = vi.fn().mockReturnValue({});
     // @ts-expect-error - private field
     interceptor.interceptUnary(next, { name: 'test' }, null, null);
     expect(next).toHaveBeenCalled();
@@ -53,28 +52,6 @@ describe('createClient', () => {
     );
     expect(next).toHaveBeenCalled();
     expect(trace).toHaveBeenCalledWith('TestMethod', { param: 'value' });
-  });
-
-  it('withRequestTracer should add an error trace', () => {
-    const trace = vi.fn();
-    const interceptor = withRequestTracer(trace);
-    const err = new Error('test error');
-    const next = vi.fn(() => {
-      throw err;
-    });
-    expect(() =>
-      interceptor.interceptUnary(
-        next,
-        // @ts-expect-error - invalid name
-        { name: 'TestMethod' },
-        { param: 'value' },
-        { meta: {} },
-      ),
-    ).toThrow('test error');
-    expect(trace).toHaveBeenLastCalledWith('TestMethodOnFailure', [
-      err,
-      { param: 'value' },
-    ]);
   });
 
   it('withRequestTracer should add a failure trace when the SFU returns an error', async () => {

--- a/packages/client/src/rpc/retryable.ts
+++ b/packages/client/src/rpc/retryable.ts
@@ -49,8 +49,8 @@ export const retryable = async <
       const isAborted = signal?.aborted ?? false;
       if (isRequestCancelled || isAborted) throw err;
       getLogger(['sfu-client', 'rpc'])('debug', `rpc failed (${attempt})`, err);
-      attempt++;
     }
+    attempt++;
   } while (!result || result.response.error?.shouldRetry);
 
   return result;

--- a/packages/client/src/rpc/retryable.ts
+++ b/packages/client/src/rpc/retryable.ts
@@ -49,8 +49,8 @@ export const retryable = async <
       const isAborted = signal?.aborted ?? false;
       if (isRequestCancelled || isAborted) throw err;
       getLogger(['sfu-client', 'rpc'])('debug', `rpc failed (${attempt})`, err);
+      attempt++;
     }
-    attempt++;
   } while (!result || result.response.error?.shouldRetry);
 
   return result;


### PR DESCRIPTION
### 💡 Overview

When an error happens while processing an RPC, our SFU returns an HTTP 200 status and a response body with an `error` object. This is a bit of non-standard behavior that we can't fix without breaking the existing API.
This means that data errors will never throw an error, and hence, making our try/catch interceptor useless in some circumstances.
In this PR, we unwrap the response in the interceptor (asynchronously) and inspect its content.

