### PR TITLE
Blocked participants list is not visible in CallParticipantsList

### DIFF
--- a/packages/styling/src/CallParticipantList/CallParticipantList-layout.scss
+++ b/packages/styling/src/CallParticipantList/CallParticipantList-layout.scss
@@ -25,7 +25,7 @@ $scope-name: 'str-video__participant-list';
   }
 
   .str-video__participant-list__content-header {
-    display: none;
+    display: flex;
     align-items: center;
     gap: 0.5rem;
     margin-top: var(--str-video__spacing-md);


### PR DESCRIPTION
### 💡 Overview

For some reason toggle for Active/Blocked participants lists is not visible (`display: none;` in `.str-video__participant-list__content-header` class).

[Docs](https://getstream.io/video/docs/react/ui-components/participants/call-participants-list/#debouncesearchinterval) states that CallParticipantsList supports `list blocked participants`.

Currently if you block participant, there is no way of unblocking in this UI component.

### 📝 Implementation notes

Changed to `display: flex;` to make sure it's possible to see list of blocked participants and perhaps unblock them.

Before:
<img width="376" height="211" alt="image" src="https://github.com/user-attachments/assets/51f99ef1-eb29-470d-9f86-4f8e388f72e6" />

After:
<img width="378" height="272" alt="image" src="https://github.com/user-attachments/assets/5bc8f3bd-7656-4bd3-9339-36684cb1d5e6" />

