### PR TITLE
chore: support connecting to any coordinator instance

### DIFF
--- a/sample-apps/react/react-dogfood/helpers/client.ts
+++ b/sample-apps/react/react-dogfood/helpers/client.ts
@@ -17,7 +17,12 @@ let client: StreamVideoClient | undefined;
  * call, and ignored for subsequent calls.
  */
 export const getClient = (
-  creds: { apiKey: string; user?: User; userToken?: string },
+  creds: {
+    apiKey: string;
+    user?: User;
+    userToken?: string;
+    coordinatorUrl?: string;
+  },
   environment: AppEnvironment,
 ) => {
   if (!client) {
@@ -27,7 +32,7 @@ export const getClient = (
       token: creds.userToken,
       tokenProvider: createTokenProvider(creds.user?.id, environment),
       options: {
-        baseURL: process.env.NEXT_PUBLIC_STREAM_API_URL,
+        baseURL: creds.coordinatorUrl || process.env.NEXT_PUBLIC_STREAM_API_URL,
         logLevel: 'debug',
         logger: customSentryLogger(),
         transformRequest: defaultRequestTransformers,

--- a/sample-apps/react/react-dogfood/pages/index.tsx
+++ b/sample-apps/react/react-dogfood/pages/index.tsx
@@ -44,8 +44,17 @@ export default function Home({
   const [client, setClient] = useState<StreamVideoClient>();
   const environment = useAppEnvironment();
 
+  const router = useRouter();
+  const useLocalCoordinator = router.query['use_local_coordinator'] === 'true';
+  const coordinatorUrl = useLocalCoordinator
+    ? 'http://localhost:3030/video'
+    : (router.query['coordinator_url'] as string | undefined);
+
   useEffect(() => {
-    const _client = getClient({ apiKey, user, userToken }, environment);
+    const _client = getClient(
+      { apiKey, user, userToken, coordinatorUrl },
+      environment,
+    );
     setClient(_client);
     window.client = _client;
 
@@ -53,7 +62,7 @@ export default function Home({
       setClient(undefined);
       window.client = undefined;
     };
-  }, [apiKey, environment, user, userToken]);
+  }, [apiKey, coordinatorUrl, environment, user, userToken]);
 
   if (!client) {
     return null;

--- a/sample-apps/react/react-dogfood/pages/join/[callId].tsx
+++ b/sample-apps/react/react-dogfood/pages/join/[callId].tsx
@@ -37,6 +37,10 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
   } = useSettings();
   const callId = router.query['callId'] as string;
   const callType = (router.query['type'] as string) || 'default';
+  const useLocalCoordinator = router.query['use_local_coordinator'] === 'true';
+  const coordinatorUrl = useLocalCoordinator
+    ? 'http://localhost:3030/video'
+    : (router.query['coordinator_url'] as string | undefined);
 
   const { apiKey, userToken, user, gleapApiKey } = props;
 
@@ -44,7 +48,10 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
 
   const [client, setClient] = useState<StreamVideoClient>();
   useEffect(() => {
-    const _client = getClient({ apiKey, user, userToken }, environment);
+    const _client = getClient(
+      { apiKey, user, userToken, coordinatorUrl },
+      environment,
+    );
     setClient(_client);
     window.client = _client;
 
@@ -52,7 +59,7 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
       setClient(undefined);
       window.client = undefined;
     };
-  }, [apiKey, environment, user, userToken]);
+  }, [apiKey, coordinatorUrl, environment, user, userToken]);
 
   const tokenProvider = useMemo(
     () => createTokenProvider(user.id, environment),


### PR DESCRIPTION
### 💡 Overview

Allows one to specify `use_local_coordinator` and `coordinator_url` query params in Pronto for easier end-to-end development without running Pronto locally.