### PR TITLE
chore(pronto): use preview visualType for device selection in active call

### DIFF
--- a/sample-apps/react/react-dogfood/components/ToggleDualCameraButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleDualCameraButton.tsx
@@ -12,7 +12,7 @@ export const ToggleDualCameraButton = () => {
       <div className="rd__dual-toggle">
         <DegradedPerformanceNotification className="rd__call-controls__notification" />
         <ToggleVideoPublishingButton
-          Menu={<DeviceSelectorVideo visualType="list" />}
+          Menu={<DeviceSelectorVideo visualType="preview" />}
           menuPlacement="top"
         />
       </div>

--- a/sample-apps/react/react-dogfood/components/ToggleDualMicButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleDualMicButton.tsx
@@ -13,7 +13,10 @@ export const ToggleDualMicButton = () => {
         <ToggleAudioPublishingButton
           Menu={
             <>
-              <DeviceSelectorAudioInput visualType="list" title="Microphone" />
+              <DeviceSelectorAudioInput
+                visualType="preview"
+                title="Microphone"
+              />
               <DeviceSelectorAudioOutput visualType="list" title="Speaker" />
             </>
           }


### PR DESCRIPTION
### 💡 Overview
This PR updated the visualType to `preview` for device selection in active call.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated camera and microphone device selector interface displays for improved presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->