### PR TITLE
Fix/default device

### DIFF
--- a/packages/client/src/devices/MicrophoneManagerState.ts
+++ b/packages/client/src/devices/MicrophoneManagerState.ts
@@ -1,15 +1,10 @@
 import { BehaviorSubject, distinctUntilChanged, Observable } from 'rxjs';
+import { RxUtils } from '../store';
 import {
   InputMediaDeviceManagerState,
   TrackDisableMode,
 } from './InputMediaDeviceManagerState';
-import {
-  getAudioBrowserPermission,
-  getAudioDevices,
-  resolveDeviceId,
-} from './devices';
-import { RxUtils } from '../store';
-import { getCurrentValue } from '../store/rxUtils';
+import { getAudioBrowserPermission, resolveDeviceId } from './devices';
 
 export class MicrophoneManagerState extends InputMediaDeviceManagerState {
   private speakingWhileMutedSubject = new BehaviorSubject<boolean>(false);
@@ -48,9 +43,6 @@ export class MicrophoneManagerState extends InputMediaDeviceManagerState {
   protected getDeviceIdFromStream(stream: MediaStream): string | undefined {
     const [track] = stream.getAudioTracks();
     const unresolvedDeviceId = track?.getSettings().deviceId;
-    return resolveDeviceId(
-      unresolvedDeviceId,
-      getCurrentValue(getAudioDevices()),
-    );
+    return resolveDeviceId(unresolvedDeviceId, 'audioinput');
   }
 }

--- a/packages/client/src/devices/MicrophoneManagerState.ts
+++ b/packages/client/src/devices/MicrophoneManagerState.ts
@@ -3,8 +3,13 @@ import {
   InputMediaDeviceManagerState,
   TrackDisableMode,
 } from './InputMediaDeviceManagerState';
-import { getAudioBrowserPermission } from './devices';
+import {
+  getAudioBrowserPermission,
+  getAudioDevices,
+  resolveDeviceId,
+} from './devices';
 import { RxUtils } from '../store';
+import { getCurrentValue } from '../store/rxUtils';
 
 export class MicrophoneManagerState extends InputMediaDeviceManagerState {
   private speakingWhileMutedSubject = new BehaviorSubject<boolean>(false);
@@ -42,6 +47,10 @@ export class MicrophoneManagerState extends InputMediaDeviceManagerState {
 
   protected getDeviceIdFromStream(stream: MediaStream): string | undefined {
     const [track] = stream.getAudioTracks();
-    return track?.getSettings().deviceId;
+    const unresolvedDeviceId = track?.getSettings().deviceId;
+    return resolveDeviceId(
+      unresolvedDeviceId,
+      getCurrentValue(getAudioDevices()),
+    );
   }
 }

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -386,3 +386,24 @@ export const disposeOfMediaStream = (stream: MediaStream) => {
     stream.release();
   }
 };
+
+/**
+ * Resolves `default` device id into the real device id. Some browsers (notably,
+ * Chromium-based) report device with id `default` among audio input and output
+ * devices. Since not every browser does that, we never want `default` id to be
+ * used within our SDK. This function tries to find the real id for the `default`
+ * device.
+ */
+export function resolveDeviceId(
+  deviceId: string | undefined,
+  devices: MediaDeviceInfo[],
+): string | undefined {
+  if (deviceId !== 'default') return deviceId;
+  const defaultDeviceInfo = devices.find((d) => d.deviceId === deviceId);
+  if (!defaultDeviceInfo) return deviceId;
+  const groupId = defaultDeviceInfo.groupId;
+  const candidates = devices.filter(
+    (d) => d.deviceId !== 'default' && d.groupId === groupId,
+  );
+  return candidates.length === 1 ? candidates[0].deviceId : deviceId;
+}

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -13,6 +13,7 @@ import { BrowserPermission } from './BrowserPermission';
 import { lazy } from '../helpers/lazy';
 import { isFirefox } from '../helpers/browsers';
 import { dumpStream, Tracer } from '../stats';
+import { getCurrentValue } from '../store/rxUtils';
 
 /**
  * Returns an Observable that emits the list of available devices
@@ -396,14 +397,16 @@ export const disposeOfMediaStream = (stream: MediaStream) => {
  */
 export function resolveDeviceId(
   deviceId: string | undefined,
-  devices: MediaDeviceInfo[],
+  kind: MediaDeviceKind,
 ): string | undefined {
   if (deviceId !== 'default') return deviceId;
+  const devices = deviceIds$ && getCurrentValue(deviceIds$);
+  if (!devices) return deviceId;
   const defaultDeviceInfo = devices.find((d) => d.deviceId === deviceId);
   if (!defaultDeviceInfo) return deviceId;
   const groupId = defaultDeviceInfo.groupId;
   const candidates = devices.filter(
-    (d) => d.deviceId !== 'default' && d.groupId === groupId,
+    (d) => d.kind === kind && d.deviceId !== 'default' && d.groupId === groupId,
   );
   return candidates.length === 1 ? candidates[0].deviceId : deviceId;
 }


### PR DESCRIPTION
### 💡 Overview

As we are well-aware at this point, Chromium-based browsers report a special device with id `default` for audio input and output. For cross-browser consistency, we filter out this device from all our device lists.

However, Chrome can also have `default` as the device id in MediaStream's audio track settings. When this happens, we should replace `default` with the real device id.

### 📝 Implementation notes

We rely on `groupId` to find the "real" device that corresponds to the `default` one. If we find a device with the same `kind`, same `groupId` as the `default` one, and if it's the only device like this, we can safely replace `default` with it.
