### PR TITLE
fix(pronto): show correct transport protocol for TURN-relayed paths

### DIFF
--- a/sample-apps/react/react-dogfood/components/Inspector/TransportDiagram.tsx
+++ b/sample-apps/react/react-dogfood/components/Inspector/TransportDiagram.tsx
@@ -89,9 +89,15 @@ function TransportDiagramPlaceholder(props: PropsWithChildren) {
 
 async function fetchPeerConnectionCandidatePair(pc: RTCPeerConnection) {
   const reportObj = Object.fromEntries((await pc.getStats()).entries());
-  const transportEntry: RTCTransportStats | undefined = Object.values(
-    reportObj,
-  ).find((entry) => entry.type === 'transport');
+  const activeTransports = Object.values(reportObj).filter(
+    (entry): entry is RTCTransportStats =>
+      entry.type === 'transport' && !!entry.selectedCandidatePairId,
+  );
+  const transportEntry =
+    activeTransports.find(
+      (entry) =>
+        reportObj[entry.selectedCandidatePairId!]?.state === 'succeeded',
+    ) ?? activeTransports[0];
 
   if (!transportEntry?.selectedCandidatePairId) {
     return null;
@@ -104,11 +110,13 @@ async function fetchPeerConnectionCandidatePair(pc: RTCPeerConnection) {
     reportObj[candidatePairEntry.localCandidateId];
   const remoteCandidateEntry: any =
     reportObj[candidatePairEntry.remoteCandidateId];
-  const rawProtocol =
-    localCandidateEntry.protocol ?? localCandidateEntry.relayProtocol;
-  const protocol: string = rawProtocol
-    ? localCandidateEntry.protocol.toUpperCase()
-    : '-';
+  // For relay candidates, `protocol` is the TURN→peer leg (usually UDP);
+  // `relayProtocol` is the client↔TURN leg — that's the one the user sees.
+  const isRelay = localCandidateEntry.candidateType === 'relay';
+  const rawProtocol: string | undefined = isRelay
+    ? localCandidateEntry.relayProtocol
+    : localCandidateEntry.protocol;
+  const protocol = rawProtocol ? rawProtocol.toUpperCase() : '-';
 
   return {
     local: formatCandidateEntry(localCandidateEntry),


### PR DESCRIPTION
### 💡 Overview

Fixes a mislabel in the dogfood Inspector's `/test` transport diagram: relayed ICE paths reported their TURN→peer protocol (UDP) instead of the client↔TURN protocol the user actually sees, so a TCP-to-TURN connection was displayed as "UDP".

### 📝 Implementation notes

- For relay local candidates, use `relayProtocol` instead of `protocol` (`protocol` on a relay candidate is the TURN→peer leg).
- Transport-entry selection now filters to transports that have a `selectedCandidatePairId` and prefers one whose candidate pair is `succeeded`, stabilising the label under multi-transport / SFU migration scenarios.
- Also drops a latent NPE in the previous `rawProtocol ?? relayProtocol` fallback, which re-dereferenced `.protocol` after the `??`.

🎫 Ticket: n/a

📑 Docs: n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transport candidate selection to prioritize connections with successful pair states, improving diagnostic accuracy with fallback to active transports when needed.
  * Refined protocol detection for relay connections to report client-to-TURN protocol information instead of internal TURN-to-peer details for clearer transport diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->