### PR TITLE
fix(pronto): fix blur level icon sizing not being applied

### DIFF
--- a/sample-apps/react/react-dogfood/style/SettingsTabModal.scss
+++ b/sample-apps/react/react-dogfood/style/SettingsTabModal.scss
@@ -106,18 +106,14 @@
           }
         }
 
-        .rd__video-effects__blur--medium {
-          .str-video__icon {
-            width: 1.7rem;
-            height: 1.7rem;
-          }
+        .str-video__icon.rd__video-effects__blur--medium {
+          width: 1.7rem;
+          height: 1.7rem;
         }
 
-        .rd__video-effects__blur--low {
-          .str-video__icon {
-            width: 1.25rem;
-            height: 1.25rem;
-          }
+        .str-video__icon.rd__video-effects__blur--low {
+          width: 1.25rem;
+          height: 1.25rem;
         }
       }
 


### PR DESCRIPTION
### 💡 Overview
Correctly apply sizing for different blur levels in setting dialog.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized styling selectors for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->