### PR TITLE
fix: force `play-and-record` audioSession on Safari

### DIFF
--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -617,6 +617,12 @@ export class DynascaleManager {
     if (context.state === 'suspended') {
       document.addEventListener('click', this.resumeAudioContext);
     }
+    // @ts-expect-error audioSession is available in Safari only
+    const audioSession = navigator.audioSession;
+    if (audioSession) {
+      // https://github.com/w3c/audio-session/blob/main/explainer.md
+      audioSession.type = 'play-and-record';
+    }
     return (this.audioContext = context);
   };
 


### PR DESCRIPTION
### 💡 Overview

Unless we explicitly set the `audioSession.type`, the silent switch on iPhone mutes incoming audio in cases where the device's microphone isn't in use.
