### PR TITLE
chore: added expo plugins

### DIFF
--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidRingtone.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidRingtone.test.ts
@@ -1,0 +1,122 @@
+import withAndroidRingtone from '../src/withCallResources/withAndroidRingtone';
+import { normalizeAndroidResourceName } from '../src/withCallResources/withAndroidRingtone';
+import { ExpoConfig } from '@expo/config-types';
+import { ConfigProps } from '../src/common/types';
+import * as fs from 'fs';
+
+interface CustomExpoConfig extends ExpoConfig {
+  modRequest: {
+    projectRoot: string;
+    platformProjectRoot: string;
+  };
+}
+
+jest.mock('fs');
+
+jest.mock('@expo/config-plugins', () => {
+  return {
+    withDangerousMod: jest.fn((config, [_platform, callback]) => {
+      return callback(config as CustomExpoConfig);
+    }),
+  };
+});
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+describe('withAndroidRingtone', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFs.existsSync.mockReturnValue(true);
+  });
+
+  const baseConfig: CustomExpoConfig = {
+    name: 'test-app',
+    slug: 'test-app',
+    modRequest: {
+      projectRoot: '/project',
+      platformProjectRoot: '/project/android',
+    },
+  };
+
+  it('should skip when androidRingtone is not set', () => {
+    const props: ConfigProps = {};
+    const result = withAndroidRingtone(baseConfig, props);
+    expect(result).toBe(baseConfig);
+    expect(mockedFs.copyFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should copy ringtone to res/raw/', () => {
+    const props: ConfigProps = {
+      androidRingtone: './assets/ringtone.mp3',
+    };
+
+    withAndroidRingtone(baseConfig, props);
+
+    expect(mockedFs.mkdirSync).toHaveBeenCalledWith(
+      '/project/android/app/src/main/res/raw',
+      { recursive: true },
+    );
+    expect(mockedFs.copyFileSync).toHaveBeenCalledWith(
+      '/project/assets/ringtone.mp3',
+      '/project/android/app/src/main/res/raw/ringtone.mp3',
+    );
+  });
+
+  it('should throw when file does not exist', () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    const props: ConfigProps = {
+      androidRingtone: './assets/missing.mp3',
+    };
+
+    expect(() => withAndroidRingtone(baseConfig, props)).toThrow(
+      /Android ringtone file not found/,
+    );
+  });
+
+  it('should throw on invalid extension', () => {
+    const props: ConfigProps = {
+      androidRingtone: './assets/ringtone.aac',
+    };
+
+    expect(() => withAndroidRingtone(baseConfig, props)).toThrow(
+      /Invalid Android ringtone format/,
+    );
+  });
+
+  it('should normalize filename with hyphens', () => {
+    const props: ConfigProps = {
+      androidRingtone: './assets/my-ringtone.mp3',
+    };
+
+    withAndroidRingtone(baseConfig, props);
+
+    expect(mockedFs.copyFileSync).toHaveBeenCalledWith(
+      '/project/assets/my-ringtone.mp3',
+      '/project/android/app/src/main/res/raw/my_ringtone.mp3',
+    );
+  });
+});
+
+describe('normalizeAndroidResourceName', () => {
+  it('should lowercase the filename', () => {
+    expect(normalizeAndroidResourceName('MyRingtone.MP3')).toBe(
+      'myringtone.mp3',
+    );
+  });
+
+  it('should replace hyphens with underscores', () => {
+    expect(normalizeAndroidResourceName('my-ringtone.mp3')).toBe(
+      'my_ringtone.mp3',
+    );
+  });
+
+  it('should remove invalid characters', () => {
+    expect(normalizeAndroidResourceName('my ringtone (1).mp3')).toBe(
+      'myringtone1.mp3',
+    );
+  });
+
+  it('should handle already valid names', () => {
+    expect(normalizeAndroidResourceName('ringtone.mp3')).toBe('ringtone.mp3');
+  });
+});

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidRingtone.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidRingtone.test.ts
@@ -15,7 +15,7 @@ jest.mock('fs');
 
 jest.mock('@expo/config-plugins', () => {
   return {
-    withDangerousMod: jest.fn((config, [_platform, callback]) => {
+    withDangerousMod: jest.fn((config, [, callback]) => {
       return callback(config as CustomExpoConfig);
     }),
   };

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidRingtone.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidRingtone.test.ts
@@ -119,4 +119,16 @@ describe('normalizeAndroidResourceName', () => {
   it('should handle already valid names', () => {
     expect(normalizeAndroidResourceName('ringtone.mp3')).toBe('ringtone.mp3');
   });
+
+  it('should throw when normalized name starts with digit', () => {
+    expect(() => normalizeAndroidResourceName('1ringtone.mp3')).toThrow(
+      /must start with a lowercase letter/,
+    );
+  });
+
+  it('should throw when normalized name starts with underscore', () => {
+    expect(() => normalizeAndroidResourceName('_ringtone.mp3')).toThrow(
+      /must start with a lowercase letter/,
+    );
+  });
 });

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
@@ -1,0 +1,129 @@
+import withIosCallkitIcon from '../src/withCallResources/withIosCallkitIcon';
+import { deriveImageSetName } from '../src/withCallResources/withIosCallkitIcon';
+import { ExpoConfig } from '@expo/config-types';
+import { ConfigProps } from '../src/common/types';
+import * as fs from 'fs';
+
+interface CustomExpoConfig extends ExpoConfig {
+  modRequest: {
+    projectRoot: string;
+    platformProjectRoot: string;
+    projectName: string;
+  };
+}
+
+jest.mock('fs');
+
+jest.mock('@expo/config-plugins', () => {
+  return {
+    withDangerousMod: jest.fn((config, [_platform, callback]) => {
+      return callback(config as CustomExpoConfig);
+    }),
+  };
+});
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+const baseConfig: CustomExpoConfig = {
+  name: 'test-app',
+  slug: 'test-app',
+  modRequest: {
+    projectRoot: '/project',
+    platformProjectRoot: '/project/ios',
+    projectName: 'TestApp',
+  },
+};
+
+describe('withIosCallkitIcon', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFs.existsSync.mockReturnValue(true);
+  });
+
+  it('should skip when iosCallkitIcon is not set', () => {
+    const props: ConfigProps = {};
+    const result = withIosCallkitIcon(baseConfig, props);
+    expect(result).toBe(baseConfig);
+    expect(mockedFs.copyFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should create imageset directory and copy icon', () => {
+    const props: ConfigProps = {
+      iosCallkitIcon: './assets/callkit_icon.png',
+    };
+
+    withIosCallkitIcon(baseConfig, props);
+
+    expect(mockedFs.mkdirSync).toHaveBeenCalledWith(
+      '/project/ios/TestApp/Images.xcassets/CallkitIcon.imageset',
+      { recursive: true },
+    );
+    expect(mockedFs.copyFileSync).toHaveBeenCalledWith(
+      '/project/assets/callkit_icon.png',
+      '/project/ios/TestApp/Images.xcassets/CallkitIcon.imageset/callkit_icon.png',
+    );
+  });
+
+  it('should write Contents.json with template rendering intent', () => {
+    const props: ConfigProps = {
+      iosCallkitIcon: './assets/callkit_icon.png',
+    };
+
+    withIosCallkitIcon(baseConfig, props);
+
+    expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      '/project/ios/TestApp/Images.xcassets/CallkitIcon.imageset/Contents.json',
+      expect.stringContaining('"template-rendering-intent": "template"'),
+    );
+
+    const writtenJson = JSON.parse(
+      (mockedFs.writeFileSync as jest.Mock).mock.calls[0][1],
+    );
+    expect(writtenJson.images).toEqual([
+      { filename: 'callkit_icon.png', idiom: 'universal' },
+    ]);
+    expect(writtenJson.info).toEqual({ author: 'expo', version: 1 });
+    expect(writtenJson.properties).toEqual({
+      'template-rendering-intent': 'template',
+    });
+  });
+
+  it('should throw when file does not exist', () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    const props: ConfigProps = {
+      iosCallkitIcon: './assets/missing.png',
+    };
+
+    expect(() => withIosCallkitIcon(baseConfig, props)).toThrow(
+      /iOS CallKit icon file not found/,
+    );
+  });
+
+  it('should throw on non-PNG file', () => {
+    const props: ConfigProps = {
+      iosCallkitIcon: './assets/icon.jpg',
+    };
+
+    expect(() => withIosCallkitIcon(baseConfig, props)).toThrow(
+      /iOS CallKit icon must be a PNG file/,
+    );
+  });
+});
+
+describe('deriveImageSetName', () => {
+  it('should convert underscored names to PascalCase', () => {
+    expect(deriveImageSetName('callkit_icon.png')).toBe('CallkitIcon');
+  });
+
+  it('should convert hyphenated names to PascalCase', () => {
+    expect(deriveImageSetName('my-app-icon.png')).toBe('MyAppIcon');
+  });
+
+  it('should handle single word names', () => {
+    expect(deriveImageSetName('icon.png')).toBe('Icon');
+  });
+
+  it('should handle mixed separators', () => {
+    expect(deriveImageSetName('my_app-icon.png')).toBe('MyAppIcon');
+  });
+});

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
@@ -40,7 +40,7 @@ describe('withIosCallkitIcon', () => {
     mockedFs.existsSync.mockReturnValue(true);
   });
 
-  it('should skip when iosCallkitIcon is not set', () => {
+  it('should skip when iosCallKitIcon is not set', () => {
     const props: ConfigProps = {};
     const result = withIosCallkitIcon(baseConfig, props);
     expect(result).toBe(baseConfig);
@@ -49,7 +49,7 @@ describe('withIosCallkitIcon', () => {
 
   it('should create imageset directory and copy icon', () => {
     const props: ConfigProps = {
-      iosCallkitIcon: './assets/callkit_icon.png',
+      iosCallKitIcon: './assets/callkit_icon.png',
     };
 
     withIosCallkitIcon(baseConfig, props);
@@ -66,7 +66,7 @@ describe('withIosCallkitIcon', () => {
 
   it('should write Contents.json with template rendering intent', () => {
     const props: ConfigProps = {
-      iosCallkitIcon: './assets/callkit_icon.png',
+      iosCallKitIcon: './assets/callkit_icon.png',
     };
 
     withIosCallkitIcon(baseConfig, props);
@@ -91,7 +91,7 @@ describe('withIosCallkitIcon', () => {
   it('should throw when file does not exist', () => {
     mockedFs.existsSync.mockReturnValue(false);
     const props: ConfigProps = {
-      iosCallkitIcon: './assets/missing.png',
+      iosCallKitIcon: './assets/missing.png',
     };
 
     expect(() => withIosCallkitIcon(baseConfig, props)).toThrow(
@@ -101,7 +101,7 @@ describe('withIosCallkitIcon', () => {
 
   it('should throw on non-PNG file', () => {
     const props: ConfigProps = {
-      iosCallkitIcon: './assets/icon.jpg',
+      iosCallKitIcon: './assets/icon.jpg',
     };
 
     expect(() => withIosCallkitIcon(baseConfig, props)).toThrow(

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
@@ -16,7 +16,7 @@ jest.mock('fs');
 
 jest.mock('@expo/config-plugins', () => {
   return {
-    withDangerousMod: jest.fn((config, [_platform, callback]) => {
+    withDangerousMod: jest.fn((config, [, callback]) => {
       return callback(config as CustomExpoConfig);
     }),
   };

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
@@ -126,4 +126,8 @@ describe('deriveImageSetName', () => {
   it('should handle mixed separators', () => {
     expect(deriveImageSetName('my_app-icon.png')).toBe('MyAppIcon');
   });
+
+  it('should sanitize dot-separated names', () => {
+    expect(deriveImageSetName('my.icon.png')).toBe('MyIcon');
+  });
 });

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withIosCallkitIcon.test.ts
@@ -80,7 +80,7 @@ describe('withIosCallkitIcon', () => {
       (mockedFs.writeFileSync as jest.Mock).mock.calls[0][1],
     );
     expect(writtenJson.images).toEqual([
-      { filename: 'callkit_icon.png', idiom: 'universal' },
+      { filename: 'callkit_icon.png', idiom: 'universal', scale: '2x' },
     ]);
     expect(writtenJson.info).toEqual({ author: 'expo', version: 1 });
     expect(writtenJson.properties).toEqual({

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withIosRingtone.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withIosRingtone.test.ts
@@ -1,0 +1,154 @@
+import withIosRingtone from '../src/withCallResources/withIosRingtone';
+import { ExpoConfig } from '@expo/config-types';
+import { ConfigProps } from '../src/common/types';
+import * as fs from 'fs';
+
+interface CustomExpoConfig extends ExpoConfig {
+  modRequest: {
+    projectRoot: string;
+    platformProjectRoot: string;
+    projectName: string;
+  };
+  modResults: {
+    hasFile: jest.Mock;
+    addFile: jest.Mock;
+    findPBXGroupKey: jest.Mock;
+    getFirstTarget: jest.Mock;
+    generateUuid: jest.Mock;
+    addToPbxBuildFileSection: jest.Mock;
+    addToPbxResourcesBuildPhase: jest.Mock;
+  };
+}
+
+jest.mock('fs');
+
+jest.mock('@expo/config-plugins', () => {
+  return {
+    withXcodeProject: jest.fn((config, callback) => {
+      return callback(config as CustomExpoConfig);
+    }),
+  };
+});
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+function createMockFile() {
+  return { uuid: 'file-uuid', fileRef: 'file-ref', target: undefined };
+}
+
+function createConfig(
+  overrides?: Partial<CustomExpoConfig['modResults']>,
+): CustomExpoConfig {
+  return {
+    name: 'test-app',
+    slug: 'test-app',
+    modRequest: {
+      projectRoot: '/project',
+      platformProjectRoot: '/project/ios',
+      projectName: 'TestApp',
+    },
+    modResults: {
+      hasFile: jest.fn().mockReturnValue(false),
+      addFile: jest.fn().mockReturnValue(createMockFile()),
+      findPBXGroupKey: jest.fn().mockReturnValue('app-group-key'),
+      getFirstTarget: jest.fn().mockReturnValue({ uuid: 'target-uuid' }),
+      generateUuid: jest.fn().mockReturnValue('generated-uuid'),
+      addToPbxBuildFileSection: jest.fn(),
+      addToPbxResourcesBuildPhase: jest.fn(),
+      ...overrides,
+    },
+  };
+}
+
+describe('withIosRingtone', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFs.existsSync.mockReturnValue(true);
+  });
+
+  it('should skip when iosCallkitRingtone is not set', () => {
+    const config = createConfig();
+    const props: ConfigProps = {};
+    const result = withIosRingtone(config, props);
+    expect(result).toBe(config);
+    expect(mockedFs.copyFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should copy ringtone and add to Xcode project', () => {
+    const config = createConfig();
+    const props: ConfigProps = {
+      iosCallkitRingtone: './assets/ringtone.caf',
+    };
+
+    withIosRingtone(config, props);
+
+    expect(mockedFs.mkdirSync).toHaveBeenCalledWith('/project/ios/TestApp', {
+      recursive: true,
+    });
+    expect(mockedFs.copyFileSync).toHaveBeenCalledWith(
+      '/project/assets/ringtone.caf',
+      '/project/ios/TestApp/ringtone.caf',
+    );
+    expect(config.modResults.findPBXGroupKey).toHaveBeenCalledWith({
+      name: 'TestApp',
+    });
+    expect(config.modResults.addFile).toHaveBeenCalledWith(
+      'TestApp/ringtone.caf',
+      'app-group-key',
+      { target: 'target-uuid' },
+    );
+    expect(config.modResults.addToPbxBuildFileSection).toHaveBeenCalled();
+    expect(config.modResults.addToPbxResourcesBuildPhase).toHaveBeenCalled();
+  });
+
+  it('should not add resource file if it already exists in Xcode project', () => {
+    const config = createConfig({
+      hasFile: jest.fn().mockReturnValue(true),
+    });
+    const props: ConfigProps = {
+      iosCallkitRingtone: './assets/ringtone.caf',
+    };
+
+    withIosRingtone(config, props);
+
+    expect(mockedFs.copyFileSync).toHaveBeenCalled();
+    expect(config.modResults.addFile).not.toHaveBeenCalled();
+  });
+
+  it('should throw when file does not exist', () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    const config = createConfig();
+    const props: ConfigProps = {
+      iosCallkitRingtone: './assets/missing.caf',
+    };
+
+    expect(() => withIosRingtone(config, props)).toThrow(
+      /iOS ringtone file not found/,
+    );
+  });
+
+  it('should throw on invalid extension', () => {
+    const config = createConfig();
+    const props: ConfigProps = {
+      iosCallkitRingtone: './assets/ringtone.mp3',
+    };
+
+    expect(() => withIosRingtone(config, props)).toThrow(
+      /Invalid iOS ringtone format/,
+    );
+  });
+
+  it('should accept .aiff extension', () => {
+    const config = createConfig();
+    const props: ConfigProps = {
+      iosCallkitRingtone: './assets/ringtone.aiff',
+    };
+
+    withIosRingtone(config, props);
+
+    expect(mockedFs.copyFileSync).toHaveBeenCalledWith(
+      '/project/assets/ringtone.aiff',
+      '/project/ios/TestApp/ringtone.aiff',
+    );
+  });
+});

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withIosRingtone.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withIosRingtone.test.ts
@@ -77,7 +77,7 @@ describe('withIosRingtone', () => {
   it('should copy ringtone and add to Xcode project', () => {
     const config = createConfig();
     const props: ConfigProps = {
-      iosCallkitRingtone: './assets/ringtone.caf',
+      iosRingtone: './assets/ringtone.caf',
     };
 
     withIosRingtone(config, props);
@@ -106,7 +106,7 @@ describe('withIosRingtone', () => {
       hasFile: jest.fn().mockReturnValue(true),
     });
     const props: ConfigProps = {
-      iosCallkitRingtone: './assets/ringtone.caf',
+      iosRingtone: './assets/ringtone.caf',
     };
 
     withIosRingtone(config, props);
@@ -119,7 +119,7 @@ describe('withIosRingtone', () => {
     mockedFs.existsSync.mockReturnValue(false);
     const config = createConfig();
     const props: ConfigProps = {
-      iosCallkitRingtone: './assets/missing.caf',
+      iosRingtone: './assets/missing.caf',
     };
 
     expect(() => withIosRingtone(config, props)).toThrow(
@@ -130,7 +130,7 @@ describe('withIosRingtone', () => {
   it('should throw on invalid extension', () => {
     const config = createConfig();
     const props: ConfigProps = {
-      iosCallkitRingtone: './assets/ringtone.mp3',
+      iosRingtone: './assets/ringtone.mp3',
     };
 
     expect(() => withIosRingtone(config, props)).toThrow(
@@ -141,7 +141,7 @@ describe('withIosRingtone', () => {
   it('should accept .aiff extension', () => {
     const config = createConfig();
     const props: ConfigProps = {
-      iosCallkitRingtone: './assets/ringtone.aiff',
+      iosRingtone: './assets/ringtone.aiff',
     };
 
     withIosRingtone(config, props);

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withIosRingtone.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withIosRingtone.test.ts
@@ -66,7 +66,7 @@ describe('withIosRingtone', () => {
     mockedFs.existsSync.mockReturnValue(true);
   });
 
-  it('should skip when iosCallkitRingtone is not set', () => {
+  it('should skip when iosRingtone is not set', () => {
     const config = createConfig();
     const props: ConfigProps = {};
     const result = withIosRingtone(config, props);

--- a/packages/react-native-sdk/expo-config-plugin/src/common/types.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/common/types.ts
@@ -8,5 +8,11 @@ export type ConfigProps =
       addNoiseCancellation?: boolean;
       appleTeamId?: string;
       iOSEnableMultitaskingCameraAccess?: boolean;
+      /** Path to a custom ringtone file for iOS CallKit (relative to project root). Supported: .caf, .aiff, .m4a, .wav */
+      iosRingtone?: string;
+      /** Path to a custom CallKit icon PNG file for iOS (relative to project root). Must be a template image (monochrome). */
+      iosCallKitIcon?: string;
+      /** Path to a custom ringtone file for Android incoming calls (relative to project root). Supported: .mp3, .ogg, .wav, .m4a */
+      androidRingtone?: string;
     }
   | undefined;

--- a/packages/react-native-sdk/expo-config-plugin/src/index.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/index.ts
@@ -12,6 +12,7 @@ import withMainApplication from './withMainApplication';
 import withBuildProperties from './withBuildProperties';
 import withAppBuildGradle from './withAppBuildGradle';
 import withIosScreenCapture from './withIosScreenCapture';
+import withCallResources from './withCallResources';
 import { type ConfigProps } from './common/types';
 
 // path should be relative to dist
@@ -33,6 +34,7 @@ const withStreamVideoReactNativeSDK: ConfigPlugin<ConfigProps> = (
     () => withAndroidManifest(config, props),
     () => withMainActivity(config, props),
     () => withMainApplication(config, props),
+    () => withCallResources(config, props),
   ]);
 };
 

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/index.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/index.ts
@@ -1,0 +1,23 @@
+import { type ConfigPlugin, withPlugins } from '@expo/config-plugins';
+import type { ConfigProps } from '../common/types';
+import withIosRingtone from './withIosRingtone';
+import withIosCallkitIcon from './withIosCallkitIcon';
+import withAndroidRingtone from './withAndroidRingtone';
+
+const withCallResources: ConfigPlugin<ConfigProps> = (config, props) => {
+  //we don't need to add call resources if ringing is not enabled, or if no custom resources are provided
+  if (
+    !props?.ringing ||
+    (!props?.iosRingtone && !props?.iosCallKitIcon && !props?.androidRingtone)
+  ) {
+    return config;
+  }
+
+  return withPlugins(config, [
+    () => withIosRingtone(config, props),
+    () => withIosCallkitIcon(config, props),
+    () => withAndroidRingtone(config, props),
+  ]);
+};
+
+export default withCallResources;

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/index.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/index.ts
@@ -5,19 +5,30 @@ import withIosCallkitIcon from './withIosCallkitIcon';
 import withAndroidRingtone from './withAndroidRingtone';
 
 const withCallResources: ConfigPlugin<ConfigProps> = (config, props) => {
-  //we don't need to add call resources if ringing is not enabled, or if no custom resources are provided
-  if (
-    !props?.ringing ||
-    (!props?.iosRingtone && !props?.iosCallKitIcon && !props?.androidRingtone)
-  ) {
+  //we don't need to add call resources if ringing is not enabled
+  if (!props?.ringing) {
     return config;
   }
 
-  return withPlugins(config, [
-    () => withIosRingtone(config, props),
-    () => withIosCallkitIcon(config, props),
-    () => withAndroidRingtone(config, props),
-  ]);
+  const plugins: ConfigPlugin[] = [];
+  if (props?.iosRingtone) {
+    plugins.push(() => withIosRingtone(config, props));
+  }
+
+  if (props?.iosCallKitIcon) {
+    plugins.push(() => withIosCallkitIcon(config, props));
+  }
+
+  if (props?.androidRingtone) {
+    plugins.push(() => withAndroidRingtone(config, props));
+  }
+
+  //if no plugins are added, return the config
+  if (plugins.length === 0) {
+    return config;
+  }
+
+  return withPlugins(config, plugins);
 };
 
 export default withCallResources;

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withAndroidRingtone.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withAndroidRingtone.ts
@@ -1,0 +1,72 @@
+import { type ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ConfigProps } from '../common/types';
+
+const SUPPORTED_EXTENSIONS = ['.mp3', '.ogg', '.wav', '.m4a'];
+
+/**
+ * Normalize a filename for Android resources:
+ * - lowercase
+ * - replace hyphens with underscores
+ * - remove characters that are not alphanumeric or underscores (except the dot before extension)
+ */
+function normalizeAndroidResourceName(fileName: string): string {
+  const ext = path.extname(fileName);
+  const baseName = path.basename(fileName, ext);
+  const normalized = baseName
+    .toLowerCase()
+    .replace(/-/g, '_')
+    .replace(/[^a-z0-9_]/g, '');
+  return normalized + ext.toLowerCase();
+}
+
+const withAndroidRingtone: ConfigPlugin<ConfigProps> = (config, props) => {
+  if (!props?.androidRingtone) {
+    return config;
+  }
+
+  return withDangerousMod(config, [
+    'android',
+    (dangerousConfig) => {
+      const projectRoot = dangerousConfig.modRequest.projectRoot;
+      const sourcePath = path.resolve(projectRoot, props.androidRingtone!);
+
+      if (!fs.existsSync(sourcePath)) {
+        throw new Error(
+          `[StreamVideo] Android ringtone file not found: ${sourcePath}. ` +
+            `Check that the "androidRingtone" path in your plugin config is correct.`,
+        );
+      }
+
+      const ext = path.extname(sourcePath).toLowerCase();
+      if (!SUPPORTED_EXTENSIONS.includes(ext)) {
+        throw new Error(
+          `[StreamVideo] Invalid Android ringtone format "${ext}". ` +
+            `Supported formats: ${SUPPORTED_EXTENSIONS.join(', ')}`,
+        );
+      }
+
+      const fileName = path.basename(sourcePath);
+      const normalizedName = normalizeAndroidResourceName(fileName);
+
+      const rawDir = path.join(
+        dangerousConfig.modRequest.platformProjectRoot,
+        'app',
+        'src',
+        'main',
+        'res',
+        'raw',
+      );
+      fs.mkdirSync(rawDir, { recursive: true });
+
+      const destPath = path.join(rawDir, normalizedName);
+      fs.copyFileSync(sourcePath, destPath);
+
+      return dangerousConfig;
+    },
+  ]);
+};
+
+export default withAndroidRingtone;
+export { normalizeAndroidResourceName };

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withAndroidRingtone.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withAndroidRingtone.ts
@@ -26,10 +26,10 @@ function normalizeAndroidResourceName(fileName: string): string {
     );
   }
 
-  if (/^\d/.test(normalized)) {
+  if (!/^[a-z]/.test(normalized)) {
     throw new Error(
-      `[StreamVideo] Android ringtone name "${fileName}" starts with a digit after normalization ("${normalized}"). ` +
-        `Android resource names must start with a letter or underscore.`,
+      `[StreamVideo] Android ringtone name "${fileName}" starts with a non-letter after normalization ("${normalized}"). ` +
+        `Android resource names must start with a lowercase letter.`,
     );
   }
 

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withAndroidRingtone.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withAndroidRingtone.ts
@@ -18,6 +18,21 @@ function normalizeAndroidResourceName(fileName: string): string {
     .toLowerCase()
     .replace(/-/g, '_')
     .replace(/[^a-z0-9_]/g, '');
+
+  if (normalized.length === 0) {
+    throw new Error(
+      `[StreamVideo] Android ringtone name "${fileName}" contains no valid characters after normalization. ` +
+        `The name must contain at least one lowercase letter, digit, or underscore.`,
+    );
+  }
+
+  if (/^\d/.test(normalized)) {
+    throw new Error(
+      `[StreamVideo] Android ringtone name "${fileName}" starts with a digit after normalization ("${normalized}"). ` +
+        `Android resource names must start with a letter or underscore.`,
+    );
+  }
+
   return normalized + ext.toLowerCase();
 }
 

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosCallkitIcon.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosCallkitIcon.ts
@@ -1,0 +1,85 @@
+import { type ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ConfigProps } from '../common/types';
+
+/**
+ * Derive an xcassets image set name from a filename.
+ * e.g. "callkit_icon.png" -> "CallkitIcon"
+ * e.g. "my-app-icon.png" -> "MyAppIcon"
+ */
+function deriveImageSetName(fileName: string): string {
+  const baseName = path.basename(fileName, path.extname(fileName));
+  return baseName
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join('');
+}
+
+const withIosCallkitIcon: ConfigPlugin<ConfigProps> = (config, props) => {
+  if (!props?.iosCallKitIcon) {
+    return config;
+  }
+
+  return withDangerousMod(config, [
+    'ios',
+    (dangerousConfig) => {
+      const projectRoot = dangerousConfig.modRequest.projectRoot;
+      const sourcePath = path.resolve(projectRoot, props.iosCallKitIcon!);
+
+      if (!fs.existsSync(sourcePath)) {
+        throw new Error(
+          `[StreamVideo] iOS CallKit icon file not found: ${sourcePath}. ` +
+            `Check that the "iosCallkitIcon" path in your plugin config is correct.`,
+        );
+      }
+
+      const ext = path.extname(sourcePath).toLowerCase();
+      if (ext !== '.png') {
+        throw new Error(
+          `[StreamVideo] iOS CallKit icon must be a PNG file, got "${ext}".`,
+        );
+      }
+
+      const imageSetName = deriveImageSetName(path.basename(sourcePath));
+      const appName = dangerousConfig.modRequest.projectName!;
+      const imageSetDir = path.join(
+        dangerousConfig.modRequest.platformProjectRoot,
+        appName,
+        'Images.xcassets',
+        `${imageSetName}.imageset`,
+      );
+
+      fs.mkdirSync(imageSetDir, { recursive: true });
+
+      const destFileName = path.basename(sourcePath);
+      fs.copyFileSync(sourcePath, path.join(imageSetDir, destFileName));
+
+      const contentsJson = {
+        images: [
+          {
+            filename: destFileName,
+            idiom: 'universal',
+          },
+        ],
+        info: {
+          author: 'expo',
+          version: 1,
+        },
+        properties: {
+          'template-rendering-intent': 'template',
+        },
+      };
+
+      fs.writeFileSync(
+        path.join(imageSetDir, 'Contents.json'),
+        JSON.stringify(contentsJson, null, 2),
+      );
+
+      return dangerousConfig;
+    },
+  ]);
+};
+
+export default withIosCallkitIcon;
+export { deriveImageSetName };

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosCallkitIcon.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosCallkitIcon.ts
@@ -11,7 +11,8 @@ import type { ConfigProps } from '../common/types';
 function deriveImageSetName(fileName: string): string {
   const baseName = path.basename(fileName, path.extname(fileName));
   return baseName
-    .split(/[-_]/)
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
     .join('');
 }

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosCallkitIcon.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosCallkitIcon.ts
@@ -30,7 +30,7 @@ const withIosCallkitIcon: ConfigPlugin<ConfigProps> = (config, props) => {
       if (!fs.existsSync(sourcePath)) {
         throw new Error(
           `[StreamVideo] iOS CallKit icon file not found: ${sourcePath}. ` +
-            `Check that the "iosCallkitIcon" path in your plugin config is correct.`,
+            `Check that the "iosCallKitIcon" path in your plugin config is correct.`,
         );
       }
 

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosCallkitIcon.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosCallkitIcon.ts
@@ -60,6 +60,7 @@ const withIosCallkitIcon: ConfigPlugin<ConfigProps> = (config, props) => {
           {
             filename: destFileName,
             idiom: 'universal',
+            scale: '2x',
           },
         ],
         info: {

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosRingtone.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosRingtone.ts
@@ -1,0 +1,65 @@
+import { type ConfigPlugin, withXcodeProject } from '@expo/config-plugins';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ConfigProps } from '../common/types';
+
+const SUPPORTED_EXTENSIONS = ['.caf', '.aiff', '.m4a', '.wav'];
+
+const withIosRingtone: ConfigPlugin<ConfigProps> = (config, props) => {
+  if (!props?.iosRingtone) {
+    return config;
+  }
+
+  return withXcodeProject(config, (xCodeConfig) => {
+    const projectRoot = xCodeConfig.modRequest.projectRoot;
+    const sourcePath = path.resolve(projectRoot, props.iosRingtone!);
+
+    if (!fs.existsSync(sourcePath)) {
+      throw new Error(
+        `[StreamVideo] iOS ringtone file not found: ${sourcePath}. ` +
+          `Check that the "iosCallkitRingtone" path in your plugin config is correct.`,
+      );
+    }
+
+    const ext = path.extname(sourcePath).toLowerCase();
+    if (!SUPPORTED_EXTENSIONS.includes(ext)) {
+      throw new Error(
+        `[StreamVideo] Invalid iOS ringtone format "${ext}". ` +
+          `Supported formats: ${SUPPORTED_EXTENSIONS.join(', ')}`,
+      );
+    }
+
+    const fileName = path.basename(sourcePath);
+    const appName = xCodeConfig.modRequest.projectName!;
+    const destDir = path.join(
+      xCodeConfig.modRequest.platformProjectRoot,
+      appName,
+    );
+    const destPath = path.join(destDir, fileName);
+    // Path relative to the ios/ directory — Xcode needs this to locate the file
+    const projectFilePath = path.join(appName, fileName);
+
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.copyFileSync(sourcePath, destPath);
+
+    const proj = xCodeConfig.modResults;
+    if (!proj.hasFile(fileName)) {
+      // Find the main app group by name (Expo projects don't have a "Resources" group,
+      // so we can't use addResourceFile which crashes on correctForResourcesPath)
+      const appGroupKey = proj.findPBXGroupKey({ name: appName });
+      const file = proj.addFile(projectFilePath, appGroupKey, {
+        target: proj.getFirstTarget().uuid,
+      });
+      if (file) {
+        file.uuid = proj.generateUuid();
+        file.target = proj.getFirstTarget().uuid;
+        proj.addToPbxBuildFileSection(file);
+        proj.addToPbxResourcesBuildPhase(file);
+      }
+    }
+
+    return xCodeConfig;
+  });
+};
+
+export default withIosRingtone;

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosRingtone.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosRingtone.ts
@@ -52,7 +52,6 @@ const withIosRingtone: ConfigPlugin<ConfigProps> = (config, props) => {
       });
       if (file) {
         file.uuid = proj.generateUuid();
-        file.target = proj.getFirstTarget().uuid;
         proj.addToPbxBuildFileSection(file);
         proj.addToPbxResourcesBuildPhase(file);
       }

--- a/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosRingtone.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withCallResources/withIosRingtone.ts
@@ -17,7 +17,7 @@ const withIosRingtone: ConfigPlugin<ConfigProps> = (config, props) => {
     if (!fs.existsSync(sourcePath)) {
       throw new Error(
         `[StreamVideo] iOS ringtone file not found: ${sourcePath}. ` +
-          `Check that the "iosCallkitRingtone" path in your plugin config is correct.`,
+          `Check that the "iosRingtone" path in your plugin config is correct.`,
       );
     }
 


### PR DESCRIPTION
### 💡 Overview

This PR contains expo plugins which will export custom ringtone resources for iOS and Android and custom icon for CallKit dial UI.

🎫 Ticket: https://linear.app/stream/issue/RN-377/implement-expo-plugins-for-importing-custom-ringtones-for-rining

📑 Docs: https://github.com/GetStream/docs-content/pull/1207


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure custom ringtones on iOS and Android and a custom CallKit icon on iOS via Expo config
  * Automatic Android resource name normalization and derived iOS image-set naming
  * Validation with clear errors for unsupported formats and missing files

* **Tests**
  * Added comprehensive tests for copying/registration, validation, error cases, and name normalization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->