### PR TITLE
fix: attach original token provider error as cause to loadToken rejection

### DIFF
--- a/packages/client/src/coordinator/connection/token_manager.ts
+++ b/packages/client/src/coordinator/connection/token_manager.ts
@@ -113,7 +113,9 @@ export class TokenManager {
           this.token = token;
         } catch (e) {
           return reject(
-            new Error(`Call to tokenProvider failed with message: ${e}`),
+            new Error(`Call to tokenProvider failed with message: ${e}`, {
+              cause: e,
+            }),
           );
         }
         resolve(this.token);


### PR DESCRIPTION
### 💡 Overview

When `loadToken` rejects because of an error originating in `tokenProvider`, the original error is hidden behind this new error. That makes debugging the problem more difficult.

We now attach original error as a `cause` to the rejection error.

### 📝 Implementation notes

Error monitoring services like Sentry will also show show call stack and message from `Error.prototype.cause`.
