### PR TITLE
chore(pronto): Swap order of microphone and speaker in menu

### DIFF
--- a/sample-apps/react/react-dogfood/components/ToggleDualMicButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleDualMicButton.tsx
@@ -13,8 +13,8 @@ export const ToggleDualMicButton = () => {
         <ToggleAudioPublishingButton
           Menu={
             <>
-              <DeviceSelectorAudioOutput visualType="list" title="Speaker" />
               <DeviceSelectorAudioInput visualType="list" title="Microphone" />
+              <DeviceSelectorAudioOutput visualType="list" title="Speaker" />
             </>
           }
           menuPlacement="top"

--- a/sample-apps/react/react-dogfood/components/ToggleMicButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleMicButton.tsx
@@ -41,8 +41,8 @@ export const ToggleMicButton = () => {
       ToggleButton={ToggleMenuButton}
       visualType={MenuVisualType.MENU}
     >
-      <DeviceSelectorAudioOutput visualType="list" title="Speaker" />
       <DeviceSelectorAudioInput visualType="list" title="Microphone" />
+      <DeviceSelectorAudioOutput visualType="list" title="Speaker" />
     </MenuToggle>
   );
 };


### PR DESCRIPTION
### 💡 Overview
Swap the order of microphone and speaker in the menu for both lobby and active call.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reordered audio device selectors so Microphone selector consistently appears before Speaker selector in the audio settings menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->