### PR TITLE
fix: use AudioContext for Safari

### DIFF
--- a/packages/audio-filters-web/src/NoiseCancellation.ts
+++ b/packages/audio-filters-web/src/NoiseCancellation.ts
@@ -54,7 +54,7 @@ export interface INoiseCancellation {
   enable: () => void;
   disable: () => void;
   dispose: () => Promise<void>;
-  resume: () => Promise<void>;
+  resume: () => void;
   setSuppressionLevel: (level: number) => void;
   toFilter: () => (mediaStream: MediaStream) => {
     output: MediaStream;
@@ -277,10 +277,10 @@ export class NoiseCancellation implements INoiseCancellation {
     return { output: destination.stream };
   };
 
-  resume = async () => {
+  resume = () => {
     // resume if still suspended
     if (this.audioContext?.state === 'suspended') {
-      return this.audioContext.resume().catch((err) => {
+      this.audioContext.resume().catch((err) => {
         console.warn(
           'Failed to resume the audio context. Noise Cancellation may not work correctly',
           err,

--- a/packages/audio-filters-web/src/NoiseCancellation.ts
+++ b/packages/audio-filters-web/src/NoiseCancellation.ts
@@ -54,6 +54,7 @@ export interface INoiseCancellation {
   enable: () => void;
   disable: () => void;
   dispose: () => Promise<void>;
+  resume: () => Promise<void>;
   setSuppressionLevel: (level: number) => void;
   toFilter: () => (mediaStream: MediaStream) => {
     output: MediaStream;
@@ -168,15 +169,7 @@ export class NoiseCancellation implements INoiseCancellation {
     // AudioContext requires user interaction to start:
     // https://developer.chrome.com/blog/autoplay/#webaudio
     const resume = () => {
-      // resume if still suspended
-      if (this.audioContext?.state === 'suspended') {
-        this.audioContext.resume().catch((err) => {
-          console.warn(
-            'Failed to resume the audio context. Noise Cancellation may not work correctly',
-            err,
-          );
-        });
-      }
+      this.resume();
       document.removeEventListener('click', resume);
     };
 
@@ -277,7 +270,23 @@ export class NoiseCancellation implements INoiseCancellation {
     const destination = this.audioContext.createMediaStreamDestination();
 
     source.connect(this.filterNode).connect(destination);
+    // When filter is started, user's microphone media stream is active.
+    // That means that most probably we can resume audio context without
+    // any autoplay policy limitations.
+    this.resume();
     return { output: destination.stream };
+  };
+
+  resume = async () => {
+    // resume if still suspended
+    if (this.audioContext?.state === 'suspended') {
+      return this.audioContext.resume().catch((err) => {
+        console.warn(
+          'Failed to resume the audio context. Noise Cancellation may not work correctly',
+          err,
+        );
+      });
+    }
   };
 
   /**

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -46,7 +46,7 @@
     "@types/ua-parser-js": "^0.7.39",
     "@vitest/coverage-v8": "^3.1.3",
     "dotenv": "^16.5.0",
-    "happy-dom": "^11.0.2",
+    "happy-dom": "^17.5.6",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "rollup": "^4.40.2",

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -606,6 +606,7 @@ export class Call {
       );
       this.sfuClient = undefined;
       this.dynascaleManager.setSfuClient(undefined);
+      await this.dynascaleManager.dispose();
 
       this.state.setCallingState(CallingState.LEFT);
       this.state.setParticipants([]);
@@ -844,6 +845,7 @@ export class Call {
     this.state.setCallingState(CallingState.JOINING);
 
     maxJoinRetries = Math.max(maxJoinRetries, 1);
+    // TODO ask for a new SFU when rejoining
     for (let attempt = 0; attempt < maxJoinRetries; attempt++) {
       try {
         this.logger('trace', `Joining call (${attempt})`, this.cid);

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -177,6 +177,7 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
       await this.disableNoiseCancellation().catch((err) => {
         this.logger('warn', 'Failed to disable noise cancellation', err);
       });
+      throw e;
     }
   }
 

--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -516,7 +516,7 @@ export class DynascaleManager {
       deviceId: string,
       audioContext: AudioContext | undefined,
     ) => {
-      if (deviceId == null) return; // allow ''
+      if (!deviceId) return;
       if ('setSinkId' in audioElement) {
         audioElement.setSinkId(deviceId).catch((e) => {
           this.logger('warn', `Can't to set AudioElement sinkId`, e);

--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -502,7 +502,6 @@ export class DynascaleManager {
     sessionId: string,
     trackType: AudioTrackType,
   ) => {
-    console.log('>>> Bound participant audio', sessionId);
     const participant = this.callState.findParticipantBySessionId(sessionId);
     if (!participant || participant.isLocalParticipant) return;
 
@@ -533,7 +532,7 @@ export class DynascaleManager {
     };
 
     let sourceNode: MediaStreamAudioSourceNode | undefined = undefined;
-    const gainNode: GainNode | undefined = undefined;
+    let gainNode: GainNode | undefined = undefined;
 
     const updateMediaStreamSubscription = participant$
       .pipe(
@@ -550,37 +549,38 @@ export class DynascaleManager {
             : p.audioStream;
         if (audioElement.srcObject === source) return;
 
-        audioElement.srcObject = source ?? null;
-        if (!source) return;
+        setTimeout(() => {
+          audioElement.srcObject = source ?? null;
+          if (!source) return;
 
-        // Safari has a special quirk that prevents playing audio until the user
-        // interacts with the page or focuses on the tab where the call happens.
-        // This is a workaround for the issue where:
-        // - A and B are in a call
-        // - A switches to another tab
-        // - B mutes their microphone and unmutes it
-        // - A does not hear B's unmuted audio until they focus the tab
-        const audioContext = this.getOrCreateAudioContext();
-        if (audioContext) {
-          // we will play audio through the audio context in Safari
-          audioElement.muted = true;
-          sourceNode?.disconnect();
-          sourceNode = audioContext.createMediaStreamSource(source);
-          // gainNode ??= audioContext.createGain();
-          // gainNode.gain.value = p.audioVolume ?? this.speaker.state.volume;
-          // sourceNode.connect(gainNode).connect(audioContext.destination);
-          sourceNode.connect(audioContext.destination);
-          this.resumeAudioContext();
-        } else {
-          // we will play audio directly through the audio element in other browsers
-          audioElement.muted = false;
-          audioElement.play().catch((e) => {
-            this.logger('warn', `Failed to play audio stream`, e);
-          });
-        }
+          // Safari has a special quirk that prevents playing audio until the user
+          // interacts with the page or focuses on the tab where the call happens.
+          // This is a workaround for the issue where:
+          // - A and B are in a call
+          // - A switches to another tab
+          // - B mutes their microphone and unmutes it
+          // - A does not hear B's unmuted audio until they focus the tab
+          const audioContext = this.getOrCreateAudioContext();
+          if (audioContext) {
+            // we will play audio through the audio context in Safari
+            audioElement.muted = true;
+            sourceNode?.disconnect();
+            sourceNode = audioContext.createMediaStreamSource(source);
+            gainNode ??= audioContext.createGain();
+            gainNode.gain.value = p.audioVolume ?? this.speaker.state.volume;
+            sourceNode.connect(gainNode).connect(audioContext.destination);
+            this.resumeAudioContext();
+          } else {
+            // we will play audio directly through the audio element in other browsers
+            audioElement.muted = false;
+            audioElement.play().catch((e) => {
+              this.logger('warn', `Failed to play audio stream`, e);
+            });
+          }
 
-        const { selectedDevice } = this.speaker.state;
-        if (selectedDevice) updateSinkId(selectedDevice, audioContext);
+          const { selectedDevice } = this.speaker.state;
+          if (selectedDevice) updateSinkId(selectedDevice, audioContext);
+        });
       });
 
     const sinkIdSubscription = !('setSinkId' in audioElement)
@@ -596,7 +596,7 @@ export class DynascaleManager {
     ]).subscribe(([volume, p]) => {
       const participantVolume = p.audioVolume ?? volume;
       audioElement.volume = participantVolume;
-      // if (gainNode) gainNode.gain.value = participantVolume;
+      if (gainNode) gainNode.gain.value = participantVolume;
     });
 
     audioElement.autoplay = true;
@@ -606,8 +606,7 @@ export class DynascaleManager {
       volumeSubscription.unsubscribe();
       updateMediaStreamSubscription.unsubscribe();
       sourceNode?.disconnect();
-      // gainNode?.disconnect();
-      console.log('>>> Unbound participant audio', sessionId);
+      gainNode?.disconnect();
     };
   };
 

--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -605,6 +605,7 @@ export class DynascaleManager {
       sinkIdSubscription?.unsubscribe();
       volumeSubscription.unsubscribe();
       updateMediaStreamSubscription.unsubscribe();
+      audioElement.srcObject = null;
       sourceNode?.disconnect();
       gainNode?.disconnect();
     };

--- a/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
+++ b/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
@@ -4,7 +4,16 @@
 
 import '../../rtc/__tests__/mocks/webrtc.mocks';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  Mock,
+  vi,
+} from 'vitest';
 import { DynascaleManager } from '../DynascaleManager';
 import { Call } from '../../Call';
 import { StreamClient } from '../../coordinator/connection/client';
@@ -89,18 +98,42 @@ describe('DynascaleManager', () => {
     let videoElement: globalThis.HTMLVideoElement;
 
     beforeEach(() => {
+      // Mock global isSafari to false for testing
+      globalThis._isSafari = false;
+      vi.mock(import('../browsers'), async (importOriginal) => {
+        const module = await importOriginal();
+        return {
+          ...module,
+          isSafari: () => globalThis._isSafari ?? false,
+        };
+      });
+
       videoElement = document.createElement('video');
+
+      // circumvent happy-dom's extensive validation rules
+      Object.defineProperties(videoElement, {
+        srcObject: { writable: true },
+        clientWidth: { writable: true },
+        clientHeight: { writable: true },
+      });
+
       // @ts-expect-error private property
       videoElement.clientWidth = 100;
       // @ts-expect-error private property
       videoElement.clientHeight = 100;
     });
 
+    afterAll(() => {
+      vi.resetModules();
+    });
+
     it('audio: should bind audio element', () => {
       vi.useFakeTimers();
       const audioElement = document.createElement('audio');
+      // circumvent happy-dom's MediaStream validation
+      Object.defineProperty(audioElement, 'srcObject', { writable: true });
       const play = vi.spyOn(audioElement, 'play').mockResolvedValue();
-      audioElement.setSinkId = vi.fn();
+      audioElement.setSinkId = vi.fn().mockResolvedValue({});
 
       // @ts-expect-error incomplete data
       call.state.updateOrAddParticipant('session-id', {
@@ -134,7 +167,7 @@ describe('DynascaleManager', () => {
       expect(play).toHaveBeenCalled();
       expect(audioElement.srcObject).toBe(mediaStream);
       expect(audioElement.volume).toBe(1);
-      expect(audioElement.setSinkId).not.toHaveBeenCalled();
+      expect(audioElement.setSinkId).toHaveBeenCalled();
 
       call.speaker.select('different-device-id');
       expect(audioElement.setSinkId).toHaveBeenCalledWith(
@@ -153,9 +186,100 @@ describe('DynascaleManager', () => {
       cleanup?.();
     });
 
+    it('audio: Safari should use AudioContext for audio playback', () => {
+      globalThis._isSafari = true;
+
+      vi.useFakeTimers();
+      const audioElement = document.createElement('audio');
+      // circumvent happy-dom's MediaStream validation
+      Object.defineProperty(audioElement, 'srcObject', { writable: true });
+      const play = vi.spyOn(audioElement, 'play').mockResolvedValue();
+      audioElement.setSinkId = vi.fn().mockResolvedValue({});
+
+      // @ts-expect-error incomplete data
+      call.state.updateOrAddParticipant('session-id', {
+        userId: 'user-id',
+        sessionId: 'session-id',
+        publishedTracks: [],
+      });
+
+      // @ts-expect-error incomplete data
+      call.state.updateOrAddParticipant('session-id-local', {
+        userId: 'user-id-local',
+        sessionId: 'session-id-local',
+        isLocalParticipant: true,
+        publishedTracks: [],
+      });
+
+      const cleanup = dynascaleManager.bindAudioElement(
+        audioElement,
+        'session-id',
+        'audioTrack',
+      );
+      expect(audioElement.autoplay).toBe(true);
+
+      const mediaStream = new MediaStream();
+      call.state.updateParticipant('session-id', { audioStream: mediaStream });
+
+      vi.runAllTimers();
+
+      expect(play).not.toHaveBeenCalled();
+      expect(audioElement.srcObject).toBe(mediaStream);
+      expect(audioElement.volume).toBe(1);
+      expect(audioElement.setSinkId).toHaveBeenCalled();
+      expect(audioElement.muted).toBe(true);
+
+      // @ts-expect-error private property
+      const audioContext = dynascaleManager.audioContext;
+      expect(audioContext).toBeDefined();
+      expect(audioContext.resume).toHaveBeenCalled();
+      expect(audioContext.state).toBe('running');
+      expect(audioContext.createMediaStreamSource).toHaveBeenCalledWith(
+        mediaStream,
+      );
+      expect(audioContext.createGain).toHaveBeenCalled();
+      expect(audioContext.resume).toHaveBeenCalled();
+
+      const sourceNode = (
+        audioContext.createMediaStreamSource as Mock<
+          AudioContext['createMediaStreamSource']
+        >
+      ).mock.results[0].value;
+
+      const gainNode = (
+        audioContext.createGain as Mock<AudioContext['createGain']>
+      ).mock.results[0].value;
+
+      expect(sourceNode.connect).toHaveBeenCalledWith(gainNode);
+      expect(gainNode.connect).toHaveBeenCalledWith(audioContext.destination);
+
+      call.speaker.select('different-device-id');
+      expect(audioElement.setSinkId).toHaveBeenCalledWith(
+        'different-device-id',
+      );
+      // @ts-expect-error sinkId isn't available in the TS definition
+      expect(audioContext.sinkId).toBe('different-device-id');
+
+      call.speaker.setVolume(0.5);
+      expect(audioElement.volume).toBe(0.5);
+      expect(gainNode.gain.value).toBe(0.5);
+
+      call.speaker.setParticipantVolume('session-id', 0.7);
+      expect(audioElement.volume).toBe(0.7);
+      expect(gainNode.gain.value).toBe(0.7);
+
+      call.speaker.setParticipantVolume('session-id', undefined);
+      expect(audioElement.volume).toBe(0.5);
+      expect(gainNode.gain.value).toBe(0.5);
+
+      cleanup?.();
+    });
+
     it('audio: should bind screenShare audio element', () => {
       vi.useFakeTimers();
       const audioElement = document.createElement('audio');
+      // circumvent happy-dom's MediaStream validation
+      Object.defineProperty(audioElement, 'srcObject', { writable: true });
       const play = vi.spyOn(audioElement, 'play').mockResolvedValue();
 
       // @ts-expect-error incomplete data
@@ -249,7 +373,6 @@ describe('DynascaleManager', () => {
         call.state,
         'updateParticipantTracks',
       );
-      const play = vi.spyOn(videoElement, 'play').mockResolvedValue();
 
       // @ts-expect-error incomplete data
       call.state.updateOrAddParticipant('session-id', {
@@ -280,9 +403,10 @@ describe('DynascaleManager', () => {
           },
         },
       });
-      expect(play).toHaveBeenCalled();
+
       expect(videoElement.srcObject).toBe(mediaStream);
 
+      expect(cleanup).toBeDefined();
       cleanup?.();
 
       expect(updateSubscription).toHaveBeenLastCalledWith('videoTrack', {

--- a/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
+++ b/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
@@ -168,7 +168,7 @@ describe('DynascaleManager', () => {
       expect(play).toHaveBeenCalled();
       expect(audioElement.srcObject).toBe(mediaStream);
       expect(audioElement.volume).toBe(1);
-      expect(audioElement.setSinkId).toHaveBeenCalled();
+      expect(audioElement.setSinkId).not.toHaveBeenCalled();
 
       call.speaker.select('different-device-id');
       expect(audioElement.setSinkId).toHaveBeenCalledWith(
@@ -227,7 +227,7 @@ describe('DynascaleManager', () => {
       expect(play).not.toHaveBeenCalled();
       expect(audioElement.srcObject).toBe(mediaStream);
       expect(audioElement.volume).toBe(1);
-      expect(audioElement.setSinkId).toHaveBeenCalled();
+      expect(audioElement.setSinkId).not.toHaveBeenCalled();
       expect(audioElement.muted).toBe(true);
 
       // @ts-expect-error private property

--- a/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
+++ b/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
@@ -124,6 +124,7 @@ describe('DynascaleManager', () => {
     });
 
     afterAll(() => {
+      delete globalThis._isSafari;
       vi.resetModules();
     });
 

--- a/packages/client/src/rtc/__tests__/mocks/webrtc.mocks.ts
+++ b/packages/client/src/rtc/__tests__/mocks/webrtc.mocks.ts
@@ -89,3 +89,35 @@ const RTCRtpSenderMock = vi.fn((): Partial<typeof RTCRtpSender> => {
   };
 });
 vi.stubGlobal('RTCRtpSender', RTCRtpSenderMock);
+
+const AudioContextMock = vi.fn((): Partial<AudioContext> => {
+  return {
+    state: 'suspended',
+    sinkId: '',
+    // @ts-expect-error - incomplete data
+    destination: {},
+    createMediaStreamSource: vi.fn(() => {
+      return {
+        connect: vi.fn((v) => v),
+        disconnect: vi.fn(),
+      } as unknown as MediaStreamAudioSourceNode;
+    }),
+    createGain: vi.fn(() => {
+      return {
+        connect: vi.fn((v) => v),
+        disconnect: vi.fn(),
+        gain: { value: 1 },
+      } as unknown as GainNode;
+    }),
+    close: vi.fn(async function () {
+      this.state = 'closed';
+    }),
+    resume: vi.fn(async function () {
+      this.state = 'running';
+    }),
+    setSinkId: vi.fn(async function (sinkId: string) {
+      this.sinkId = sinkId;
+    }),
+  };
+});
+vi.stubGlobal('AudioContext', AudioContextMock);

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -634,6 +634,13 @@ export class CallState {
   }
 
   /**
+   * The stable list of participants in the current call, unsorted.
+   */
+  get rawParticipants() {
+    return this.getCurrentValue(this.rawParticipants$);
+  }
+
+  /**
    * Sets the list of participants in the current call.
    *
    * @internal

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -149,7 +149,14 @@ export class CallState {
   anonymousParticipantCount$: Observable<number>;
 
   /**
-   * All participants of the current call (this includes the current user and other participants as well).
+   * All participants of the current call (this includes the current user and other participants as well),
+   * unsorted. This observable only updates when participants join or leave the call.
+   */
+  rawParticipants$: Observable<StreamVideoParticipant[]>;
+
+  /**
+   * All participants of the current call (this includes the current user and other participants as well),
+   * sorted according to the current `sortByParticipantsBy` setting
    */
   participants$: Observable<StreamVideoParticipant[]>;
 
@@ -323,6 +330,10 @@ export class CallState {
    *
    */
   constructor() {
+    this.rawParticipants$ = this.participantsSubject
+      .asObservable()
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
     this.participants$ = this.participantsSubject.asObservable().pipe(
       // maintain stable-sort by mutating the participants stored
       // in the original subject

--- a/packages/noise-cancellation-react-native/src/index.ts
+++ b/packages/noise-cancellation-react-native/src/index.ts
@@ -62,6 +62,9 @@ export class NoiseCancellation implements INoiseCancellation {
   // no-op in React Native
   setSuppressionLevel = () => {};
 
+  // no-op in React Native
+  resume = () => {};
+
   isEnabled = async () => {
     return isEnabled();
   };

--- a/packages/noise-cancellation-react-native/src/types.ts
+++ b/packages/noise-cancellation-react-native/src/types.ts
@@ -6,6 +6,7 @@ export interface INoiseCancellation {
   enable: () => void;
   disable: () => void;
   dispose: () => Promise<void>;
+  resume: () => void;
   setSuppressionLevel: (level: number) => void;
   toFilter: () => (mediaStream: MediaStream) => {
     output: MediaStream;

--- a/packages/react-bindings/src/hooks/callStateHooks.ts
+++ b/packages/react-bindings/src/hooks/callStateHooks.ts
@@ -280,6 +280,18 @@ export const useParticipants = ({
 };
 
 /**
+ * A hook which provides a list of all participants that have joined an active call.
+ * Unlike `useParticipants`, it returns a more stable reference that is not affected
+ * by participant sort settings.
+ *
+ * @category Call State
+ */
+export const useRawParticipants = () => {
+  const { rawParticipants$ } = useCallState();
+  return useObservableValue(rawParticipants$);
+};
+
+/**
  * A hook which provides a StreamVideoLocalParticipant object.
  * It signals that I have joined a call.
  *

--- a/packages/react-sdk/src/core/components/Audio/Audio.tsx
+++ b/packages/react-sdk/src/core/components/Audio/Audio.tsx
@@ -31,10 +31,8 @@ export const Audio = ({
 
   useEffect(() => {
     if (!call || !audioElement) return;
-    console.log('>>> Audio effect setup', sessionId);
     const cleanup = call.bindAudioElement(audioElement, sessionId, trackType);
     return () => {
-      console.log('>>> Audio effect cleanup', sessionId);
       cleanup?.();
     };
   }, [call, sessionId, audioElement, trackType]);

--- a/packages/react-sdk/src/core/components/Audio/Audio.tsx
+++ b/packages/react-sdk/src/core/components/Audio/Audio.tsx
@@ -31,8 +31,10 @@ export const Audio = ({
 
   useEffect(() => {
     if (!call || !audioElement) return;
+    console.log('>>> Audio effect setup', sessionId);
     const cleanup = call.bindAudioElement(audioElement, sessionId, trackType);
     return () => {
+      console.log('>>> Audio effect cleanup', sessionId);
       cleanup?.();
     };
   }, [call, sessionId, audioElement, trackType]);

--- a/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   useCall,
   useCallStateHooks,
@@ -62,12 +62,16 @@ export type LivestreamLayoutProps = {
 };
 
 export const LivestreamLayout = (props: LivestreamLayoutProps) => {
-  const { useParticipants, useRemoteParticipants, useHasOngoingScreenShare } =
+  const { useParticipants, useRawParticipants, useHasOngoingScreenShare } =
     useCallStateHooks();
   const call = useCall();
   const participants = useParticipants();
   const [currentSpeaker] = participants;
-  const remoteParticipants = useRemoteParticipants();
+  const rawParicipants = useRawParticipants();
+  const remoteParticipants = useMemo(
+    () => rawParicipants.filter((p) => !p.isLocalParticipant),
+    [rawParicipants],
+  );
   const hasOngoingScreenShare = useHasOngoingScreenShare();
   const presenter = hasOngoingScreenShare
     ? participants.find(hasScreenShare)

--- a/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   useCall,
   useCallStateHooks,
@@ -8,7 +8,10 @@ import {
 import { hasScreenShare } from '@stream-io/video-client';
 import { ParticipantView, useParticipantViewContext } from '../ParticipantView';
 import { ParticipantsAudio } from '../Audio';
-import { usePaginatedLayoutSortPreset } from './hooks';
+import {
+  usePaginatedLayoutSortPreset,
+  useRawRemoteParticipants,
+} from './hooks';
 
 /**
  * The props for the {@link LivestreamLayout} component.
@@ -62,16 +65,11 @@ export type LivestreamLayoutProps = {
 };
 
 export const LivestreamLayout = (props: LivestreamLayoutProps) => {
-  const { useParticipants, useRawParticipants, useHasOngoingScreenShare } =
-    useCallStateHooks();
+  const { useParticipants, useHasOngoingScreenShare } = useCallStateHooks();
   const call = useCall();
   const participants = useParticipants();
   const [currentSpeaker] = participants;
-  const rawParicipants = useRawParticipants();
-  const remoteParticipants = useMemo(
-    () => rawParicipants.filter((p) => !p.isLocalParticipant),
-    [rawParicipants],
-  );
+  const remoteParticipants = useRawRemoteParticipants();
   const hasOngoingScreenShare = useHasOngoingScreenShare();
   const presenter = hasOngoingScreenShare
     ? participants.find(hasScreenShare)

--- a/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
@@ -137,8 +137,12 @@ export const PaginatedGridLayout = (props: PaginatedGridLayoutProps) => {
   ] = useState<HTMLDivElement | null>(null);
 
   const call = useCall();
-  const { useRemoteParticipants } = useCallStateHooks();
-  const remoteParticipants = useRemoteParticipants();
+  const { useRawParticipants } = useCallStateHooks();
+  const rawParicipants = useRawParticipants();
+  const remoteParticipants = useMemo(
+    () => rawParicipants.filter((p) => !p.isLocalParticipant),
+    [rawParicipants],
+  );
   const participants = useFilteredParticipants({
     excludeLocalParticipant,
     filterParticipants,

--- a/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/PaginatedGridLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
+import { useCall } from '@stream-io/video-react-bindings';
 import { StreamVideoParticipant } from '@stream-io/video-client';
 import clsx from 'clsx';
 
@@ -16,6 +16,7 @@ import {
   ParticipantPredicate,
   useFilteredParticipants,
   usePaginatedLayoutSortPreset,
+  useRawRemoteParticipants,
 } from './hooks';
 
 const GROUP_SIZE = 16;
@@ -137,12 +138,7 @@ export const PaginatedGridLayout = (props: PaginatedGridLayoutProps) => {
   ] = useState<HTMLDivElement | null>(null);
 
   const call = useCall();
-  const { useRawParticipants } = useCallStateHooks();
-  const rawParicipants = useRawParticipants();
-  const remoteParticipants = useMemo(
-    () => rawParicipants.filter((p) => !p.isLocalParticipant),
-    [rawParicipants],
-  );
+  const remoteParticipants = useRawRemoteParticipants();
   const participants = useFilteredParticipants({
     excludeLocalParticipant,
     filterParticipants,

--- a/packages/react-sdk/src/core/components/CallLayout/PipLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/PipLayout.tsx
@@ -1,10 +1,8 @@
-import {
-  useCall,
-  useCallStateHooks,
-  useI18n,
-} from '@stream-io/video-react-bindings';
-import { useEffect, useMemo, useState } from 'react';
+import { useCall, useI18n } from '@stream-io/video-react-bindings';
+import { useEffect, useState } from 'react';
 
+import { hasScreenShare } from '@stream-io/video-client';
+import { Icon } from '../../../components';
 import { ParticipantsAudio } from '../Audio';
 import {
   DefaultParticipantViewUI,
@@ -16,9 +14,8 @@ import {
   ParticipantPredicate,
   useFilteredParticipants,
   usePaginatedLayoutSortPreset,
+  useRawRemoteParticipants,
 } from './hooks';
-import { hasScreenShare } from '@stream-io/video-client';
-import { Icon } from '../../../components';
 
 export type PipLayoutProps = {
   /**
@@ -121,12 +118,7 @@ const Pip = (props: PipLayoutProps) => {
 Pip.displayName = 'PipLayout.Pip';
 
 const Host = () => {
-  const { useRawParticipants } = useCallStateHooks();
-  const rawParicipants = useRawParticipants();
-  const remoteParticipants = useMemo(
-    () => rawParicipants.filter((p) => !p.isLocalParticipant),
-    [rawParicipants],
-  );
+  const remoteParticipants = useRawRemoteParticipants();
   return <ParticipantsAudio participants={remoteParticipants} />;
 };
 

--- a/packages/react-sdk/src/core/components/CallLayout/PipLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/PipLayout.tsx
@@ -3,7 +3,7 @@ import {
   useCallStateHooks,
   useI18n,
 } from '@stream-io/video-react-bindings';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { ParticipantsAudio } from '../Audio';
 import {
@@ -121,8 +121,12 @@ const Pip = (props: PipLayoutProps) => {
 Pip.displayName = 'PipLayout.Pip';
 
 const Host = () => {
-  const { useRemoteParticipants } = useCallStateHooks();
-  const remoteParticipants = useRemoteParticipants();
+  const { useRawParticipants } = useCallStateHooks();
+  const rawParicipants = useRawParticipants();
+  const remoteParticipants = useMemo(
+    () => rawParicipants.filter((p) => !p.isLocalParticipant),
+    [rawParicipants],
+  );
   return <ParticipantsAudio participants={remoteParticipants} />;
 };
 

--- a/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { hasScreenShare } from '@stream-io/video-client';
 import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
@@ -17,6 +17,7 @@ import {
   ParticipantFilter,
   ParticipantPredicate,
   useFilteredParticipants,
+  useRawRemoteParticipants,
   useSpeakerLayoutSortPreset,
 } from './hooks';
 import { useCalculateHardLimit } from '../../hooks/useCalculateHardLimit';
@@ -110,13 +111,9 @@ export const SpeakerLayout = ({
   muted,
 }: SpeakerLayoutProps) => {
   const call = useCall();
-  const { useParticipants, useRawParticipants } = useCallStateHooks();
+  const { useParticipants } = useCallStateHooks();
   const allParticipants = useParticipants();
-  const rawParicipants = useRawParticipants();
-  const remoteParticipants = useMemo(
-    () => rawParicipants.filter((p) => !p.isLocalParticipant),
-    [rawParicipants],
-  );
+  const remoteParticipants = useRawRemoteParticipants();
   const [participantInSpotlight, ...otherParticipants] =
     useFilteredParticipants({ excludeLocalParticipant, filterParticipants });
   const [participantsBarWrapperElement, setParticipantsBarWrapperElement] =

--- a/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/SpeakerLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
 import { hasScreenShare } from '@stream-io/video-client';
 import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
@@ -110,9 +110,13 @@ export const SpeakerLayout = ({
   muted,
 }: SpeakerLayoutProps) => {
   const call = useCall();
-  const { useParticipants, useRemoteParticipants } = useCallStateHooks();
+  const { useParticipants, useRawParticipants } = useCallStateHooks();
   const allParticipants = useParticipants();
-  const remoteParticipants = useRemoteParticipants();
+  const rawParicipants = useRawParticipants();
+  const remoteParticipants = useMemo(
+    () => rawParicipants.filter((p) => !p.isLocalParticipant),
+    [rawParicipants],
+  );
   const [participantInSpotlight, ...otherParticipants] =
     useFilteredParticipants({ excludeLocalParticipant, filterParticipants });
   const [participantsBarWrapperElement, setParticipantsBarWrapperElement] =

--- a/packages/react-sdk/src/core/components/CallLayout/hooks.ts
+++ b/packages/react-sdk/src/core/components/CallLayout/hooks.ts
@@ -109,6 +109,15 @@ export const useSpeakerLayoutSortPreset = (
   }, [call, isOneOnOneCall]);
 };
 
+export const useRawRemoteParticipants = () => {
+  const { useRawParticipants } = useCallStateHooks();
+  const rawParicipants = useRawParticipants();
+  return useMemo(
+    () => rawParicipants.filter((p) => !p.isLocalParticipant),
+    [rawParicipants],
+  );
+};
+
 const resetSortPreset = (call: Call) => {
   // reset the sorting to the default for the call type
   const callConfig = CallTypes.get(call.type);

--- a/sample-apps/react/react-dogfood/helpers/logger.ts
+++ b/sample-apps/react/react-dogfood/helpers/logger.ts
@@ -20,7 +20,7 @@ export const customSentryLogger =
 
     const { enableVerboseLogging = false } = opts;
     if (
-      enableVerboseLogging &&
+      !enableVerboseLogging &&
       message.startsWith('[Dispatcher]') &&
       /audioLevelChanged|dominantSpeakerChanged/.test(message)
     ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6833,7 +6833,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^3.1.3"
     axios: "npm:^1.8.1"
     dotenv: "npm:^16.5.0"
-    happy-dom: "npm:^11.0.2"
+    happy-dom: "npm:^17.5.6"
     prettier: "npm:^3.5.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.40.2"
@@ -10431,13 +10431,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css.escape@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "css.escape@npm:1.5.1"
-  checksum: 10/f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
-  languageName: node
-  linkType: hard
-
 "csscolorparser@npm:~1.0.3":
   version: 1.0.3
   resolution: "csscolorparser@npm:1.0.3"
@@ -13489,17 +13482,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"happy-dom@npm:^11.0.2":
-  version: 11.2.0
-  resolution: "happy-dom@npm:11.2.0"
+"happy-dom@npm:^17.5.6":
+  version: 17.5.6
+  resolution: "happy-dom@npm:17.5.6"
   dependencies:
-    css.escape: "npm:^1.5.1"
-    entities: "npm:^4.5.0"
-    iconv-lite: "npm:^0.6.3"
     webidl-conversions: "npm:^7.0.0"
-    whatwg-encoding: "npm:^2.0.0"
     whatwg-mimetype: "npm:^3.0.0"
-  checksum: 10/5a1b2a773b79192724f5ff0b6fe79e9bf72f0209a88c41c2fc8c1aaeced7afaaaaca6f6ec38f909ba91bcab538a06cf9acfb545603330677abe8ed7906464030
+  checksum: 10/dcec81d51aa95a0d145e954e4ff14a507cc6757007c8b1b5146e66934ccabbca57f7e01cd8c1e4e6229bd85fd4528511ce2968feffa28bda7dbb7a420779d4af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 💡 Overview

Safari's power-management and autoplay policy do not allow a tab to start playing audio through an `<audio />` element when the user doesn't have the tab in focus. This behavior causes an issue where a remote participant can't be heard until the local participant focuses on the tab that has the ongoing call.

Steps to reproduce:
- The local participant switches to a different tab
- The remote participant mutes and unmutes while the local participant is browsing on a different tab
- The remote participant becomes audible only after the local participant switches back to the call tab

### 📝 Implementation notes
- Uses `AudioContext` for Safari, as it doesn't seem to be restricted by the above-mentioned policies
- The rendered `audio` elements are now muted by default on Safari, as we want to prevent "double audio"
- The implementation is scoped to Safari only, but we should consider moving fully to it in a future major release, and reduce the amount of `<audio>` elements our SDK renders

🎫 Ticket: https://linear.app/stream/issue/REACT-405