### PR TITLE
fix: prefer pinned participant for single participant recording layout

### DIFF
--- a/sample-apps/react/egress-composite/src/components/layouts/DominantSpeaker/useSpotlightParticipant.ts
+++ b/sample-apps/react/egress-composite/src/components/layouts/DominantSpeaker/useSpotlightParticipant.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import {
   hasVideo,
+  isPinned,
   StreamVideoParticipant,
   useFilteredParticipants,
 } from '@stream-io/video-react-sdk';
@@ -35,6 +36,7 @@ export const useSpotlightParticipant = () => {
       };
     } else {
       const spotlightSpeaker =
+        participants.find((p) => isPinned(p)) ||
         participants.find((p) => p.isDominantSpeaker) ||
         participants.find((p) => hasVideo(p)) ||
         participants[0];


### PR DESCRIPTION
### 💡 Overview

When picking participant for Single Participant recording layout, previously dominant speaker was always preferred. We now also take pinned status into account as well.
