### PR TITLE
fix: do not have a default for objectfit

### DIFF
--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantView.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantView.tsx
@@ -105,7 +105,7 @@ export const ParticipantView = ({
   VideoRenderer = DefaultVideoRenderer,
   ParticipantNetworkQualityIndicator = DefaultParticipantNetworkQualityIndicator,
   ParticipantVideoFallback = DefaultParticipantVideoFallback,
-  objectFit = 'cover',
+  objectFit,
   videoZOrder = 0,
   supportedReactions,
 }: ParticipantViewProps) => {


### PR DESCRIPTION
### 💡 Overview

Before             |  After
:-------------------------:|:-------------------------:
![Screenshot_20250703-133440](https://github.com/user-attachments/assets/07b27f7b-63b9-47f9-b0ae-b1206ddba27f) | ![Screenshot_20250703-133459](https://github.com/user-attachments/assets/f388ef9f-91dc-4fef-b4c9-4f561c487eb4)

  
### 📝 Implementation notes

Our SDK by default already treats landscape video as contain, portrait as cover. And that is now applied to callcontent by default

🎫 Ticket: https://getstream.zendesk.com/agent/tickets/67391
