### PR TITLE
fix(react-native-sdk): remove lodash.merge from theme context

### DIFF
--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -53,7 +53,6 @@
     "@stream-io/video-client": "workspace:*",
     "@stream-io/video-react-bindings": "workspace:*",
     "intl-pluralrules": "2.0.1",
-    "lodash.merge": "^4.6.2",
     "react-native-url-polyfill": "^3.0.0",
     "rxjs": "~7.8.2",
     "text-encoding-polyfill": "0.6.7"
@@ -137,7 +136,6 @@
     "@testing-library/react-native": "13.3.3",
     "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^29.5.14",
-    "@types/lodash.merge": "^4.6.9",
     "@types/react": "~19.1.17",
     "@types/react-test-renderer": "^19.1.0",
     "expo": "~54.0.12",

--- a/packages/react-native-sdk/src/contexts/ThemeContext.tsx
+++ b/packages/react-native-sdk/src/contexts/ThemeContext.tsx
@@ -5,8 +5,6 @@ import React, {
   useMemo,
 } from 'react';
 
-import merge from 'lodash.merge';
-
 import { defaultTheme, type Theme } from '../theme/theme';
 
 export type DeepPartial<T> = {
@@ -30,6 +28,26 @@ export type MergedThemesParams = {
 
 export type ThemeContextValue = {
   theme: Theme;
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const merge = <T extends Record<string, unknown>>(
+  target: T,
+  source: DeepPartial<T>,
+) => {
+  for (const key in source) {
+    const sourceValue = source[key];
+    if (sourceValue === undefined) continue;
+
+    const targetValue = target[key as keyof T];
+    if (isObject(sourceValue) && isObject(targetValue)) {
+      merge(targetValue, sourceValue as DeepPartial<Record<string, unknown>>);
+    } else {
+      target[key as keyof T] = sourceValue as T[keyof T];
+    }
+  }
 };
 
 export const mergeThemes = (params: MergedThemesParams) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7767,7 +7767,6 @@ __metadata:
     "@testing-library/react-native": "npm:13.3.3"
     "@tsconfig/node18": "npm:^18.2.4"
     "@types/jest": "npm:^29.5.14"
-    "@types/lodash.merge": "npm:^4.6.9"
     "@types/react": "npm:~19.1.17"
     "@types/react-test-renderer": "npm:^19.1.0"
     expo: "npm:~54.0.12"
@@ -7776,7 +7775,6 @@ __metadata:
     expo-notifications: "npm:~0.32.12"
     intl-pluralrules: "npm:2.0.1"
     jest: "npm:^29.7.0"
-    lodash.merge: "npm:^4.6.2"
     react: "npm:19.1.0"
     react-native: "npm:^0.81.5"
     react-native-builder-bob: "npm:~0.23"
@@ -8250,22 +8248,6 @@ __metadata:
     "@types/ms": "npm:*"
     "@types/node": "npm:*"
   checksum: 10/ef4dc05ae5ae78e3d2e20c364437e4afb788017cc80dd8a23a3eb17a3fcecb41e6abba254aba974d45a71307dd375aba4fda73cec358923aaaf8dff4667bea09
-  languageName: node
-  linkType: hard
-
-"@types/lodash.merge@npm:^4.6.9":
-  version: 4.6.9
-  resolution: "@types/lodash.merge@npm:4.6.9"
-  dependencies:
-    "@types/lodash": "npm:*"
-  checksum: 10/d0dd6654547c9d8d905184d14aa5c2a37a1ed1c3204f5ab20b7d591a05f34859ef09d3b72c065e94ca1989abf9109eb8230f67c4d64a5768b1d65b9ed8baf8e7
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:*":
-  version: 4.14.197
-  resolution: "@types/lodash@npm:4.14.197"
-  checksum: 10/a09f6c9308089e02ffb16da7b557c680ca38d3af9591455a0a257e5a7a78febd3d6da615c4f738ac9a575e68b0de81f399f13058cab1691a0737d552d3d02971
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 💡 Overview
Remove `lodash.merge` usage from the React Native SDK theme context and replace it with a local deep merge helper.

### 📝 Implementation notes
- Removed `lodash.merge` import in `ThemeContext.tsx`.
- Added an internal recursive `merge` utility with object guards.
- Removed `lodash.merge` and `@types/lodash.merge` from `packages/react-native-sdk/package.json`.
- Updated `yarn.lock` accordingly.

🎫 Ticket: N/A

📑 Docs: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed external dependency to reduce bundle size and improve code maintainability. Theme merging logic continues to work as before with no changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->