### PR TITLE
fix: start speaking while muted detection in pristine state too

### DIFF
--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -66,7 +66,7 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
             if (!this.speakingWhileMutedNotificationEnabled) return;
 
             if (ownCapabilities.includes(OwnCapability.SEND_AUDIO)) {
-              if (status === 'disabled') {
+              if (status !== 'enabled') {
                 await this.startSpeakingWhileMutedDetection(deviceId);
               } else {
                 await this.stopSpeakingWhileMutedDetection();

--- a/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
@@ -34,6 +34,7 @@ import {
 } from '../../helpers/no-audio-detector';
 import { PermissionsContext } from '../../permissions';
 import { Tracer } from '../../stats';
+import { settled, withoutConcurrency } from '../../helpers/concurrency';
 
 vi.mock('../devices.ts', () => {
   console.log('MOCKING devices API');
@@ -171,6 +172,10 @@ describe('MicrophoneManager', () => {
       manager['soundDetectorCleanup'] = async () => {};
 
       await manager.enable();
+      // @ts-expect-error private field
+      const syncTag = manager.soundDetectorConcurrencyTag;
+      await withoutConcurrency(syncTag, () => Promise.resolve());
+      await settled(syncTag);
 
       expect(manager.state.speakingWhileMuted).toBe(false);
     });


### PR DESCRIPTION
### 💡 Overview

Fixes a bug where Speaking While Muted detection didn't start when the `mic` was in a pristine state.

🎫 Ticket: https://linear.app/stream/issue/RN-342/fix-isspeakingwhilemuted-false-until-mic-toggled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced speaking-while-muted detection to activate reliably across all non-enabled microphone states, improving notification accuracy.

* **Tests**
  * Updated tests to properly synchronize concurrent microphone cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->