### PR TITLE
chore(rn): automatically dismiss the keyboard on the ringing screen

### DIFF
--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -3028,7 +3028,7 @@ PODS:
   - stream-react-native-webrtc (137.0.2):
     - React-Core
     - StreamWebRTC (~> 137.0.52)
-  - stream-video-react-native (1.26.5):
+  - stream-video-react-native (1.27.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3465,7 +3465,7 @@ SPEC CHECKSUMS:
   stream-io-noise-cancellation-react-native: 208e38e34b4bc2922b7f2837cdb2e477e2202784
   stream-io-video-filters-react-native: 3f44cffc89a66b2c6216ab11f3ac4bd3ac725d0f
   stream-react-native-webrtc: 1bef09475caf435abbbd8aec8f8c3a9b1ee1fdf0
-  stream-video-react-native: f52d912ce960a221ea43fce73771973c7b93ea12
+  stream-video-react-native: b9b7b0f01411b98d22bf6a174df29dd3989ff1a0
   StreamVideoNoiseCancellation: 41f5a712aba288f9636b64b17ebfbdff52c61490
   StreamWebRTC: 57bd35729bcc46b008de4e741a5b23ac28b8854d
   VisionCamera: 891edb31806dd3a239c8a9d6090d6ec78e11ee80

--- a/sample-apps/react-native/dogfood/src/screens/Call/JoinCallScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Call/JoinCallScreen.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import {
   Alert,
   Image,
+  Keyboard,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -36,6 +37,7 @@ const JoinCallScreen = () => {
   const [isLoading, setIsLoading] = useState(false);
 
   const startCallHandler = useCallback(async () => {
+    Keyboard.dismiss();
     setIsLoading(true);
     let ringingUserIds = !ringingUserIdsText
       ? ringingUsers


### PR DESCRIPTION
### 💡 Overview

The ringing call screen doesn't automatically dismiss the keyboard after starting the call. This PR fixes that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call initiation experience by automatically dismissing the keyboard when starting a call, streamlining the user workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->