### PR TITLE
fix(react-bindings): getSnapshot caching

### DIFF
--- a/packages/react-bindings/src/hooks/callStateHooks.ts
+++ b/packages/react-bindings/src/hooks/callStateHooks.ts
@@ -294,6 +294,14 @@ export const useRemoteParticipants = () => {
 };
 
 /**
+ * A hook which provides a list of participants that are currently pinned.
+ */
+export const usePinnedParticipants = () => {
+  const { pinnedParticipants$ } = useCallState();
+  return useObservableValue(pinnedParticipants$);
+};
+
+/**
  * Returns the approximate participant count of the active call.
  * This includes the anonymous users as well, and it is computed on the server.
  */


### PR DESCRIPTION
### 💡 Overview

Fixes #2006. Cold-derived `Observable` instances (`remoteParticipants$` and similar) get read twice in strict mode, and as such, the derivative runs multiple times, creating multiple shallow-equal arrays.
Although this isn't exactly an issue, as we had this behavior before #1953, the emitter warning could be confusing.

Docs: https://github.com/GetStream/docs-content/pull/778
