### PR TITLE
chore(react-native): disable location APIs in dogfood

### DIFF
--- a/sample-apps/react-native/dogfood/ios/Podfile
+++ b/sample-apps/react-native/dogfood/ios/Podfile
@@ -34,6 +34,9 @@ target 'StreamReactNativeVideoSDKSample' do
   use_frameworks! :linkage => :static
   $RNFirebaseAsStaticFramework = true
 
+  # Disable Location APIs
+  $VCEnableLocation = false
+
   use_react_native!(
     :path => config[:reactNativePath],
     # An absolute path to your application root.


### PR DESCRIPTION
### 💡 Overview

Introducing the `react-native-vision-camera` dependency in the dogfood app caused this issue: 
Location APIs are considered privacy-sensitive APIs by Apple. When you are not using privacy-sensitive APIs (like location) but still include them in your app's code, the Apple review team rejects your app. 

To avoid this, we need to disable the location APIs and VisionCamera will not compile those privacy-sensitive APIs into our app.

### 📝 Implementation notes

In the podfile we need to 

```
  # Disable Location APIs
  $VCEnableLocation = false
```

🎫 Ticket: https://linear.app/stream/issue/rn-223

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
