### PR TITLE
fix(react): resolve call state race condition when using join with ring 

### DIFF
--- a/packages/client/src/__tests__/StreamVideoClient.ringing.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.ringing.test.ts
@@ -225,23 +225,20 @@ describe('StreamVideoClient Ringing', () => {
     it('new call instance with doJoinRequest({ ring: true }) should replace old instance in store', async () => {
       const callId = crypto.randomUUID();
 
+      const call = oliverClient.call('default', callId, {
+        reuseInstance: true,
+      });
+      const callCreatedEvent = expectEvent(oliverClient, 'call.created');
       const serverCall = serverClient.video.call('default', callId);
-      const createPromise = serverCall.create({
+      await serverCall.create({
         data: {
           created_by_id: 'oliver',
           members: [{ user_id: 'oliver' }, { user_id: 'sacha' }],
         },
       });
 
-      // call.created event still hasn't arrived and the store is empty
-      expect(oliverClient.state.calls.length).toBe(0);
-      // .call creates the call as the store is empty but does not register the call in the store
-      const call = oliverClient.call('default', callId, {
-        reuseInstance: true,
-      });
-
       // the event arrives and since the store is empty registers a new IDLE call
-      await createPromise;
+      await callCreatedEvent;
 
       // join registers or updates the call
       await call.doJoinRequest({ ring: true });


### PR DESCRIPTION
### 💡 Overview

This PR adds a test for the behavior introduced in https://github.com/GetStream/stream-video-js/pull/2084.

🔗 Ref: #1755 #2035 
🎫 Ticket: https://linear.app/stream/issue/RN-315/create-ring-type-call-issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test covering call instance replacement when joining a new call with ringing enabled. Verifies that the store maintains a single call instance, the instance is preserved when reused, and the ringing state is set correctly to handle concurrent call scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->