### PR TITLE
fix: exclude RCT-Folly from prebuilt RN modes

### DIFF
--- a/packages/noise-cancellation-react-native/stream-io-noise-cancellation-react-native.podspec
+++ b/packages/noise-cancellation-react-native/stream-io-noise-cancellation-react-native.podspec
@@ -40,7 +40,12 @@ Pod::Spec.new do |s|
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
+    # Prebuilt RN modes already handle Folly (or don't expose RCT-Folly podspec).
+    use_prebuilt_core = ENV['RCT_USE_PREBUILT_RNCORE'] == '1'
+    use_prebuilt_deps = ENV['RCT_USE_RN_DEP'] == '1'
+    unless use_prebuilt_core || use_prebuilt_deps
+      s.dependency "RCT-Folly"
+    end
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"

--- a/packages/react-native-sdk/stream-video-react-native.podspec
+++ b/packages/react-native-sdk/stream-video-react-native.podspec
@@ -34,7 +34,12 @@ Pod::Spec.new do |s|
       }
       s.dependency "React-RCTFabric"
       s.dependency "React-Codegen"
-      s.dependency "RCT-Folly"
+      # Prebuilt RN modes already handle Folly (or don't expose RCT-Folly podspec).
+      use_prebuilt_core = ENV['RCT_USE_PREBUILT_RNCORE'] == '1'
+      use_prebuilt_deps = ENV['RCT_USE_RN_DEP'] == '1'
+      unless use_prebuilt_core || use_prebuilt_deps
+        s.dependency "RCT-Folly"
+      end
       s.dependency "RCTRequired"
       s.dependency "RCTTypeSafety"
       s.dependency "ReactCommon/turbomodule/core"

--- a/packages/video-filters-react-native/stream-io-video-filters-react-native.podspec
+++ b/packages/video-filters-react-native/stream-io-video-filters-react-native.podspec
@@ -37,7 +37,12 @@ Pod::Spec.new do |s|
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
+    # Prebuilt RN modes already handle Folly (or don't expose RCT-Folly podspec).
+    use_prebuilt_core = ENV['RCT_USE_PREBUILT_RNCORE'] == '1'
+    use_prebuilt_deps = ENV['RCT_USE_RN_DEP'] == '1'
+    unless use_prebuilt_core || use_prebuilt_deps
+      s.dependency "RCT-Folly"
+    end
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"


### PR DESCRIPTION
### 💡 Overview

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>

This is a port of [this fix](https://github.com/GetStream/stream-chat-react-native/pull/3447) that was just added on the Chat SDK. All details are explained in the PR.

To reproduce, simply run:

```
RCT_NEW_ARCH_ENABLED=1 RCT_USE_RN_DEP=1 pod install --repo-update
```

for RN versions `<= 0.80.X`

or

```
RCT_NEW_ARCH_ENABLED=1 RCT_USE_PREBUILT_RNCORE=1 pod install --repo-update
```

for RN versions `>= 0.81.X`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency configurations in React Native packages for audio processing, video streaming, and video filtering. Updates improve compatibility with prebuilt React Native core installations and reduce configuration conflicts. Changes provide better build flexibility and stability across different installation scenarios and development environments without affecting runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->