### PR TITLE
feat: add proper endCall reasoning

### DIFF
--- a/packages/react-native-callingx/README.md
+++ b/packages/react-native-callingx/README.md
@@ -171,8 +171,9 @@ End a call with a specific reason:
 ```typescript
 import type { EndCallReason } from 'react-native-callingx';
 
-// Available reasons: 'local' | 'remote' | 'rejected' | 'busy' |
-//                    'answeredElsewhere' | 'missed' | 'error'
+// Available reasons:
+//   'local' | 'remote' | 'rejected' | 'busy' | 'answeredElsewhere' |
+//   'missed' | 'error' | 'canceled' | 'restricted' | 'unknown'
 await CallingxModule.endCallWithReason('unique-call-id', 'remote');
 ```
 
@@ -329,13 +330,16 @@ await CallingxModule.stopBackgroundTask();
 
 ```typescript
 type EndCallReason =
-  | 'local' // Call ended by local user
-  | 'remote' // Call ended by remote party
-  | 'rejected' // Call was rejected
-  | 'busy' // Remote party is busy
+  | 'local' // Call ended by the local user (e.g., hanging up)
+  | 'remote' // Call ended by the remote party, or outgoing not answered
+  | 'rejected' // Call was rejected/declined
+  | 'busy' // Remote party was busy
   | 'answeredElsewhere' // Answered on another device
-  | 'missed' // Call was missed
-  | 'error'; // Call failed due to error
+  | 'missed' // No response to an incoming call
+  | 'error' // Call failed due to an error (e.g., network issue)
+  | 'canceled' // Call canceled before the remote party could answer
+  | 'restricted' // Call restricted (e.g., airplane mode)
+  | 'unknown'; // Unknown or unspecified disconnect reason
 
 type CallingExpiOSOptions = {
   appName: string;

--- a/packages/react-native-callingx/ios/CallingxImpl.swift
+++ b/packages/react-native-callingx/ios/CallingxImpl.swift
@@ -203,19 +203,8 @@ import stream_react_native_webrtc
             return
         }
         
-        let endedReason: CXCallEndedReason
-        switch reason {
-        case 1:
-            endedReason = .remoteEnded
-        case 2:
-            endedReason = .unanswered
-        case 3:
-            endedReason = .answeredElsewhere
-        case 4:
-            endedReason = .declinedElsewhere
-        default:
-            endedReason = .failed
-        }
+        // CXCallEndedReason raw values: failed=1, remoteEnded=2, unanswered=3, answeredElsewhere=4, declinedElsewhere=5
+        let endedReason = CXCallEndedReason(rawValue: reason) ?? .failed
         
         sharedProvider?.reportCall(with: uuid, endedAt: Date(), reason: endedReason)
         uuidStorage?.removeCid(callId)

--- a/packages/react-native-callingx/src/types.ts
+++ b/packages/react-native-callingx/src/types.ts
@@ -314,11 +314,33 @@ export type VoipEventParams = {
   };
 };
 
+/**
+ * The reason for ending a call. These values are mapped to platform-specific
+ * constants on each platform:
+ * - iOS: `CXCallEndedReason` (CallKit)
+ * - Android: `DisconnectCause` (Telecom)
+ *
+ * @see https://developer.apple.com/documentation/callkit/cxcallendedreason
+ * @see https://developer.android.com/reference/android/telecom/DisconnectCause
+ */
 export type EndCallReason =
-  | 'local' // when call is ended by the user
+  /** Call ended by the local user (e.g., hanging up). */
+  | 'local'
+  /** Call ended by the remote party, or outgoing call was not answered. */
   | 'remote'
+  /** Call was rejected/declined by the user. */
   | 'rejected'
+  /** Remote party was busy. */
   | 'busy'
+  /** Call was answered on another device. */
   | 'answeredElsewhere'
+  /** No response to an incoming call. */
   | 'missed'
-  | 'error';
+  /** Call failed due to an error (e.g., network issue). */
+  | 'error'
+  /** Call was canceled before the remote party could answer. */
+  | 'canceled'
+  /** Call restricted (e.g., airplane mode, dialing restrictions). */
+  | 'restricted'
+  /** Unknown or unspecified disconnect reason. */
+  | 'unknown';

--- a/packages/react-native-callingx/src/utils/constants.ts
+++ b/packages/react-native-callingx/src/utils/constants.ts
@@ -32,24 +32,33 @@ export const defaultAndroidOptions: DeepRequired<InternalAndroidOptions> = {
   },
 };
 
-// See ios/Callingx.mm for native iOS logic and constants mapping.
+// iOS: maps to CXCallEndedReason raw values.
+// See https://developer.apple.com/documentation/callkit/cxcallendedreason
+// CXCallEndedReason: failed=1, remoteEnded=2, unanswered=3, answeredElsewhere=4, declinedElsewhere=5
 export const iosEndCallReasonMap: Record<EndCallReason, number> = {
-  local: -1,
-  remote: 1,
-  rejected: 4,
-  busy: 2,
-  answeredElsewhere: 3,
-  missed: 2,
-  error: 0,
+  local: -1, // special: uses endCall() instead of endCallWithReason()
+  remote: 2, // .remoteEnded
+  rejected: 5, // .declinedElsewhere
+  busy: 3, // .unanswered
+  answeredElsewhere: 4, // .answeredElsewhere
+  missed: 3, // .unanswered
+  error: 1, // .failed
+  canceled: 2, // .remoteEnded (caller canceled before answer)
+  restricted: 1, // .failed (no iOS equivalent)
+  unknown: 1, // .failed (no iOS equivalent)
 };
 
-// https://developer.android.com/reference/android/telecom/DisconnectCause
+// Android: maps to android.telecom.DisconnectCause constants.
+// See https://developer.android.com/reference/android/telecom/DisconnectCause
 export const androidEndCallReasonMap: Record<EndCallReason, number> = {
-  local: 2,
-  remote: 3,
-  rejected: 6,
-  busy: 7,
-  answeredElsewhere: 11,
-  missed: 5,
-  error: 1,
+  local: 2, // LOCAL
+  remote: 3, // REMOTE
+  rejected: 6, // REJECTED
+  busy: 7, // BUSY
+  answeredElsewhere: 11, // ANSWERED_ELSEWHERE
+  missed: 5, // MISSED
+  error: 1, // ERROR
+  canceled: 4, // CANCELED
+  restricted: 8, // RESTRICTED
+  unknown: 0, // UNKNOWN
 };

--- a/packages/react-native-sdk/src/utils/push/internal/ios.ts
+++ b/packages/react-native-sdk/src/utils/push/internal/ios.ts
@@ -31,7 +31,9 @@ export const onVoipNotificationReceived = async (
         "version": "v2"
       }
     } */
-  const logger = videoLoggerSystem.getLogger('setupIosVoipPushEvents');
+  const logger = videoLoggerSystem.getLogger(
+    'callingx - onVoipNotificationReceived',
+  );
 
   const sender = notification?.stream?.sender;
   const type = notification?.stream?.type;
@@ -65,11 +67,15 @@ export const onVoipNotificationReceived = async (
   const callFromPush = await client.onRingingCall(call_cid);
 
   function closeCallIfNecessary() {
-    const mustEndCall = shouldCallBeClosed(callFromPush, notification?.stream);
+    const { mustEndCall, endCallReason } = shouldCallBeClosed(
+      callFromPush,
+      notification?.stream,
+    );
     if (mustEndCall) {
-      logger.debug(`callkeep.reportEndCallWithUUID for call_cid: ${call_cid}`);
-      //TODO: think about sending appropriate reason for end call
-      callingx.endCallWithReason(call_cid, 'local');
+      logger.debug(
+        `callingx.endCallWithReason for call_cid: ${call_cid} endCallReason: ${endCallReason}`,
+      );
+      callingx.endCallWithReason(call_cid, endCallReason);
       return true;
     }
     return false;


### PR DESCRIPTION
### 💡 Overview

Add proper reasoning for callingx endCall methods

This is important for callkit especially.. paraphrasing callkit doc

```
[Respond to Call Hang Ups and Failures](https://developer.apple.com/documentation/pushkit/responding-to-voip-notifications-from-pushkit#Respond-to-Call-Hang-Ups-and-Failures)
Many things can go wrong when connecting a VoIP call, and CallKit makes it easy to handle problems when they occur.

If the person who initiated the call hangs up, use the network connection between your app and server to notify the app. In your app, call the [reportCall(with:endedAt:reason:)](https://developer.apple.com/documentation/CallKit/CXProvider/reportCall(with:endedAt:reason:)) method of its [CXProvider](https://developer.apple.com/documentation/CallKit/CXProvider) object, specifying [CXCallEndedReason.remoteEnded](https://developer.apple.com/documentation/CallKit/CXCallEndedReason/remoteEnded) as the reason for the end of the call. If the incoming call interface is onscreen, CallKit updates the interface to reflect the end of the call, and dismisses the interface.

If the recipient of a call answers before the app establishes a connection to your server, don’t fulfill the [CXAnswerCallAction](https://developer.apple.com/documentation/CallKit/CXAnswerCallAction) object sent to the [provider(_:perform:)](https://developer.apple.com/documentation/CallKit/CXProviderDelegate/provider(_:perform:)-h4in) method of your delegate immediately. Instead, wait until you establish a connection and then fulfill the object. While it waits for your app to fulfill the request, the incoming call interface lets the user know that the call is connecting, but not yet ready.

If your app fails to establish a connection to your server, call the [reportCall(with:endedAt:reason:)](https://developer.apple.com/documentation/CallKit/CXProvider/reportCall(with:endedAt:reason:)) method with the [CXCallEndedReason.failed](https://developer.apple.com/documentation/CallKit/CXCallEndedReason/failed) option. If the incoming call interface is currently onscreen, the system updates it to indicate a failed call.

After sending the initial push notification, don’t send additional push notifications to cancel the call or communicate new details to your app. Instead, communicate with the app directly over the network connection you established between it and your server. Using an existing network connection is generally faster than sending a push notification, and if network conditions are poor, APNs may be unable to deliver push notifications to the device anyway.
```
### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
