### PR TITLE
fix: synchronize updateMuteState; use correct fallback dimensions

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1884,10 +1884,13 @@ export class Call {
    * @internal
    */
   notifyTrackMuteState = async (muted: boolean, ...trackTypes: TrackType[]) => {
-    if (!this.sfuClient) return;
-    await this.sfuClient.updateMuteStates(
-      trackTypes.map((trackType) => ({ trackType, muted })),
-    );
+    const key = `muteState.${this.cid}.${trackTypes.join('-')}`;
+    await withoutConcurrency(key, async () => {
+      if (!this.sfuClient) return;
+      await this.sfuClient.updateMuteStates(
+        trackTypes.map((trackType) => ({ trackType, muted })),
+      );
+    });
   };
 
   /**

--- a/packages/client/src/rtc/__tests__/videoLayers.test.ts
+++ b/packages/client/src/rtc/__tests__/videoLayers.test.ts
@@ -74,24 +74,22 @@ describe('videoLayers', () => {
   });
 
   it('should use predefined bitrate values when track dimensions cant be determined', () => {
-    const width = 0;
-    const height = 0;
     const bitrate = 3000000;
     const track = new MediaStreamTrack();
-    vi.spyOn(track, 'getSettings').mockReturnValue({ width, height });
+    vi.spyOn(track, 'getSettings').mockReturnValue({});
     const layers = computeVideoLayers(track, {
       bitrate,
       // @ts-expect-error - incomplete data
       codec: { name: 'vp8' },
       fps: 30,
-      videoDimension: { width, height },
+      videoDimension: { width: 320, height: 180 },
     });
     expect(layers).toEqual([
       {
         active: true,
         rid: 'q',
-        width: 0,
-        height: 0,
+        width: 320,
+        height: 180,
         maxBitrate: bitrate,
         scaleResolutionDownBy: 1,
         maxFramerate: 30,


### PR DESCRIPTION
### 💡 Overview

Synchronizes the `updateMuteStates` operation and prevents having racy updates.
Also fixes an issue with Firefox and video filters. In Firefox, MediaStreamTracks having a `canvas` as a source don't report any dimensions. Our SDK wrongly defaulted to 0x0 instead of the expected dimension asked by our backend and caused an issue where only a single simulcast layer was announced.
This PR fixes both issues.
