### PR TITLE
fix: noise cancellation import error in case of no use_frameworks!

### DIFF
--- a/packages/noise-cancellation-react-native/ios/Classes/NoiseCancellationManagerObjc.m
+++ b/packages/noise-cancellation-react-native/ios/Classes/NoiseCancellationManagerObjc.m
@@ -1,5 +1,11 @@
 #import "NoiseCancellationManagerObjc.h"
-#import "stream_io_noise_cancellation_react_native/stream_io_noise_cancellation_react_native-Swift.h"
+// use_frameworks! (dynamic framework)
+#if __has_include(<stream_io_noise_cancellation_react_native/stream_io_noise_cancellation_react_native-Swift.h>)
+#import <stream_io_noise_cancellation_react_native/stream_io_noise_cancellation_react_native-Swift.h>
+// no use_frameworks! (static library)
+#else
+#import "stream_io_noise_cancellation_react_native-Swift.h"
+#endif
 
 @interface NoiseCancellationManagerObjc ()
 @end


### PR DESCRIPTION
Rarely in some react native apps, use_frameworks! are not be defined. And in this case our import in noise cancellation failed. This PR fixes it.

fixes #1962

