### PR TITLE
fix: relax SFU leaveAndClose constraints

### DIFF
--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -344,9 +344,9 @@ export class StreamSfuClient {
   };
 
   leaveAndClose = async (reason: string) => {
-    await this.joinTask;
     try {
       this.isLeaving = true;
+      await this.joinTask;
       await this.notifyLeave(reason);
     } catch (err) {
       this.logger('debug', 'Error notifying SFU about leaving call', err);


### PR DESCRIPTION
### 💡 Overview

Follow-up to #1846. `call.leave()` throws an error after unrecoverable FAST reconnect.
Our "leave" flow requires the client to announce its disconnect from the call to the SFU so the SFU can perform certain state cleanups faster. However, in the case described above, this isn't possible because the new SFU client never successfully connected to the SFU, and the signal WS was never established. This makes it impossible to send the announcement.

This PR adds better error handling and doesn't prevent the `call` instance disposal.

🎫 Ticket: https://linear.app/stream/issue/RN-241/refresh-call-state-after-a-failed-reconnect
