### PR TITLE
feat: overridable location randomization

### DIFF
--- a/sample-apps/react/react-dogfood/helpers/axiosApiTransformers.ts
+++ b/sample-apps/react/react-dogfood/helpers/axiosApiTransformers.ts
@@ -52,13 +52,19 @@ const generalLocationOverrideTransformer: AxiosRequestTransformer =
    * as it executes in the context of the current axios instance.
    */
   function generalLocationOverrideTransformer(data) {
-    if (
-      typeof window === 'undefined' ||
-      !this.url?.endsWith('/join') ||
-      process.env.NEXT_PUBLIC_ENABLE_LOCATION_RANDOMIZATION !== 'true'
-    ) {
+    if (typeof window === 'undefined' || !this.url?.endsWith('/join'))
       return data;
-    }
+
+    const params = new URLSearchParams(window.location.search);
+    const forceRandomLocation = params.get('random_location');
+    const randomize =
+      forceRandomLocation === 'true'
+        ? true
+        : forceRandomLocation === 'false'
+          ? false
+          : process.env.NEXT_PUBLIC_ENABLE_LOCATION_RANDOMIZATION === 'true';
+
+    if (!randomize) return data;
 
     // prettier-ignore
     const iataCodes = [


### PR DESCRIPTION
### 💡 Overview

Allows enabling or disabling location randomization through the `?random_location=true|false` query parameter.