### PR TITLE
fix: flush rtc stats when reconnecting

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1288,6 +1288,7 @@ export class Call {
     }
 
     this.tracer.setEnabled(enableTracing);
+    this.sfuStatsReporter?.flush();
     this.sfuStatsReporter?.stop();
     if (statsOptions?.reporting_interval_ms > 0) {
       this.sfuStatsReporter = new SfuStatsReporter(sfuClient, {


### PR DESCRIPTION
### 💡 Overview

During reconnect, it could happen that we lose some pending stats as we aggressively stop the stats reporter.
Now, before stopping, we attempt to flush the pending stats.