### PR TITLE
fix: Don't fallback to MediaPipe model when TF is not supported

### DIFF
--- a/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
+++ b/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
@@ -413,7 +413,6 @@ export const BackgroundFiltersProvider = (
   }, [defaultFps]);
 
   const [engine, setEngine] = useState<FilterEngine>(FilterEngine.NONE);
-  console.log(engine);
   const [isSupported, setIsSupported] = useState(false);
   useEffect(() => {
     determineEngine(


### PR DESCRIPTION
- don't fallback to mediapipe if tf is not available

### 💡 Overview

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
