### PR TITLE
fix(react): remove default broken microphone notification from call controls

### DIFF
--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -169,7 +169,6 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
                 deviceId,
                 label,
               };
-              console.log(event);
               this.call.tracer.trace('mic.capture_report', event);
               this.call.streamClient.dispatchEvent(event);
             },

--- a/packages/react-sdk/src/components/CallControls/CallControls.tsx
+++ b/packages/react-sdk/src/components/CallControls/CallControls.tsx
@@ -1,9 +1,6 @@
 import { OwnCapability } from '@stream-io/video-client';
 import { Restricted } from '@stream-io/video-react-bindings';
-import {
-  SpeakingWhileMutedNotification,
-  MicCaptureErrorNotification,
-} from '../Notification';
+import { SpeakingWhileMutedNotification } from '../Notification';
 import { RecordCallButton } from './RecordCallButton';
 import { ReactionsButton } from './ReactionsButton';
 import { ScreenShareButton } from './ScreenShareButton';
@@ -18,11 +15,9 @@ export type CallControlsProps = {
 export const CallControls = ({ onLeave }: CallControlsProps) => (
   <div className="str-video__call-controls">
     <Restricted requiredGrants={[OwnCapability.SEND_AUDIO]}>
-      <MicCaptureErrorNotification>
-        <SpeakingWhileMutedNotification>
-          <ToggleAudioPublishingButton />
-        </SpeakingWhileMutedNotification>
-      </MicCaptureErrorNotification>
+      <SpeakingWhileMutedNotification>
+        <ToggleAudioPublishingButton />
+      </SpeakingWhileMutedNotification>
     </Restricted>
     <Restricted requiredGrants={[OwnCapability.SEND_VIDEO]}>
       <ToggleVideoPublishingButton />

--- a/sample-apps/react/react-dogfood/components/ActiveCall.tsx
+++ b/sample-apps/react/react-dogfood/components/ActiveCall.tsx
@@ -5,7 +5,6 @@ import {
   CancelCallConfirmButton,
   CompositeButton,
   Icon,
-  MicCaptureErrorNotification,
   OwnCapability,
   PermissionRequests,
   PipLayout,
@@ -245,7 +244,6 @@ export const ActiveCall = (props: ActiveCallProps) => {
             hasPermissionsOnly
           >
             <SpeakingWhileMutedNotification />
-            <MicCaptureErrorNotification />
           </Restricted>
         </div>
         <div


### PR DESCRIPTION
### 💡 Overview
This PR removes the broken microphone notification from the default call controls, giving users the flexibility to add it when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed debug console logging from microphone capture handling.
  * Removed MicCaptureErrorNotification component from call controls and sample applications.
  * Simplified error notification handling in audio controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->