### PR TITLE
fix: add allowBluetoothA2DP option for audio routing too

### DIFF
--- a/packages/react-native-sdk/ios/StreamInCallManager.swift
+++ b/packages/react-native-sdk/ios/StreamInCallManager.swift
@@ -140,10 +140,10 @@ class StreamInCallManager: RCTEventEmitter {
 
             if (defaultAudioDevice == .speaker) {
                 // defaultToSpeaker will route to speaker if nothing else is connected
-                intendedOptions = [bluetoothOption, .defaultToSpeaker]
+                intendedOptions = [bluetoothOption, .allowBluetoothA2DP, .defaultToSpeaker]
             } else {
                 // having no defaultToSpeaker makes sure audio goes to earpiece if nothing is connected
-                intendedOptions = [bluetoothOption]
+                intendedOptions = [bluetoothOption, .allowBluetoothA2DP]
             }
         }
 


### PR DESCRIPTION
Aligns with Swift SDK to allow A2DP also 

The behaviour will be as follows, taken from apple docs

> If this option and the allowBluetooth option are both set, when a single device supports both the Hands-Free Profile (HFP) and A2DP, the system gives hands-free ports a higher priority for routing.

so if there is only A2DP device, it will be played in mono currently with this added.. and we wont eliminate a A2DP only BT headset 

