### PR TITLE
fix(pronto): apply screen share styling only to screen share track view

### DIFF
--- a/sample-apps/react/react-dogfood/components/Debug/DebugParticipantViewUI.tsx
+++ b/sample-apps/react/react-dogfood/components/Debug/DebugParticipantViewUI.tsx
@@ -23,7 +23,8 @@ import { useIsDemoEnvironment } from '../../context/AppEnvironmentContext';
 
 export const DebugParticipantViewUI = () => {
   const call = useCall();
-  const { participant, participantViewElement } = useParticipantViewContext();
+  const { participant, participantViewElement, trackType } =
+    useParticipantViewContext();
   const { sessionId, userId } = participant;
 
   const isDemoEnvironment = useIsDemoEnvironment();
@@ -42,13 +43,14 @@ export const DebugParticipantViewUI = () => {
   }, [participantViewElement]);
 
   const isDebug = useIsDebugMode();
-  const screenShare = hasScreenShare(participant);
+  const isScreenShareTrackView = trackType === 'screenShareTrack';
+
   if (!isDebug) {
     return (
       <div
         className={clsx(
           'rd__debug__participant-view',
-          screenShare && 'rd__debug__participant-view--screen-share',
+          isScreenShareTrackView && 'rd__debug__participant-view--screen-share',
           isDemoEnvironment && 'rd__debug__participant-view--hide-elements',
         )}
         onDoubleClick={enterFullScreen}


### PR DESCRIPTION
### 💡 Overview

This PR fixes an issue where the screen share overlay styling was applied to camera thumbnails of participants sharing their screen, so it now only affects the screen share track.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced screen-share track detection in debug participant views for more accurate display state identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->