### PR TITLE
fix: apply the crossorigin attribute before applying src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as packager
+FROM node:22-alpine AS packager
 WORKDIR /e2e
 
 COPY sample-apps/ sample-apps/
@@ -7,11 +7,11 @@ RUN find sample-apps \! -name "package.json" -mindepth 3 -maxdepth 3 -print | xa
 COPY packages/ packages/
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
 
-FROM node:20-bullseye as runner
+FROM node:22-bullseye AS runner
 WORKDIR /e2e
 
 COPY .yarn/ ./.yarn/
-COPY yarn.lock package.json .yarnrc.yml tsconfig.json ./
+COPY yarn.lock package.json .yarnrc.yml ./
 COPY --from=packager /e2e/packages ./packages
 COPY --from=packager /e2e/sample-apps ./sample-apps
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,5 @@ services:
       - ./sample-apps/react/egress-composite/tests/:/e2e/sample-apps/react/egress-composite/tests/
     environment:
       VITE_STREAM_API_KEY: hd8szvscpxvd
-      VITE_STREAM_USER_TOKEN: <token>
+      VITE_STREAM_USER_TOKEN: <jane-token>
       CI: true

--- a/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
+++ b/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
@@ -360,8 +360,8 @@ const useRenderer = (tfLite: TFLite, call: Call | undefined) => {
           className="str-video__background-filters__background-image"
           alt="Background"
           ref={bgImageRef}
-          src={backgroundImage}
           crossOrigin="anonymous"
+          src={backgroundImage}
           {...videoSize}
         />
       )}

--- a/sample-apps/react/egress-composite/package.json
+++ b/sample-apps/react/egress-composite/package.json
@@ -20,7 +20,7 @@
     "react-dom": "19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.37.1",
+    "@playwright/test": "^1.54.2",
     "@sentry/vite-plugin": "^2.23.0",
     "@types/react": "^19.1.3",
     "@types/react-dom": "^19.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5140,19 +5140,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.37.1":
-  version: 1.37.1
-  resolution: "@playwright/test@npm:1.37.1"
+"@playwright/test@npm:^1.54.2":
+  version: 1.54.2
+  resolution: "@playwright/test@npm:1.54.2"
   dependencies:
-    "@types/node": "npm:*"
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.37.1"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: "npm:1.54.2"
   bin:
     playwright: cli.js
-  checksum: 10/c445f4a590cf5a980e37ed020a8a9020a490d513590bb4d79b24034c7f76add1e540762e313f50376f988ec7d5007542788b53866b957fb84d4359abf814ff30
+  checksum: 10/33d6c0780ef6cca12c008cae166ba06978ae975138a1654e14cd8691ad7826dbbc03e492ed42c65889c44ca893d0fd47d8ae4dc8d824020d7f767260b395dc6b
   languageName: node
   linkType: hard
 
@@ -6780,7 +6775,7 @@ __metadata:
   resolution: "@stream-io/egress-composite@workspace:sample-apps/react/egress-composite"
   dependencies:
     "@emotion/css": "npm:^11.13.5"
-    "@playwright/test": "npm:^1.37.1"
+    "@playwright/test": "npm:^1.54.2"
     "@sentry/react": "npm:^8.55.0"
     "@sentry/vite-plugin": "npm:^2.23.0"
     "@stream-io/video-react-sdk": "workspace:^"
@@ -19346,12 +19341,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.37.1":
-  version: 1.37.1
-  resolution: "playwright-core@npm:1.37.1"
+"playwright-core@npm:1.54.2":
+  version: 1.54.2
+  resolution: "playwright-core@npm:1.54.2"
   bin:
     playwright-core: cli.js
-  checksum: 10/9db000892cbe330d5e047e78de11febf53f708bcd8bacaf727eceedb57d67abc7a74e6bb793dabce13b420da8896e6fef840ba1bb9ace2dac3ade3b81f801502
+  checksum: 10/8eb8b37d7b02c2394f85567c5703464ee7c85929e1de7118946548a0277cacd41a6f247b8f7eb50c921433346f785356eff8132a9d3c6c2dcf3402c6a83e4f18
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.54.2":
+  version: 1.54.2
+  resolution: "playwright@npm:1.54.2"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.54.2"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10/3f4fedc1e2290b6da6960eedf0d78b9097251848b499b0627186ca85e94178fe6be1590c4926246ff4dad5729fc80ab63fee6554fe736d29c0a1808ec483467f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 💡 Overview

Related to: https://github.com/facebook/react/issues/14035
To ensure that CORS headers are properly set, we need to apply the `crossorigin` attribute before we apply the `src` one.
