### PR TITLE
Wait contain

### DIFF
--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -222,6 +222,7 @@ export const CallContent = ({
                 onPressHandler={handleFloatingViewParticipantSwitch}
                 supportedReactions={supportedReactions}
                 {...participantViewProps}
+                objectFit="cover"
               />
             )}
           </View>

--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer.tsx
@@ -73,6 +73,9 @@ export const VideoRenderer = ({
   } = useScreenshotIosContext();
 
   const videoDimensions = useTrackDimensions(participant, trackType);
+  const isVideoDimensionsValid =
+    videoDimensions.width > 0 && videoDimensions.height > 0;
+
   const {
     isLocalParticipant,
     sessionId,
@@ -288,7 +291,9 @@ export const VideoRenderer = ({
       onLayout={onLayout}
       style={[styles.container, videoRenderer.container]}
     >
-      {canShowVideo && videoStreamToRender ? (
+      {canShowVideo &&
+      videoStreamToRender &&
+      (objectFit ? true : isVideoDimensionsValid) ? (
         <RTCView
           style={[styles.videoStream, videoRenderer.videoStream]}
           streamURL={videoStreamToRender.toURL()}


### PR DESCRIPTION
### 💡 Overview

In this PR, we make sure that objectFit doesn't change unnecessarily due to fetching of dimensions. We wait until dimensions are ready to mount the video component first time

### 📝 Implementation notes

- we make sure that floating participant view is always cover, because its always a small view
- and we check if dimensions are not 0
- we also remove usage of track.getSettings() for local participant
