### PR TITLE
fix(nc): switch to a stable version channel

### DIFF
--- a/packages/noise-cancellation-react-native/android/build.gradle
+++ b/packages/noise-cancellation-react-native/android/build.gradle
@@ -94,7 +94,7 @@ println "Using targetSdkVersion: ${getExtOrIntegerDefault("targetSdkVersion")}"
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation 'io.getstream:stream-video-android-noise-cancellation:1.0.2.1-SNAPSHOT'
+    implementation 'io.getstream:stream-video-android-noise-cancellation:1.0.2-kotlin-1.9.25'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation project(':stream-io_react-native-webrtc')
 }


### PR DESCRIPTION
### 💡 Overview

Switches to a "stable" release channel for our `stream-video-android-noise-cancellation` Kotlin 1.9.25 flavor.
