### PR TITLE
chore: extended react native workflow to support manual deployments

### DIFF
--- a/.github/workflows/react-native-workflow.yml
+++ b/.github/workflows/react-native-workflow.yml
@@ -37,6 +37,16 @@ on:
       - 'packages/video-filters-react-native/**'
       - '!**.md'
   workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to build and deploy (manual runs only)'
+        required: true
+        type: choice
+        default: both
+        options:
+          - ios
+          - android
+          - both
 
 concurrency:
   group: react-native-workflow-${{ github.ref }}
@@ -67,6 +77,7 @@ jobs:
     name: Build iOS
     timeout-minutes: 60
     needs: code_review
+    if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.platform || github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both' }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +108,7 @@ jobs:
     name: Deploy iOS
     needs: build_ios
     timeout-minutes: 60
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ (github.event_name != 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && (!github.event.inputs.platform || github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both')) }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -121,6 +132,7 @@ jobs:
     name: Build Android
     timeout-minutes: 60
     needs: code_review
+    if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.platform || github.event.inputs.platform == 'android' || github.event.inputs.platform == 'both' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -170,7 +182,7 @@ jobs:
     name: Deploy Android
     needs: build_android
     timeout-minutes: 60
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ (github.event_name != 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && (!github.event.inputs.platform || github.event.inputs.platform == 'android' || github.event.inputs.platform == 'both')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### 💡 Overview

The goal of this PR is add more flexibility for building/deploying dogfood app. It might be useful for some testing to provide a build for exact platform from selected branch.

### 📝 Implementation notes

Main workflow logic remains the same. But now when triggered manually it will allow to deploy from selected branch. By default it will deploy for both platforms (questionable), but may be configured to deploy only for selected platform. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform selection option for manual workflow triggers. Users can now choose to build and deploy specifically for iOS, Android, or both platforms in a single run. This allows more flexible, targeted releases while preserving automatic continuous integration workflows on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->