### PR TITLE
chore(revert-restore): ensure the call is joined before notifying readiness

### DIFF
--- a/sample-apps/react/egress-composite/src/hooks/useNotifyEgress.tsx
+++ b/sample-apps/react/egress-composite/src/hooks/useNotifyEgress.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useState,
 } from 'react';
+import { CallingState, useCallStateHooks } from '@stream-io/video-react-sdk';
 
 const EgressReadyNotificationContext = createContext((isReady: boolean) => {
   // no-op
@@ -14,10 +15,13 @@ const EgressReadyNotificationContext = createContext((isReady: boolean) => {
 
 export const EgressReadyNotificationProvider = (props: PropsWithChildren) => {
   const [isReady, setIsReady] = useState(false);
+  const { useCallCallingState } = useCallStateHooks();
+  const callingState = useCallCallingState();
   useEffect(() => {
-    if (isReady) return;
+    if (isReady || callingState !== CallingState.JOINED) return;
     // it could happen that components won't notify us that they are ready
     // in that case, we start recording anyway after 4 seconds.
+    console.log('Egress: Started waiting for components to notify readiness');
     const timeout = setTimeout(() => {
       if (!isReady) {
         console.log('Timeout: Egress is ready');
@@ -28,7 +32,7 @@ export const EgressReadyNotificationProvider = (props: PropsWithChildren) => {
     return () => {
       clearTimeout(timeout);
     };
-  }, [isReady]);
+  }, [callingState, isReady]);
 
   const spyIsReady = useCallback((value: boolean) => {
     setIsReady((current) => {


### PR DESCRIPTION
Reverts GetStream/stream-video-js#2194

Now that the infra issue is fixed, we can restore this behavior.
Ref: https://getstream.slack.com/archives/C040262MY9K/p1776161175592379