### PR TITLE
fix: forward all query params

### DIFF
--- a/sample-apps/react/react-dogfood/components/DevMenu.tsx
+++ b/sample-apps/react/react-dogfood/components/DevMenu.tsx
@@ -303,10 +303,10 @@ const TraceStats = () => {
       disabled={!call}
       onClick={() => {
         const appId = process.env.NEXT_PUBLIC_STREAM_APP_ID || '';
-        if (!appId) return window.open('http://localhost:8081/', '_blank');
+        if (!appId) return window.open('http://rtcstats.gtstrm.com/', '_blank');
         const path = `app/${appId}/${call.cid}/${call.state.session?.id}/`;
         window.open(
-          `http://localhost:8081/?path=${encodeURIComponent(path)}`,
+          `http://rtcstats.gtstrm.com/?path=${encodeURIComponent(path)}`,
           '_blank',
         );
       }}

--- a/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
+++ b/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
@@ -151,7 +151,11 @@ export const DialerPage = ({
 
   const handleJoin = () => {
     if (ringingCall) {
-      router.push(`/join/${ringingCall.id}?skip_lobby=true`);
+      const params = new URLSearchParams(
+        router.query as Record<string, string>,
+      );
+      params.set('skip_lobby', 'true');
+      router.push(`/join/${ringingCall.id}?${params.toString()}`);
     }
   };
 

--- a/sample-apps/react/react-dogfood/components/Ringing/DialingCallNotification.tsx
+++ b/sample-apps/react/react-dogfood/components/Ringing/DialingCallNotification.tsx
@@ -38,7 +38,7 @@ export function DialingCallNotification(props: {
   const handleReject = () => {
     if (call) {
       call.leave({ reject: true, reason: 'cancel' }).catch((err) => {
-        console.error('Failed to cancel rining call', err);
+        console.error('Failed to cancel ringing call', err);
       });
     }
   };

--- a/sample-apps/react/react-dogfood/components/Ringing/RingingCallNotification.tsx
+++ b/sample-apps/react/react-dogfood/components/Ringing/RingingCallNotification.tsx
@@ -50,14 +50,20 @@ function RingingCallUI() {
 
   const handleAccept = () => {
     if (call) {
-      router.push(`/join/${call.id}?skip_lobby=true`);
+      const params = new URLSearchParams(
+        router.query as Record<string, string>,
+      );
+      params.delete('callId');
+      params.set('type', call.type);
+      params.set('skip_lobby', 'true');
+      router.push(`/join/${call.id}?${params.toString()}`);
     }
   };
 
   const handleReject = () => {
     if (call) {
       call.leave({ reject: true, reason: 'decline' }).catch((err) => {
-        console.error('Failed to decline rining call', err);
+        console.error('Failed to decline ringing call', err);
       });
     }
   };


### PR DESCRIPTION
### 💡 Overview

We need to forward all query params in ringing calls. Useful when testing with different call types.