### PR TITLE
fix: correctly setup and dispose device managers

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -345,6 +345,11 @@ export class Call {
       this.registerEffects();
       this.registerReconnectHandlers();
 
+      this.camera.setup();
+      this.microphone.setup();
+      this.screenShare.setup();
+      this.speaker.setup();
+
       if (this.state.callingState === CallingState.LEFT) {
         this.state.setCallingState(CallingState.IDLE);
       }
@@ -631,6 +636,7 @@ export class Call {
       this.microphone.dispose();
       this.screenShare.dispose();
       this.speaker.dispose();
+      this.deviceSettingsAppliedOnce = false;
 
       const stopOnLeavePromises: Promise<void>[] = [];
       if (this.camera.stopOnLeave) {

--- a/packages/client/src/devices/CameraManagerState.ts
+++ b/packages/client/src/devices/CameraManagerState.ts
@@ -42,7 +42,7 @@ export class CameraManagerState extends InputMediaDeviceManagerState {
   /**
    * @internal
    */
-  setMediaStream(
+  override setMediaStream(
     stream: MediaStream | undefined,
     rootStream: MediaStream | undefined,
   ): void {

--- a/packages/client/src/devices/InputMediaDeviceManager.ts
+++ b/packages/client/src/devices/InputMediaDeviceManager.ts
@@ -35,6 +35,7 @@ export abstract class InputMediaDeviceManager<
   protected readonly call: Call;
   protected readonly trackType: TrackType;
   protected subscriptions: Function[] = [];
+  private areSubscriptionsSetUp = false;
   private isTrackStoppedDueToTrackEnd = false;
   private filters: MediaStreamFilterEntry[] = [];
   private statusChangeConcurrencyTag = Symbol('statusChangeConcurrencyTag');
@@ -47,6 +48,16 @@ export abstract class InputMediaDeviceManager<
     this.state = state;
     this.trackType = trackType;
     this.logger = getLogger([`${TrackType[trackType].toLowerCase()} manager`]);
+    this.setup();
+  }
+
+  setup() {
+    if (this.areSubscriptionsSetUp) {
+      return;
+    }
+
+    this.areSubscriptionsSetUp = true;
+
     if (
       deviceIds$ &&
       !isReactNative() &&
@@ -232,6 +243,8 @@ export abstract class InputMediaDeviceManager<
    */
   dispose = () => {
     this.subscriptions.forEach((s) => s());
+    this.subscriptions = [];
+    this.areSubscriptionsSetUp = false;
   };
 
   protected async applySettingsToStream() {

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -33,7 +33,10 @@ export class MicrophoneManager extends InputMediaDeviceManager<MicrophoneManager
 
   constructor(call: Call, disableMode: TrackDisableMode = 'stop-tracks') {
     super(call, new MicrophoneManagerState(disableMode), TrackType.AUDIO);
+  }
 
+  override setup(): void {
+    super.setup();
     this.subscriptions.push(
       createSafeAsyncSubscription(
         combineLatest([

--- a/packages/client/src/devices/ScreenShareManager.ts
+++ b/packages/client/src/devices/ScreenShareManager.ts
@@ -13,9 +13,12 @@ export class ScreenShareManager extends InputMediaDeviceManager<
 > {
   constructor(call: Call) {
     super(call, new ScreenShareState(), TrackType.SCREEN_SHARE);
+  }
 
+  override setup(): void {
+    super.setup();
     this.subscriptions.push(
-      createSubscription(call.state.settings$, (settings) => {
+      createSubscription(this.call.state.settings$, (settings) => {
         const maybeTargetResolution = settings?.screensharing.target_resolution;
 
         if (maybeTargetResolution) {
@@ -89,7 +92,7 @@ export class ScreenShareManager extends InputMediaDeviceManager<
     return stream;
   }
 
-  protected async stopPublishStream(): Promise<void> {
+  protected override async stopPublishStream(): Promise<void> {
     return this.call.stopPublish(
       TrackType.SCREEN_SHARE,
       TrackType.SCREEN_SHARE_AUDIO,
@@ -99,7 +102,7 @@ export class ScreenShareManager extends InputMediaDeviceManager<
   /**
    * Overrides the default `select` method to throw an error.
    */
-  async select(): Promise<void> {
+  override async select(): Promise<void> {
     throw new Error('Not supported');
   }
 }

--- a/packages/client/src/devices/SpeakerManager.ts
+++ b/packages/client/src/devices/SpeakerManager.ts
@@ -7,11 +7,22 @@ import { deviceIds$, getAudioOutputDevices } from './devices';
 export class SpeakerManager {
   readonly state: SpeakerState;
   private subscriptions: Subscription[] = [];
+  private areSubscriptionsSetUp = false;
   private readonly call: Call;
 
   constructor(call: Call) {
     this.call = call;
     this.state = new SpeakerState(call.tracer);
+    this.setup();
+  }
+
+  setup() {
+    if (this.areSubscriptionsSetUp) {
+      return;
+    }
+
+    this.areSubscriptionsSetUp = true;
+
     if (deviceIds$ && !isReactNative()) {
       this.subscriptions.push(
         combineLatest([deviceIds$!, this.state.selectedDevice$]).subscribe(
@@ -71,6 +82,8 @@ export class SpeakerManager {
    */
   dispose = () => {
     this.subscriptions.forEach((s) => s.unsubscribe());
+    this.subscriptions = [];
+    this.areSubscriptionsSetUp = false;
   };
 
   /**


### PR DESCRIPTION
### 💡 Overview

We had a discrepancy in how device managers were created and disposed.

Device manager is created in Call constructor, and is available for the whole lifetime of the call instance.

When created, device manager also sets up some subscriptions. Some of these subscriptions only really work within a fully initialized call (after `call.get()`, `call.join()` etc). Some, like `handleDisconnectedOrReplacedDevices` are nice to have even if the call is not initialized.

When leaving call, all subscriptions are removed in the device manager's `dispose()` method. However, the call can be joined again after leaving, and device manager subscriptions were not set up again in this case.

This PR fixes that by setting up device manager subscriptions again when the call is initialized again after leaving.

**Sidenote:** device config was also not applied again when joining the call after leaving because the `deviceSettingsAppliedOnce` flag was not reset on leaving the call. This is also fixed in this PR.

### 📝 Implementation notes

The solution in this PR is not ideal. The reason is that we don't really have a method to dispose call instance. Instead, `leave()` _kind of_ stops most running side effects, but the call instance can be then revived by calling `get()`, `join()`, `create()` etc.

To keep supporting this behavior, we set up device manager subscriptions twice:
1. When device manager is created
2. When call is initialized within the `call.setup()` method

That allows us to stop side effects in device manager when call is left, but also to run them again if the call instance is reused.

There's a flag `areSubscriptionsSetUp` in place to prevent duplication of subscriptions.

🎫 Ticket: https://linear.app/stream/issue/REACT-428/camera-and-mic-not-enabling-when-rejoining-call-in-web-client
