### PR TITLE
fix: added call state update for handling case when call.ring event as not triggered

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -757,7 +757,7 @@ export class Call {
 
     if (this.streamClient._hasConnectionID()) {
       this.watching = true;
-      this.clientStore.registerCall(this);
+      this.clientStore.registerOrUpdateCall(this);
     }
 
     await this.applyDeviceConfig(response.call.settings, false);
@@ -787,7 +787,7 @@ export class Call {
 
     if (this.streamClient._hasConnectionID()) {
       this.watching = true;
-      this.clientStore.registerCall(this);
+      this.clientStore.registerOrUpdateCall(this);
     }
 
     await this.applyDeviceConfig(response.call.settings, false);

--- a/packages/client/src/store/stateStore.ts
+++ b/packages/client/src/store/stateStore.ts
@@ -82,6 +82,21 @@ export class StreamVideoWriteableStateStore {
   };
 
   /**
+   * Registers a {@link Call} object if it doesn't exist, otherwise updates it.
+   *
+   * @param call the call to register or update.
+   */
+  registerOrUpdateCall = (call: Call) => {
+    if (this.calls.find((c) => c.cid === call.cid)) {
+      return this.setCalls((calls) =>
+        calls.map((c) => (c.cid === call.cid ? call : c)),
+      );
+    } else {
+      return this.registerCall(call);
+    }
+  };
+
+  /**
    * Removes a {@link Call} object from the list of {@link Call} objects created/tracked by this client.
    *
    * @param call the call to remove


### PR DESCRIPTION
### 💡 Overview

The case: 
when creating a ring type call with `getOrCreate` method, ws `call.created` event triggers first (for some reason `call.ring` is not detected) –> it creates a call instance with `ringing` property set to false and registers it in the state store. After that we handle response in `getOrCreateMethod` which tries to register the call (at this point with `ringing` set to true) which is skipped as the call was already registered. So in this scenario `useCalls` doesn't return the ringing call.

### 📝 Implementation notes
The fix adds register or update method, which will override call properties inside `get` and `getOrCreate` methods, which fixes behavior in the case described above.

🎫 Ticket: https://linear.app/stream/issue/RN-315/create-ring-type-call-issue

