### PR TITLE
fix: callingx listeners did not work on relogin

### DIFF
--- a/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
@@ -148,12 +148,12 @@ export class StreamVideoRN {
    * Typically used on user logout.
    */
   static onPushLogout() {
-    if (pushLogoutCallbacks.current) {
-      return Promise.all(
-        pushLogoutCallbacks.current.map((callback) => callback()),
-      ).then(() => {});
+    const callbacks = pushLogoutCallbacks.current;
+    if (!callbacks) {
+      return Promise.resolve();
     }
-    return Promise.resolve();
+    pushLogoutCallbacks.current = [];
+    return Promise.all(callbacks.map((callback) => callback())).then(() => {});
   }
 
   static clearPushLogoutCallbacks() {

--- a/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
+++ b/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
@@ -4,7 +4,6 @@ import {
   clearPushWSEventSubscriptions,
   processCallFromPushInBackground,
 } from './internal/utils';
-import { setPushLogoutCallback } from '../internal/pushLogoutCallback';
 import { resolvePendingAudioSession } from '../internal/callingx/audioSessionPromise';
 import {
   getCallingxLib,
@@ -31,25 +30,19 @@ export function setupCallingExpEvents(pushConfig: NonNullable<PushConfig>) {
 
   const callingx = getCallingxLib();
 
-  const { remove: removeAnswerCall } = callingx.addEventListener(
-    'answerCall',
-    (params) => {
-      onAcceptCall(pushConfig)(params);
-    },
-  );
+  callingx.addEventListener('answerCall', (params) => {
+    onAcceptCall(pushConfig)(params);
+  });
 
-  const { remove: removeEndCall } = callingx.addEventListener(
-    'endCall',
-    (params) => {
-      onEndCall(pushConfig)(params);
-    },
-  );
+  callingx.addEventListener('endCall', (params) => {
+    onEndCall(pushConfig)(params);
+  });
 
-  const { remove: removeDidActivateAudioSession } = callingx.addEventListener(
+  callingx.addEventListener(
     'didActivateAudioSession',
     onDidActivateAudioSession,
   );
-  const { remove: removeDidDeactivateAudioSession } = callingx.addEventListener(
+  callingx.addEventListener(
     'didDeactivateAudioSession',
     onDidDeactivateAudioSession,
   );
@@ -70,13 +63,6 @@ export function setupCallingExpEvents(pushConfig: NonNullable<PushConfig>) {
     } else if (eventName === 'didDeactivateAudioSession') {
       onDidDeactivateAudioSession();
     }
-  });
-
-  setPushLogoutCallback(async () => {
-    removeAnswerCall();
-    removeEndCall();
-    removeDidActivateAudioSession();
-    removeDidDeactivateAudioSession();
   });
 }
 

--- a/packages/react-native-sdk/src/utils/push/setupIosVoipPushEvents.ts
+++ b/packages/react-native-sdk/src/utils/push/setupIosVoipPushEvents.ts
@@ -2,7 +2,6 @@
 
 import { Platform } from 'react-native';
 import { onVoipNotificationReceived } from './internal/ios';
-import { setPushLogoutCallback } from '../internal/pushLogoutCallback';
 import { StreamVideoConfig } from '../StreamVideoRN/types';
 import { videoLoggerSystem } from '@stream-io/video-client';
 import { getCallingxLib } from './libs';
@@ -23,17 +22,7 @@ export function setupIosVoipPushEvents(
   }
 
   const callingx = getCallingxLib();
-  const voipNotificationReceivedListener = callingx.addEventListener(
-    'voipNotificationReceived',
-    (params) => {
-      onVoipNotificationReceived(params, pushConfig);
-    },
-  );
-
-  setPushLogoutCallback(async () => {
-    videoLoggerSystem
-      .getLogger('setPushLogoutCallback')
-      .debug('notification event listener removed');
-    voipNotificationReceivedListener.remove();
+  callingx.addEventListener('voipNotificationReceived', (params) => {
+    onVoipNotificationReceived(params, pushConfig);
   });
 }


### PR DESCRIPTION
### 💡 Overview

Ringing push stops working after a user logs out and logs back in on the same app instance. Users don't see or can't answer incoming calls until they kill and reopen the app.

### 📝 Implementation notes

`StreamVideoRN.setPushConfig()` runs once at app startup and installs native event listeners (CallKit `answerCall`/`endCall`, iOS VoIP `voipNotificationReceived`). Those listeners were tied to `onPushLogout()` — so the
first logout removed them for good, and `setPushConfig()` has a guard that blocks re-registration.

Fix:
- Don't tear down those listeners on logout. They live for the app's lifetime, push tokens were removed on logout anyway so if logout happened we wont get incoming call pushes anyway.
- Clear `pushLogoutCallbacks` after `onPushLogout()` runs, so per-login token cleanup callbacks don't pile up across login/logout cycles.

Token registration and removal on login/logout are unchanged — those already work correctly per-login.

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
