### PR TITLE
chore(egress-composite): upgrade layout to 1.0.17

### DIFF
--- a/sample-apps/react/egress-composite/package.json
+++ b/sample-apps/react/egress-composite/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.5",
     "@sentry/react": "^10.30.0",
-    "@skooldev/skool-stream-layout": "1.0.14",
+    "@skooldev/skool-stream-layout": "1.0.15",
     "@stream-io/video-react-sdk": "workspace:^",
     "clsx": "^2.0.0",
     "js-base64": "^3.7.8",

--- a/sample-apps/react/egress-composite/package.json
+++ b/sample-apps/react/egress-composite/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.5",
     "@sentry/react": "^10.30.0",
-    "@skooldev/skool-stream-layout": "1.0.15",
+    "@skooldev/skool-stream-layout": "1.0.16",
     "@stream-io/video-react-sdk": "workspace:^",
     "clsx": "^2.0.0",
     "js-base64": "^3.7.8",

--- a/sample-apps/react/egress-composite/package.json
+++ b/sample-apps/react/egress-composite/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.5",
     "@sentry/react": "^10.30.0",
-    "@skooldev/skool-stream-layout": "1.0.16",
+    "@skooldev/skool-stream-layout": "1.0.17",
     "@stream-io/video-react-sdk": "workspace:^",
     "clsx": "^2.0.0",
     "js-base64": "^3.7.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8259,14 +8259,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skooldev/skool-stream-layout@npm:1.0.14":
-  version: 1.0.14
-  resolution: "@skooldev/skool-stream-layout@npm:1.0.14"
+"@skooldev/skool-stream-layout@npm:1.0.15":
+  version: 1.0.15
+  resolution: "@skooldev/skool-stream-layout@npm:1.0.15"
   peerDependencies:
-    "@stream-io/video-react-sdk": ^1.25.0
+    "@stream-io/video-react-sdk": ^1.34.2
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10/8d458f4c1e7bae7975f2599914b4c985c9819591a9f8cb04d18b74318e74d3b1f68a3a9e59bb26696bd0171f4c2b76d939b26731372d2cd6b7eb36908bbf129c
+  checksum: 10/d70e0b74de93467f3e398af2194ae75cadfeb3bda4601cd5a93c37132f35930a90de01db543ef18375a83e8c9187ad191f020d6823eda7d0451c9cfa578e513d
   languageName: node
   linkType: hard
 
@@ -8325,7 +8325,7 @@ __metadata:
     "@playwright/test": "npm:^1.56.0"
     "@sentry/react": "npm:^10.30.0"
     "@sentry/vite-plugin": "npm:^4.6.1"
-    "@skooldev/skool-stream-layout": "npm:1.0.14"
+    "@skooldev/skool-stream-layout": "npm:1.0.15"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.1.17"
     "@types/react-dom": "npm:~19.1.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8259,14 +8259,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skooldev/skool-stream-layout@npm:1.0.15":
-  version: 1.0.15
-  resolution: "@skooldev/skool-stream-layout@npm:1.0.15"
+"@skooldev/skool-stream-layout@npm:1.0.16":
+  version: 1.0.16
+  resolution: "@skooldev/skool-stream-layout@npm:1.0.16"
   peerDependencies:
     "@stream-io/video-react-sdk": ^1.34.2
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10/d70e0b74de93467f3e398af2194ae75cadfeb3bda4601cd5a93c37132f35930a90de01db543ef18375a83e8c9187ad191f020d6823eda7d0451c9cfa578e513d
+  checksum: 10/74ebab96cc3a3022e8a78592cc9cfbe94836b75765a29cf3acc3e9d44ce7f086852f0e6fa534a5b80740ab1a8427441a8945f23c1215ddeab054458a187ac40e
   languageName: node
   linkType: hard
 
@@ -8325,7 +8325,7 @@ __metadata:
     "@playwright/test": "npm:^1.56.0"
     "@sentry/react": "npm:^10.30.0"
     "@sentry/vite-plugin": "npm:^4.6.1"
-    "@skooldev/skool-stream-layout": "npm:1.0.15"
+    "@skooldev/skool-stream-layout": "npm:1.0.16"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.1.17"
     "@types/react-dom": "npm:~19.1.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8259,14 +8259,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skooldev/skool-stream-layout@npm:1.0.16":
-  version: 1.0.16
-  resolution: "@skooldev/skool-stream-layout@npm:1.0.16"
+"@skooldev/skool-stream-layout@npm:1.0.17":
+  version: 1.0.17
+  resolution: "@skooldev/skool-stream-layout@npm:1.0.17"
   peerDependencies:
     "@stream-io/video-react-sdk": ^1.34.2
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10/74ebab96cc3a3022e8a78592cc9cfbe94836b75765a29cf3acc3e9d44ce7f086852f0e6fa534a5b80740ab1a8427441a8945f23c1215ddeab054458a187ac40e
+  checksum: 10/5669407f8e64b36e7f56dea14ac486415a267a28d93b31ba3572be466359cb5c0448439edfdf18efcd0eb53bf7cc9c3db6d4b6346205257e0a209506758e1e36
   languageName: node
   linkType: hard
 
@@ -8325,7 +8325,7 @@ __metadata:
     "@playwright/test": "npm:^1.56.0"
     "@sentry/react": "npm:^10.30.0"
     "@sentry/vite-plugin": "npm:^4.6.1"
-    "@skooldev/skool-stream-layout": "npm:1.0.16"
+    "@skooldev/skool-stream-layout": "npm:1.0.17"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.1.17"
     "@types/react-dom": "npm:~19.1.11"


### PR DESCRIPTION
### 💡 Overview

Upgrade `@skooldev/skool-stream-layout` from `1.0.14` to `1.0.17` in the egress-composite sample app.

### 📝 Implementation notes

- Bumped the dependency version in `sample-apps/react/egress-composite/package.json`
- Updated `yarn.lock` accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency in a sample application to pull in the latest improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->