### PR TITLE
fix: restore calling state after unrecoverable join fail

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -892,7 +892,6 @@ export class Call {
           // if the error is unrecoverable, we should not retry as that signals
           // that connectivity is good, but the coordinator doesn't allow the user
           // to join the call due to some reason (e.g., ended call, expired token...)
-
           throw err;
         }
 


### PR DESCRIPTION
### 💡 Overview

When `call.join()` fails, we don't want calling state to be stuck at `JOINING`. This PR makes sure previous calling state is reset on error.

### 📝 Implementation notes

Previously, both `join()` and `doJoin()` were setting calling state to `JOINING` and restoring it afterwards. That means that `doJoin()` always started already in `JOINING` state.

Here we make sure that only `doJoin()` updates calling state and resets it.