### PR TITLE
fix: default menu for ToggleAudioPreviewButton

### DIFF
--- a/packages/react-sdk/src/components/Button/CompositeButton.tsx
+++ b/packages/react-sdk/src/components/Button/CompositeButton.tsx
@@ -4,8 +4,8 @@ import {
   ComponentProps,
   ComponentType,
   forwardRef,
-  JSX,
   PropsWithChildren,
+  ReactElement,
 } from 'react';
 import { Placement } from '@floating-ui/react';
 
@@ -15,7 +15,7 @@ import { isComponentType } from '../../utilities';
 export type IconButtonWithMenuProps<E extends HTMLElement = HTMLButtonElement> =
   PropsWithChildren<{
     active?: boolean;
-    Menu?: ComponentType | JSX.Element;
+    Menu?: ComponentType | ReactElement | null;
     caption?: string;
     className?: string;
     menuPlacement?: Placement;

--- a/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
+++ b/packages/react-sdk/src/components/CallControls/ToggleAudioButton.tsx
@@ -27,7 +27,13 @@ export type ToggleAudioPreviewButtonProps = PropsWithErrorHandler<
 export const ToggleAudioPreviewButton = (
   props: ToggleAudioPreviewButtonProps,
 ) => {
-  const { caption, onMenuToggle, ...restCompositeButtonProps } = props;
+  const {
+    caption,
+    Menu = DeviceSelectorAudioInput,
+    menuPlacement = 'top',
+    onMenuToggle,
+    ...restCompositeButtonProps
+  } = props;
   const { t } = useI18n();
   const { useMicrophoneState } = useCallStateHooks();
   const {
@@ -64,6 +70,8 @@ export const ToggleAudioPreviewButton = (
             : 'preview-audio-mute-button'
         }
         onClick={handleClick}
+        Menu={Menu}
+        menuPlacement={menuPlacement}
         {...restCompositeButtonProps}
         onMenuToggle={(shown) => {
           setTooltipDisabled(shown);

--- a/sample-apps/react/react-dogfood/components/Lobby.tsx
+++ b/sample-apps/react/react-dogfood/components/Lobby.tsx
@@ -129,8 +129,7 @@ export const Lobby = ({ onJoin, mode = 'regular' }: LobbyProps) => {
                       }
                     />
                     <div className="rd__lobby-media-toggle">
-                      <ToggleAudioPreviewButton />
-                      {/* @ts-expect-error disable Menu */}
+                      <ToggleAudioPreviewButton Menu={null} />
                       <ToggleVideoPreviewButton Menu={null} />
                     </div>
                   </div>


### PR DESCRIPTION
### 💡 Overview

Fixes device selection menu missing by default in `ToggleAudioPreviewButton`.
