### PR TITLE
chore(client): trace updatePublishOptions overrides

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1919,6 +1919,7 @@ export class Call {
         'Updating publish options after joining the call does not have an effect',
       );
     }
+    this.tracer.trace('updatePublishOptions', options);
     this.clientPublishOptions = { ...this.clientPublishOptions, ...options };
   };
 


### PR DESCRIPTION
### 💡 Overview
Add trace logging when publish options are manually overridden on `Call`.

### 📝 Implementation notes
- Added `this.tracer.trace('updatePublishOptions', options);` in `Call.updatePublishOptions(...)`.
- No behavior changes; this is observability-only.
- Typechecked with `yarn exec tsc --noEmit` in `packages/client`.

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented additional tracing for call publish options to improve internal monitoring and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->