### PR TITLE
fix: prevent cross-origin bg filter images from tainting canvas

### DIFF
--- a/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
+++ b/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
@@ -361,6 +361,7 @@ const useRenderer = (tfLite: TFLite, call: Call | undefined) => {
           alt="Background"
           ref={bgImageRef}
           src={backgroundImage}
+          crossOrigin="anonymous"
           {...videoSize}
         />
       )}


### PR DESCRIPTION
### 💡 Overview

When rendering the background image filter, we don't set any `crossorigin` attribute on the background image `<img>` tag. Because of that, rendering background image to `<canvas>` makes the canvas [tainted](https://developer.mozilla.org/en-US/docs/Web/HTML/How_to/CORS_enabled_image), and the filter can't start.

We fix that by adding `crossorigin="anonymous"` attribute to the `<img>` tag. The case for actual CORS image fetching is super-rare and can be avoided by fetching the image separately and using `createObjectURL`.