### PR TITLE
fix(react): Fix InvalidStateException when track is stopped

### DIFF
--- a/packages/video-filters-web/src/VirtualBackground.ts
+++ b/packages/video-filters-web/src/VirtualBackground.ts
@@ -92,7 +92,7 @@ export class VirtualBackground {
 
     readable
       .pipeThrough(transformStream, { signal })
-      .pipeTo(writable)
+      .pipeTo(writable, { signal })
       .catch((e) => {
         if (e.name !== 'AbortError') {
           console.error('[virtual-background] Error processing track:', e);


### PR DESCRIPTION

### 💡 Overview
Fixes https://github.com/GetStream/stream-video-js/issues/2011. Pass signal to pipeTo to avoid InvalidStateException when the track is stopped.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
