### PR TITLE
fix(react): resolve call state race condition when using join with ring

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1350,7 +1350,7 @@ export class Call {
 
     if (this.streamClient._hasConnectionID()) {
       this.watching = true;
-      this.clientStore.registerCall(this);
+      this.clientStore.registerOrUpdateCall(this);
     }
 
     return joinResponse;


### PR DESCRIPTION
### 💡 Overview

This PR fixes a race condition in the join({ ring }) flow. Previously, if a call already existed, the join path wouldn’t apply updates to it, which could result in an incorrect call state depending on timing. The fix ensures the existing call is updated so the correct state is applied.

🔗 Ref: #1755 #2035 
🎫 Ticket: https://linear.app/stream/issue/RN-315/create-ring-type-call-issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced call state management to properly synchronize call information during active connections and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->