### PR TITLE
fix: RTL layout for call controls

### DIFF
--- a/packages/styling/src/Button/Button-layout.scss
+++ b/packages/styling/src/Button/Button-layout.scss
@@ -20,7 +20,7 @@
   }
 
   &__icon {
-    margin-right: var(--str-video__spacing-xs);
+    margin-inline-end: var(--str-video__spacing-xs);
     background-color: var(--str-video__text-color1);
   }
 
@@ -58,8 +58,8 @@
 
     .str-video__menu-toggle-button {
       padding: 0;
-      margin-left: -30px;
-      margin-right: 8px;
+      margin-inline-start: -30px;
+      margin-inline-end: 8px;
     }
 
     .str-video__loading-indicator__icon {
@@ -71,7 +71,7 @@
   }
 
   &.str-video__composite-button--menu .str-video__composite-button__button {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 }
 


### PR DESCRIPTION
### 💡 Overview

Our call controls was broken for RTL direction locales. This PR fixes it.

Before:

![Screenshot 2025-06-26 at 13 58 15](https://github.com/user-attachments/assets/2dcce14e-fb80-4a8c-8e51-d3bb6bcb4dca)

After:

![Screenshot 2025-06-26 at 13 59 01](https://github.com/user-attachments/assets/154a2df8-1548-4b8b-9ca8-2e988dab3a38)

### 📝 Implementation notes

We had some styles using `*-left` and `*-right` properties. They are now replaced with logical `*-inline-start` and `*-inline-end`.

🎫 Ticket: https://linear.app/stream/issue/REACT-425/update-ui-margins-for-better-rtl-ui-experience
