### PR TITLE
fix: always forward callkit audio events to webrtc

### DIFF
--- a/packages/react-native-sdk/src/utils/push/setupIosCallKeepEvents.ts
+++ b/packages/react-native-sdk/src/utils/push/setupIosCallKeepEvents.ts
@@ -92,7 +92,7 @@ export function setupIosCallKeepEvents(
    * - flaky audio routing (speaker/earpiece/Bluetooth) across subsequent calls
    *
    * We forward CallKeep’s `didActivateAudioSession` / `didDeactivateAudioSession` events to WebRTC’s
-   * `RTCAudioSession.
+   * `RTCAudioSession.audioSessionDidActivate()` / `audioSessionDidDeactivate()` methods.
    */
   function didActivateAudioSession() {
     logger.debug('didActivateAudioSession');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS call audio handling so CallKit audio-session activation/deactivation is correctly propagated, reducing dropouts and improving call audio reliability.
  * Registered additional CallKit audio-session event listeners and ensured they are removed on logout to prevent stale handlers and improve stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->