### PR TITLE
chore: switch to partialUpdateUser to preserve previously set props

### DIFF
--- a/sample-apps/react/react-dogfood/components/MeetingUI.tsx
+++ b/sample-apps/react/react-dogfood/components/MeetingUI.tsx
@@ -74,11 +74,10 @@ export const MeetingUI = ({ chatClient, mode }: MeetingUIProps) => {
           if (typeof options.displayName === 'string') {
             const name = options.displayName || getRandomName();
             const id = chatClient?.user?.id ?? sanitizeUserId(name);
-            await chatClient?.upsertUser({
-              id,
-              name,
-              email: (chatClient?.user as any)?.email,
-            } as any);
+            const email = chatClient?.user?.email;
+            await chatClient
+              ?.partialUpdateUser({ id, set: { name, email } })
+              .catch((err) => console.error(`Failed to update user`, err));
           }
 
           if (videoFile) {

--- a/sample-apps/react/react-dogfood/lib/stream-chat.d.ts
+++ b/sample-apps/react/react-dogfood/lib/stream-chat.d.ts
@@ -1,0 +1,7 @@
+import 'stream-chat';
+
+declare module 'stream-chat' {
+  interface CustomUserData {
+    email?: string;
+  }
+}


### PR DESCRIPTION
### 💡 Overview

Switch to `partialUpdateUser`, as `upsertUser` seems to be overwriting previously set custom props.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for user profile updates with comprehensive logging of failures to assist in troubleshooting and debugging.

* **Improvements**
  * Enhanced type definitions for user data management, ensuring better type safety and full support for email field attributes throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->