### PR TITLE
chore: avoid unncessary error log during callingx cleanup

### DIFF
--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -24,6 +24,7 @@ import io.getstream.rn.callingx.notifications.NotificationsConfig
 import io.getstream.rn.callingx.repo.CallRepository
 import io.getstream.rn.callingx.repo.CallRepositoryFactory
 import io.getstream.rn.callingx.utils.SettingsStore
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -502,6 +503,12 @@ class CallService : Service(), CallRepository.Listener {
                         incoming,
                         callInfo.isVideo,
                         callInfo.displayOptions,
+                )
+            } catch (e: CancellationException) {
+                // Swallow cancellation: nothing runs after this catch, and nobody awaits this launch.
+                debugLog(
+                        TAG,
+                        "[service] registerCall: Registration canceled for ${callInfo.callId} during teardown"
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "[service] registerCall: Error registering call: ${e.message}")

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/TelecomCallRepository.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/TelecomCallRepository.kt
@@ -14,6 +14,7 @@ import androidx.core.telecom.CallsManager
 import io.getstream.rn.callingx.debugLog
 import io.getstream.rn.callingx.model.Call
 import io.getstream.rn.callingx.model.CallAction
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
@@ -213,6 +214,12 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
                     TAG,
                     "[repository] registerCall: Call $callId scope ended normally"
             )
+        } catch (e: CancellationException) {
+            debugLog(
+                    TAG,
+                    "[repository] registerCall: Registration canceled for $callId during teardown"
+            )
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "[repository] registerCall: Error registering call $callId", e)
             throw e


### PR DESCRIPTION
### 💡 Overview

Avoid the false "Error registering call" log that fires during normal call teardown. 

```
 D  [store] removeTrackedCall: Removing tracked call: default:testany
 D  [service] onDestroy: TelecomCallService destroyed
 D  [headless] stopHeadlessTask: Stopping headless task
 E  [repository] registerCall: Error registering call default:testany
    kotlinx.coroutines.JobCancellationException: Job was cancelled; job=SupervisorJobImpl{Cancelling}@1f09281
 D  [repository] registerCall: Cleaning up call default:testany
 E  [service] registerCall: Error registering call: Job was cancelled
 D  [notifications] cancelNotification[default:testany]
```

line 4,6 are unnecessarily scary

### 📝 Implementation notes

Added a dedicated catch (CancellationException) branch ahead of the generic Exception handler 

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of call registration cancellation handling during shutdown with more explicit error management.
  * Enhanced call registration failure recovery with better error handling and service cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->