### PR TITLE
fix(react-native): skip browser permission for react native

### DIFF
--- a/packages/client/src/devices/BrowserPermission.ts
+++ b/packages/client/src/devices/BrowserPermission.ts
@@ -24,7 +24,11 @@ export class BrowserPermission {
 
     this.ready = (async () => {
       const assumeGranted = () => {
-        this.setState('prompt');
+        if (isReactNative()) {
+          this.setState('granted');
+        } else {
+          this.setState('prompt');
+        }
       };
 
       if (!canQueryPermissions()) {

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -13,7 +13,6 @@ import { BrowserPermission } from './BrowserPermission';
 import { lazy } from '../helpers/lazy';
 import { isFirefox } from '../helpers/browsers';
 import { dumpStream, Tracer } from '../stats';
-import { isReactNative } from '../helpers/platforms';
 
 /**
  * Returns an Observable that emits the list of available devices
@@ -239,12 +238,10 @@ export const getAudioStream = async (
   };
 
   try {
-    if (!isReactNative()) {
-      await getAudioBrowserPermission().prompt({
-        throwOnNotAllowed: true,
-        forcePrompt: true,
-      });
-    }
+    await getAudioBrowserPermission().prompt({
+      throwOnNotAllowed: true,
+      forcePrompt: true,
+    });
     return await getStream(constraints, tracer);
   } catch (error) {
     if (isNotFoundOrOverconstrainedError(error) && trackConstraints?.deviceId) {
@@ -285,12 +282,10 @@ export const getVideoStream = async (
     },
   };
   try {
-    if (!isReactNative()) {
-      await getVideoBrowserPermission().prompt({
-        throwOnNotAllowed: true,
-        forcePrompt: true,
-      });
-    }
+    await getVideoBrowserPermission().prompt({
+      throwOnNotAllowed: true,
+      forcePrompt: true,
+    });
     return await getStream(constraints, tracer);
   } catch (error) {
     if (isNotFoundOrOverconstrainedError(error) && trackConstraints?.deviceId) {


### PR DESCRIPTION
### 💡 Overview

Clients reported browser permission error: `Permission was not granted previously, and prompting again is not allowed'` generated on their react native devices, which should not happen. 

### 📝 Implementation notes

`BrowserPermission` method `ready()` is updated to grant permissions for React Native by default.  

🎫 Ticket: https://linear.app/stream/issue/rn-226

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
