### PR TITLE
fix: synchronize ring events

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -165,6 +165,8 @@ export class StreamVideoClient {
     if (this.effectsRegistered) return;
 
     this.eventHandlersToUnregister.push(
+      this.on('call.created', (event) => this.initCallFromEvent(event)),
+      this.on('call.ring', (event) => this.initCallFromEvent(event)),
       this.on('connection.changed', (event) => {
         if (!event.online) return;
 
@@ -182,11 +184,6 @@ export class StreamVideoClient {
           this.logger('error', 'Failed to re-watch calls', err);
         });
       }),
-    );
-
-    this.eventHandlersToUnregister.push(
-      this.on('call.created', (event) => this.initCallFromEvent(event)),
-      this.on('call.ring', (event) => this.initCallFromEvent(event)),
     );
 
     this.effectsRegistered = true;

--- a/packages/client/src/__tests__/StreamVideoClient.ringing.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.ringing.test.ts
@@ -51,7 +51,9 @@ describe('StreamVideoClient Ringing', () => {
   });
 
   describe('standard ringing', async () => {
-    it('server-side: oliver should ring all members', async () => {
+    // TODO OL: enable this test once we know more:
+    // https://getstream.slack.com/archives/C040262MY9K/p1755178272202659
+    it.skip('server-side: oliver should ring all members', async () => {
       const oliverRing = expectEvent(oliverClient, 'call.ring');
       const sachaRing = expectEvent(sachaClient, 'call.ring');
       const marceloRing = expectEvent(marceloClient, 'call.ring');

--- a/packages/client/src/__tests__/StreamVideoClient.ringing.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.ringing.test.ts
@@ -1,0 +1,201 @@
+import 'dotenv/config';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { StreamVideoClient } from '../StreamVideoClient';
+import { StreamClient } from '@stream-io/node-sdk';
+import {
+  AllClientEvents,
+  StreamVideoEvent,
+} from '../coordinator/connection/types';
+import { CallingState, RxUtils } from '../store';
+import { settled } from '../helpers/concurrency';
+import { Call } from '../Call';
+import { CallCreatedPayload, CallRingPayload } from './data';
+
+const apiKey = process.env.STREAM_API_KEY!;
+const secret = process.env.STREAM_SECRET!;
+
+describe('StreamVideoClient Ringing', () => {
+  const serverClient = new StreamClient(apiKey, secret);
+
+  let oliverClient: StreamVideoClient;
+  let sachaClient: StreamVideoClient;
+  let marceloClient: StreamVideoClient;
+
+  beforeEach(async () => {
+    const makeClient = async (userId: string) => {
+      const client = new StreamVideoClient(apiKey, {
+        // tests run in node, so we have to fake being in browser env
+        browser: true,
+        timeout: 15000,
+      });
+      const token = serverClient.generateUserToken({ user_id: userId });
+      await client.connectUser({ id: userId }, token);
+      return client;
+    };
+    [oliverClient, sachaClient, marceloClient] = await Promise.all([
+      makeClient('oliver'),
+      makeClient('sacha'),
+      makeClient('marcelo'),
+    ]);
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      oliverClient.disconnectUser(),
+      sachaClient.disconnectUser(),
+      marceloClient.disconnectUser(),
+    ]);
+  });
+
+  describe('standard ringing', async () => {
+    it('server-side: oliver should ring all members', async () => {
+      const oliverRing = expectEvent(oliverClient, 'call.ring');
+      const sachaRing = expectEvent(sachaClient, 'call.ring');
+      const marceloRing = expectEvent(marceloClient, 'call.ring');
+
+      const call = serverClient.video.call('default', crypto.randomUUID());
+      await call.create({
+        ring: true,
+        data: {
+          created_by_id: 'oliver',
+          members: [
+            { user_id: 'oliver' },
+            { user_id: 'sacha' },
+            { user_id: 'marcelo' },
+          ],
+        },
+      });
+
+      const [oliverRingEvent, sachaRingEvent, marceloRingEvent] =
+        await Promise.all([oliverRing, sachaRing, marceloRing]);
+
+      expect(oliverRingEvent.call.cid).toBe(call.cid);
+      expect(sachaRingEvent.call.cid).toBe(call.cid);
+      expect(marceloRingEvent.call.cid).toBe(call.cid);
+
+      const oliverCall = await expectCall(oliverClient, call.cid);
+      const sachaCall = await expectCall(sachaClient, call.cid);
+      const marceloCall = await expectCall(marceloClient, call.cid);
+      expect(oliverCall).toBeDefined();
+      expect(sachaCall).toBeDefined();
+      expect(marceloCall).toBeDefined();
+      expect(oliverCall.ringing).toBe(true);
+      expect(sachaCall.ringing).toBe(true);
+      expect(marceloCall.ringing).toBe(true);
+    });
+
+    it('client-side: oliver should ring all members', async () => {
+      const oliverRing = expectEvent(oliverClient, 'call.ring');
+      const sachaRing = expectEvent(sachaClient, 'call.ring');
+      const marceloRing = expectEvent(marceloClient, 'call.ring');
+
+      const call = oliverClient.call('default', crypto.randomUUID());
+      await call.create({
+        ring: true,
+        data: {
+          members: [
+            { user_id: 'oliver' },
+            { user_id: 'sacha' },
+            { user_id: 'marcelo' },
+          ],
+        },
+      });
+
+      const [oliverRingEvent, sachaRingEvent, marceloRingEvent] =
+        await Promise.all([oliverRing, sachaRing, marceloRing]);
+
+      expect(oliverRingEvent.call.cid).toBe(call.cid);
+      expect(sachaRingEvent.call.cid).toBe(call.cid);
+      expect(marceloRingEvent.call.cid).toBe(call.cid);
+
+      const oliverCall = await expectCall(oliverClient, call.cid);
+      const sachaCall = await expectCall(sachaClient, call.cid);
+      const marceloCall = await expectCall(marceloClient, call.cid);
+      expect(oliverCall).toBeDefined();
+      expect(sachaCall).toBeDefined();
+      expect(marceloCall).toBeDefined();
+      expect(oliverCall.ringing).toBe(true);
+      expect(sachaCall.ringing).toBe(true);
+      expect(marceloCall.ringing).toBe(true);
+    });
+  });
+
+  describe('ringing concurrently', async () => {
+    it('dispatches `call.ring` before `call.created`', async () => {
+      oliverClient.streamClient.dispatchEvent(
+        CallRingPayload as StreamVideoEvent,
+      );
+      oliverClient.streamClient.dispatchEvent(
+        CallCreatedPayload as StreamVideoEvent,
+      );
+      await settled(`call.init-${CallCreatedPayload.call_cid}`);
+      expect(oliverClient.state.calls.length).toBe(1);
+      expect(oliverClient.state.calls[0].state.callingState).toBe(
+        CallingState.RINGING,
+      );
+    });
+
+    it('dispatches `call.created` then `call.ring`', async () => {
+      oliverClient.streamClient.dispatchEvent(
+        CallCreatedPayload as StreamVideoEvent,
+      );
+      oliverClient.streamClient.dispatchEvent(
+        CallRingPayload as StreamVideoEvent,
+      );
+
+      await settled(`call.init-${CallCreatedPayload.call_cid}`);
+      expect(oliverClient.state.calls.length).toBe(1);
+      expect(oliverClient.state.calls[0].state.callingState).toBe(
+        CallingState.RINGING,
+      );
+    });
+  });
+});
+
+const expectEvent = async <E extends keyof AllClientEvents>(
+  client: StreamVideoClient,
+  eventName: E,
+  timeout: number = 2500,
+): Promise<AllClientEvents[E]> => {
+  return new Promise<AllClientEvents[E]>((resolve, reject) => {
+    let timeoutId: NodeJS.Timeout | undefined = undefined;
+    const off = client.on(eventName, (e) => {
+      off();
+      clearTimeout(timeoutId);
+      resolve(e);
+    });
+    timeoutId = setTimeout(() => {
+      off();
+      reject(
+        new Error(
+          `Timeout waiting for event: ${eventName}, user_id: ${client.state.connectedUser?.id}`,
+        ),
+      );
+    }, timeout);
+  });
+};
+
+const expectCall = async (
+  client: StreamVideoClient,
+  cid: string,
+  timeout: number = 2500,
+) => {
+  return new Promise<Call>((resolve, reject) => {
+    let timeoutId: NodeJS.Timeout | undefined = undefined;
+    const off = RxUtils.createSubscription(client.state.calls$, (calls) => {
+      const call = calls.find((c) => c.cid === cid);
+      if (call) {
+        clearTimeout(timeoutId);
+        resolve(call);
+      }
+    });
+    timeoutId = setTimeout(() => {
+      off();
+      reject(
+        new Error(
+          `Timeout waiting for call: ${cid}, user_id: ${client.state.connectedUser?.id}`,
+        ),
+      );
+    }, timeout);
+  });
+};

--- a/packages/client/src/__tests__/clientTestUtils.ts
+++ b/packages/client/src/__tests__/clientTestUtils.ts
@@ -1,0 +1,72 @@
+import { AllClientEvents } from '../coordinator/connection/types';
+import { StreamVideoClient } from '../StreamVideoClient';
+import { Call } from '../Call';
+import { RxUtils } from '../store';
+
+/**
+ * Waits for a specified event to occur on the provided StreamVideoClient instance within a given timeout period.
+ *
+ * @template E - The type of event to wait for.
+ * @param client - An instance of the StreamVideoClient where the event is expected to occur.
+ * @param {E} eventName - The name of the event to wait for.
+ * @param [timeout=2500] - The maximum time, in milliseconds, to wait for the event. Defaults to 2500ms.
+ * @returns A promise that resolves with the event data if the event occurs within the timeout period, or rejects with an error if the timeout is reached.
+ * @throws {Error} Throws an error if the event does not occur within the specified timeout.
+ */
+export const expectEvent = async <E extends keyof AllClientEvents>(
+  client: StreamVideoClient,
+  eventName: E,
+  timeout: number = 2500,
+): Promise<AllClientEvents[E]> => {
+  return new Promise<AllClientEvents[E]>((resolve, reject) => {
+    let timeoutId: NodeJS.Timeout | undefined = undefined;
+    const off = client.on(eventName, (e) => {
+      off();
+      clearTimeout(timeoutId);
+      resolve(e);
+    });
+    timeoutId = setTimeout(() => {
+      off();
+      reject(
+        new Error(
+          `Timeout waiting for event: ${eventName}, user_id: ${client.state.connectedUser?.id}`,
+        ),
+      );
+    }, timeout);
+  });
+};
+
+/**
+ * Waits for a specific call to appear in the client's state and resolves with the call object.
+ * If the call does not appear within the specified timeout, the promise is rejected with an error.
+ *
+ * @param client - The Stream Video client instance to monitor for calls.
+ * @param cid - The unique identifier of the call to wait for.
+ * @param [timeout=2500] - The timeout duration, in milliseconds, to wait for the call.
+ * @returns A promise that resolves with the target call object or rejects if the call does not appear within the timeout.
+ * @throws err an error if the timeout is exceeded without finding the specified call.
+ */
+export const expectCall = async (
+  client: StreamVideoClient,
+  cid: string,
+  timeout: number = 2500,
+) => {
+  return new Promise<Call>((resolve, reject) => {
+    let timeoutId: NodeJS.Timeout | undefined = undefined;
+    const off = RxUtils.createSubscription(client.state.calls$, (calls) => {
+      const call = calls.find((c) => c.cid === cid);
+      if (call) {
+        clearTimeout(timeoutId);
+        resolve(call);
+      }
+    });
+    timeoutId = setTimeout(() => {
+      off();
+      reject(
+        new Error(
+          `Timeout waiting for call: ${cid}, user_id: ${client.state.connectedUser?.id}`,
+        ),
+      );
+    }, timeout);
+  });
+};

--- a/packages/client/src/__tests__/data.ts
+++ b/packages/client/src/__tests__/data.ts
@@ -1,0 +1,621 @@
+import { CallCreatedEvent, CallRingEvent } from '../gen/coordinator';
+
+export const CallCreatedPayload: CallCreatedEvent = {
+  type: 'call.created',
+  created_at: '2025-08-14T14:48:39.988853336Z',
+  call_cid: 'default:h6c44o00NeFTH6IvsGGgM',
+  call: {
+    type: 'default',
+    id: 'h6c44o00NeFTH6IvsGGgM',
+    cid: 'default:h6c44o00NeFTH6IvsGGgM',
+    current_session_id: '',
+    created_by: {
+      id: 'oliver_1',
+      name: 'Oliver Lazoroski',
+      image:
+        'https://lh3.googleusercontent.com/a/ACg8ocJLHHaOnen-0xmJir7r65nPKpIVnF6TTvpX0QbFSXjGa8WWF9Y=s96-c',
+      custom: {
+        imageUrl:
+          'https://ca.slack-edge.com/T02RM6X6B-U03HJKTMSQZ-cdf636547793-512',
+      },
+      language: '',
+      role: 'user',
+      teams: [],
+      created_at: '2024-01-10T14:46:46.567417Z',
+      updated_at: '2025-08-14T14:48:32.808624Z',
+      // @ts-expect-error outdated types
+      banned: false,
+      online: false,
+      last_active: '2025-08-12T11:50:03.973174Z',
+      blocked_user_ids: [],
+    },
+    custom: {},
+    created_at: '2025-08-14T14:48:39.958024Z',
+    updated_at: '2025-08-14T14:48:39.958024Z',
+    recording: false,
+    transcribing: false,
+    captioning: false,
+    ended_at: null,
+    starts_at: null,
+    backstage: false,
+    settings: {
+      audio: {
+        access_request_enabled: true,
+        opus_dtx_enabled: true,
+        redundant_coding_enabled: true,
+        mic_default_on: true,
+        speaker_default_on: true,
+        default_device: 'speaker',
+        noise_cancellation: {
+          mode: 'auto-on',
+        },
+      },
+      backstage: {
+        enabled: false,
+      },
+      broadcasting: {
+        enabled: true,
+        hls: {
+          auto_on: false,
+          enabled: true,
+          quality_tracks: ['720p'],
+        },
+        rtmp: {
+          enabled: true,
+          quality: '720p',
+        },
+      },
+      geofencing: {
+        names: [],
+      },
+      recording: {
+        audio_only: false,
+        mode: 'available',
+        quality: '1080p',
+      },
+      frame_recording: {
+        mode: 'auto-on',
+        quality: '720p',
+        capture_interval_in_seconds: 3,
+      },
+      ring: {
+        incoming_call_timeout_ms: 60000,
+        auto_cancel_timeout_ms: 60000,
+        missed_call_timeout_ms: 5000,
+      },
+      screensharing: {
+        enabled: true,
+        access_request_enabled: true,
+        target_resolution: null,
+      },
+      transcription: {
+        mode: 'auto-on',
+        closed_caption_mode: 'auto-on',
+        // languages: [],
+        language: 'en',
+      },
+      video: {
+        enabled: true,
+        access_request_enabled: true,
+        target_resolution: {
+          width: 1280,
+          height: 720,
+          bitrate: 1500000,
+        },
+        camera_default_on: true,
+        camera_facing: 'front',
+      },
+      thumbnails: {
+        enabled: true,
+      },
+      limits: {
+        max_participants: null,
+        // @ts-expect-error outdated types
+        max_participants_exclude_roles: [],
+        max_duration_seconds: null,
+      },
+      session: {
+        inactivity_timeout_seconds: 30,
+      },
+      ingress: {
+        enabled: true,
+        audio_encoding_options: {
+          channels: 2,
+          enable_dtx: false,
+          bitrate: 128000,
+        },
+        video_encoding_options: {
+          '1280x720x30': {
+            layers: [
+              {
+                codec: 'h264',
+                bitrate: 3000000,
+                min_dimension: 720,
+                max_dimension: 1280,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 1000000,
+                min_dimension: 600,
+                max_dimension: 800,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 500000,
+                min_dimension: 360,
+                max_dimension: 640,
+                frame_rate_limit: 30,
+              },
+            ],
+          },
+          '1920x1080x30': {
+            layers: [
+              {
+                codec: 'h264',
+                bitrate: 4000000,
+                min_dimension: 1080,
+                max_dimension: 1920,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 3000000,
+                min_dimension: 720,
+                max_dimension: 1280,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 1000000,
+                min_dimension: 600,
+                max_dimension: 800,
+                frame_rate_limit: 30,
+              },
+            ],
+          },
+          '2560x1440x30': {
+            layers: [
+              {
+                codec: 'h264',
+                bitrate: 6000000,
+                min_dimension: 1440,
+                max_dimension: 2560,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 4000000,
+                min_dimension: 1080,
+                max_dimension: 1920,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 2000000,
+                min_dimension: 720,
+                max_dimension: 1280,
+                frame_rate_limit: 30,
+              },
+            ],
+          },
+          '3840x2160x30': {
+            layers: [
+              {
+                codec: 'h264',
+                bitrate: 18000000,
+                min_dimension: 2160,
+                max_dimension: 3840,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 8000000,
+                min_dimension: 1080,
+                max_dimension: 1920,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 2000000,
+                min_dimension: 720,
+                max_dimension: 1280,
+                frame_rate_limit: 30,
+              },
+            ],
+          },
+        },
+      },
+    },
+    blocked_user_ids: [],
+    ingress: {
+      rtmp: {
+        address:
+          'rtmps://ingress.stream-io-video.com:443/par8f5s3gn2j.default.h6c44o00NeFTH6IvsGGgM',
+      },
+    },
+    session: null,
+    egress: {
+      broadcasting: false,
+      hls: null,
+      rtmps: [],
+      frame_recording: null,
+    },
+    thumbnails: {
+      image_url:
+        'https://us-east.stream-io-cdn.com/1270131/images/default/h6c44o00NeFTH6IvsGGgM/preview/thumbnail.jpg?Key-Pair-Id=APKAIHG36VEWPDULE23Q&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly91cy1lYXN0LnN0cmVhbS1pby1jZG4uY29tLzEyNzAxMzEvaW1hZ2VzL2RlZmF1bHQvaDZjNDRvMDBOZUZUSDZJdnNHR2dNL3ByZXZpZXcvdGh1bWJuYWlsLmpwZyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTU0NDIxMTl9fX1dfQ__&Signature=ladoiTTWl8bbnSqEDswKUIQ1hbY1kVbDFuHS4mZgHBcv-L1hJ13q1UE5fKBCMbqGvrL~9AzLTYFpX2AwhX85JYRvTESHxfqqQyrSiFf9FLMmZMbi2ro-YBJOeFRE3Iz2~jVcqr~HAw26mHfcM74CMMv3cCQGBToXtYgdfUuN-snPWQidfnRGReDN6slb8mga0gufw4UoJr~WLWLc6nNYPyuYRcGMj4dghRtQiCcyfGXtuOc~Hjlnh8DTZgPY09QZlX7HwqyENfP4~qEHnMsRyZBfzqFk4mT-T~HDd3v26Ruf3clVETjdKTH4xzd2D1fpFF0Q8YjtWrS0NK1qW3pc9w__',
+    },
+    join_ahead_time_seconds: 0,
+    channel_cid: null,
+  },
+  members: [
+    {
+      user: {
+        id: 'marcelo',
+        name: 'marcelo',
+        image:
+          'https://getstream.io/static/aaf5fb17dcfd0a3dd885f62bd21b325a/802d2/marcelo-pires.webp',
+        custom: {
+          imageUrl: 'https://getstream.io/random_png/?id=marcelo&name=marcelo',
+        },
+        language: '',
+        role: 'user',
+        teams: [],
+        created_at: '2024-01-10T13:26:19.889536Z',
+        updated_at: '2025-08-07T07:35:43.81976Z',
+        // @ts-expect-error outdated types
+        banned: false,
+        online: false,
+        last_active: '2025-08-07T04:30:50.670932Z',
+        blocked_user_ids: [],
+      },
+      user_id: 'marcelo',
+      custom: {},
+      created_at: '2025-08-14T14:48:39.9691Z',
+      updated_at: '2025-08-14T14:48:39.9691Z',
+    },
+    {
+      user: {
+        id: 'oliver',
+        name: 'Oliver Lazoroski',
+        image:
+          'https://lh3.googleusercontent.com/a/ACg8ocJLHHaOnen-0xmJir7r65nPKpIVnF6TTvpX0QbFSXjGa8WWF9Y=s96-c',
+        custom: {
+          imageUrl:
+            'https://ca.slack-edge.com/T02RM6X6B-U03HJKTMSQZ-cdf636547793-512',
+        },
+        language: '',
+        role: 'user',
+        teams: [],
+        created_at: '2024-01-10T14:46:46.567417Z',
+        updated_at: '2025-08-14T14:48:32.808624Z',
+        // @ts-expect-error outdated types
+        banned: false,
+        online: false,
+        last_active: '2025-08-12T11:50:03.973174Z',
+        blocked_user_ids: [],
+      },
+      user_id: 'oliver',
+      custom: {},
+      created_at: '2025-08-14T14:48:39.9691Z',
+      updated_at: '2025-08-14T14:48:39.9691Z',
+    },
+  ],
+  received_at: '2025-08-14T14:48:39.973Z',
+};
+
+export const CallRingPayload: CallRingEvent = {
+  type: 'call.ring',
+  created_at: '2025-08-14T14:48:40.006646269Z',
+  call_cid: 'default:h6c44o00NeFTH6IvsGGgM',
+  session_id: 'b8a44039-41f3-4570-a438-187d6df65671',
+  call: {
+    type: 'default',
+    id: 'h6c44o00NeFTH6IvsGGgM',
+    cid: 'default:h6c44o00NeFTH6IvsGGgM',
+    current_session_id: 'b8a44039-41f3-4570-a438-187d6df65671',
+    created_by: {
+      id: 'oliver_1',
+      name: 'Oliver Lazoroski',
+      image:
+        'https://lh3.googleusercontent.com/a/ACg8ocJLHHaOnen-0xmJir7r65nPKpIVnF6TTvpX0QbFSXjGa8WWF9Y=s96-c',
+      custom: {
+        imageUrl:
+          'https://ca.slack-edge.com/T02RM6X6B-U03HJKTMSQZ-cdf636547793-512',
+      },
+      language: '',
+      role: 'user',
+      teams: [],
+      created_at: '2024-01-10T14:46:46.567417Z',
+      updated_at: '2025-08-14T14:48:32.808624Z',
+      // @ts-expect-error outdated types
+      banned: false,
+      online: false,
+      last_active: '2025-08-12T11:50:03.973174Z',
+      blocked_user_ids: [],
+    },
+    custom: {},
+    created_at: '2025-08-14T14:48:39.958024Z',
+    updated_at: '2025-08-14T14:48:39.958024Z',
+    recording: false,
+    transcribing: false,
+    captioning: false,
+    ended_at: null,
+    starts_at: null,
+    backstage: false,
+    settings: {
+      audio: {
+        access_request_enabled: true,
+        opus_dtx_enabled: true,
+        redundant_coding_enabled: true,
+        mic_default_on: true,
+        speaker_default_on: true,
+        default_device: 'speaker',
+        noise_cancellation: {
+          mode: 'auto-on',
+        },
+      },
+      backstage: {
+        enabled: false,
+      },
+      broadcasting: {
+        enabled: true,
+        hls: {
+          auto_on: false,
+          enabled: true,
+          quality_tracks: ['720p'],
+        },
+        rtmp: {
+          enabled: true,
+          quality: '720p',
+        },
+      },
+      geofencing: {
+        names: [],
+      },
+      recording: {
+        audio_only: false,
+        mode: 'available',
+        quality: '1080p',
+      },
+      frame_recording: {
+        mode: 'auto-on',
+        quality: '720p',
+        capture_interval_in_seconds: 3,
+      },
+      ring: {
+        incoming_call_timeout_ms: 60000,
+        auto_cancel_timeout_ms: 60000,
+        missed_call_timeout_ms: 5000,
+      },
+      screensharing: {
+        enabled: true,
+        access_request_enabled: true,
+        target_resolution: null,
+      },
+      transcription: {
+        mode: 'auto-on',
+        closed_caption_mode: 'auto-on',
+        // @ts-expect-error outdated types
+        languages: [],
+        language: 'en',
+      },
+      video: {
+        enabled: true,
+        access_request_enabled: true,
+        target_resolution: {
+          width: 1280,
+          height: 720,
+          bitrate: 1500000,
+        },
+        camera_default_on: true,
+        camera_facing: 'front',
+      },
+      thumbnails: {
+        enabled: true,
+      },
+      limits: {
+        max_participants: null,
+        // @ts-expect-error outdated types
+        max_participants_exclude_roles: [],
+        max_duration_seconds: null,
+      },
+      session: {
+        inactivity_timeout_seconds: 30,
+      },
+      ingress: {
+        enabled: true,
+        audio_encoding_options: {
+          channels: 2,
+          enable_dtx: false,
+          bitrate: 128000,
+        },
+        video_encoding_options: {
+          '1280x720x30': {
+            layers: [
+              {
+                codec: 'h264',
+                bitrate: 3000000,
+                min_dimension: 720,
+                max_dimension: 1280,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 1000000,
+                min_dimension: 600,
+                max_dimension: 800,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 500000,
+                min_dimension: 360,
+                max_dimension: 640,
+                frame_rate_limit: 30,
+              },
+            ],
+          },
+          '1920x1080x30': {
+            layers: [
+              {
+                codec: 'h264',
+                bitrate: 4000000,
+                min_dimension: 1080,
+                max_dimension: 1920,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 3000000,
+                min_dimension: 720,
+                max_dimension: 1280,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 1000000,
+                min_dimension: 600,
+                max_dimension: 800,
+                frame_rate_limit: 30,
+              },
+            ],
+          },
+          '2560x1440x30': {
+            layers: [
+              {
+                codec: 'h264',
+                bitrate: 6000000,
+                min_dimension: 1440,
+                max_dimension: 2560,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 4000000,
+                min_dimension: 1080,
+                max_dimension: 1920,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 2000000,
+                min_dimension: 720,
+                max_dimension: 1280,
+                frame_rate_limit: 30,
+              },
+            ],
+          },
+          '3840x2160x30': {
+            layers: [
+              {
+                codec: 'h264',
+                bitrate: 18000000,
+                min_dimension: 2160,
+                max_dimension: 3840,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 8000000,
+                min_dimension: 1080,
+                max_dimension: 1920,
+                frame_rate_limit: 30,
+              },
+              {
+                codec: 'h264',
+                bitrate: 2000000,
+                min_dimension: 720,
+                max_dimension: 1280,
+                frame_rate_limit: 30,
+              },
+            ],
+          },
+        },
+      },
+    },
+    blocked_user_ids: [],
+    ingress: {
+      rtmp: {
+        address:
+          'rtmps://ingress.stream-io-video.com:443/par8f5s3gn2j.default.h6c44o00NeFTH6IvsGGgM',
+      },
+    },
+    session: {
+      id: 'b8a44039-41f3-4570-a438-187d6df65671',
+      started_at: null,
+      ended_at: null,
+      participants: [],
+      participants_count_by_role: {},
+      anonymous_participant_count: 0,
+      rejected_by: {},
+      accepted_by: {},
+      missed_by: {},
+      live_started_at: null,
+      live_ended_at: null,
+      timer_ends_at: null,
+    },
+    egress: {
+      broadcasting: false,
+      hls: null,
+      rtmps: [],
+      frame_recording: null,
+    },
+    thumbnails: {
+      image_url:
+        'https://us-east.stream-io-cdn.com/1270131/images/default/h6c44o00NeFTH6IvsGGgM/preview/thumbnail.jpg?Key-Pair-Id=APKAIHG36VEWPDULE23Q&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly91cy1lYXN0LnN0cmVhbS1pby1jZG4uY29tLzEyNzAxMzEvaW1hZ2VzL2RlZmF1bHQvaDZjNDRvMDBOZUZUSDZJdnNHR2dNL3ByZXZpZXcvdGh1bWJuYWlsLmpwZyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTU0NDIxMTl9fX1dfQ__&Signature=ladoiTTWl8bbnSqEDswKUIQ1hbY1kVbDFuHS4mZgHBcv-L1hJ13q1UE5fKBCMbqGvrL~9AzLTYFpX2AwhX85JYRvTESHxfqqQyrSiFf9FLMmZMbi2ro-YBJOeFRE3Iz2~jVcqr~HAw26mHfcM74CMMv3cCQGBToXtYgdfUuN-snPWQidfnRGReDN6slb8mga0gufw4UoJr~WLWLc6nNYPyuYRcGMj4dghRtQiCcyfGXtuOc~Hjlnh8DTZgPY09QZlX7HwqyENfP4~qEHnMsRyZBfzqFk4mT-T~HDd3v26Ruf3clVETjdKTH4xzd2D1fpFF0Q8YjtWrS0NK1qW3pc9w__',
+    },
+    join_ahead_time_seconds: 0,
+    channel_cid: null,
+  },
+  members: [
+    {
+      user: {
+        id: 'marcelo',
+        name: 'marcelo',
+        image:
+          'https://getstream.io/static/aaf5fb17dcfd0a3dd885f62bd21b325a/802d2/marcelo-pires.webp',
+        custom: {
+          imageUrl: 'https://getstream.io/random_png/?id=marcelo&name=marcelo',
+        },
+        language: '',
+        role: 'user',
+        teams: [],
+        created_at: '2024-01-10T13:26:19.889536Z',
+        updated_at: '2025-08-07T07:35:43.81976Z',
+        // @ts-expect-error outdated types
+        banned: false,
+        online: false,
+        last_active: '2025-08-07T04:30:50.670932Z',
+        blocked_user_ids: [],
+      },
+      user_id: 'marcelo',
+      custom: {},
+      created_at: '2025-08-14T14:48:39.9691Z',
+      updated_at: '2025-08-14T14:48:39.9691Z',
+    },
+  ],
+  user: {
+    id: 'oliver',
+    name: 'Oliver Lazoroski',
+    image:
+      'https://lh3.googleusercontent.com/a/ACg8ocJLHHaOnen-0xmJir7r65nPKpIVnF6TTvpX0QbFSXjGa8WWF9Y=s96-c',
+    custom: {
+      imageUrl:
+        'https://ca.slack-edge.com/T02RM6X6B-U03HJKTMSQZ-cdf636547793-512',
+    },
+    language: '',
+    role: 'user',
+    teams: [],
+    created_at: '2024-01-10T14:46:46.567417Z',
+    updated_at: '2025-08-14T14:48:32.808624Z',
+    // @ts-expect-error outdated types
+    banned: false,
+    online: false,
+    last_active: '2025-08-12T11:50:03.973174Z',
+    blocked_user_ids: [],
+  },
+  video: false,
+  received_at: '2025-08-14T14:48:39.990Z',
+};

--- a/packages/client/src/helpers/__tests__/clientUtils.test.ts
+++ b/packages/client/src/helpers/__tests__/clientUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createCoordinatorClient,
   createTokenOrProvider,
+  getCallInitConcurrencyTag,
   getInstanceKey,
 } from '../clientUtils';
 import { TokenProvider } from '../../coordinator/connection/types';
@@ -12,6 +13,13 @@ describe('clientUtils', () => {
     it('should compute the correct instance key', () => {
       const instanceKey = getInstanceKey('apiKey', { id: 'userId' });
       expect(instanceKey).toBe('apiKey/userId');
+    });
+  });
+
+  describe('getCallInitConcurrencyTag', () => {
+    it('should compute the correct concurrency tag', () => {
+      const tag = getCallInitConcurrencyTag('default:123');
+      expect(tag).toBe('call.init-default:123');
     });
   });
 

--- a/packages/client/src/helpers/clientUtils.ts
+++ b/packages/client/src/helpers/clientUtils.ts
@@ -18,6 +18,14 @@ export const getInstanceKey = (apiKey: string, user: User) => {
 };
 
 /**
+ * Returns a concurrency tag for call initialization.
+ * @internal
+ *
+ * @param cid the call cid.
+ */
+export const getCallInitConcurrencyTag = (cid: string) => `call.init-${cid}`;
+
+/**
  * Utility function to get the client app identifier.
  */
 const getClientAppIdentifier = (

--- a/packages/client/src/store/stateStore.ts
+++ b/packages/client/src/store/stateStore.ts
@@ -119,14 +119,6 @@ export class StreamVideoReadOnlyStateStore {
    */
   calls$: Observable<Call[]>;
 
-  /**
-   * This method allows you the get the current value of a state variable.
-   *
-   * @param observable the observable to get the current value of.
-   * @returns the current value of the observable.
-   */
-  getCurrentValue = RxUtils.getCurrentValue;
-
   constructor(store: StreamVideoWriteableStateStore) {
     // convert and expose subjects as observables
     this.connectedUser$ = store.connectedUserSubject.asObservable();

--- a/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
+++ b/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
@@ -126,6 +126,11 @@ export const DialerPage = ({
       .filter((uid) => uid !== '')
       .map((uid) => ({ user_id: uid }));
 
+    const currentUser = videoClient.state.connectedUser?.id;
+    if (currentUser) {
+      members.push({ user_id: currentUser });
+    }
+
     try {
       setRingingCall(call);
       await call.getOrCreate({


### PR DESCRIPTION
### 💡 Overview

The order of `call.created` and `call.ringing` can't be guaranteed. Until now, the SDK assumed that `call.created` would arrive first, but we've seen that's not always the case.
When the order was flipped, the SDK had a race condition that made the `ringing` call be created in `non-ringing` mode, causing unexpected integration issues.

### 📝 Implementation notes

This PR unifies the handling of both events and correctly synchronizes the access to them.
Also, adds a few tests so future regressions are prevented.

This PR also fixes a bug in our Pronto ringing integration. The caller should always be included in the `members` array.

TODO: There is one failing test, which I believe is a backend bug. I'm waiting on our BE team's feedback.

🎫 Ticket: https://linear.app/stream/issue/REACT-528/synchronize-callring-events
