### PR TITLE
fix(CallParticipantList): prevent search results from flickering

### DIFF
--- a/packages/react-sdk/src/components/CallParticipantsList/CallParticipantsList.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/CallParticipantsList.tsx
@@ -47,8 +47,6 @@ const UserListTypes = {
   blocked: 'Blocked users',
 } as const;
 
-const DEFAULT_DEBOUNCE_SEARCH_INTERVAL = 200 as const;
-
 export const CallParticipantsList = ({
   onClose,
   activeUsersSearchFn,
@@ -103,9 +101,9 @@ const CallParticipantListContentHeader = ({
 }) => {
   const call = useCall();
 
-  const muteAll = () => {
+  const muteAll = useCallback(() => {
     call?.muteAllUsers('audio');
-  };
+  }, [call]);
 
   return (
     <div className="str-video__participant-list__content-header">
@@ -141,7 +139,7 @@ const CallParticipantListContentHeader = ({
 const ActiveUsersSearchResults = ({
   searchQuery,
   activeUsersSearchFn: activeUsersSearchFnFromProps,
-  debounceSearchInterval = DEFAULT_DEBOUNCE_SEARCH_INTERVAL,
+  debounceSearchInterval,
 }: Pick<
   CallParticipantListProps,
   'activeUsersSearchFn' | 'debounceSearchInterval'
@@ -150,23 +148,18 @@ const ActiveUsersSearchResults = ({
   const participants = useParticipants({ sortBy: name });
 
   const activeUsersSearchFn = useCallback(
-    (queryString: string) => {
+    async (queryString: string) => {
       const queryRegExp = new RegExp(queryString, 'i');
-      return Promise.resolve(
-        participants.filter((participant) => {
-          return participant.name.match(queryRegExp);
-        }),
-      );
+      return participants.filter((p) => p.name.match(queryRegExp));
     },
     [participants],
   );
 
-  const { searchQueryInProgress, searchResults } =
-    useSearch<StreamVideoParticipant>({
-      searchFn: activeUsersSearchFnFromProps ?? activeUsersSearchFn,
-      debounceInterval: debounceSearchInterval,
-      searchQuery,
-    });
+  const { searchQueryInProgress, searchResults } = useSearch({
+    searchFn: activeUsersSearchFnFromProps ?? activeUsersSearchFn,
+    debounceInterval: debounceSearchInterval,
+    searchQuery,
+  });
 
   return (
     <SearchResults<StreamVideoParticipant>
@@ -181,7 +174,7 @@ const ActiveUsersSearchResults = ({
 
 const BlockedUsersSearchResults = ({
   blockedUsersSearchFn: blockedUsersSearchFnFromProps,
-  debounceSearchInterval = DEFAULT_DEBOUNCE_SEARCH_INTERVAL,
+  debounceSearchInterval,
   searchQuery,
 }: Pick<
   CallParticipantListProps,
@@ -191,18 +184,14 @@ const BlockedUsersSearchResults = ({
   const blockedUsers = useCallBlockedUserIds();
 
   const blockedUsersSearchFn = useCallback(
-    (queryString: string) => {
+    async (queryString: string) => {
       const queryRegExp = new RegExp(queryString, 'i');
-      return Promise.resolve(
-        blockedUsers.filter((blockedUser) => {
-          return blockedUser.match(queryRegExp);
-        }),
-      );
+      return blockedUsers.filter((userId) => userId.match(queryRegExp));
     },
     [blockedUsers],
   );
 
-  const { searchQueryInProgress, searchResults } = useSearch<string>({
+  const { searchQueryInProgress, searchResults } = useSearch({
     searchFn: blockedUsersSearchFnFromProps ?? blockedUsersSearchFn,
     debounceInterval: debounceSearchInterval,
     searchQuery,


### PR DESCRIPTION
### 💡 Overview

Prevents CallParticipantList results from flickering when the `participants` array dynamically updates while searching
