### PR TITLE
fix(state): ensure stable empty array for participant predicates

### DIFF
--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -86,7 +86,7 @@ const createStableParticipantsFilter = (
   const empty: StreamVideoParticipant[] = [];
   return (participants: StreamVideoParticipant[]) => {
     // no need to filter if there are no participants
-    if (!participants.length) return participants;
+    if (!participants.length) return empty;
 
     // return a stable empty array if there are no remote participants
     // instead of creating an empty one


### PR DESCRIPTION
### 💡 Overview

Fixes #2034. Continuation of #2008.
We ensure that `empty` data always return stable array references, as otherwise `useSyncExternalStore` logs a warning about potential infinite loops.
