### PR TITLE
fix(react): hide livestream layout fullscreen button when fullscreen is unsupported

### DIFF
--- a/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
+++ b/packages/react-sdk/src/core/components/CallLayout/LivestreamLayout.tsx
@@ -247,7 +247,7 @@ const ParticipantOverlay = (props: {
     showLiveBadge ||
     showMuteButton ||
     showSpeakerName;
-  const { participant } = useParticipantViewContext();
+  const { participant, participantViewElement } = useParticipantViewContext();
   const { useParticipantCount, useSpeakerState } = useCallStateHooks();
   const participantCount = useParticipantCount();
   const duration = useUpdateCallDuration();
@@ -294,12 +294,14 @@ const ParticipantOverlay = (props: {
               onClick={() => speaker.setVolume(isSpeakerMuted ? 1 : 0)}
             />
           )}
-          {enableFullScreen && (
-            <span
-              className="str-video__livestream-layout__go-fullscreen"
-              onClick={toggleFullScreen}
-            />
-          )}
+          {enableFullScreen &&
+            participantViewElement &&
+            typeof participantViewElement.requestFullscreen !== 'undefined' && (
+              <span
+                className="str-video__livestream-layout__go-fullscreen"
+                onClick={toggleFullScreen}
+              />
+            )}
         </div>
       )}
     </div>


### PR DESCRIPTION
### 💡 Overview

This PR ensures the livestream layout fullscreen button is only shown when requestFullscreen is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen button reliability by preventing errors when fullscreen is unavailable or unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->