### PR TITLE
feat: Participant Source

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -112,6 +112,7 @@ import {
   ClientCapability,
   ClientDetails,
   Codec,
+  ParticipantSource,
   PublishOption,
   SubscribeOption,
   TrackType,
@@ -1004,6 +1005,7 @@ export class Call {
             preferredPublishOptions,
             preferredSubscribeOptions,
             capabilities: Array.from(this.clientCapabilities),
+            source: ParticipantSource.WEBRTC_UNSPECIFIED,
           });
 
         this.currentPublishOptions = publishOptions;

--- a/packages/client/src/gen/video/sfu/event/events.ts
+++ b/packages/client/src/gen/video/sfu/event/events.ts
@@ -15,6 +15,7 @@ import {
   ICETrickle as ICETrickle$,
   Participant,
   ParticipantCount,
+  ParticipantSource,
   PeerType,
   Pin,
   PublishOption,
@@ -522,6 +523,10 @@ export interface JoinRequest {
    * @generated from protobuf field: repeated stream.video.sfu.models.ClientCapability capabilities = 11;
    */
   capabilities: ClientCapability[];
+  /**
+   * @generated from protobuf field: stream.video.sfu.models.ParticipantSource source = 12;
+   */
+  source: ParticipantSource;
 }
 /**
  * @generated from protobuf message stream.video.sfu.event.ReconnectDetails
@@ -1402,6 +1407,16 @@ class JoinRequest$Type extends MessageType<JoinRequest> {
           'stream.video.sfu.models.ClientCapability',
           ClientCapability,
           'CLIENT_CAPABILITY_',
+        ],
+      },
+      {
+        no: 12,
+        name: 'source',
+        kind: 'enum',
+        T: () => [
+          'stream.video.sfu.models.ParticipantSource',
+          ParticipantSource,
+          'PARTICIPANT_SOURCE_',
         ],
       },
     ]);

--- a/packages/client/src/gen/video/sfu/models/models.ts
+++ b/packages/client/src/gen/video/sfu/models/models.ts
@@ -137,6 +137,10 @@ export interface Participant {
    * @generated from protobuf field: repeated string roles = 13;
    */
   roles: string[];
+  /**
+   * @generated from protobuf field: stream.video.sfu.models.ParticipantSource source = 14;
+   */
+  source: ParticipantSource;
 }
 /**
  * @generated from protobuf message stream.video.sfu.models.StreamQuality
@@ -760,6 +764,37 @@ export enum TrackType {
   SCREEN_SHARE_AUDIO = 4,
 }
 /**
+ * must be aligned with kit
+ *
+ * @generated from protobuf enum stream.video.sfu.models.ParticipantSource
+ */
+export enum ParticipantSource {
+  /**
+   * @generated from protobuf enum value: PARTICIPANT_SOURCE_WEBRTC_UNSPECIFIED = 0;
+   */
+  WEBRTC_UNSPECIFIED = 0,
+  /**
+   * @generated from protobuf enum value: PARTICIPANT_SOURCE_RTMP = 1;
+   */
+  RTMP = 1,
+  /**
+   * @generated from protobuf enum value: PARTICIPANT_SOURCE_WHIP = 2;
+   */
+  WHIP = 2,
+  /**
+   * @generated from protobuf enum value: PARTICIPANT_SOURCE_SIP = 3;
+   */
+  SIP = 3,
+  /**
+   * @generated from protobuf enum value: PARTICIPANT_SOURCE_RTSP = 4;
+   */
+  RTSP = 4,
+  /**
+   * @generated from protobuf enum value: PARTICIPANT_SOURCE_SRT = 5;
+   */
+  SRT = 5,
+}
+/**
  * @generated from protobuf enum stream.video.sfu.models.ErrorCode
  */
 export enum ErrorCode {
@@ -1210,6 +1245,16 @@ class Participant$Type extends MessageType<Participant> {
         kind: 'scalar',
         repeat: 2 /*RepeatType.UNPACKED*/,
         T: 9 /*ScalarType.STRING*/,
+      },
+      {
+        no: 14,
+        name: 'source',
+        kind: 'enum',
+        T: () => [
+          'stream.video.sfu.models.ParticipantSource',
+          ParticipantSource,
+          'PARTICIPANT_SOURCE_',
+        ],
       },
     ]);
   }

--- a/packages/client/src/sorting/participants.ts
+++ b/packages/client/src/sorting/participants.ts
@@ -1,5 +1,6 @@
 import { Comparator } from './';
 import { StreamVideoParticipant } from '../types';
+import { ParticipantSource } from '../gen/video/sfu/models/models';
 import {
   hasAudio,
   hasScreenShare,
@@ -85,6 +86,20 @@ export const pinned: Comparator<StreamVideoParticipant> = (a, b) => {
 
   return 0;
 };
+
+/**
+ * A comparator creator which will set up a comparator which prioritizes
+ * participants who are from a specific source (e.g., WebRTC, RTMP, WHIP...).
+ *
+ * @param source the source to prioritize.
+ */
+export const withParticipantSource =
+  (source: ParticipantSource): Comparator<StreamVideoParticipant> =>
+  (a, b) => {
+    if (a.source === source && b.source !== source) return -1;
+    if (a.source !== source && b.source === source) return 1;
+    return 0;
+  };
 
 /**
  * A comparator creator which will set up a comparator which prioritizes

--- a/packages/client/src/sorting/presets.ts
+++ b/packages/client/src/sorting/presets.ts
@@ -1,3 +1,4 @@
+import { ParticipantSource } from '../gen/video/sfu/models/models';
 import { StreamVideoParticipant, VisibilityState } from '../types';
 import { combineComparators, conditional } from './comparator';
 import {
@@ -9,6 +10,7 @@ import {
   role,
   screenSharing,
   speaking,
+  withParticipantSource,
 } from './participants';
 
 // a comparator decorator which applies the decorated comparator only if the
@@ -48,7 +50,6 @@ export const defaultSortPreset = combineComparators(
       publishingAudio,
     ),
   ),
-  // ifInvisibleBy(name),
 );
 
 /**
@@ -66,7 +67,6 @@ export const speakerLayoutSortPreset = combineComparators(
       publishingAudio,
     ),
   ),
-  // ifInvisibleBy(name),
 );
 
 /**
@@ -84,7 +84,6 @@ export const paginatedLayoutSortPreset = combineComparators(
       publishingAudio,
     ),
   ),
-  // ifInvisibleOrUnknownBy(name),
 );
 
 /**
@@ -96,10 +95,10 @@ export const livestreamOrAudioRoomSortPreset = combineComparators(
       dominantSpeaker,
       speaking,
       reactionType('raised-hand'),
+      withParticipantSource(ParticipantSource.RTMP),
       publishingVideo,
       publishingAudio,
     ),
   ),
   role('admin', 'host', 'speaker'),
-  // name,
 );


### PR DESCRIPTION
### 💡 Overview

Extend `StreamVideoParticipant` model with an additional `source` property.
This prop can be used in various filtering and sorting criteria and tells about the "source" channel: WebRTC, RTMP, WHIP, etc...

```ts
import { SfuModels } from "@stream-io/video-react-sdk";

const { useParticipants } = useCallStateHooks();
const participants = useParticipants();

// participants joining thrugh OBS have RTMP source
const rtmpParticipants = participants.filter(
  (p) => p.source === SfuModels.ParticipantSource.RTMP,
);
```

📑 Docs: https://github.com/GetStream/docs-content/pull/552
