### PR TITLE
chore: align screen-share overlay view in pronto

### DIFF
--- a/sample-apps/react/react-dogfood/components/Debug/DebugParticipantViewUI.tsx
+++ b/sample-apps/react/react-dogfood/components/Debug/DebugParticipantViewUI.tsx
@@ -23,10 +23,8 @@ import { useIsDemoEnvironment } from '../../context/AppEnvironmentContext';
 
 export const DebugParticipantViewUI = () => {
   const call = useCall();
-  const {
-    participant: { sessionId, userId },
-    participantViewElement,
-  } = useParticipantViewContext();
+  const { participant, participantViewElement } = useParticipantViewContext();
+  const { sessionId, userId } = participant;
 
   const isDemoEnvironment = useIsDemoEnvironment();
   const participantContextMenuActions = isDemoEnvironment
@@ -44,11 +42,13 @@ export const DebugParticipantViewUI = () => {
   }, [participantViewElement]);
 
   const isDebug = useIsDebugMode();
+  const screenShare = hasScreenShare(participant);
   if (!isDebug) {
     return (
       <div
         className={clsx(
           'rd__debug__participant-view',
+          screenShare && 'rd__debug__participant-view--screen-share',
           isDemoEnvironment && 'rd__debug__participant-view--hide-elements',
         )}
         onDoubleClick={enterFullScreen}

--- a/sample-apps/react/react-dogfood/style/Debug/Debug.scss
+++ b/sample-apps/react/react-dogfood/style/Debug/Debug.scss
@@ -26,6 +26,11 @@
   padding-left: var(--str-video__spacing-md);
 }
 
+.rd__debug__participant-view--screen-share {
+  padding-top: 0;
+  padding-left: 0;
+}
+
 .rd__debug__participant-view--hide-elements {
   .str-video__participant-details__connection-quality,
   .str-video__notification {


### PR DESCRIPTION
### 💡 Overview

The screen share overlay was misaligned for the presenter. This PR fixes it.