### PR TITLE
fix(safari): verify that AudioContext supports `setSinkId`

### DIFF
--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -11,7 +11,7 @@ import {
 } from 'rxjs';
 import { BrowserPermission } from './BrowserPermission';
 import { lazy } from '../helpers/lazy';
-import { isFirefox } from '../helpers/browsers';
+import { isFirefox, isSafari } from '../helpers/browsers';
 import { dumpStream, Tracer } from '../stats';
 import { getCurrentValue } from '../store/rxUtils';
 import { videoLoggerSystem } from '../logger';
@@ -61,6 +61,8 @@ const getDevices = (
  */
 export const checkIfAudioOutputChangeSupported = () => {
   if (typeof document === 'undefined') return false;
+  // Safari uses WebAudio API for playing audio, so we check the AudioContext prototype
+  if (isSafari()) return 'setSinkId' in AudioContext.prototype;
   const element = document.createElement('audio');
   return 'setSinkId' in element;
 };


### PR DESCRIPTION
### 💡 Overview

On Safari, our SDK uses WebAudio to play back the remote audio.
Currently, the Safari WebAudio implementation (version 26.2 at this moment) doesn't support the `setSinkId` API; however, our SDK does not consider it.
- https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/setSinkId
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId

This led to incorrect behavior of our Web SDKs - in our case, it isn't yet possible to select a speaker in Safari.

🎫 Ticket: https://linear.app/stream/issue/REACT-727/safari-correctly-verify-that-audiooutputselection-is-available
