### PR TITLE
fix: fallback to user_id when user.name is missing

### DIFF
--- a/sample-apps/react/react-dogfood/helpers/gong.ts
+++ b/sample-apps/react/react-dogfood/helpers/gong.ts
@@ -47,7 +47,7 @@ export async function uploadCallRecording(
             name: primaryMember.user.name,
             emailAddress: primaryMember.user.custom.email,
           }
-        : { name: member.user.name },
+        : { name: member.user.name || member.user_id },
     ),
     direction: 'Outbound',
   });


### PR DESCRIPTION
### 💡 Overview

Fixes an edge case in Gong's integration
```
Could not upload recording for call default:m7mwRh24OfNweGN8G2Lay {
  requestId: '1tg8hsly8vytebs7xlw',
  errors: [
    'parties[4]: non company party must include at least 1 identification information'
  ]
}
```