### PR TITLE
fix(pronto): forward all query parameters

### DIFF
--- a/sample-apps/react/react-dogfood/lib/getServerSideCredentialsProps.ts
+++ b/sample-apps/react/react-dogfood/lib/getServerSideCredentialsProps.ts
@@ -25,7 +25,7 @@ export const getServerSideCredentialsProps = async (
     const url = context.req.url;
     return {
       redirect: {
-        destination: `/auth/signin?callbackUrl=${url}`,
+        destination: `/auth/signin?callbackUrl=${encodeURIComponent(url || '')}`,
         permanent: false,
       },
     };


### PR DESCRIPTION
### 💡 Overview

Forwards all provided query params to the target route after performing a log-in.

🎫 Ticket: https://linear.app/stream/issue/REACT-445/video-pronto-app-does-not-forward-all-query-params-on-login
