### PR TITLE
fix: stop of android system prompt from screenshare overlay

### DIFF
--- a/packages/react-native-sdk/src/components/utility/ScreenShareOverlay.tsx
+++ b/packages/react-native-sdk/src/components/utility/ScreenShareOverlay.tsx
@@ -3,7 +3,6 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { StopScreenShare } from '../../icons';
 import { useTheme } from '../../contexts';
 import { useCall, useI18n } from '@stream-io/video-react-bindings';
-import { SfuModels } from '@stream-io/video-client';
 
 /**
  * Props for the ScreenShareOverlay component
@@ -26,7 +25,8 @@ export const ScreenShareOverlay = ({}: ScreenShareOverlayProps) => {
   } = useTheme();
 
   const onStopScreenshareHandler = async () => {
-    await call?.stopPublish(SfuModels.TrackType.SCREEN_SHARE);
+    // force-stop is required to stop the OS prompts of screen share
+    await call?.screenShare.disable(true);
   };
 
   return (


### PR DESCRIPTION
### 💡 Overview

From default screenshareoverlay component in RN SDK (does not happen from default screenshare toggle button), pressing stop button only unpublished the video stream. It did not stop the OS overlay.  This PR fixes it.
