### PR TITLE
fix: iOS PiP cleanup

### DIFF
--- a/packages/react-native-sdk/ios/RTCViewPip.swift
+++ b/packages/react-native-sdk/ios/RTCViewPip.swift
@@ -13,17 +13,6 @@ class RTCViewPip: UIView {
     private var pictureInPictureController = StreamPictureInPictureController()
     private var webRtcModule: WebRTCModule?
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        setupNotificationObserver()
-        self.pictureInPictureController?.sourceView = self
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        setupNotificationObserver()
-    }
-    
     private func setupNotificationObserver() {
         NotificationCenter.default.addObserver(
             self,
@@ -31,10 +20,6 @@ class RTCViewPip: UIView {
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
-    }
-    
-    deinit {
-        NotificationCenter.default.removeObserver(self)
     }
     
     func setWebRtcModule(_ module: WebRTCModule) {
@@ -82,15 +67,20 @@ class RTCViewPip: UIView {
         self.pictureInPictureController = nil
     }
     
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        let isVisible = self.superview != nil && self.window != nil;
-        if (!isVisible) {
-            // view is detached so we cleanup the pip controller
-            // taken from:  https://github.com/software-mansion/react-native-screens/blob/main/Example/ios/ScreensExample/RNSSampleLifecycleAwareView.m
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        if self.superview == nil {
+            print("PiP - RTCViewPip has been removed from its superview.")
+            NotificationCenter.default.removeObserver(self)
             DispatchQueue.main.async {
                 NSLog("PiP - onCallClosed called due to view detaching")
                 self.onCallClosed()
+            }
+        } else {
+            print("PiP - RTCViewPip has been added to a superview.")
+            setupNotificationObserver()
+            DispatchQueue.main.async {
+                self.pictureInPictureController?.sourceView = self
             }
         }
     }

--- a/packages/react-native-sdk/ios/RTCViewPipManager.swift
+++ b/packages/react-native-sdk/ios/RTCViewPipManager.swift
@@ -9,34 +9,21 @@ import Foundation
 
 @objc(RTCViewPipManager)
 class RTCViewPipManager: RCTViewManager {
-
-    // A cached RTCViewPip reference.
-    //
-    // Often, the view unmounts before the `onCallClosed` command arrives and as a consequence
-    // pipView.onCallClosed() method wasn't called, as the view can't be found in the ViewRegistry
-    // causing dangling PiP window with the last video frame frozen.
-    // Now, once this happens, instead forwarding the command to the view returned by the registry,
-    // we manually apply it to the cached view. The current setup allows only one PipView, so we
-    // don't have to introduce more complex view tracking mechanism.
-    private var _view: RTCViewPip? = nil
-
+    
     override func view() -> UIView! {
         let view = RTCViewPip()
         view.setWebRtcModule(self.bridge.module(forName: "WebRTCModule") as! WebRTCModule)
-        self._view = view
         return view
     }
-
+    
     override static func requiresMainQueueSetup() -> Bool {
         return true
     }
-
+    
     @objc func onCallClosed(_ reactTag: NSNumber) {
         self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
             guard let pipView = viewRegistry?[reactTag] as? RTCViewPip else {
-                NSLog("PiP - onCallClosed can't be called, Invalid view returned from registry, expecting RTCViewPip. Disposing the cached view.")
-                self._view?.onCallClosed()
-                self._view = nil
+                NSLog("PiP - onCallClosed cant be called, Invalid view returned from registry, expecting RTCViewPip")
                 return
             }
             DispatchQueue.main.async {

--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -2240,7 +2240,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - stream-io-noise-cancellation-react-native (0.1.1):
+  - stream-io-noise-cancellation-react-native (0.2.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2266,7 +2266,7 @@ PODS:
     - stream-react-native-webrtc
     - StreamVideoNoiseCancellation
     - Yoga
-  - stream-io-video-filters-react-native (0.5.0):
+  - stream-io-video-filters-react-native (0.6.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2291,10 +2291,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - stream-react-native-webrtc
     - Yoga
-  - stream-react-native-webrtc (125.3.2-alpha.2):
+  - stream-react-native-webrtc (125.4.0):
     - React-Core
     - StreamWebRTC (~> 125.6422.070)
-  - stream-video-react-native (1.17.6):
+  - stream-video-react-native (1.20.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2629,12 +2629,12 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 84b955f7b4da8b895faf5946f73748267347c975
-  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 83ffb90c23ee5cea353bd32008a7bca100908f8c
@@ -2720,10 +2720,10 @@ SPEC CHECKSUMS:
   RNVoipPushNotification: 4998fe6724d421da616dca765da7dc421ff54c4e
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   stream-chat-react-native: 1803cedc0bf16361b6762e8345f9256e26c60e6f
-  stream-io-noise-cancellation-react-native: e919a0f10d96ec0c4078fbd1cc7a463478ef6b9d
-  stream-io-video-filters-react-native: 727508c13772abce7b21d9e1dadf819213415a2b
-  stream-react-native-webrtc: ae8caf09ca33dec4d0bb9438d285b3abf224ff56
-  stream-video-react-native: 60e980344712b5a5d51c1785bc9105ddaf5a103b
+  stream-io-noise-cancellation-react-native: dfb7e676688de6feab3c8e1a58fa500d17e3554a
+  stream-io-video-filters-react-native: 96287b284c953821fda3439be5e39a2afcc3cbad
+  stream-react-native-webrtc: c1fd66eafb078f1ae943b9e0c9c93c66c127348d
+  stream-video-react-native: 2f2277ef1f2fdd3511e3e6dfcb3a508ba77a1ed3
   StreamVideoNoiseCancellation: c936093dfb72540f1205cd5caec1cf31e27f40ce
   StreamWebRTC: a50ebd8beba4def8f4e378b4895824c3520f9889
   VisionCamera: d19797da4d373ada2c167a6e357e520cc1d9dc56
@@ -2731,4 +2731,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: aa62ba474533b73121c2068a13a8b909b17efbaa
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2


### PR DESCRIPTION
### 💡 Overview

* Guarenteed way to cleanup after view is unmounted
* reverts #1854 as now there is a guarenteed and also that PR caused the cached property to hold a strong reference and so deinit was never called. 

### 📝 Implementation notes

uses `didMoveToSuperview` instead of  `didMoveToWindow` to ensure cleanup is always done on unmount

Here is Gemini 2.5 explanation of why to prefer didMoveToSuperView

```
Potential pitfalls for "unmounting" detection via didMoveToWindow in RN:

1. View removed from superview, but parent not in a window: If a view is removed from a superview, and that superview (or its ancestor) was never actually added to a window, didMoveToWindow might not have been called with a nil window because the view never had a non-nil window to begin with.

2. Container view removed: If you have a complex view hierarchy (e.g., ViewA contains ViewB, and ViewA is removed from its superview), ViewA and all its subviews (including ViewB) will have their superview become nil. However, didMoveToWindow might only be called on ViewA with nil, and ViewB would receive didMoveToSuperview with nil, but its didMoveToWindow might not fire again if it never had a window. (Though, typically, if a view is removed from a hierarchy that was in a window, its didMoveToWindow would also be called with nil).

3. App backgrounding/foregrounding: When your app goes to the background, views might be removed from the window. When it comes back to the foreground, they might be re-added. didMoveToWindow will be called in these scenarios, which might not be what you consider "unmounting" if you're specifically looking for removal from the view hierarchy rather than screen visibility changes.
```
