### PR TITLE
fix: made expo module resolving from workspace root

### DIFF
--- a/sample-apps/react-native/expo-video-sample/metro.config.js
+++ b/sample-apps/react-native/expo-video-sample/metro.config.js
@@ -25,14 +25,22 @@ const uniqueModules = dependencyPackageNames.map((packageName) => {
   };
 });
 
+// Filter out expo from unique modules to avoid blocking expo virtual files
+// Expo virtual files are in the workspace root's node_modules and must be accessible
+const uniqueModulesFiltered = uniqueModules.filter(
+  ({ packageName }) => packageName !== 'expo',
+);
+
 // provide the path for the unique modules
-const extraNodeModules = uniqueModules.reduce((acc, item) => {
+// Exclude expo from extraNodeModules to allow it to resolve from workspace root
+// (needed for Expo virtual files)
+const extraNodeModules = uniqueModulesFiltered.reduce((acc, item) => {
   acc[item.packageName] = item.modulePath;
   return acc;
 }, {});
 
 // block the other paths for unique modules from being resolved
-const blockList = uniqueModules.map(({ blockPattern }) => blockPattern);
+const blockList = uniqueModulesFiltered.map(({ blockPattern }) => blockPattern);
 
 const workspaceRoot = path.resolve(projectRoot, '../../..');
 


### PR DESCRIPTION
### 💡 Overview
Expo sample app cannot launch due to problem of resolving files from `node_modules/expo/virtual/` from workspace root.

### 📝 Implementation notes
Update `metro.config.js` so that it resolves metro package from workspace root.

🎫 Ticket: https://linear.app/stream/issue/RN-319/expo-sample-app-not-launching