### PR TITLE
fix: android OEM specific pip crash

### DIFF
--- a/packages/react-native-sdk/expo-config-plugin/src/withMainActivity.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withMainActivity.ts
@@ -65,7 +65,9 @@ function addOnPictureInPictureModeChanged(contents: string, isJava: boolean) {
       @Override
       public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode, Configuration newConfig) {
           super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
-
+          if (isFinishing()) {
+            return;
+          }
           if (lifecycleOwner.getLifecycle().getCurrentState() == Lifecycle.State.CREATED) {
               // When user clicks on Close button of PIP
               finishAndRemoveTask();
@@ -78,6 +80,9 @@ function addOnPictureInPictureModeChanged(contents: string, isJava: boolean) {
       statementToInsert = `         
       override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode)
+        if (isFinishing) {
+          return
+        }
         if (lifecycle.currentState === Lifecycle.State.CREATED) {
             // when user clicks on Close button of PIP
             finishAndRemoveTask()

--- a/sample-apps/react-native/dogfood/android/app/src/main/java/io/getstream/rnvideosample/MainActivity.kt
+++ b/sample-apps/react-native/dogfood/android/app/src/main/java/io/getstream/rnvideosample/MainActivity.kt
@@ -35,6 +35,9 @@ class MainActivity : ReactActivity() {
 
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode)
+        if (isFinishing) {
+            return
+        }
         if (lifecycle.currentState == Lifecycle.State.CREATED) {
             // when user clicks on Close button of PIP
             finishAndRemoveTask()


### PR DESCRIPTION
### 💡 Overview

We have found that in some OEM implementations of Android, they will finish the activity then call onPictureInPictureModeChanged, causing a race condition

This PR adds a way to work around this on the expo plugin level and dogfood 

📑 Docs: https://github.com/GetStream/docs-content/pull/496
