### PR TITLE
fix(react): await initialization before enabling / disabling noise cancellation

### DIFF
--- a/packages/audio-filters-web/src/NoiseCancellation.ts
+++ b/packages/audio-filters-web/src/NoiseCancellation.ts
@@ -209,9 +209,9 @@ export class NoiseCancellation implements INoiseCancellation {
    * Enables the noise cancellation.
    */
   enable = async () => {
+    if (!this.filterNode) return;
     await this.initializing;
 
-    if (!this.filterNode) return;
     this.filterNode.enable();
     this.dispatch('change', true);
   };
@@ -220,9 +220,9 @@ export class NoiseCancellation implements INoiseCancellation {
    * Disables the noise cancellation.
    */
   disable = async () => {
+    if (!this.filterNode) return;
     await this.initializing;
 
-    if (!this.filterNode) return;
     this.filterNode.disable();
     this.dispatch('change', false);
   };

--- a/packages/react-sdk/src/components/NoiseCancellation/NoiseCancellationProvider.tsx
+++ b/packages/react-sdk/src/components/NoiseCancellation/NoiseCancellationProvider.tsx
@@ -31,6 +31,10 @@ export type NoiseCancellationAPI = {
    */
   isSupported: boolean | undefined;
   /**
+   * Provides information whether Noise Cancellation is initialized and ready.
+   */
+  isReady: boolean;
+  /**
    * Provides information whether Noise Cancellation is active or not.
    */
   isEnabled: boolean;
@@ -105,6 +109,8 @@ export const NoiseCancellationProvider = (
     isSupportedByBrowser && hasCapability && noiseCancellationAllowed;
 
   const [isEnabled, setIsEnabled] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+
   const deinit = useRef<Promise<void>>(undefined);
   useEffect(() => {
     if (!call || !isSupported) return;
@@ -112,20 +118,26 @@ export const NoiseCancellationProvider = (
     const unsubscribe = noiseCancellation.on('change', (v) => setIsEnabled(v));
     const init = (deinit.current || Promise.resolve())
       .then(() => noiseCancellation.init({ tracer: call.tracer }))
-      .then(() => call.microphone.enableNoiseCancellation(noiseCancellation))
+      .then(() => {
+        setIsReady(true);
+        return call.microphone.enableNoiseCancellation(noiseCancellation);
+      })
       .catch((e) => console.error(`Can't initialize noise cancellation`, e));
 
     return () => {
       deinit.current = init
         .then(() => call.microphone.disableNoiseCancellation())
         .then(() => noiseCancellation.dispose())
-        .then(() => unsubscribe());
+        .then(() => unsubscribe())
+        .catch((e) => console.error("Can't clean up noise cancellation", e))
+        .finally(() => setIsReady(false));
     };
   }, [call, isSupported, noiseCancellation]);
 
   const contextValue = useMemo<NoiseCancellationAPI>(
     () => ({
       isSupported,
+      isReady,
       isEnabled,
       setSuppressionLevel: (level) => {
         if (!noiseCancellation) return;
@@ -148,7 +160,7 @@ export const NoiseCancellationProvider = (
         }
       },
     }),
-    [isEnabled, isSupported, noiseCancellation],
+    [isEnabled, isReady, isSupported, noiseCancellation],
   );
   return (
     <NoiseCancellationContext.Provider value={contextValue}>

--- a/sample-apps/react/react-dogfood/components/Lobby.tsx
+++ b/sample-apps/react/react-dogfood/components/Lobby.tsx
@@ -36,6 +36,7 @@ import {
   useIsProntoEnvironment,
 } from '../context/AppEnvironmentContext';
 import { getRandomName } from '../lib/names';
+import { ToggleNoiseCancellationButton } from './ToggleNoiseCancellationButton';
 
 export type UserMode = 'regular' | 'guest' | 'anon';
 
@@ -182,6 +183,7 @@ export const Lobby = ({ onJoin, mode = 'regular' }: LobbyProps) => {
                     <div className="rd__lobby-settings">
                       <ToggleParticipantsPreviewButton onJoin={onJoin} />
                       <ToggleHiFiButton />
+                      <ToggleNoiseCancellationButton />
                       <ToggleEffectsButton inMeeting={false} />
                       <ToggleSettingsTabModal
                         layoutProps={{

--- a/sample-apps/react/react-dogfood/components/ToggleNoiseCancellationButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleNoiseCancellationButton.tsx
@@ -1,19 +1,31 @@
 import {
   CompositeButton,
   Icon,
+  LoadingIndicator,
   WithTooltip,
   useNoiseCancellation,
 } from '@stream-io/video-react-sdk';
 
 export const ToggleNoiseCancellationButton = () => {
-  const { isSupported, isEnabled, setEnabled } = useNoiseCancellation();
+  const { isSupported, isEnabled, isReady, setEnabled } =
+    useNoiseCancellation();
+
   if (!isSupported) return null;
+
   return (
     <WithTooltip
-      title={`Noise cancellation is ${isEnabled ? 'active' : 'inactive'}`}
+      title={`Noise cancellation is ${!isReady ? 'loading' : isEnabled ? 'active' : 'inactive'}`}
     >
-      <CompositeButton onClick={() => setEnabled((v) => !v)} variant="primary">
-        <Icon icon={isEnabled ? 'anc' : 'anc-off'} />
+      <CompositeButton
+        disabled={!isReady}
+        onClick={() => setEnabled((v) => !v)}
+        variant="primary"
+      >
+        {!isReady ? (
+          <LoadingIndicator />
+        ) : (
+          <Icon icon={isEnabled ? 'anc' : 'anc-off'} />
+        )}
       </CompositeButton>
     </WithTooltip>
   );


### PR DESCRIPTION
### 💡 Overview
This PR fixes a race condition where calling `setEnabled` before noise cancellation initialization completed could silently no-op because filterNode was still undefined. 

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-833/timing-issue-with-noise-cancellation-implementation-on-web
📑 Docs: https://github.com/GetStream/docs-content/pull/1065


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved noise cancellation initialization timing for more reliable enable/disable behavior.

* **New Features**
  * Exposes an "isReady" readiness state for noise cancellation so components can react to initialization.

* **Bug Fixes / UX**
  * Added a toggle for noise cancellation in the lobby UI.
  * Toggle shows a loading indicator and is disabled while noise cancellation is initializing, and reflects active/inactive state once ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->