### PR TITLE
fix: add audio context state tracing

### DIFF
--- a/packages/audio-filters-web/src/tracer.ts
+++ b/packages/audio-filters-web/src/tracer.ts
@@ -1,0 +1,5 @@
+export interface Tracer {
+  trace: Trace;
+}
+
+export type Trace = (tag: string, data: string) => void;

--- a/packages/react-sdk/src/components/NoiseCancellation/NoiseCancellationProvider.tsx
+++ b/packages/react-sdk/src/components/NoiseCancellation/NoiseCancellationProvider.tsx
@@ -111,7 +111,7 @@ export const NoiseCancellationProvider = (
     noiseCancellation.isEnabled().then((e) => setIsEnabled(e));
     const unsubscribe = noiseCancellation.on('change', (v) => setIsEnabled(v));
     const init = (deinit.current || Promise.resolve())
-      .then(() => noiseCancellation.init())
+      .then(() => noiseCancellation.init({ tracer: call.tracer }))
       .then(() => call.microphone.enableNoiseCancellation(noiseCancellation))
       .catch((e) => console.error(`Can't initialize noise cancellation`, e));
 


### PR DESCRIPTION
### 💡 Overview

Adds tracing for Noise Cancellation AudioContext state.

### 📝 Implementation notes

Since starting AudioContext requires user interaction, it's possible that some integrations can experience audio issues when using noise cancellation because AudioContext is suspended. This trace should help discover these issues.
