### PR TITLE
chore(composite): add debug timestamp option in the recorder app

### DIFF
--- a/sample-apps/react/egress-composite/src/CompositeApp.tsx
+++ b/sample-apps/react/egress-composite/src/CompositeApp.tsx
@@ -15,11 +15,16 @@ import {
   useParticipantLabelStyles,
   useVideoStyles,
 } from './hooks';
-import { LogoAndTitleOverlay, UIDispatcher } from './components';
+import {
+  DebugTimestamp,
+  LogoAndTitleOverlay,
+  UIDispatcher,
+} from './components';
 
 import './CompositeApp.scss';
 import { useParticipantStyles } from './hooks/options/useParticipantStyles';
 import { WithCustomActions } from './components/CustomActionsContext';
+import { useConfigurationContext } from './ConfigurationContext';
 
 export const CompositeApp = () => {
   const { client, call } = useInitializeClientAndCall();
@@ -29,6 +34,10 @@ export const CompositeApp = () => {
   // @ts-expect-error makes it easy to debug in the browser console
   window.client = client;
 
+  const {
+    options: { 'debug.show_timestamp': showDebugTimestamp = false },
+  } = useConfigurationContext();
+
   return (
     <StreamVideo client={client}>
       <StreamCall call={call}>
@@ -37,6 +46,7 @@ export const CompositeApp = () => {
             <EgressReadyNotificationProvider>
               <UIDispatcher />
               <LogoAndTitleOverlay />
+              {showDebugTimestamp && <DebugTimestamp />}
             </EgressReadyNotificationProvider>
             {/* <StyleComponent /> */}
           </StreamThemeWrapper>

--- a/sample-apps/react/egress-composite/src/ConfigurationContext.tsx
+++ b/sample-apps/react/egress-composite/src/ConfigurationContext.tsx
@@ -140,6 +140,10 @@ export type ConfigurationValue = {
     // them by specifying their identifier in call recording's advanced options.
     custom_layout_override?: Layout;
     custom_screen_share_layout_override?: ScreenshareLayout;
+
+    // for debugging purposes, will render a high-precision timestamp overlay
+    // over the video element. Useful for measuring the time between video frames.
+    'debug.show_timestamp'?: boolean;
   };
 } & {
   setOptionsOverride: Dispatch<

--- a/sample-apps/react/egress-composite/src/components/DebugTimestamp.scss
+++ b/sample-apps/react/egress-composite/src/components/DebugTimestamp.scss
@@ -1,0 +1,17 @@
+.eca__debug-timestamp {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 9999;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-family:
+    SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  font-size: 12pt;
+  line-height: 1.2;
+  pointer-events: none;
+  user-select: none;
+}

--- a/sample-apps/react/egress-composite/src/components/DebugTimestamp.tsx
+++ b/sample-apps/react/egress-composite/src/components/DebugTimestamp.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from 'react';
+import './DebugTimestamp.scss';
+
+/**
+ * A lightweight overlay that renders a high-precision timestamp for video debugging.
+ * Shows UTC wall-clock time (ms) and a monotonic timer from performance.now().
+ */
+export const DebugTimestamp = () => {
+  const [display, setDisplay] = useState('');
+  const rafRef = useRef<number | null>(null);
+  useEffect(() => {
+    const loop = () => {
+      const wall = new Date().toISOString();
+      const monoMs = performance.now();
+      const epochMs = performance.timeOrigin + monoMs;
+      const msg = `${wall} | mono ${monoMs.toFixed(3)}ms | epoch ${epochMs.toFixed(3)}ms`;
+      setDisplay(msg);
+      rafRef.current = requestAnimationFrame(loop);
+    };
+
+    rafRef.current = requestAnimationFrame(loop);
+    return () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  return <div className="eca__debug-timestamp">{display}</div>;
+};

--- a/sample-apps/react/egress-composite/src/components/index.ts
+++ b/sample-apps/react/egress-composite/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './LogoAndTitleOverlay';
 export * from './UIDispatcher';
+export * from './DebugTimestamp';

--- a/sample-apps/react/egress-composite/src/main.tsx
+++ b/sample-apps/react/egress-composite/src/main.tsx
@@ -132,6 +132,7 @@ window.setupLayout = (configuration: ConfigurationValue) => {
       'video.background_color': '#000000',
       'video.scale_mode': 'fit',
       'video.screenshare_scale_mode': 'fit',
+      'debug.show_timestamp': true,
     },
   } satisfies Partial<ConfigurationValue>)});`;
   document.head.appendChild(v);


### PR DESCRIPTION
### 💡 Overview

Adds a `debug.show_timestamp` option that, once enabled, displays a high-precision timer/overlay during recording.
Useful for debugging purposes.

Ref: https://getstream.slack.com/archives/C04MA3MMLBB/p1765547112867049?thread_ts=1765542595.933369&cid=C04MA3MMLBB