### PR TITLE
fix: viewer livestream muting issue in SDK

### DIFF
--- a/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewLiveStream.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LiveStream/ViewLiveStream.tsx
@@ -41,21 +41,10 @@ export const ViewLiveStreamChildren = ({
     params: { callId },
   } = route;
 
-  const client = useStreamVideoClient();
-  const call = useSetCall(callId, 'livestream', client);
-
-  if (!call) {
-    return null;
-  }
-
   /**
    * Note: Here we provide the `StreamCall` component again. This is done, so that the call used, is created by the anonymous user.
    */
-  return (
-    <StreamCall call={call}>
-      <LivestreamPlayer callId={callId} callType="livestream" />
-    </StreamCall>
-  );
+  return <LivestreamPlayer callId={callId} callType="livestream" />;
 };
 
 export const ViewLiveStreamScreen = ({


### PR DESCRIPTION
### 💡 Overview

This pull request updates the livestream viewer and layout components to improve audio muting and video dimension handling, while simplifying the way livestream calls are rendered in the sample app. The most important changes are grouped below:

**Audio Muting Logic Improvements:**

* The `ViewerLivestreamControls` component now mutes/unmutes the dominant speaker's audio by adjusting the audio track volume directly, instead of toggling the speakerphone via `InCallManager`. This provides more precise control over audio muting in livestreams. [[1]](diffhunk://#diff-3e283ba65aa850f2face2d090fa023e4a8b8f887f9f2d8ddb4e7c8bd51d1b395L21-R27) [[2]](diffhunk://#diff-3e283ba65aa850f2face2d090fa023e4a8b8f887f9f2d8ddb4e7c8bd51d1b395R68-R70) [[3]](diffhunk://#diff-3e283ba65aa850f2face2d090fa023e4a8b8f887f9f2d8ddb4e7c8bd51d1b395L107-R119)

**Livestream Layout and Video Dimension Handling:**

* The `LivestreamLayout` component now uses a new `VideoTrackDimensionsRenderLessComponent` that leverages the `useTrackDimensions` hook to accurately track and update video dimensions for both the presenter (during screen share) and the current speaker. This replaces the previous approach based on call stats reports. [[1]](diffhunk://#diff-d17edc74b4031211f79b5bbc1f4c63dadf7f6212d93f158547ba29153dbf81f8L2-R6) [[2]](diffhunk://#diff-d17edc74b4031211f79b5bbc1f4c63dadf7f6212d93f158547ba29153dbf81f8R16) [[3]](diffhunk://#diff-d17edc74b4031211f79b5bbc1f4c63dadf7f6212d93f158547ba29153dbf81f8L59-L63) [[4]](diffhunk://#diff-d17edc74b4031211f79b5bbc1f4c63dadf7f6212d93f158547ba29153dbf81f8L87-R137)
* The logic for setting the `objectFit` property on `VideoRenderer` has been simplified, and the property is now consistently passed for both presenter and current speaker video tracks. [[1]](diffhunk://#diff-d17edc74b4031211f79b5bbc1f4c63dadf7f6212d93f158547ba29153dbf81f8L59-L63) [[2]](diffhunk://#diff-d17edc74b4031211f79b5bbc1f4c63dadf7f6212d93f158547ba29153dbf81f8L87-R137)

**Sample App Simplification:**

* The sample app's `ViewLiveStreamChildren` component no longer manually creates and manages the call object, and instead directly renders the `LivestreamPlayer` component, reducing complexity.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
