### PR TITLE
fix(client): harden flat-line no-audio detection

### DIFF
--- a/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
@@ -562,6 +562,26 @@ describe('MicrophoneManager', () => {
     });
   });
 
+  describe('no-audio detector configuration', () => {
+    it('applies silence threshold and emit interval in runtime monitoring', async () => {
+      const noAudioDetector = vi.mocked(createNoAudioDetector);
+
+      manager.setSilenceThreshold(3000);
+      manager['call'].state.setCallingState(CallingState.JOINED);
+      await manager.enable();
+
+      await vi.waitFor(() => {
+        expect(noAudioDetector).toHaveBeenCalled();
+      });
+
+      const options = noAudioDetector.mock.calls.at(-1)?.[1];
+      expect(options).toMatchObject({
+        noAudioThresholdMs: 3000,
+        emitIntervalMs: 3000,
+      });
+    });
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();

--- a/packages/client/src/devices/__tests__/web-audio.mocks.ts
+++ b/packages/client/src/devices/__tests__/web-audio.mocks.ts
@@ -18,8 +18,12 @@ export const createMockAnalyserNode = (
     get frequencyBinCount() {
       return fftSize / 2;
     },
-    // Default implementation fills array with zeros
-    // Tests can override with mockImplementation to simulate different audio levels
+    // Default implementation fills array with midpoint (silence waveform)
+    // Tests can override with mockImplementation to simulate different audio levels.
+    getByteTimeDomainData: vi.fn((array: Uint8Array) => {
+      array.fill(128);
+    }),
+    // Keep frequency-domain API for other helpers that use it.
     getByteFrequencyData: vi.fn((array: Uint8Array) => {
       array.fill(0);
     }),


### PR DESCRIPTION
### 💡 Overview

This PR hardens the client no-audio detector for the flat-line detection strategy and reduces false positives from tiny waveform jitter.

### 📝 Implementation notes

- Switched no-audio detection to time-domain RMS analysis (`getByteTimeDomainData`).
- Added a small internal dead zone (`|sample - 128| <= 1`) so 127/128 quantization jitter is treated as silence.
- Simplified detector options by removing `audioLevelThreshold` and `maxNoAudioEmits` from the helper.
- Updated behavior so missing/ended tracks are treated as no-audio and can emit `capturesAudio: false` after threshold.
- Kept `enabled === false` track behavior as state reset (no alert) to avoid intentional mute false alarms.
- Updated unit tests and Web Audio mocks to match the time-domain implementation and new edge-case behavior.
- Added/updated regression tests for:
  - pre-threshold audio recovery
  - tiny 127/128 jitter treated as no-audio
  - ended/missing track no-audio reporting
  - async cleanup assertion (`await expect(stop()).resolves.toBeUndefined()`)
  - MicrophoneManager runtime detector config wiring

🎫 Ticket: https://linear.app/stream/issue/REACT-759/detectors-api-detection-of-broken-microphone-setup