### PR TITLE
chore: ongoing calls adjustments

### DIFF
--- a/packages/react-native-callingx/src/CallingxModule.ts
+++ b/packages/react-native-callingx/src/CallingxModule.ts
@@ -30,7 +30,10 @@ import { isVoipEvent } from './utils/utils';
 
 class CallingxModule implements ICallingxModule {
   private _isSetup = false;
-  private _isOngoingCallsEnabled = false;
+  private _isOngoingCallsEnabled = {
+    android: false,
+    ios: false,
+  };
   private _isHeadlessTaskRegistered = false;
 
   private titleTransformer: (memberName: string, incoming: boolean) => string =
@@ -50,7 +53,9 @@ class CallingxModule implements ICallingxModule {
   }
 
   get isOngoingCallsEnabled(): boolean {
-    return this._isOngoingCallsEnabled;
+    return Platform.OS === 'ios'
+      ? this._isOngoingCallsEnabled.ios
+      : this._isOngoingCallsEnabled.android;
   }
 
   get isSetup(): boolean {
@@ -62,7 +67,10 @@ class CallingxModule implements ICallingxModule {
       return;
     }
 
-    this._isOngoingCallsEnabled = options.enableOngoingCalls ?? false;
+    this._isOngoingCallsEnabled = {
+      android: options.android?.enableOngoingCalls ?? false,
+      ios: options.ios?.enableOngoingCalls ?? false,
+    };
     this.setShouldRejectCallWhenBusy(options.shouldRejectCallWhenBusy ?? false);
 
     if (Platform.OS === 'ios') {

--- a/packages/react-native-callingx/src/types.ts
+++ b/packages/react-native-callingx/src/types.ts
@@ -189,6 +189,11 @@ export type InternalIOSOptions = {
    * @default 60000 (1 minute)
    */
   displayCallTimeout?: number;
+  /**
+   * Whether to enable ongoing calls.
+   * @default false
+   */
+  enableOngoingCalls?: boolean;
 };
 type iOSOptions = Omit<
   InternalIOSOptions,
@@ -230,6 +235,11 @@ export type InternalAndroidOptions = {
      */
     rejecting?: string;
   };
+  /**
+   * Whether to enable ongoing calls.
+   * @default false
+   */
+  enableOngoingCalls?: boolean;
 };
 type AndroidOptions = InternalAndroidOptions & NotificationTransformers;
 
@@ -240,11 +250,6 @@ export type NotificationTransformers = {
 export type CallingExpOptions = {
   ios?: iOSOptions;
   android?: AndroidOptions;
-  /**
-   * Whether to enable ongoing calls.
-   * @default false
-   */
-  enableOngoingCalls?: boolean;
   /**
    * Whether to reject calls when the user is busy.
    * @default false

--- a/packages/react-native-callingx/src/utils/constants.ts
+++ b/packages/react-native-callingx/src/utils/constants.ts
@@ -14,6 +14,7 @@ export const defaultiOSOptions: Required<InternalIOSOptions> = {
   imageName: '',
   callsHistory: false,
   displayCallTimeout: 60000, // 1 minute
+  enableOngoingCalls: false,
 };
 
 export const defaultAndroidOptions: Omit<
@@ -30,6 +31,7 @@ export const defaultAndroidOptions: Omit<
     id: 'stream_ongoing_calls_channel',
     name: 'Ongoing calls',
   },
+  enableOngoingCalls: false,
 };
 
 // iOS: maps to CXCallEndedReason raw values.

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withiOSInfoPlist.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withiOSInfoPlist.test.ts
@@ -120,6 +120,30 @@ describe('withStreamVideoReactNativeSDKiOSInfoPList', () => {
     ]);
   });
 
+  it('should add audio and voip for iosKeepCallAlive', async () => {
+    const config: CustomExpoConfig = {
+      name: 'test-app',
+      slug: 'test-app',
+      modResults: {
+        UIBackgroundModes: undefined,
+      },
+    };
+    const props: ConfigProps = {
+      iosKeepCallAlive: true,
+    };
+    const modifiedConfig = withStreamVideoReactNativeSDKiOSInfoPList(
+      config,
+      props,
+    ) as CustomExpoConfig;
+
+    expect(modifiedConfig.modResults.UIBackgroundModes).toContain('audio');
+    expect(modifiedConfig.modResults.UIBackgroundModes).toContain('voip');
+    expect(modifiedConfig.modResults.UIBackgroundModes).not.toContain('fetch');
+    expect(modifiedConfig.modResults.UIBackgroundModes).not.toContain(
+      'processing',
+    );
+  });
+
   it('should add multiple modes for ringing notifications', async () => {
     const config: CustomExpoConfig = {
       name: 'test-app',

--- a/packages/react-native-sdk/expo-config-plugin/src/common/types.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/common/types.ts
@@ -4,6 +4,7 @@ export type ConfigProps =
       enableNonRingingPushNotifications?: boolean;
       androidPictureInPicture?: boolean;
       androidKeepCallAlive?: boolean;
+      iosKeepCallAlive?: boolean;
       enableScreenshare?: boolean;
       addNoiseCancellation?: boolean;
       appleTeamId?: string;

--- a/packages/react-native-sdk/expo-config-plugin/src/withiOSInfoPlist.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withiOSInfoPlist.ts
@@ -15,8 +15,10 @@ const withStreamVideoReactNativeSDKiOSInfoPList: ConfigPlugin<ConfigProps> = (
       }
     }
     addBackgroundMode('audio');
-    if (props?.ringing) {
+    if (props?.ringing || props?.iosKeepCallAlive) {
       addBackgroundMode('voip');
+    }
+    if (props?.ringing) {
       addBackgroundMode('fetch');
       addBackgroundMode('processing');
       config.modResults['BGTaskSchedulerPermittedIdentifiers'] = [

--- a/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useIosVoipPushEventsSetupEffect.ts
@@ -88,7 +88,7 @@ export const useIosVoipPushEventsSetupEffect = () => {
 
   useEffect(() => {
     const pushConfig = StreamVideoRN.getConfig().push;
-    const pushProviderName = pushConfig?.ios.pushProviderName;
+    const pushProviderName = pushConfig?.ios?.pushProviderName;
     const callingx = getCallingxLibIfAvailable();
 
     if (Platform.OS !== 'ios' || !client || !pushProviderName || !callingx) {

--- a/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
+++ b/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
@@ -53,7 +53,7 @@ async function startForegroundService(call_cid: string) {
   const foregroundServiceConfig = videoConfig.foregroundService;
   const notificationTexts = foregroundServiceConfig.android.notificationTexts;
   const channel = foregroundServiceConfig.android.channel;
-  const smallIconName = videoConfig.push?.android.smallIcon;
+  const smallIconName = videoConfig.push?.android?.smallIcon;
 
   // NOTE: we use requestAnimationFrame to ensure that the foreground service is started after all the current UI operations are done
   // this is a workaround for the crash - android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException: Context.startForegroundService() did not then call Service.startForeground()

--- a/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
+++ b/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
@@ -89,13 +89,12 @@ export const useAndroidKeepCallAliveEffect = () => {
   const { useCallCallingState } = useCallStateHooks();
   const callingState = useCallCallingState();
 
-  const isOutgoingCall =
-    callingState === CallingState.RINGING && call?.isCreatedByMe;
   const isCallJoined = callingState === CallingState.JOINED;
   const isRingingCall = call?.ringing;
+  const isLivestreamCall = call?.type === 'livestream';
 
   const shouldStartForegroundService =
-    !foregroundServiceStartedRef.current && (isOutgoingCall || isCallJoined);
+    !foregroundServiceStartedRef.current && isCallJoined;
 
   useEffect((): (() => void) | undefined => {
     if (Platform.OS === 'ios' || !activeCallCid) {
@@ -105,7 +104,10 @@ export const useAndroidKeepCallAliveEffect = () => {
     const callingx = getCallingxLibIfAvailable();
     if (
       callingx?.isSetup &&
-      (isRingingCall || (!isRingingCall && callingx?.isOngoingCallsEnabled))
+      (isRingingCall ||
+        (!isRingingCall &&
+          callingx?.isOngoingCallsEnabled &&
+          !isLivestreamCall))
     ) {
       return undefined;
     }
@@ -154,6 +156,7 @@ export const useAndroidKeepCallAliveEffect = () => {
     callingState,
     shouldStartForegroundService,
     isRingingCall,
+    isLivestreamCall,
   ]);
 
   useEffect(() => {

--- a/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
+++ b/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
@@ -91,7 +91,6 @@ export const useAndroidKeepCallAliveEffect = () => {
 
   const isCallJoined = callingState === CallingState.JOINED;
   const isRingingCall = call?.ringing;
-  const isLivestreamCall = call?.type === 'livestream';
 
   const shouldStartForegroundService =
     !foregroundServiceStartedRef.current && isCallJoined;
@@ -104,10 +103,7 @@ export const useAndroidKeepCallAliveEffect = () => {
     const callingx = getCallingxLibIfAvailable();
     if (
       callingx?.isSetup &&
-      (isRingingCall ||
-        (!isRingingCall &&
-          callingx?.isOngoingCallsEnabled &&
-          !isLivestreamCall))
+      (isRingingCall || (!isRingingCall && callingx?.isOngoingCallsEnabled))
     ) {
       return undefined;
     }
@@ -156,7 +152,6 @@ export const useAndroidKeepCallAliveEffect = () => {
     callingState,
     shouldStartForegroundService,
     isRingingCall,
-    isLivestreamCall,
   ]);
 
   useEffect(() => {

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
@@ -37,7 +37,7 @@ export type StreamVideoConfig = {
      */
     publishOptions?: ClientPublishOptions;
 
-    ios: {
+    ios?: {
       /**
        * The name for the alias of push provider used for iOS
        * Pass undefined if you will not be using stream's push notifications but still want to use the functionality of the SDK
@@ -66,7 +66,7 @@ export type StreamVideoConfig = {
        */
       displayCallTimeout?: number;
     };
-    android: {
+    android?: {
       /**
        * The small icon to be used for push notifications for Android
        * Reference the name created (Optional, defaults to 'ic_launcher')

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
@@ -65,6 +65,11 @@ export type StreamVideoConfig = {
        * @default 60000 (1 minute)
        */
       displayCallTimeout?: number;
+      /**
+       * Whether to enable ongoing calls.
+       * @default false
+       */
+      enableOngoingCalls?: boolean;
     };
     android?: {
       /**
@@ -145,12 +150,12 @@ export type StreamVideoConfig = {
         ) => string;
         getBody: (type: NonRingingPushEvent, createdUserName: string) => string;
       };
+      /**
+       * Whether to enable ongoing calls.
+       * @default false
+       */
+      enableOngoingCalls?: boolean;
     };
-    /**
-     * Whether to enable ongoing calls.
-     * @default false
-     */
-    enableOngoingCalls?: boolean;
     /**
      * Whether to reject calls when the user is busy.
      * @default false

--- a/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
+++ b/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
@@ -64,6 +64,7 @@ function getCallDisplayNameFromCall(call: Call): string {
   );
 }
 
+// currently this method is called only for handling outgoing ringing calls, so this logic won't be applied for livestream calls
 export async function registerOutgoingCall(call: Call) {
   if (!CallingxModule || !CallingxModule.isSetup) {
     return;
@@ -102,6 +103,12 @@ export async function registerOutgoingCall(call: Call) {
  */
 export async function joinCallingxCall(call: Call, activeCalls: Call[]) {
   if (!CallingxModule || !CallingxModule.isSetup) {
+    return;
+  }
+
+  const isLivestreamCall = call.type === 'livestream';
+  if (isLivestreamCall && Platform.OS === 'android') {
+    // we don't want to register call in callingx for Android livestream calls
     return;
   }
 

--- a/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
+++ b/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
@@ -64,7 +64,6 @@ function getCallDisplayNameFromCall(call: Call): string {
   );
 }
 
-// currently this method is called only for handling outgoing ringing calls, so this logic won't be applied for livestream calls
 export async function registerOutgoingCall(call: Call) {
   if (!CallingxModule || !CallingxModule.isSetup) {
     return;
@@ -103,12 +102,6 @@ export async function registerOutgoingCall(call: Call) {
  */
 export async function joinCallingxCall(call: Call, activeCalls: Call[]) {
   if (!CallingxModule || !CallingxModule.isSetup) {
-    return;
-  }
-
-  const isLivestreamCall = call.type === 'livestream';
-  if (isLivestreamCall && Platform.OS === 'android') {
-    // we don't want to register call in callingx for Android livestream calls
     return;
   }
 

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -40,7 +40,7 @@ export async function initAndroidPushToken(
   pushConfig: PushConfig,
   setUnsubscribeListener: (unsubscribe: () => void) => void,
 ) {
-  if (Platform.OS !== 'android' || !pushConfig.android.pushProviderName) {
+  if (Platform.OS !== 'android' || !pushConfig.android?.pushProviderName) {
     return;
   }
   const logger = videoLoggerSystem.getLogger('initAndroidPushToken');
@@ -69,7 +69,7 @@ export async function initAndroidPushToken(
         logger.warn('Failed to remove firebase token from stream', err);
       }
     });
-    const push_provider_name = pushConfig.android.pushProviderName;
+    const push_provider_name = pushConfig.android?.pushProviderName;
     logger.debug(`sending firebase token: ${token} for userId: ${userId}`);
     await client.addDevice(token, 'firebase', push_provider_name);
   };
@@ -336,9 +336,9 @@ export const firebaseDataHandler = async (
     }
 
     // the other types are call.live_started and call.notification
-    const callChannel = pushConfig.android.callChannel;
+    const callChannel = pushConfig.android?.callChannel;
     const callNotificationTextGetters =
-      pushConfig.android.callNotificationTextGetters;
+      pushConfig.android?.callNotificationTextGetters;
     if (!callChannel || !callNotificationTextGetters) {
       logger.debug(
         "Can't show call notification as either or both callChannel and callNotificationTextGetters is not provided",
@@ -364,7 +364,7 @@ export const firebaseDataHandler = async (
       data,
       android: {
         sound: callChannel.sound,
-        smallIcon: pushConfig.android.smallIcon,
+        smallIcon: pushConfig.android?.smallIcon,
         vibrationPattern: callChannel.vibrationPattern,
         channelId,
         importance: 4, // high importance

--- a/packages/react-native-sdk/src/utils/push/internal/ios.ts
+++ b/packages/react-native-sdk/src/utils/push/internal/ios.ts
@@ -1,9 +1,9 @@
+import { videoLoggerSystem } from '@stream-io/video-client';
 import { Platform } from 'react-native';
+import { StreamVideoConfig } from '../../StreamVideoRN/types';
+import { getCallingxLib } from '../libs/callingx';
 import { pushUnsubscriptionCallbacks } from './constants';
 import { canListenToWS, shouldCallBeClosed } from './utils';
-import { StreamVideoConfig } from '../../StreamVideoRN/types';
-import { videoLoggerSystem } from '@stream-io/video-client';
-import { getCallingxLib } from '../libs/callingx';
 
 export const onVoipNotificationReceived = async (
   notification: any,
@@ -43,7 +43,7 @@ export const onVoipNotificationReceived = async (
   }
 
   const call_cid = notification?.stream?.call_cid;
-  if (!call_cid || Platform.OS !== 'ios' || !pushConfig.ios.pushProviderName) {
+  if (!call_cid || Platform.OS !== 'ios' || !pushConfig.ios?.pushProviderName) {
     return;
   }
 

--- a/packages/react-native-sdk/src/utils/push/ios.ts
+++ b/packages/react-native-sdk/src/utils/push/ios.ts
@@ -127,7 +127,7 @@ export async function initIosNonVoipToken(
 ) {
   if (
     Platform.OS !== 'ios' ||
-    !pushConfig.ios.pushProviderName ||
+    !pushConfig.ios?.pushProviderName ||
     !pushConfig.onTapNonRingingCallNotification
   ) {
     return;
@@ -155,7 +155,7 @@ export async function initIosNonVoipToken(
         );
       }
     });
-    const push_provider_name = pushConfig.ios.pushProviderName;
+    const push_provider_name = pushConfig.ios?.pushProviderName;
     logger.debug('Add device token to stream', token);
     await client
       .addDevice(token, 'apn', push_provider_name)

--- a/packages/react-native-sdk/src/utils/push/libs/callingx.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/callingx.ts
@@ -49,6 +49,9 @@ export function extractCallingExpOptions(
     if (pushConfig.ios.displayCallTimeout !== undefined) {
       iosOptions.displayCallTimeout = pushConfig.ios.displayCallTimeout;
     }
+    if (pushConfig.ios.enableOngoingCalls !== undefined) {
+      iosOptions.enableOngoingCalls = pushConfig.ios.enableOngoingCalls;
+    }
 
     if (Object.keys(iosOptions).length > 0) {
       callingExpOptions.ios = iosOptions;
@@ -66,6 +69,9 @@ export function extractCallingExpOptions(
     if (pushConfig.android.notificationTexts) {
       androidOptions.notificationTexts = pushConfig.android.notificationTexts;
     }
+    if (pushConfig.android.enableOngoingCalls !== undefined) {
+      androidOptions.enableOngoingCalls = pushConfig.android.enableOngoingCalls;
+    }
   }
 
   if (foregroundServiceConfig.android.channel) {
@@ -79,10 +85,6 @@ export function extractCallingExpOptions(
   if (pushConfig?.shouldRejectCallWhenBusy !== undefined) {
     callingExpOptions.shouldRejectCallWhenBusy =
       pushConfig.shouldRejectCallWhenBusy;
-  }
-
-  if (pushConfig?.enableOngoingCalls !== undefined) {
-    callingExpOptions.enableOngoingCalls = pushConfig?.enableOngoingCalls;
   }
 
   return callingExpOptions;

--- a/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
+++ b/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
@@ -25,7 +25,7 @@ export function setupCallingExpEvents(pushConfig: NonNullable<PushConfig>) {
     (Platform.OS === 'android' && pushConfig.android?.pushProviderName) ||
     (Platform.OS === 'ios' && pushConfig.ios?.pushProviderName);
 
-  if (!hasPushProvider) {
+  if (!hasPushProvider && !pushConfig.enableOngoingCalls) {
     return;
   }
 

--- a/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
+++ b/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
@@ -24,8 +24,11 @@ export function setupCallingExpEvents(pushConfig: NonNullable<PushConfig>) {
   const hasPushProvider =
     (Platform.OS === 'android' && pushConfig.android?.pushProviderName) ||
     (Platform.OS === 'ios' && pushConfig.ios?.pushProviderName);
+  const hasOngoingCalls =
+    (Platform.OS === 'android' && pushConfig.android?.enableOngoingCalls) ||
+    (Platform.OS === 'ios' && pushConfig.ios?.enableOngoingCalls);
 
-  if (!hasPushProvider && !pushConfig.enableOngoingCalls) {
+  if (!hasPushProvider && !hasOngoingCalls) {
     return;
   }
 

--- a/sample-apps/react-native/dogfood/src/utils/setPushConfig.ts
+++ b/sample-apps/react-native/dogfood/src/utils/setPushConfig.ts
@@ -33,6 +33,7 @@ export function setPushConfig() {
     ios: {
       pushProviderName: 'rn-apn-video',
       callsHistory: true,
+      enableOngoingCalls: true,
     },
     android: {
       pushProviderName: 'rn-fcm-video',
@@ -60,8 +61,8 @@ export function setPushConfig() {
           }
         },
       },
+      enableOngoingCalls: true,
     },
-    enableOngoingCalls: true,
     shouldRejectCallWhenBusy: false,
     createStreamVideoClient,
     onTapNonRingingCallNotification: (call_cid) => {


### PR DESCRIPTION
### 💡 Overview

Added CallKit support for non-ringing call cases for iOS to use background mode `voip` to keep call alive while the app is in background.
Excluded `livestream` type calls from being registered in CallKit. Livestream call alive is using separate FGS independent from Android Telecom. 

🎫 Ticket: https://linear.app/stream/issue/RN-379/call-alive-tweaks

📑 Docs: [https://github.com/GetStream/docs-content/pull/<id>](https://github.com/GetStream/docs-content/pull/1218)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iOS keep-call-alive configuration option to help maintain call stability on iOS.

* **Configuration Changes**
  * Ongoing calls feature is now configured separately per platform (iOS and Android) instead of globally.
  * Push provider configuration is now more flexible and can be omitted if not required.

* **Improvements**
  * Enhanced robustness of push configuration handling throughout the SDK with better safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->