### PR TITLE
fix: layout shift when call control is in loading state

### DIFF
--- a/packages/styling/src/Button/Button-layout.scss
+++ b/packages/styling/src/Button/Button-layout.scss
@@ -63,8 +63,8 @@
     }
 
     .str-video__loading-indicator__icon {
-      width: 1.375rem;
-      height: 1.375rem;
+      width: 1.25rem;
+      height: 1.25rem;
       -webkit-mask-size: 1.25rem;
       mask-size: 1.25rem;
     }


### PR DESCRIPTION
Fixes layout shift when call control (such as `RecordingButton`) is in loading state.