### PR TITLE
fix(dogfood):  join call UI issues

### DIFF
--- a/sample-apps/react-native/dogfood/src/screens/Call/JoinCallScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Call/JoinCallScreen.tsx
@@ -96,8 +96,8 @@ const JoinCallScreen = () => {
   return (
     <KeyboardAvoidingView
       style={styles.container}
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 20 : 20}
+      behavior={'padding'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 20 : 0}
     >
       <ScrollView
         contentContainerStyle={[styles.scrollContent, landscapeStyles]}
@@ -165,6 +165,7 @@ const useStyles = () => {
           paddingHorizontal: appTheme.spacing.lg,
         },
         topContainer: {
+          paddingTop: appTheme.spacing.lg,
           paddingHorizontal: appTheme.spacing.lg,
         },
         participant: {


### PR DESCRIPTION
### 💡 Overview
Fixed small ui issues with join call screen layout, including UI elements overlapping and keyboard dismissal behavior

### 📝 Implementation notes

| Befor | After |
|--------|--------|
| <img width="1179" height="2556" alt="IMG_3351" src="https://github.com/user-attachments/assets/ea2c01fa-c5e9-4e60-936e-19d8ea20cccc" /> | <img width="1179" height="2556" alt="IMG_3353" src="https://github.com/user-attachments/assets/98661704-550f-4a86-a079-0bd642167f2b" /> |
| <img width="1179" height="2556" alt="IMG_3352" src="https://github.com/user-attachments/assets/05904a54-470f-4607-98eb-53cef8ae8df5" />| <img width="1179" height="2556" alt="IMG_3354" src="https://github.com/user-attachments/assets/eb0b491e-a444-4ba3-a04d-60b19ce2063b" /> |

🎫 Ticket: [RN-305](https://linear.app/stream/issue/RN-305/dogfood-app-join-call-screen-layout-issues) 