### PR TITLE
feat: add audio only ringing notification support for iOS 

### DIFF
--- a/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAppDelegate.ts
@@ -474,6 +474,8 @@ function addDidReceiveIncomingPushCallbackSwift(contents: string) {
     }
     
     let uuid = UUID().uuidString
+    let videoIncluded = stream["video"] as? String
+    let hasVideo = videoIncluded == "false" ? false : true
     
     StreamVideoReactNative.registerIncomingCall(cid, uuid: uuid)
     
@@ -484,7 +486,7 @@ function addDidReceiveIncomingPushCallbackSwift(contents: string) {
     RNCallKeep.reportNewIncomingCall(uuid,
                                      handle: createdCallerName,
                                      handleType: "generic",
-                                     hasVideo: true,
+                                     hasVideo: hasVideo,
                                      localizedCallerName: createdCallerName,
                                      supportsHolding: false,
                                      supportsDTMF: false,
@@ -534,6 +536,9 @@ function addDidReceiveIncomingPushCallbackObjc(contents: string) {
   NSString *uuid = [[NSUUID UUID] UUIDString];
   NSString *createdCallerName = stream[@"created_by_display_name"];
   NSString *cid = stream[@"call_cid"];
+  
+  NSString *videoIncluded = stream[@"video"];
+  BOOL hasVideo = [videoIncluded isEqualToString:@"false"] ? NO : YES;
 
   // store the call cid and uuid in the native module's cache
   [StreamVideoReactNative registerIncomingCall:cid uuid:uuid];
@@ -548,7 +553,7 @@ function addDidReceiveIncomingPushCallbackObjc(contents: string) {
   [RNCallKeep reportNewIncomingCall: uuid
                              handle: createdCallerName
                          handleType: @"generic"
-                           hasVideo: YES
+                           hasVideo: hasVideo
                 localizedCallerName: createdCallerName
                     supportsHolding: NO
                        supportsDTMF: NO

--- a/sample-apps/react-native/dogfood/ios/AppDelegate.swift
+++ b/sample-apps/react-native/dogfood/ios/AppDelegate.swift
@@ -77,6 +77,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     let uuid = UUID().uuidString
+    let videoIncluded = stream["video"] as? String
+    let hasVideo = videoIncluded == "false" ? false : true
     
     StreamVideoReactNative.registerIncomingCall(cid, uuid: uuid)
     
@@ -89,7 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     RNCallKeep.reportNewIncomingCall(uuid,
                                      handle: createdCallerName,
                                      handleType: "generic",
-                                     hasVideo: true,
+                                     hasVideo: hasVideo,
                                      localizedCallerName: createdCallerName,
                                      supportsHolding: false,
                                      supportsDTMF: false,


### PR DESCRIPTION
### 💡 Overview

Callkit gives a way to indicate audio only calls. This is supported by our backend. 

In this PR, we add it to expo plugin and dogfood app

### 📝 Implementation notes

This pull request introduces changes to handle the presence of video in incoming calls more dynamically by checking the `video` field in the incoming stream data. The updates ensure that the `hasVideo` parameter is set based on the value of the `video` field instead of being hardcoded.

* **Swift updates in `withAppDelegate.ts` and `AppDelegate.swift`:**
  - Added logic to parse the `video` field from the incoming stream data and determine the `hasVideo` value dynamically. 
  - Updated `RNCallKeep.reportNewIncomingCall` to use the dynamically determined `hasVideo` value instead of a hardcoded `true`. 

* **Objective-C updates in `withAppDelegate.ts`:**
  - Introduced logic to evaluate the `video` field and set the `hasVideo` value accordingly. 
  - Modified `RNCallKeep.reportNewIncomingCall` to utilize the dynamically calculated `hasVideo` value. (

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
