### PR TITLE
fix: no video if camera is disabled on init and then enabled

### DIFF
--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/TrackSubscriber.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/TrackSubscriber.tsx
@@ -83,7 +83,10 @@ const TrackSubscriber = forwardRef<TrackSubscriberHandle, TrackSubscriberProps>(
         dimensions$,
         isPublishingTrack$,
         isJoinedState$,
-      ]).subscribe(([dimension, , isJoined]) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ]).subscribe(([dimension, isPublishing, isJoined]) => {
+        // isPublishing is not used here, but we need to keep it for the subscription
+        // to send the dimensions again when the participant starts publishing the track again
         if (isJoined) {
           if (!isVisible) {
             requestTrackWithDimensions(DebounceType.MEDIUM, undefined);


### PR DESCRIPTION
### 💡 Overview

The videorenderer latest refactor introduced a bug. If remote video was disabled initially and then joined.  The video was not received. We sent the dimensions to the SFU only after the published tracks bool came true. But SFU doesnt set the video stream after that. It expects the dimensions to be known before this.

The SFU contract for sending updateSubscriptions is 

* send dimensions whenever it changes if view is visible
* send undefined dimensions if view is invisible
* send dimensions again whenever subscriber or publisher reconnects

This change ensures that the contract is satisfied now. It fixes the issue.

Ticket: https://linear.app/stream/issue/RN-298/