### PR TITLE
fix: early join in LivestreamPlayer

### DIFF
--- a/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
+++ b/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
@@ -148,6 +148,8 @@ const useCanJoinEearly = () => {
       return () => clearInterval(handle);
     }
   }, [canJoinEarly, startsAt, joinAheadTimeSeconds]);
+
+  return canJoinEarly;
 };
 
 const checkCanJoinEarly = (

--- a/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
+++ b/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
@@ -108,7 +108,7 @@ const useLivestreamCall = (props: {
   const call = useCall();
   const { useIsCallLive, useOwnCapabilities } = useCallStateHooks();
   const canJoinLive = useIsCallLive();
-  const canJoinEarly = useCanJoinEearly();
+  const canJoinEarly = useCanJoinEarly();
   const canJoinBackstage =
     useOwnCapabilities()?.includes('join-backstage') ?? false;
   const canJoinAsap = canJoinLive || canJoinEarly || canJoinBackstage;
@@ -130,7 +130,7 @@ const useLivestreamCall = (props: {
   return call;
 };
 
-const useCanJoinEearly = () => {
+const useCanJoinEarly = () => {
   const { useCallStartsAt, useCallSettings } = useCallStateHooks();
   const startsAt = useCallStartsAt();
   const settings = useCallSettings();

--- a/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
+++ b/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
@@ -135,14 +135,14 @@ const useCanJoinEarly = () => {
   const startsAt = useCallStartsAt();
   const settings = useCallSettings();
   const joinAheadTimeSeconds = settings?.backstage.join_ahead_time_seconds;
-  const [canJoinEarly, setCanJoinEearly] = useState(() =>
+  const [canJoinEarly, setCanJoinEarly] = useState(() =>
     checkCanJoinEarly(startsAt, joinAheadTimeSeconds),
   );
 
   useEffect(() => {
     if (!canJoinEarly) {
       const handle = setInterval(() => {
-        setCanJoinEearly(checkCanJoinEarly(startsAt, joinAheadTimeSeconds));
+        setCanJoinEarly(checkCanJoinEarly(startsAt, joinAheadTimeSeconds));
       }, 1000);
 
       return () => clearInterval(handle);


### PR DESCRIPTION
Fix a typo that led to a bug with early join flow in `LivestreamPlayer` wrapper.