### PR TITLE
fix: automatically exit android pip mode if call is lef

### DIFF
--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/StreamVideoReactNativeModule.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/StreamVideoReactNativeModule.kt
@@ -116,6 +116,16 @@ class StreamVideoReactNativeModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun exitPipMode(promise: Promise) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val success = PiPHelper.exitPipMode(reactApplicationContext)
+            promise.resolve(success)
+        } else {
+            promise.resolve(false)
+        }
+    }
+
+    @ReactMethod
     fun startThermalStatusUpdates(promise: Promise) {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/PiPHelper.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/PiPHelper.kt
@@ -88,6 +88,24 @@ object PiPHelper {
         return reactApplicationContext.currentActivity?.isInPictureInPictureMode
     }
 
+    fun exitPipMode(reactApplicationContext: ReactApplicationContext): Boolean {
+        return try {
+            reactApplicationContext.currentActivity?.let { activity ->
+                if (activity.isInPictureInPictureMode) {
+                    // Move the task to back to exit PiP mode and return to normal app view
+                    activity.moveTaskToBack(false)
+                    true
+                } else {
+                    // Not in PiP mode, so nothing to do
+                    false
+                }
+            } ?: false
+        } catch (e: Exception) {
+            Log.e(NAME, "Failed to exit Picture-in-Picture mode", e)
+            false
+        }
+    }
+
     private fun getPiPParams(activity: Activity): PictureInPictureParams.Builder {
         val currentOrientation = activity.resources.configuration.orientation
         val aspect =


### PR DESCRIPTION
### 💡 Overview

Currently, iOS exits PiP mode when a call is left, but Android doesn't. This PR aligns the behaviour.

### 📝 Implementation notes

Added a native method to do `moveTaskToBack(false)` to bring the app back to normal view
