### PR TITLE
feat(client): bound SFU reconnection attempts and harden ICE recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,54 @@ Examples:
 - Public surfaces: explicit TypeScript types/interfaces
 - Consistent naming: `camelCase` for functions/properties, `PascalCase` for components/types
 
+## Class style
+
+- **All class methods must be arrow-function class fields**, not method syntax — including `private`/`protected` methods. This is the convention across `packages/client/src/` (e.g., `Call.leave = async (...) => {}`, `BasePeerConnection.isHealthy = () => {}`). Method syntax breaks it.
+
+  ```ts
+  // good
+  class Foo {
+    doThing = (x: number) => x + 1;
+    private helper = () => {
+      /* ... */
+    };
+  }
+
+  // bad
+  class Foo {
+    doThing(x: number) {
+      return x + 1;
+    }
+    private helper() {
+      /* ... */
+    }
+  }
+  ```
+
+- **Declare state as explicit class fields** at the class body level, not as TypeScript parameter-property shorthand (`constructor(private foo: Foo)`). Assign them from the constructor body. Use field initializers for constants.
+
+  ```ts
+  // good
+  class Foo {
+    private a: number;
+    private b: number;
+    private cache: Map<string, number> = new Map();
+
+    constructor(a: number, b: number) {
+      this.a = a;
+      this.b = b;
+    }
+  }
+
+  // bad
+  class Foo {
+    constructor(
+      private a: number,
+      private b: number,
+    ) {}
+  }
+  ```
+
 ### Deprecation lifecycle
 
 1. Mark with `@deprecated` + rationale + alternative.

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -226,6 +226,36 @@ Sorting is **visibility-aware**: only applies sorting logic to invisible partici
 
 ## Key Patterns
 
+### Class Style
+
+- All class methods (including `private`/`protected`) are **arrow-function class fields**, not method syntax. This preserves `this` binding automatically across callbacks and observable subscriptions that pull methods off instances (`call.leave`, dispatcher listeners, RxJS operators, etc.) and matches existing code throughout `src/`.
+
+  ```ts
+  // good (matches the codebase)
+  class Publisher extends BasePeerConnection {
+    restartIce = async (): Promise<void> => {
+      /* ... */
+    };
+    private negotiate = async (options?: RTCOfferOptions): Promise<void> => {
+      /* ... */
+    };
+  }
+
+  // bad
+  class Publisher extends BasePeerConnection {
+    async restartIce(): Promise<void> {
+      /* ... */
+    }
+    private async negotiate(options?: RTCOfferOptions): Promise<void> {
+      /* ... */
+    }
+  }
+  ```
+
+- Declare state as explicit class fields at the body level (not TypeScript parameter-property shorthand) and assign from the constructor body. Initialize constants inline.
+
+  See the root `AGENTS.md` "Class style" section for the full rule and rationale.
+
 ### Reactive State
 
 All state is exposed through RxJS observables. When updating state:

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1600,11 +1600,12 @@ export class Call {
       // connection that never reached `connected`/`completed`.
       if (reason === ReconnectReason.ICE_NEVER_CONNECTED) {
         this.iceFailuresWithoutConnect++;
-      }
-
-      if (this.iceFailuresWithoutConnect >= this.maxIceFailuresWithoutConnect) {
-        await giveUpAndLeave('webrtc_unsupported_network');
-        return;
+        if (
+          this.iceFailuresWithoutConnect >= this.maxIceFailuresWithoutConnect
+        ) {
+          await giveUpAndLeave('webrtc_unsupported_network');
+          return;
+        }
       }
 
       let attempt = 0;

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -7,7 +7,9 @@ import {
   isAudioTrackType,
   isSfuEvent,
   muteTypeToTrackType,
+  NegotiationError,
   Publisher,
+  ReconnectReason,
   Subscriber,
   toRtcConfiguration,
   TrackPublishOptions,
@@ -148,6 +150,7 @@ import { PermissionsContext } from './permissions';
 import { CallTypes } from './CallType';
 import { StreamClient } from './coordinator/connection/client';
 import { retryInterval, sleep } from './coordinator/connection/utils';
+import { SlidingWindowRateLimiter } from './helpers/SlidingWindowRateLimiter';
 import {
   AllCallEvents,
   CallEventListener,
@@ -271,6 +274,17 @@ export class Call {
   private disconnectionTimeoutSeconds: number = 0;
   private lastOfflineTimestamp: number = 0;
   private networkAvailableTask: PromiseWithResolvers<void> | undefined;
+
+  // (10 attempts per rolling 120 s window).
+  private readonly rejoinRateLimiter = new SlidingWindowRateLimiter(10, 120000);
+  // "Network doesn't support WebRTC" detector: counts peer-connection
+  // failures where ICE never reached `connected`/`completed`.
+  private maxIceFailuresWithoutConnect = 2;
+  private iceFailuresWithoutConnect = 0;
+  // Consecutive-negotiation-failure detector: stops the reconnect loop when
+  // the SFU keeps failing to negotiate SDP for us.
+  private maxConsecutiveNegotiationFailures = 3;
+  private consecutiveNegotiationFailures = 0;
   // maintain the order of publishing tracks to restore them after a reconnection
   // it shouldn't contain duplicates
   private trackPublishOrder: TrackType[] = [];
@@ -693,6 +707,13 @@ export class Call {
       this.state.setCallingState(CallingState.LEFT);
       this.state.setParticipants([]);
       this.state.dispose();
+
+      // Reset reconnect-related accumulators so a future `call.join()` on the
+      // same instance starts with a fresh budget. The `Call` may be reused
+      // (see `Call.test.ts` "can reuse call instance") so this is required.
+      this.rejoinRateLimiter.reset();
+      this.iceFailuresWithoutConnect = 0;
+      this.consecutiveNegotiationFailures = 0;
 
       // Call all leave call hooks, e.g. to clean up global event handlers
       this.leaveCallHooks.forEach((hook) => hook());
@@ -1169,9 +1190,23 @@ export class Call {
     // when performing fast reconnect, or when we reuse the same SFU client,
     // (ws remained healthy), we just need to restore the ICE connection
     if (performingFastReconnect) {
-      // the SFU automatically issues an ICE restart on the subscriber
-      // we don't have to do it ourselves
-      await this.restoreICE(sfuClient, { includeSubscriber: false });
+      // The SFU automatically issues an ICE restart on the subscriber,
+      // so we only need to decide about the publisher. If the publisher's
+      // peer connection is still stable (ICE still connected end-to-end),
+      // the signal WebSocket drop was the only problem — the new WS alone
+      // is enough, and restarting ICE would add unnecessary SDP/ICE churn.
+      const publisherIsStable = this.publisher?.isStable() ?? true;
+      const includePublisher =
+        !!this.publisher?.isPublishing() && !publisherIsStable;
+      if (!includePublisher && this.publisher?.isPublishing()) {
+        this.logger.info(
+          '[Reconnect] FAST: skipping publisher ICE restart, publisher PC is stable',
+        );
+      }
+      await this.restoreICE(sfuClient, {
+        includeSubscriber: false,
+        includePublisher,
+      });
     } else {
       const connectionConfig = toRtcConfiguration(this.credentials.ice_servers);
       this.initPublisherAndSubscriber({
@@ -1223,6 +1258,15 @@ export class Call {
     // reset the reconnect strategy to unspecified after a successful reconnection
     this.reconnectStrategy = WebsocketReconnectStrategy.UNSPECIFIED;
     this.reconnectReason = '';
+    // A successful SFU join handshake resets the consecutive-negotiation
+    // counter (negotiation just succeeded). It does NOT reset
+    // `iceFailuresWithoutConnect` or the rolling `rejoinRateLimiter`;
+    // those track WebRTC-level health and rejoin frequency, which are not
+    // proven by the SFU handshake alone. ICE-failures-without-connect is
+    // cleared via the `onIceConnected` callback when the peer connection
+    // actually reaches `connected`/`completed` end-to-end. The rejoin
+    // rolling window decays naturally as old timestamps age out.
+    this.consecutiveNegotiationFailures = 0;
 
     this.logger.info(`Joined call ${this.cid}`);
   };
@@ -1375,6 +1419,12 @@ export class Call {
           this.logger.warn(message, err);
         });
       },
+      onIceConnected: () => {
+        // ICE has reached `connected`/`completed` end-to-end on at least
+        // one peer connection, WebRTC is actually working, so the
+        // "ICE never connected" failure budget can be cleared.
+        this.iceFailuresWithoutConnect = 0;
+      },
     };
 
     this.subscriber = new Subscriber(basePeerConnectionOptions);
@@ -1505,7 +1555,7 @@ export class Call {
    */
   private reconnect = async (
     strategy: WebsocketReconnectStrategy,
-    reason: string,
+    reason: ReconnectReason,
   ): Promise<void> => {
     if (
       this.state.callingState === CallingState.RECONNECTING ||
@@ -1529,6 +1579,34 @@ export class Call {
         }
       };
 
+      const giveUpAndLeave = async (message: string) => {
+        this.logger.warn(
+          `[Reconnect] Giving up: ${message}. Leaving the call.`,
+        );
+        // If we're mid-iteration, the state can be JOINING; `Call.leave` would
+        // then wait for JOINED before proceeding, but no more attempts will run
+        // so JOINED never comes. Transition to RECONNECTING so `leave()` proceeds.
+        if (this.state.callingState === CallingState.JOINING) {
+          this.state.setCallingState(CallingState.RECONNECTING);
+        }
+        try {
+          await this.leave({ message });
+        } catch (err) {
+          this.logger.warn(`[Reconnect] leave() failed after ${message}`, err);
+        }
+      };
+
+      // Count this entry into reconnect if it was triggered by a peer
+      // connection that never reached `connected`/`completed`.
+      if (reason === ReconnectReason.ICE_NEVER_CONNECTED) {
+        this.iceFailuresWithoutConnect++;
+      }
+
+      if (this.iceFailuresWithoutConnect >= this.maxIceFailuresWithoutConnect) {
+        await giveUpAndLeave('webrtc_unsupported_network');
+        return;
+      }
+
       let attempt = 0;
       do {
         const reconnectingTime = Date.now() - reconnectStartTime;
@@ -1542,6 +1620,19 @@ export class Call {
           );
           await markAsReconnectingFailed();
           return;
+        }
+
+        // Rejoin rate limit: bound the number of REJOIN (and MIGRATE)
+        // transitions inside a rolling window. FAST is not counted because
+        // it does not issue a new backend `joinCall`.
+        if (
+          this.reconnectStrategy === WebsocketReconnectStrategy.REJOIN ||
+          this.reconnectStrategy === WebsocketReconnectStrategy.MIGRATE
+        ) {
+          if (!this.rejoinRateLimiter.tryRegister()) {
+            await giveUpAndLeave('rejoin_attempt_limit_exceeded');
+            return;
+          }
         }
 
         // we don't increment reconnect attempts for the FAST strategy.
@@ -1581,6 +1672,8 @@ export class Call {
               );
               break;
           }
+          // reconnection worked — reset the negotiation-failure streak.
+          this.consecutiveNegotiationFailures = 0;
           break; // do-while loop, reconnection worked, exit the loop
         } catch (error) {
           if (this.state.callingState === CallingState.OFFLINE) {
@@ -1599,8 +1692,19 @@ export class Call {
             await markAsReconnectingFailed();
             return;
           }
+          if (error instanceof NegotiationError) {
+            this.consecutiveNegotiationFailures++;
+            if (
+              this.consecutiveNegotiationFailures >=
+              this.maxConsecutiveNegotiationFailures
+            ) {
+              await giveUpAndLeave('repeated_negotiation_failures');
+              return;
+            }
+          }
 
-          await sleep(500);
+          // exponential backoff with jitter, capped at 5 s
+          await sleep(retryInterval(attempt));
 
           const wasMigrating =
             this.reconnectStrategy === WebsocketReconnectStrategy.MIGRATE;
@@ -1741,9 +1845,10 @@ export class Call {
   private registerReconnectHandlers = () => {
     // handles the legacy "goAway" event
     const unregisterGoAway = this.on('goAway', () => {
-      this.reconnect(WebsocketReconnectStrategy.MIGRATE, 'goAway').catch(
-        (err) => this.logger.warn('[Reconnect] Error reconnecting', err),
-      );
+      this.reconnect(
+        WebsocketReconnectStrategy.MIGRATE,
+        ReconnectReason.GO_AWAY,
+      ).catch((err) => this.logger.warn('[Reconnect] Error reconnecting', err));
     });
 
     // handles the "error" event, through which the SFU can request a reconnect
@@ -1760,7 +1865,10 @@ export class Call {
           this.logger.warn(`Can't leave call after disconnect request`, err);
         });
       } else {
-        this.reconnect(strategy, error?.message || 'SFU Error').catch((err) => {
+        this.reconnect(
+          strategy,
+          error?.message || ReconnectReason.SFU_ERROR,
+        ).catch((err) => {
           this.logger.warn('[Reconnect] Error reconnecting', err);
         });
       }
@@ -1787,12 +1895,14 @@ export class Call {
               }
             }
 
-            this.reconnect(strategy, 'Going online').catch((err) => {
-              this.logger.warn(
-                '[Reconnect] Error reconnecting after going online',
-                err,
-              );
-            });
+            this.reconnect(strategy, ReconnectReason.NETWORK_BACK_ONLINE).catch(
+              (err) => {
+                this.logger.warn(
+                  '[Reconnect] Error reconnecting after going online',
+                  err,
+                );
+              },
+            );
           });
           this.networkAvailableTask = networkAvailableTask;
           this.sfuStatsReporter?.stop();
@@ -3056,6 +3166,41 @@ export class Call {
    */
   setDisconnectionTimeout = (timeoutSeconds: number) => {
     this.disconnectionTimeoutSeconds = timeoutSeconds;
+  };
+
+  /**
+   * Configures the rolling-window limit for REJOIN/MIGRATE attempts. Once
+   * `maxAttempts` rejoins have been registered inside `windowSeconds`, the
+   * SDK stops retrying and transitions the call to `LEFT` with the
+   * `rejoin_attempt_limit_exceeded` leave message.
+   *
+   * Defaults: 10 attempts per 120 seconds (aligned with the Swift SDK).
+   */
+  setRejoinAttemptLimit = (maxAttempts: number, windowSeconds: number) => {
+    this.rejoinRateLimiter.setLimits(maxAttempts, windowSeconds * 1000);
+  };
+
+  /**
+   * Configures how many peer-connection failures where ICE never reached
+   * `connected`/`completed` are tolerated before the SDK concludes that the
+   * current network cannot support WebRTC and transitions the call to
+   * `LEFT` with the `webrtc_unsupported_network` leave message.
+   *
+   * Default: 2.
+   */
+  setMaxIceFailuresWithoutConnect = (n: number) => {
+    this.maxIceFailuresWithoutConnect = n;
+  };
+
+  /**
+   * Configures how many consecutive SDP `NegotiationError`s are tolerated
+   * before the SDK stops retrying and transitions the call to `LEFT` with
+   * the `repeated_negotiation_failures` leave message.
+   *
+   * Default: 3.
+   */
+  setMaxConsecutiveNegotiationFailures = (n: number) => {
+    this.maxConsecutiveNegotiationFailures = n;
   };
 
   /**

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1551,7 +1551,9 @@ export class Call {
    * @internal
    *
    * @param strategy the reconnection strategy to use.
-   * @param reason the reason for the reconnection.
+   * @param reason the reason for the reconnection. Pass a `ReconnectReason.*`
+   *   constant when the SDK should react to it (e.g.
+   *   `ICE_NEVER_CONNECTED` increments the unsupported-network counter).
    */
   private reconnect = async (
     strategy: WebsocketReconnectStrategy,
@@ -3176,9 +3178,13 @@ export class Call {
    * `rejoin_attempt_limit_exceeded` leave message.
    *
    * Defaults: 10 attempts per 120 seconds (aligned with the Swift SDK).
+   * Both arguments are clamped to a minimum of 1.
    */
   setRejoinAttemptLimit = (maxAttempts: number, windowSeconds: number) => {
-    this.rejoinRateLimiter.setLimits(maxAttempts, windowSeconds * 1000);
+    this.rejoinRateLimiter.setLimits(
+      Math.max(1, maxAttempts),
+      Math.max(1, windowSeconds) * 1000,
+    );
   };
 
   /**
@@ -3187,10 +3193,10 @@ export class Call {
    * current network cannot support WebRTC and transitions the call to
    * `LEFT` with the `webrtc_unsupported_network` leave message.
    *
-   * Default: 2.
+   * Default: 2. Clamped to a minimum of 1.
    */
   setMaxIceFailuresWithoutConnect = (n: number) => {
-    this.maxIceFailuresWithoutConnect = n;
+    this.maxIceFailuresWithoutConnect = Math.max(1, n);
   };
 
   /**
@@ -3198,10 +3204,10 @@ export class Call {
    * before the SDK stops retrying and transitions the call to `LEFT` with
    * the `repeated_negotiation_failures` leave message.
    *
-   * Default: 3.
+   * Default: 3. Clamped to a minimum of 1.
    */
   setMaxConsecutiveNegotiationFailures = (n: number) => {
-    this.maxConsecutiveNegotiationFailures = n;
+    this.maxConsecutiveNegotiationFailures = Math.max(1, n);
   };
 
   /**

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -711,9 +711,16 @@ export class Call {
       // Reset reconnect-related accumulators so a future `call.join()` on the
       // same instance starts with a fresh budget. The `Call` may be reused
       // (see `Call.test.ts` "can reuse call instance") so this is required.
+      // Strategy/reason/attempts must also be cleared: when `leave()` is
+      // reached via `giveUpAndLeave()` the success-path reset at the end of
+      // `joinFlow` never runs, leaving stale values that would make the next
+      // fresh `join()` send a stale `ReconnectDetails` to the SFU.
       this.rejoinRateLimiter.reset();
       this.iceFailuresWithoutConnect = 0;
       this.consecutiveNegotiationFailures = 0;
+      this.reconnectStrategy = WebsocketReconnectStrategy.UNSPECIFIED;
+      this.reconnectReason = '';
+      this.reconnectAttempts = 0;
 
       // Call all leave call hooks, e.g. to clean up global event handlers
       this.leaveCallHooks.forEach((hook) => hook());

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -105,6 +105,21 @@ type SfuWebSocketParams = {
 };
 
 /**
+ * Creates a fresh `joinResponseTask` with a no-op rejection handler attached
+ * to the underlying promise. The handler marks the rejection path as handled
+ * so a teardown-time reject (e.g., from `close()` during disposal) does not
+ * surface as an `UnhandledPromiseRejection`. Explicit awaiters of
+ * `StreamSfuClient.joinTask` still observe the rejection through their own
+ * `then`/`catch` chain. `.catch()` returns a new promise; the original is
+ * unchanged.
+ */
+const makeJoinResponseTask = (): PromiseWithResolvers<JoinResponse> => {
+  const task = promiseWithResolvers<JoinResponse>();
+  task.promise.catch(() => {}); // see the comment above
+  return task;
+};
+
+/**
  * The client used for exchanging information with the SFU.
  */
 export class StreamSfuClient {
@@ -171,9 +186,10 @@ export class StreamSfuClient {
   private networkAvailableTask: PromiseWithResolvers<void> | undefined;
   /**
    * Promise that resolves when the JoinResponse is received.
-   * Rejects after a certain threshold if the response is not received.
+   * Rejects after a certain threshold if the response is not received,
+   * or when the SFU client is disposed before a join completes.
    */
-  private joinResponseTask = promiseWithResolvers<JoinResponse>();
+  private joinResponseTask = makeJoinResponseTask();
 
   /**
    * Promise that resolves when the migration is complete.
@@ -358,15 +374,24 @@ export class StreamSfuClient {
 
   close = (code: number = StreamSfuClient.NORMAL_CLOSURE, reason?: string) => {
     this.isClosingClean = code !== StreamSfuClient.ERROR_CONNECTION_UNHEALTHY;
-    if (this.signalWs.readyState === WebSocket.OPEN) {
+    // Close the WebSocket whether it has fully opened (`OPEN`) or is still
+    // mid-handshake (`CONNECTING`). The WebSocket spec aborts the handshake
+    // when `close()` is called on a CONNECTING socket. Without this, an
+    // SFU socket that opens just after teardown would dispatch events into
+    // a Call instance that has already moved on.
+    const ws = this.signalWs;
+    if (
+      ws.readyState === WebSocket.OPEN ||
+      ws.readyState === WebSocket.CONNECTING
+    ) {
       this.logger.debug(`Closing SFU WS connection: ${code} - ${reason}`);
-      this.signalWs.close(code, `js-client: ${reason}`);
-      this.signalWs.removeEventListener('close', this.handleWebSocketClose);
+      ws.close(code, `js-client: ${reason}`);
+      ws.removeEventListener('close', this.handleWebSocketClose);
     }
-    this.dispose();
+    this.dispose(reason);
   };
 
-  private dispose = () => {
+  private dispose = (reason?: string) => {
     this.logger.debug('Disposing SFU client');
     this.unsubscribeIceTrickle();
     this.unsubscribeNetworkChanged();
@@ -375,6 +400,19 @@ export class StreamSfuClient {
     clearTimeout(this.migrateAwayTimeout);
     this.abortController.abort();
     this.migrationTask?.resolve();
+    // Settle a pending `joinResponseTask` so `leaveAndClose`, `join()`, and
+    // any other awaiters (`await this.joinTask`) don't hang indefinitely
+    // when the SFU client is torn down before the SFU sent a JoinResponse.
+    if (
+      !this.joinResponseTask.isResolved() &&
+      !this.joinResponseTask.isRejected()
+    ) {
+      this.joinResponseTask.reject(
+        new Error(
+          `SFU client disposed before join completed${reason ? `: ${reason}` : ''}`,
+        ),
+      );
+    }
     this.iceTrickleBuffer.dispose();
   };
 
@@ -385,8 +423,10 @@ export class StreamSfuClient {
   leaveAndClose = async (reason: string) => {
     try {
       this.isLeaving = true;
-      await this.joinTask;
-      await this.notifyLeave(reason);
+      // Only attempt to notify the SFU if the join handshake actually completed
+      if (this.joinResponseTask.isResolved()) {
+        await this.notifyLeave(reason);
+      }
     } catch (err) {
       this.logger.debug('Error notifying SFU about leaving call', err);
     }
@@ -535,9 +575,9 @@ export class StreamSfuClient {
     ) {
       // we need to lock the RPC requests until we receive a JoinResponse.
       // that's why we have this primitive lock mechanism.
-      // the client starts with already initialized joinResponseTask,
+      // the client starts with an already initialized joinResponseTask,
       // and this code creates a new one for the next join request.
-      this.joinResponseTask = promiseWithResolvers<JoinResponse>();
+      this.joinResponseTask = makeJoinResponseTask();
     }
 
     // capture a reference to the current joinResponseTask as it might

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -28,7 +28,7 @@ import {
 } from './gen/video/sfu/signal_rpc/signal';
 import { ICETrickle } from './gen/video/sfu/models/models';
 import { StreamClient } from './coordinator/connection/client';
-import { generateUUIDv4 } from './coordinator/connection/utils';
+import { generateUUIDv4, sleep } from './coordinator/connection/utils';
 import { Credentials } from './gen/coordinator';
 import { ScopedLogger, videoLoggerSystem } from './logger';
 import {
@@ -223,6 +223,12 @@ export class StreamSfuClient {
    * The close code used when the client fails to join the call (on the SFU).
    */
   static JOIN_FAILED = 4101;
+  /**
+   * Best-effort grace period in `leaveAndClose` for an in-flight join to
+   * complete before we give up and close without sending `leaveCallRequest`.
+   * Bounded so a stuck join can never hang the leave path.
+   */
+  static LEAVE_NOTIFY_GRACE_MS = 1000;
 
   /**
    * Constructs a new SFU client.
@@ -423,9 +429,26 @@ export class StreamSfuClient {
   leaveAndClose = async (reason: string) => {
     try {
       this.isLeaving = true;
-      // Only attempt to notify the SFU if the join handshake actually completed
+      // Best-effort: give an in-flight join a short grace period to complete
+      // so we can send a graceful `leaveCallRequest`. Bounded so we never hang
+      // here if the SFU is unresponsive. If the task settles either way during
+      // the wait, the re-check below decides whether to notify.
+      if (
+        !this.joinResponseTask.isResolved() &&
+        !this.joinResponseTask.isRejected()
+      ) {
+        await Promise.race([
+          // swallow rejection — we re-check `isResolved()` below to decide
+          this.joinResponseTask.promise.catch(() => {}),
+          sleep(StreamSfuClient.LEAVE_NOTIFY_GRACE_MS),
+        ]);
+      }
       if (this.joinResponseTask.isResolved()) {
         await this.notifyLeave(reason);
+      } else {
+        this.logger.debug(
+          '[leaveAndClose] join not completed within grace period, skipping notifyLeave',
+        );
       }
     } catch (err) {
       this.logger.debug('Error notifying SFU about leaving call', err);

--- a/packages/client/src/__tests__/StreamSfuClient.test.ts
+++ b/packages/client/src/__tests__/StreamSfuClient.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StreamSfuClient } from '../StreamSfuClient';
+import { Dispatcher } from '../rtc';
+import { StreamClient } from '../coordinator/connection/client';
+
+/**
+ * Minimal `WebSocket` stub used to drive `StreamSfuClient.close()` while the
+ * underlying connection is still in `CONNECTING` state. The constructor
+ * leaves `readyState = CONNECTING`; `close()` records the call and flips
+ * to `CLOSED` so subsequent assertions can see what happened.
+ */
+class CapturingWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: CapturingWebSocket[] = [];
+
+  readyState = CapturingWebSocket.CONNECTING;
+  url: string;
+  binaryType = 'blob';
+  closeArgs: { code?: number; reason?: string } | undefined;
+  private listeners = new Map<string, Set<(e: unknown) => void>>();
+
+  constructor(url: string | URL) {
+    this.url = typeof url === 'string' ? url : url.toString();
+    CapturingWebSocket.instances.push(this);
+  }
+
+  addEventListener(event: string, listener: (e: unknown) => void) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+  }
+  removeEventListener(event: string, listener: (e: unknown) => void) {
+    this.listeners.get(event)?.delete(listener);
+  }
+  close(code?: number, reason?: string) {
+    this.closeArgs = { code, reason };
+    this.readyState = CapturingWebSocket.CLOSED;
+  }
+}
+
+const buildSfuClient = () => {
+  const dispatcher = new Dispatcher();
+  const streamClient = new StreamClient('test-key');
+  return new StreamSfuClient({
+    dispatcher,
+    sessionId: 'session-id-test',
+    streamClient,
+    cid: 'default:test',
+    credentials: {
+      server: {
+        url: 'https://test.invalid',
+        ws_endpoint: 'wss://test.invalid/ws',
+        edge_name: 'sfu-test',
+      },
+      token: 'token',
+      ice_servers: [],
+    },
+    tag: 'test',
+    enableTracing: false,
+  });
+};
+
+describe('StreamSfuClient.close()', () => {
+  beforeEach(() => {
+    CapturingWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', CapturingWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('closes the WebSocket even when it is still in CONNECTING state', () => {
+    const sfuClient = buildSfuClient();
+    const ws = CapturingWebSocket.instances.at(-1)!;
+    expect(ws.readyState).toBe(CapturingWebSocket.CONNECTING);
+
+    sfuClient.close(1000, 'tearing down');
+
+    expect(ws.closeArgs).toBeDefined();
+    expect(ws.closeArgs?.code).toBe(1000);
+    expect(ws.readyState).toBe(CapturingWebSocket.CLOSED);
+  });
+
+  it('rejects a pending joinResponseTask on close so awaiters do not hang', async () => {
+    const sfuClient = buildSfuClient();
+    const joinTask = sfuClient.joinTask;
+
+    sfuClient.close(1000, 'aborting');
+
+    await expect(joinTask).rejects.toThrow(/SFU client disposed/);
+  });
+
+  it('does not blow up when the WebSocket is already CLOSED', () => {
+    const sfuClient = buildSfuClient();
+    const ws = CapturingWebSocket.instances.at(-1)!;
+    ws.readyState = CapturingWebSocket.CLOSED;
+
+    expect(() => sfuClient.close(1000, 'noop')).not.toThrow();
+    // close() should not be called twice
+    expect(ws.closeArgs).toBeUndefined();
+  });
+
+  it('close() does NOT produce an unhandled rejection when nobody awaits joinTask', async () => {
+    // Capture unhandledrejection events that fire during this test. Without
+    // the safe-catch attached to `joinResponseTask.promise`, dispose-time
+    // reject would surface here.
+    const unhandled: PromiseRejectionEvent[] = [];
+    const onUnhandled = (e: PromiseRejectionEvent) => {
+      unhandled.push(e);
+      // mark as handled so it doesn't crash the test runner
+      e.preventDefault?.();
+    };
+    if (typeof window !== 'undefined') {
+      window.addEventListener('unhandledrejection', onUnhandled);
+    }
+    // Node-side fallback so the test passes regardless of test environment.
+    const onProcessUnhandled = (reason: unknown) => {
+      unhandled.push({ reason } as unknown as PromiseRejectionEvent);
+    };
+    process.on('unhandledRejection', onProcessUnhandled);
+
+    try {
+      const sfuClient = buildSfuClient();
+      // Intentionally do NOT touch joinTask anywhere — no .catch, no await.
+      sfuClient.close(1000, 'aborting before any join');
+
+      // give microtasks + a tick for any unhandledrejection event to fire
+      await new Promise((r) => setTimeout(r, 50));
+      expect(unhandled).toHaveLength(0);
+    } finally {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('unhandledrejection', onUnhandled);
+      }
+      process.off('unhandledRejection', onProcessUnhandled);
+    }
+  });
+});

--- a/packages/client/src/__tests__/StreamSfuClient.test.ts
+++ b/packages/client/src/__tests__/StreamSfuClient.test.ts
@@ -104,6 +104,30 @@ describe('StreamSfuClient.close()', () => {
     expect(ws.closeArgs).toBeUndefined();
   });
 
+  it('leaveAndClose returns within ~grace period when the SFU is silent (no hang)', async () => {
+    const sfuClient = buildSfuClient();
+    vi.spyOn(
+      sfuClient as unknown as {
+        notifyLeave: (reason: string) => Promise<void>;
+      },
+      'notifyLeave',
+    ).mockResolvedValue(undefined);
+
+    // joinResponseTask stays pending forever — verify leaveAndClose still returns.
+    const start = Date.now();
+    await Promise.race([
+      sfuClient.leaveAndClose('silent-sfu'),
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error('leaveAndClose hung past 2x grace')),
+          StreamSfuClient.LEAVE_NOTIFY_GRACE_MS * 2,
+        ),
+      ),
+    ]);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(StreamSfuClient.LEAVE_NOTIFY_GRACE_MS * 2);
+  });
+
   it('close() does NOT produce an unhandled rejection when nobody awaits joinTask', async () => {
     // Capture unhandledrejection events that fire during this test. Without
     // the safe-catch attached to `joinResponseTask.promise`, dispose-time
@@ -137,5 +161,115 @@ describe('StreamSfuClient.close()', () => {
       }
       process.off('unhandledRejection', onProcessUnhandled);
     }
+  });
+});
+
+describe('StreamSfuClient.leaveAndClose()', () => {
+  beforeEach(() => {
+    CapturingWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', CapturingWebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  type JoinResponseTaskHandle = {
+    joinResponseTask: {
+      resolve: (v: unknown) => void;
+      reject: (err: unknown) => void;
+    };
+  };
+
+  it('notifies the SFU when joinResponseTask is already resolved', async () => {
+    const sfuClient = buildSfuClient();
+    (sfuClient as unknown as JoinResponseTaskHandle).joinResponseTask.resolve(
+      {},
+    );
+    const notifyLeaveSpy = vi
+      .spyOn(
+        sfuClient as unknown as {
+          notifyLeave: (reason: string) => Promise<void>;
+        },
+        'notifyLeave',
+      )
+      .mockResolvedValue(undefined);
+
+    await sfuClient.leaveAndClose('user-leaving');
+
+    expect(notifyLeaveSpy).toHaveBeenCalledWith('user-leaving');
+  });
+
+  it('waits for an in-flight join and notifies the SFU when it resolves within the grace period', async () => {
+    const sfuClient = buildSfuClient();
+    const notifyLeaveSpy = vi
+      .spyOn(
+        sfuClient as unknown as {
+          notifyLeave: (reason: string) => Promise<void>;
+        },
+        'notifyLeave',
+      )
+      .mockResolvedValue(undefined);
+
+    vi.useFakeTimers();
+    const leavePromise = sfuClient.leaveAndClose('user-leaving');
+
+    // simulate the SFU sending JoinResponse 50 ms in (well within the grace window)
+    await vi.advanceTimersByTimeAsync(50);
+    (sfuClient as unknown as JoinResponseTaskHandle).joinResponseTask.resolve(
+      {},
+    );
+    // flush remaining timers (the losing race branch and any microtasks)
+    await vi.runAllTimersAsync();
+    await leavePromise;
+
+    expect(notifyLeaveSpy).toHaveBeenCalledWith('user-leaving');
+  });
+
+  it('skips notifyLeave when the join does not complete within the grace period', async () => {
+    const sfuClient = buildSfuClient();
+    const notifyLeaveSpy = vi
+      .spyOn(
+        sfuClient as unknown as {
+          notifyLeave: (reason: string) => Promise<void>;
+        },
+        'notifyLeave',
+      )
+      .mockResolvedValue(undefined);
+
+    vi.useFakeTimers();
+    const leavePromise = sfuClient.leaveAndClose('silent-sfu');
+    // run past the grace window — the task is never resolved
+    await vi.advanceTimersByTimeAsync(
+      StreamSfuClient.LEAVE_NOTIFY_GRACE_MS + 50,
+    );
+    await leavePromise;
+
+    expect(notifyLeaveSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips notifyLeave when joinResponseTask rejects within the grace period', async () => {
+    const sfuClient = buildSfuClient();
+    const notifyLeaveSpy = vi
+      .spyOn(
+        sfuClient as unknown as {
+          notifyLeave: (reason: string) => Promise<void>;
+        },
+        'notifyLeave',
+      )
+      .mockResolvedValue(undefined);
+
+    vi.useFakeTimers();
+    const leavePromise = sfuClient.leaveAndClose('rejected');
+    await vi.advanceTimersByTimeAsync(20);
+    (sfuClient as unknown as JoinResponseTaskHandle).joinResponseTask.reject(
+      new Error('SFU went away'),
+    );
+    await vi.runAllTimersAsync();
+    await leavePromise;
+
+    expect(notifyLeaveSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/client/src/helpers/SlidingWindowRateLimiter.ts
+++ b/packages/client/src/helpers/SlidingWindowRateLimiter.ts
@@ -1,0 +1,49 @@
+/**
+ * A generic sliding-window rate limiter.
+ *
+ * Allows at most `maxAttempts` registrations inside a rolling `windowMs`.
+ * Attempts spaced further apart than `windowMs` are always allowed.
+ */
+export class SlidingWindowRateLimiter {
+  private maxAttempts: number;
+  private windowMs: number;
+  private timestamps: number[] = [];
+
+  constructor(maxAttempts: number, windowMs: number) {
+    this.maxAttempts = maxAttempts;
+    this.windowMs = windowMs;
+  }
+
+  /**
+   * Attempts to register a new event at `now`. Returns `true` if the attempt
+   * fits inside the budget (and records it), or `false` if the budget is
+   * exhausted (in which case no timestamp is recorded).
+   */
+  tryRegister = (now: number = Date.now()): boolean => {
+    this.prune(now);
+    if (this.timestamps.length >= this.maxAttempts) return false;
+    this.timestamps.push(now);
+    return true;
+  };
+
+  /**
+   * Clears the attempt history.
+   */
+  reset = (): void => {
+    this.timestamps = [];
+  };
+
+  /**
+   * Updates the budget and window size. Existing timestamps are kept; they
+   * will be pruned by the next `tryRegister` call.
+   */
+  setLimits = (maxAttempts: number, windowMs: number): void => {
+    this.maxAttempts = maxAttempts;
+    this.windowMs = windowMs;
+  };
+
+  private prune = (now: number): void => {
+    const cutoff = now - this.windowMs;
+    this.timestamps = this.timestamps.filter((t) => t >= cutoff);
+  };
+}

--- a/packages/client/src/helpers/__tests__/SlidingWindowRateLimiter.test.ts
+++ b/packages/client/src/helpers/__tests__/SlidingWindowRateLimiter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { SlidingWindowRateLimiter } from '../SlidingWindowRateLimiter';
+
+describe('SlidingWindowRateLimiter', () => {
+  it('allows up to the configured number of attempts inside the window', () => {
+    const limiter = new SlidingWindowRateLimiter(3, 1000);
+    expect(limiter.tryRegister(0)).toBe(true);
+    expect(limiter.tryRegister(10)).toBe(true);
+    expect(limiter.tryRegister(20)).toBe(true);
+    // fourth attempt inside the same window is denied
+    expect(limiter.tryRegister(30)).toBe(false);
+  });
+
+  it('prunes timestamps outside the rolling window so attempts after it pass', () => {
+    const limiter = new SlidingWindowRateLimiter(2, 1000);
+    expect(limiter.tryRegister(0)).toBe(true);
+    expect(limiter.tryRegister(500)).toBe(true);
+    expect(limiter.tryRegister(900)).toBe(false);
+    // at t=1501 cutoff=501, so both 0 and 500 fall out of window
+    expect(limiter.tryRegister(1501)).toBe(true);
+  });
+
+  it('reset() clears the attempt history', () => {
+    const limiter = new SlidingWindowRateLimiter(2, 1000);
+    limiter.tryRegister(0);
+    limiter.tryRegister(100);
+    expect(limiter.tryRegister(200)).toBe(false);
+    limiter.reset();
+    expect(limiter.tryRegister(300)).toBe(true);
+    expect(limiter.tryRegister(400)).toBe(true);
+    expect(limiter.tryRegister(500)).toBe(false);
+  });
+
+  it('setLimits() updates the budget and window in place', () => {
+    const limiter = new SlidingWindowRateLimiter(2, 1000);
+    limiter.tryRegister(0);
+    limiter.tryRegister(100);
+    expect(limiter.tryRegister(200)).toBe(false);
+    // raising the limit lets the next attempt through without reset
+    limiter.setLimits(5, 1000);
+    expect(limiter.tryRegister(300)).toBe(true);
+  });
+});

--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -40,6 +40,7 @@ export abstract class BasePeerConnection {
   private readonly iceRestartDelay: number;
   private iceHasEverConnected = false;
   private iceRestartTimeout?: NodeJS.Timeout;
+  private preConnectStuckTimeout?: NodeJS.Timeout;
   protected isIceRestarting = false;
   private isDisposed = false;
 
@@ -117,6 +118,8 @@ export abstract class BasePeerConnection {
   dispose() {
     clearTimeout(this.iceRestartTimeout);
     this.iceRestartTimeout = undefined;
+    clearTimeout(this.preConnectStuckTimeout);
+    this.preConnectStuckTimeout = undefined;
     this.onReconnectionNeeded = undefined;
     this.onIceConnected = undefined;
     this.isDisposed = true;
@@ -360,6 +363,8 @@ export abstract class BasePeerConnection {
     if (!this.iceHasEverConnected) {
       if (state === 'failed') {
         this.logger.info('ICE failed before connected, escalating to REJOIN');
+        clearTimeout(this.preConnectStuckTimeout);
+        this.preConnectStuckTimeout = undefined;
         this.onReconnectionNeeded?.(
           WebsocketReconnectStrategy.REJOIN,
           ReconnectReason.ICE_NEVER_CONNECTED,
@@ -369,6 +374,26 @@ export abstract class BasePeerConnection {
       }
       if (state === 'disconnected') {
         this.logger.info('ICE disconnected before connected, wait to recover');
+        // Watchdog: if the browser stays in `disconnected` without ever
+        // reaching `connected` or transitioning to `failed`, escalate to
+        // REJOIN ourselves so we don't wait silently forever. Rare but
+        // observed on flaky mobile networks.
+        clearTimeout(this.preConnectStuckTimeout);
+        this.preConnectStuckTimeout = setTimeout(() => {
+          if (
+            !this.iceHasEverConnected &&
+            this.pc.iceConnectionState === 'disconnected'
+          ) {
+            this.logger.info(
+              'ICE stuck in pre-connect disconnected, escalating to REJOIN',
+            );
+            this.onReconnectionNeeded?.(
+              WebsocketReconnectStrategy.REJOIN,
+              ReconnectReason.ICE_NEVER_CONNECTED,
+              this.peerType,
+            );
+          }
+        }, this.iceRestartDelay * 2);
         return;
       }
     }
@@ -409,6 +434,9 @@ export abstract class BasePeerConnection {
           clearTimeout(this.iceRestartTimeout);
           this.iceRestartTimeout = undefined;
         }
+        // clear the pre-connect watchdog if it was armed
+        clearTimeout(this.preConnectStuckTimeout);
+        this.preConnectStuckTimeout = undefined;
         break;
     }
   };

--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -13,7 +13,12 @@ import { StreamSfuClient } from '../StreamSfuClient';
 import { AllSfuEvents, Dispatcher } from './Dispatcher';
 import { withoutConcurrency } from '../helpers/concurrency';
 import { StatsTracer, Tracer, traceRTCPeerConnection } from '../stats';
-import type { BasePeerConnectionOpts, OnReconnectionNeeded } from './types';
+import {
+  BasePeerConnectionOpts,
+  OnIceConnected,
+  OnReconnectionNeeded,
+  ReconnectReason,
+} from './types';
 import type { ClientPublishOptions } from '../types';
 
 /**
@@ -31,7 +36,9 @@ export abstract class BasePeerConnection {
   protected sfuClient: StreamSfuClient;
 
   private onReconnectionNeeded?: OnReconnectionNeeded;
+  private onIceConnected?: OnIceConnected;
   private readonly iceRestartDelay: number;
+  private iceHasEverConnected = false;
   private iceRestartTimeout?: NodeJS.Timeout;
   protected isIceRestarting = false;
   private isDisposed = false;
@@ -56,6 +63,7 @@ export abstract class BasePeerConnection {
       state,
       dispatcher,
       onReconnectionNeeded,
+      onIceConnected,
       tag,
       enableTracing,
       clientPublishOptions,
@@ -70,6 +78,7 @@ export abstract class BasePeerConnection {
     this.clientPublishOptions = clientPublishOptions;
     this.tag = tag;
     this.onReconnectionNeeded = onReconnectionNeeded;
+    this.onIceConnected = onIceConnected;
     this.logger = videoLoggerSystem.getLogger(
       peerType === PeerType.SUBSCRIBER ? 'Subscriber' : 'Publisher',
       { tags: [tag] },
@@ -109,6 +118,7 @@ export abstract class BasePeerConnection {
     clearTimeout(this.iceRestartTimeout);
     this.iceRestartTimeout = undefined;
     this.onReconnectionNeeded = undefined;
+    this.onIceConnected = undefined;
     this.isDisposed = true;
     this.detachEventHandlers();
     this.pc.close();
@@ -145,14 +155,17 @@ export abstract class BasePeerConnection {
    */
   protected tryRestartIce = () => {
     this.restartIce().catch((e) => {
-      const reason = 'restartICE() failed, initiating reconnect';
-      this.logger.error(reason, e);
+      this.logger.error('restartICE() failed, initiating reconnect', e);
       const strategy =
         e instanceof NegotiationError &&
         e.error.code === ErrorCode.PARTICIPANT_SIGNAL_LOST
           ? WebsocketReconnectStrategy.FAST
           : WebsocketReconnectStrategy.REJOIN;
-      this.onReconnectionNeeded?.(strategy, reason, this.peerType);
+      this.onReconnectionNeeded?.(
+        strategy,
+        ReconnectReason.RESTART_ICE_FAILED,
+        this.peerType,
+      );
     });
   };
 
@@ -240,6 +253,20 @@ export abstract class BasePeerConnection {
   };
 
   /**
+   * Returns true only when the peer connection is currently fully established
+   * (ICE `connected`/`completed` AND connection state `connected`).
+   * Transient states like `disconnected`, `checking`, or `new` return false.
+   */
+  isStable = () => {
+    const iceState = this.pc.iceConnectionState;
+    const connectionState = this.pc.connectionState;
+    return (
+      (iceState === 'connected' || iceState === 'completed') &&
+      connectionState === 'connected'
+    );
+  };
+
+  /**
    * Handles the ICECandidate event and
    * Initiates an ICE Trickle process with the SFU.
    */
@@ -292,7 +319,7 @@ export abstract class BasePeerConnection {
     if (state === 'failed') {
       this.onReconnectionNeeded?.(
         WebsocketReconnectStrategy.REJOIN,
-        'Connection failed',
+        ReconnectReason.CONNECTION_FAILED,
         this.peerType,
       );
       return;
@@ -320,6 +347,32 @@ export abstract class BasePeerConnection {
     // do nothing when ICE is restarting
     if (this.isIceRestarting) return;
 
+    // Pre-connect handling: ICE has never reached `connected`/`completed`.
+    // Restart is futile here (the data plane was never established), but
+    // these two terminal-ish states need different treatment:
+    // - `failed` is terminal, escalate to REJOIN so a new SFU/credentials
+    //   /PC configuration gets a chance, and let `Call.reconnect` count
+    //   this toward the unsupported-network budget.
+    // - `disconnected` is transient, the browser may yet move back to
+    //   `checking`/`connected`. Don't restart, don't escalate; wait it
+    //   out. If it ultimately fails, ICE will transition to `failed` and
+    //   the branch above will take over.
+    if (!this.iceHasEverConnected) {
+      if (state === 'failed') {
+        this.logger.info('ICE failed before connected, escalating to REJOIN');
+        this.onReconnectionNeeded?.(
+          WebsocketReconnectStrategy.REJOIN,
+          ReconnectReason.ICE_NEVER_CONNECTED,
+          this.peerType,
+        );
+        return;
+      }
+      if (state === 'disconnected') {
+        this.logger.info('ICE disconnected before connected, wait to recover');
+        return;
+      }
+    }
+
     switch (state) {
       case 'failed':
         // in the `failed` state, we try to restart ICE immediately
@@ -341,7 +394,16 @@ export abstract class BasePeerConnection {
         break;
 
       case 'connected':
-        // in the `connected` state, we clear the ice restart timeout if it exists
+      case 'completed':
+        // Fire `onIceConnected` exactly once per peer-connection lifetime —
+        // the first time ICE reaches `connected`/`completed` end-to-end.
+        // Used by `Call` to reset the unsupported-network failure counter
+        // only after WebRTC has actually recovered, not merely on SFU join.
+        if (!this.iceHasEverConnected) {
+          this.iceHasEverConnected = true;
+          this.onIceConnected?.(this.peerType);
+        }
+        // clear any scheduled restartICE since the connection is healthy
         if (this.iceRestartTimeout) {
           this.logger.info('connected connection, canceling restartICE');
           clearTimeout(this.iceRestartTimeout);

--- a/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
+++ b/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
@@ -728,3 +728,34 @@ describe('Call reconnect wiring (PC event → leave)', () => {
     );
   });
 });
+
+/**
+ * `leave()` runs after both the success path (end of `joinFlow`) and the
+ * giveUpAndLeave path. Only the success path resets `reconnectStrategy` /
+ * `reconnectReason`. Without resetting them in `leave()` itself, a Call
+ * instance reused after a failed-reconnect terminal leave would still see
+ * `reconnectStrategy != UNSPECIFIED` on the next `join()` and would send
+ * a stale `ReconnectDetails` to the SFU.
+ */
+describe('Call.leave() reconnect-state reset', () => {
+  it('clears reconnectStrategy, reconnectReason, and reconnectAttempts', async () => {
+    const call = makeCall();
+    call.state.setCallingState(CallingState.JOINED);
+
+    call['reconnectStrategy'] = WebsocketReconnectStrategy.REJOIN;
+    call['reconnectReason'] = ReconnectReason.ICE_NEVER_CONNECTED;
+    call['reconnectAttempts'] = 3;
+    call['iceFailuresWithoutConnect'] = 2;
+    call['consecutiveNegotiationFailures'] = 1;
+
+    await call.leave();
+
+    expect(call['reconnectStrategy']).toBe(
+      WebsocketReconnectStrategy.UNSPECIFIED,
+    );
+    expect(call['reconnectReason']).toBe('');
+    expect(call['reconnectAttempts']).toBe(0);
+    expect(call['iceFailuresWithoutConnect']).toBe(0);
+    expect(call['consecutiveNegotiationFailures']).toBe(0);
+  });
+});

--- a/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
+++ b/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
@@ -376,6 +376,31 @@ describe('Call reconnect stopping conditions', () => {
         message: 'repeated_negotiation_failures',
       });
     });
+
+    it('clamps zero/negative inputs to a floor of 1', () => {
+      // Without clamping, n=0 would trip immediately on the first event
+      // (1 >= 0 is true), turning the setter into an instant kill switch.
+      call.setMaxIceFailuresWithoutConnect(0);
+      expect(
+        (call as unknown as { maxIceFailuresWithoutConnect: number })
+          .maxIceFailuresWithoutConnect,
+      ).toBe(1);
+
+      call.setMaxConsecutiveNegotiationFailures(-5);
+      expect(
+        (call as unknown as { maxConsecutiveNegotiationFailures: number })
+          .maxConsecutiveNegotiationFailures,
+      ).toBe(1);
+
+      call.setRejoinAttemptLimit(0, 0);
+      const limiter = (
+        call as unknown as {
+          rejoinRateLimiter: { maxAttempts: number; windowMs: number };
+        }
+      ).rejoinRateLimiter;
+      expect(limiter.maxAttempts).toBe(1);
+      expect(limiter.windowMs).toBe(1000);
+    });
   });
 });
 

--- a/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
+++ b/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
@@ -1,0 +1,705 @@
+import './mocks/webrtc.mocks';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Call } from '../../Call';
+import { StreamClient } from '../../coordinator/connection/client';
+import { StreamVideoWriteableStateStore } from '../../store';
+import { CallingState } from '../../store';
+import { NegotiationError } from '../NegotiationError';
+import { ReconnectReason } from '../types';
+import {
+  PeerType,
+  WebsocketReconnectStrategy,
+  ErrorCode,
+} from '../../gen/video/sfu/models/models';
+import * as connectionUtils from '../../coordinator/connection/utils';
+import { Publisher } from '../Publisher';
+import { Subscriber } from '../Subscriber';
+import { Dispatcher } from '../Dispatcher';
+import { StreamSfuClient } from '../../StreamSfuClient';
+import { IceTrickleBuffer } from '../IceTrickleBuffer';
+
+vi.mock('../../StreamSfuClient', () => ({
+  StreamSfuClient: vi.fn(),
+}));
+
+const makeCall = () => {
+  const streamClient = new StreamClient('test-key');
+  const clientStore = new StreamVideoWriteableStateStore();
+  return new Call({
+    type: 'default',
+    id: 'test-call',
+    streamClient,
+    clientStore,
+    ringing: false,
+    watching: false,
+  });
+};
+
+/**
+ * Primes the call so the reconnect loop will actually enter the
+ * strategy branch (loop guards on callingState != JOINED/LEFT/RECONNECTING_FAILED)
+ * and behaves deterministically.
+ */
+const primeForReconnect = (call: Call) => {
+  // put the call in a non-terminal, non-JOINED state so the do-while iterates
+  call.state.setCallingState(CallingState.JOINING);
+  // force the strategy-decider in the catch block to always pick REJOIN,
+  // so tests that care about the rejoin rate limiter don't bounce to FAST
+  // based on wall-clock timing. Individual tests that want to exercise the
+  // FAST branch reset this to a high value.
+  (
+    call as unknown as { fastReconnectDeadlineSeconds: number }
+  ).fastReconnectDeadlineSeconds = -1;
+};
+
+describe('Call reconnect stopping conditions', () => {
+  let call: Call;
+
+  beforeEach(() => {
+    call = makeCall();
+    // make sleep instant so the loop flushes quickly
+    vi.spyOn(connectionUtils, 'sleep').mockResolvedValue(undefined);
+    // stub leave so the terminal path doesn't attempt real teardown
+    vi.spyOn(call, 'leave').mockResolvedValue(undefined);
+    // avoid the `get()` call inside markAsReconnectingFailed hitting the network
+    vi.spyOn(call, 'get').mockResolvedValue({} as never);
+    // default-stub all three strategy implementations to reject. Individual
+    // tests override these with mockResolvedValue / mockImplementation as
+    // needed. This keeps the reconnect loop from reaching the real network.
+    vi.spyOn(
+      call as unknown as { reconnectFast: () => Promise<void> },
+      'reconnectFast',
+    ).mockRejectedValue(new Error('fast stub'));
+    vi.spyOn(
+      call as unknown as { reconnectRejoin: () => Promise<void> },
+      'reconnectRejoin',
+    ).mockRejectedValue(new Error('rejoin stub'));
+    vi.spyOn(
+      call as unknown as { reconnectMigrate: () => Promise<void> },
+      'reconnectMigrate',
+    ).mockRejectedValue(new Error('migrate stub'));
+    primeForReconnect(call);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rejoin rate limit', () => {
+    it('triggers leave with rejoin_attempt_limit_exceeded after the budget is exhausted', async () => {
+      // tight cap for speed
+      call.setRejoinAttemptLimit(3, 60);
+      // every rejoin attempt fails so the loop stays in REJOIN
+      const rejoinSpy = vi
+        .spyOn(
+          call as unknown as { reconnectRejoin: () => Promise<void> },
+          'reconnectRejoin',
+        )
+        .mockRejectedValue(new Error('rejoin failed'));
+
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+      // budget = 3 → 3 registered attempts, 4th denied and triggers leave
+      expect(rejoinSpy).toHaveBeenCalledTimes(3);
+      expect(call.leave).toHaveBeenCalledWith({
+        message: 'rejoin_attempt_limit_exceeded',
+      });
+    });
+
+    it('does NOT trigger leave while under the rejoin budget', async () => {
+      call.setRejoinAttemptLimit(10, 60);
+      const rejoinSpy = vi
+        .spyOn(
+          call as unknown as { reconnectRejoin: () => Promise<void> },
+          'reconnectRejoin',
+        )
+        .mockImplementationOnce(async () => {
+          // first call succeeds — loop exits
+          call.state.setCallingState(CallingState.JOINED);
+        });
+
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+      expect(rejoinSpy).toHaveBeenCalledTimes(1);
+      expect(call.leave).not.toHaveBeenCalled();
+    });
+
+    it('FAST strategy is NOT counted against the rejoin budget', async () => {
+      call.setRejoinAttemptLimit(2, 60);
+      // stub FAST so it "succeeds" each time (we re-enter by resetting state)
+      vi.spyOn(
+        call as unknown as { reconnectFast: () => Promise<void> },
+        'reconnectFast',
+      ).mockImplementation(async () => {
+        call.state.setCallingState(CallingState.JOINED);
+      });
+
+      for (let i = 0; i < 5; i++) {
+        call.state.setCallingState(CallingState.JOINING);
+        await call['reconnect'](WebsocketReconnectStrategy.FAST, 'test');
+      }
+
+      // the rejoin rate limiter should have no recorded attempts —
+      // FAST never registers an attempt, and because each FAST here
+      // "succeeds" on the first iteration, no REJOIN fallback kicks in
+      expect(call['rejoinRateLimiter']['timestamps']).toHaveLength(0);
+      expect(call.leave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('retryInterval backoff', () => {
+    it('invokes retryInterval(attempt) between failed iterations, not a fixed delay', async () => {
+      call.setRejoinAttemptLimit(3, 60);
+      const retryIntervalSpy = vi
+        .spyOn(connectionUtils, 'retryInterval')
+        .mockReturnValue(0);
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockRejectedValue(new Error('rejoin failed'));
+
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+      // 3 iterations → at least 3 backoff calls with increasing attempt index
+      const calls = retryIntervalSpy.mock.calls.map((c) => c[0]);
+      expect(calls.length).toBeGreaterThanOrEqual(3);
+      expect(calls[0]).toBe(0);
+      expect(calls[1]).toBe(1);
+      expect(calls[2]).toBe(2);
+    });
+  });
+
+  describe('unsupported-network detector', () => {
+    it('triggers leave with webrtc_unsupported_network after N ice_never_connected reasons', async () => {
+      call.setMaxIceFailuresWithoutConnect(2);
+      // reconnect no-ops (REJOIN not even attempted in this test because we
+      // bail out at the threshold check before the loop)
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockImplementation(async () => {
+        call.state.setCallingState(CallingState.JOINED);
+      });
+
+      // first ice_never_connected: counter = 1, still under threshold (2)
+      await call['reconnect'](
+        WebsocketReconnectStrategy.REJOIN,
+        ReconnectReason.ICE_NEVER_CONNECTED,
+      );
+      expect(call.leave).not.toHaveBeenCalled();
+
+      // After a successful SFU join (no ICE-connected event yet), the
+      // counter must NOT be reset — the reset only happens once a peer
+      // connection actually reaches `connected`/`completed` end-to-end.
+      primeForReconnect(call);
+      await call['reconnect'](
+        WebsocketReconnectStrategy.REJOIN,
+        ReconnectReason.ICE_NEVER_CONNECTED,
+      );
+      // counter now 2 → threshold met → leave
+      expect(call.leave).toHaveBeenCalledWith({
+        message: 'webrtc_unsupported_network',
+      });
+    });
+
+    it('does NOT trigger leave when the reason is NOT ice_never_connected', async () => {
+      call.setMaxIceFailuresWithoutConnect(1);
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockImplementation(async () => {
+        call.state.setCallingState(CallingState.JOINED);
+      });
+
+      await call['reconnect'](
+        WebsocketReconnectStrategy.REJOIN,
+        'some_other_reason',
+      );
+
+      expect(call.leave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('consecutive negotiation failures', () => {
+    const makeNegotiationError = () =>
+      new NegotiationError({
+        code: ErrorCode.PARTICIPANT_NOT_FOUND,
+        message: 'test',
+        shouldRetry: true,
+      } as never);
+
+    it('triggers leave with repeated_negotiation_failures after the streak threshold', async () => {
+      call.setMaxConsecutiveNegotiationFailures(3);
+      call.setRejoinAttemptLimit(100, 60); // keep rejoin cap out of the way
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockRejectedValue(makeNegotiationError());
+
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+      expect(call.leave).toHaveBeenCalledWith({
+        message: 'repeated_negotiation_failures',
+      });
+    });
+
+    it('resets the streak counter on a successful iteration', async () => {
+      call.setMaxConsecutiveNegotiationFailures(3);
+      call.setRejoinAttemptLimit(100, 60);
+      let calls = 0;
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockImplementation(async () => {
+        calls++;
+        if (calls <= 2) throw makeNegotiationError();
+        if (calls === 3) {
+          // success on the 3rd attempt — resets the streak
+          call.state.setCallingState(CallingState.JOINED);
+          return;
+        }
+      });
+
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+      expect(calls).toBe(3);
+      expect(call.leave).not.toHaveBeenCalled();
+      expect(call['consecutiveNegotiationFailures']).toBe(0);
+    });
+  });
+
+  describe('counter reset semantics', () => {
+    it('rejoinRateLimiter does NOT reset on a successful SFU reconnect — the rolling window persists', async () => {
+      call.setRejoinAttemptLimit(3, 60);
+      // Each REJOIN succeeds on the first iteration; without the bad reset,
+      // the rolling window accumulates timestamps across successful cycles.
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockImplementation(async () => {
+        call.state.setCallingState(CallingState.JOINED);
+      });
+
+      for (let i = 0; i < 3; i++) {
+        primeForReconnect(call);
+        await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+      }
+      expect(call['rejoinRateLimiter']['timestamps']).toHaveLength(3);
+
+      // 4th attempt is over the budget and triggers leave
+      primeForReconnect(call);
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+      expect(call.leave).toHaveBeenCalledWith({
+        message: 'rejoin_attempt_limit_exceeded',
+      });
+    });
+
+    it('iceFailuresWithoutConnect does NOT reset on a successful SFU reconnect', async () => {
+      call.setMaxIceFailuresWithoutConnect(3);
+      // pre-load the counter as if a previous PC had failed before connecting
+      call['iceFailuresWithoutConnect'] = 2;
+
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockImplementation(async () => {
+        call.state.setCallingState(CallingState.JOINED);
+      });
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+      // Successful SFU join — but ICE never connected; counter must persist.
+      expect(call['iceFailuresWithoutConnect']).toBe(2);
+      expect(call.leave).not.toHaveBeenCalled();
+    });
+
+    it('consecutiveNegotiationFailures DOES reset on a successful reconnect iteration', async () => {
+      call['consecutiveNegotiationFailures'] = 2;
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockImplementation(async () => {
+        call.state.setCallingState(CallingState.JOINED);
+      });
+
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+      expect(call['consecutiveNegotiationFailures']).toBe(0);
+    });
+  });
+
+  describe('tunability setters', () => {
+    it('setRejoinAttemptLimit changes the budget in place', async () => {
+      call.setRejoinAttemptLimit(1, 60);
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockRejectedValue(new Error('rejoin failed'));
+
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+      // budget=1 → one attempt, then leave
+      expect(call.leave).toHaveBeenCalledWith({
+        message: 'rejoin_attempt_limit_exceeded',
+      });
+    });
+
+    it('setMaxIceFailuresWithoutConnect=1 trips on the first ice_never_connected', async () => {
+      call.setMaxIceFailuresWithoutConnect(1);
+
+      await call['reconnect'](
+        WebsocketReconnectStrategy.REJOIN,
+        ReconnectReason.ICE_NEVER_CONNECTED,
+      );
+
+      expect(call.leave).toHaveBeenCalledWith({
+        message: 'webrtc_unsupported_network',
+      });
+    });
+
+    it('setMaxConsecutiveNegotiationFailures=1 trips on the first NegotiationError', async () => {
+      call.setMaxConsecutiveNegotiationFailures(1);
+      call.setRejoinAttemptLimit(100, 60);
+      const err = new NegotiationError({
+        code: ErrorCode.PARTICIPANT_NOT_FOUND,
+        message: 'x',
+        shouldRetry: true,
+      } as never);
+      vi.spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      ).mockRejectedValue(err);
+
+      await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+      expect(call.leave).toHaveBeenCalledWith({
+        message: 'repeated_negotiation_failures',
+      });
+    });
+  });
+});
+
+/**
+ * End-to-end-ish wiring tests: simulate failures at the peer-connection layer
+ * and verify they propagate through `onReconnectionNeeded` → `Call.reconnect` →
+ * counters → `leave({ message })`. This covers the gap between the unit tests
+ * above (which call `Call.reconnect` directly) and a true browser harness.
+ */
+describe('Call reconnect wiring (PC event → leave)', () => {
+  let call: Call;
+  let sfuClient: StreamSfuClient;
+  let dispatcher: Dispatcher;
+
+  /** Builds a Publisher wired to forward onReconnectionNeeded + onIceConnected to Call. */
+  const makePublisherWiredToCall = () => {
+    const publisher = new Publisher(
+      {
+        sfuClient,
+        dispatcher,
+        state: call.state,
+        tag: 'test',
+        enableTracing: false,
+        onReconnectionNeeded: (kind, reason) => {
+          // mirror Call.ts:1409 wiring
+          call['reconnect'](kind, reason).catch(() => {});
+        },
+        onIceConnected: () => {
+          // mirror Call.ts:1416 wiring
+          call['iceFailuresWithoutConnect'] = 0;
+        },
+      },
+      [],
+    );
+    return publisher;
+  };
+
+  beforeEach(() => {
+    dispatcher = new Dispatcher();
+    sfuClient = new StreamSfuClient({
+      dispatcher,
+      sessionId: 'session-id-test',
+      streamClient: new StreamClient('abc'),
+      cid: 'test:123',
+      credentials: {
+        server: {
+          url: 'https://getstream.io/',
+          ws_endpoint: 'https://getstream.io/ws',
+          edge_name: 'sfu-1',
+        },
+        token: 'token',
+        ice_servers: [],
+      },
+      tag: 'test',
+      enableTracing: false,
+    });
+    // @ts-expect-error readonly field
+    sfuClient.iceTrickleBuffer = new IceTrickleBuffer();
+
+    const streamClient = new StreamClient('test-key');
+    const clientStore = new StreamVideoWriteableStateStore();
+    call = new Call({
+      type: 'default',
+      id: 'test-call',
+      streamClient,
+      clientStore,
+      ringing: false,
+      watching: false,
+    });
+    primeForReconnect(call);
+
+    // make the Call.reconnect loop deterministic
+    vi.spyOn(connectionUtils, 'sleep').mockResolvedValue(undefined);
+    vi.spyOn(call, 'leave').mockResolvedValue(undefined);
+    vi.spyOn(call, 'get').mockResolvedValue({} as never);
+    vi.spyOn(
+      call as unknown as { reconnectRejoin: () => Promise<void> },
+      'reconnectRejoin',
+    ).mockImplementation(async () => {
+      // each REJOIN attempt "succeeds" so the loop exits without bouncing
+      call.state.setCallingState(CallingState.JOINED);
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Scenario 1 (manual smoke equivalent: 100% packet loss / blocked UDP):
+   * a publisher whose ICE never reaches `connected`/`completed` and goes to
+   * `failed` should make Call.reconnect count the reason. After
+   * `maxIceFailuresWithoutConnect` such failures, the call must `leave`.
+   */
+  it('publisher ICE failed (never-connected) drives Call.reconnect → webrtc_unsupported_network', async () => {
+    call.setMaxIceFailuresWithoutConnect(2);
+    const publisher = makePublisherWiredToCall();
+
+    const triggerIceFailedNeverConnected = async () => {
+      // @ts-expect-error private field
+      publisher['pc'].iceConnectionState = 'failed';
+      publisher['onIceConnectionStateChange']();
+      // flush the microtask queue so the async reconnect runs
+      await new Promise<void>((r) => setTimeout(r, 0));
+    };
+
+    await triggerIceFailedNeverConnected();
+    expect(call['iceFailuresWithoutConnect']).toBe(1);
+    expect(call.leave).not.toHaveBeenCalled();
+
+    // re-arm the loop guard for the second pass
+    primeForReconnect(call);
+    await triggerIceFailedNeverConnected();
+
+    expect(call['iceFailuresWithoutConnect']).toBe(2);
+    expect(call.leave).toHaveBeenCalledWith({
+      message: 'webrtc_unsupported_network',
+    });
+  });
+
+  /**
+   * Once ICE has reached `connected`, a subsequent `failed` is a normal
+   * recovery case — it should NOT count toward the unsupported-network
+   * threshold and should NOT cause leave.
+   */
+  it('publisher ICE failed AFTER prior connected does NOT count toward unsupported_network', async () => {
+    call.setMaxIceFailuresWithoutConnect(1);
+    const publisher = makePublisherWiredToCall();
+    // restartIce is invoked in the regular path; stub it
+    vi.spyOn(publisher, 'restartIce').mockResolvedValue();
+
+    // simulate prior healthy ICE
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'connected';
+    publisher['onIceConnectionStateChange']();
+
+    // now ICE drops to failed
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'failed';
+    publisher['onIceConnectionStateChange']();
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    expect(call['iceFailuresWithoutConnect']).toBe(0);
+    expect(call.leave).not.toHaveBeenCalled();
+    // and a regular ICE restart was attempted
+    expect(publisher.restartIce).toHaveBeenCalled();
+  });
+
+  /**
+   * Scenario 4 (manual smoke equivalent: drop only the signal WS while the
+   * publisher PC stays `connected`): the FAST path should NOT call
+   * `publisher.restartIce()` because the PC is stable.
+   */
+  it('FAST path skips publisher.restartIce when publisher PC is stable', async () => {
+    const publisher = makePublisherWiredToCall();
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'connected';
+    publisher['onIceConnectionStateChange']();
+    // @ts-expect-error private field
+    publisher['pc'].connectionState = 'connected';
+
+    // pretend the publisher has tracks so isPublishing() would return true
+    vi.spyOn(publisher, 'isPublishing').mockReturnValue(true);
+    const restartIceSpy = vi.spyOn(publisher, 'restartIce').mockResolvedValue();
+    const setSfuSpy = vi.spyOn(publisher, 'setSfuClient');
+    call['publisher'] = publisher;
+
+    // mimic the FAST branch in doJoin: restoreICE is the gateway
+    const publisherIsStable = call['publisher']?.isStable() ?? true;
+    const includePublisher =
+      !!call['publisher']?.isPublishing() && !publisherIsStable;
+    await call['restoreICE'](sfuClient, {
+      includeSubscriber: false,
+      includePublisher,
+    });
+
+    expect(includePublisher).toBe(false);
+    expect(setSfuSpy).toHaveBeenCalledWith(sfuClient); // wire still updated
+    expect(restartIceSpy).not.toHaveBeenCalled(); // but NO ICE restart
+  });
+
+  /**
+   * Counterpart to the above: when the publisher PC is NOT stable (e.g.,
+   * `disconnected`), the FAST path SHOULD still issue an ICE restart.
+   */
+  it('FAST path DOES call publisher.restartIce when publisher PC is unstable', async () => {
+    const publisher = makePublisherWiredToCall();
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'connected';
+    publisher['onIceConnectionStateChange']();
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'disconnected';
+    // @ts-expect-error private field
+    publisher['pc'].connectionState = 'connected';
+
+    vi.spyOn(publisher, 'isPublishing').mockReturnValue(true);
+    const restartIceSpy = vi.spyOn(publisher, 'restartIce').mockResolvedValue();
+    call['publisher'] = publisher;
+
+    const publisherIsStable = call['publisher']?.isStable() ?? true;
+    const includePublisher =
+      !!call['publisher']?.isPublishing() && !publisherIsStable;
+    await call['restoreICE'](sfuClient, {
+      includeSubscriber: false,
+      includePublisher,
+    });
+
+    expect(includePublisher).toBe(true);
+    expect(restartIceSpy).toHaveBeenCalled();
+  });
+
+  /**
+   * Counter reset semantics — the fix from the Codex adversarial review:
+   * `iceFailuresWithoutConnect` must persist across SFU joins; only an
+   * actual ICE-connected event clears it.
+   */
+  it('iceFailuresWithoutConnect resets when the publisher PC reaches connected', () => {
+    call['iceFailuresWithoutConnect'] = 2;
+    const publisher = makePublisherWiredToCall();
+
+    // simulate ICE reaching `connected` end-to-end on the publisher
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'connected';
+    publisher['onIceConnectionStateChange']();
+
+    expect(call['iceFailuresWithoutConnect']).toBe(0);
+  });
+
+  it('onIceConnected fires exactly once per peer-connection lifetime', () => {
+    let calls = 0;
+    const publisher = new Publisher(
+      {
+        sfuClient,
+        dispatcher,
+        state: call.state,
+        tag: 'test',
+        enableTracing: false,
+        onReconnectionNeeded: () => {},
+        onIceConnected: () => {
+          calls++;
+        },
+      },
+      [],
+    );
+
+    // connected → counts
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'connected';
+    publisher['onIceConnectionStateChange']();
+    expect(calls).toBe(1);
+
+    // disconnected → connected → does NOT fire again
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'disconnected';
+    publisher['onIceConnectionStateChange']();
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'connected';
+    publisher['onIceConnectionStateChange']();
+    expect(calls).toBe(1);
+  });
+
+  /**
+   * Cross-peer count: a publisher AND a subscriber both failing without ever
+   * connecting should add up to the same `iceFailuresWithoutConnect` budget.
+   */
+  it('publisher + subscriber failures share the same unsupported_network budget', async () => {
+    call.setMaxIceFailuresWithoutConnect(2);
+    const publisher = makePublisherWiredToCall();
+    const subscriber = new Subscriber({
+      sfuClient,
+      dispatcher,
+      state: call.state,
+      tag: 'test',
+      enableTracing: false,
+      onReconnectionNeeded: (kind, reason) => {
+        call['reconnect'](kind, reason).catch(() => {});
+      },
+    });
+
+    // first failure on the publisher
+    // @ts-expect-error private field
+    publisher['pc'].iceConnectionState = 'failed';
+    publisher['onIceConnectionStateChange']();
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(call['iceFailuresWithoutConnect']).toBe(1);
+    expect(call.leave).not.toHaveBeenCalled();
+
+    primeForReconnect(call);
+
+    // second failure on the subscriber — same shared counter, trips the limit
+    // @ts-expect-error private field
+    subscriber['pc'].iceConnectionState = 'failed';
+    subscriber['onIceConnectionStateChange']();
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    expect(call['iceFailuresWithoutConnect']).toBe(2);
+    expect(call.leave).toHaveBeenCalledWith({
+      message: 'webrtc_unsupported_network',
+    });
+  });
+
+  /**
+   * The peerType passed by Subscriber should be `SUBSCRIBER`. (Sanity check
+   * of the wiring contract.)
+   */
+  it('subscriber emits onReconnectionNeeded with PeerType.SUBSCRIBER', () => {
+    const onReconnectionNeeded = vi.fn();
+    const subscriber = new Subscriber({
+      sfuClient,
+      dispatcher,
+      state: call.state,
+      tag: 'test',
+      enableTracing: false,
+      onReconnectionNeeded,
+    });
+
+    // @ts-expect-error private field
+    subscriber['pc'].iceConnectionState = 'failed';
+    subscriber['onIceConnectionStateChange']();
+
+    expect(onReconnectionNeeded).toHaveBeenCalledWith(
+      WebsocketReconnectStrategy.REJOIN,
+      ReconnectReason.ICE_NEVER_CONNECTED,
+      PeerType.SUBSCRIBER,
+    );
+  });
+});

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -439,20 +439,62 @@ describe('Publisher', () => {
       );
     });
 
-    it(`pre-connect 'disconnected' is transient — does NOT restart and does NOT escalate`, () => {
+    it(`pre-connect 'disconnected' does not restart or escalate immediately`, () => {
       // ICE has never reached `connected`. A `disconnected` transition at
       // this point is just the browser's checking phase wobbling; the
       // browser may yet move back to checking/connected. The SDK should
-      // wait it out (no restart, no REJOIN). Only a terminal `failed`
-      // before connect should escalate via `ICE_NEVER_CONNECTED`.
+      // wait it out — no synchronous restart, no synchronous REJOIN. Only
+      // a terminal `failed` before connect, or the pre-connect watchdog
+      // expiring, should escalate via `ICE_NEVER_CONNECTED`.
       vi.spyOn(publisher, 'restartIce').mockResolvedValue();
       publisher['onReconnectionNeeded'] = vi.fn();
-      vi.useFakeTimers();
       // @ts-expect-error private api
       publisher['pc'].iceConnectionState = 'disconnected';
       publisher['onIceConnectionStateChange']();
-      vi.runOnlyPendingTimers();
       expect(publisher.restartIce).not.toHaveBeenCalled();
+      expect(publisher['onReconnectionNeeded']).not.toHaveBeenCalled();
+    });
+
+    it(`pre-connect 'disconnected' watchdog escalates to REJOIN if state stays stuck`, () => {
+      vi.spyOn(publisher, 'restartIce').mockResolvedValue();
+      publisher['onReconnectionNeeded'] = vi.fn();
+      vi.useFakeTimers();
+      const watchdogMs = publisher['iceRestartDelay'] * 2;
+
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'disconnected';
+      publisher['onIceConnectionStateChange']();
+      // before the watchdog fires, no escalation
+      vi.advanceTimersByTime(watchdogMs - 1);
+      expect(publisher['onReconnectionNeeded']).not.toHaveBeenCalled();
+
+      // watchdog fires; still stuck in disconnected → escalate
+      vi.advanceTimersByTime(2);
+      expect(publisher.restartIce).not.toHaveBeenCalled();
+      expect(publisher['onReconnectionNeeded']).toHaveBeenCalledWith(
+        WebsocketReconnectStrategy.REJOIN,
+        ReconnectReason.ICE_NEVER_CONNECTED,
+        PeerType.PUBLISHER_UNSPECIFIED,
+      );
+    });
+
+    it(`pre-connect 'disconnected' watchdog is canceled when ICE recovers to 'connected'`, () => {
+      publisher['onReconnectionNeeded'] = vi.fn();
+      vi.useFakeTimers();
+      const watchdogMs = publisher['iceRestartDelay'] * 2;
+
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'disconnected';
+      publisher['onIceConnectionStateChange']();
+      // recover before the watchdog window expires
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'connected';
+      publisher['onIceConnectionStateChange']();
+
+      // advance past the original watchdog window — must NOT fire now
+      vi.advanceTimersByTime(watchdogMs + 100);
+
+      expect(publisher['iceHasEverConnected']).toBe(true);
       expect(publisher['onReconnectionNeeded']).not.toHaveBeenCalled();
     });
 

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { anyString } from 'vitest-mock-extended';
 import { NegotiationError } from '../NegotiationError';
 import { Publisher } from '../Publisher';
+import { ReconnectReason } from '../types';
 import { CallState } from '../../store';
 import { StreamSfuClient } from '../../StreamSfuClient';
 import { DispatchableMessage, Dispatcher } from '../Dispatcher';
@@ -250,7 +251,14 @@ describe('Publisher', () => {
       expect(publisher['negotiate']).toHaveBeenCalled();
     });
 
+    const simulatePriorIceConnected = () => {
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'connected';
+      publisher['onIceConnectionStateChange']();
+    };
+
     it(`should perform ICE restart when connection state changes to 'failed'`, () => {
+      simulatePriorIceConnected();
       vi.spyOn(publisher, 'restartIce').mockResolvedValue();
       // @ts-expect-error private api
       publisher['pc'].iceConnectionState = 'failed';
@@ -259,6 +267,7 @@ describe('Publisher', () => {
     });
 
     it(`should perform rejoin when ICE restart fails after connection state changes to 'failed'`, async () => {
+      simulatePriorIceConnected();
       const { promise: lock, resolve: unlock } = promiseWithResolvers<void>();
       publisher['onReconnectionNeeded'] = vi
         .fn()
@@ -274,6 +283,7 @@ describe('Publisher', () => {
     });
 
     it(`should perform fast reconnect when ICE restart fails with SIGNAL_LOST error`, async () => {
+      simulatePriorIceConnected();
       const { promise: lock, resolve: unlock } = promiseWithResolvers<void>();
       publisher['onReconnectionNeeded'] = vi
         .fn()
@@ -325,6 +335,7 @@ describe('Publisher', () => {
     });
 
     it(`should perform REJOIN reconnect when ICE restart fails with any other error code`, async () => {
+      simulatePriorIceConnected();
       const { promise: lock, resolve: unlock } = promiseWithResolvers<void>();
       publisher['onReconnectionNeeded'] = vi
         .fn()
@@ -365,6 +376,7 @@ describe('Publisher', () => {
     });
 
     it(`should schedule ICE restart when connection state changes to 'disconnected'`, () => {
+      simulatePriorIceConnected();
       vi.spyOn(publisher, 'restartIce').mockResolvedValue();
       vi.useFakeTimers();
       // @ts-expect-error private api
@@ -376,6 +388,7 @@ describe('Publisher', () => {
     });
 
     it(`should perform rejoin when scheduled ICE restart fails`, async () => {
+      simulatePriorIceConnected();
       vi.spyOn(publisher, 'restartIce').mockRejectedValue('ICE restart failed');
       const { promise: lock, resolve } = promiseWithResolvers<void>();
       publisher['onReconnectionNeeded'] = vi
@@ -391,6 +404,160 @@ describe('Publisher', () => {
       await lock;
       expect(publisher.restartIce).toHaveBeenCalled();
       expect(publisher['onReconnectionNeeded']).toHaveBeenCalled();
+    });
+
+    it(`iceHasEverConnected is false before any connected state is observed`, () => {
+      expect(publisher['iceHasEverConnected']).toBe(false);
+    });
+
+    it(`iceHasEverConnected becomes true after 'connected' ICE state`, () => {
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'connected';
+      publisher['onIceConnectionStateChange']();
+      expect(publisher['iceHasEverConnected']).toBe(true);
+    });
+
+    it(`iceHasEverConnected also flips on 'completed' ICE state`, () => {
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'completed';
+      publisher['onIceConnectionStateChange']();
+      expect(publisher['iceHasEverConnected']).toBe(true);
+    });
+
+    it(`does NOT call restartIce when ICE never connected and state goes to 'failed' — emits REJOIN with 'ice_never_connected'`, () => {
+      vi.spyOn(publisher, 'restartIce').mockResolvedValue();
+      publisher['onReconnectionNeeded'] = vi.fn();
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'failed';
+      publisher['onIceConnectionStateChange']();
+      expect(publisher.restartIce).not.toHaveBeenCalled();
+      expect(publisher['onReconnectionNeeded']).toHaveBeenCalledWith(
+        WebsocketReconnectStrategy.REJOIN,
+        ReconnectReason.ICE_NEVER_CONNECTED,
+        PeerType.PUBLISHER_UNSPECIFIED,
+      );
+    });
+
+    it(`pre-connect 'disconnected' is transient — does NOT restart and does NOT escalate`, () => {
+      // ICE has never reached `connected`. A `disconnected` transition at
+      // this point is just the browser's checking phase wobbling; the
+      // browser may yet move back to checking/connected. The SDK should
+      // wait it out (no restart, no REJOIN). Only a terminal `failed`
+      // before connect should escalate via `ICE_NEVER_CONNECTED`.
+      vi.spyOn(publisher, 'restartIce').mockResolvedValue();
+      publisher['onReconnectionNeeded'] = vi.fn();
+      vi.useFakeTimers();
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'disconnected';
+      publisher['onIceConnectionStateChange']();
+      vi.runOnlyPendingTimers();
+      expect(publisher.restartIce).not.toHaveBeenCalled();
+      expect(publisher['onReconnectionNeeded']).not.toHaveBeenCalled();
+    });
+
+    it(`pre-connect 'disconnected' that recovers to 'connected' continues normally`, () => {
+      publisher['onReconnectionNeeded'] = vi.fn();
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'disconnected';
+      publisher['onIceConnectionStateChange']();
+      // browser now reaches connected — the normal connected branch runs
+      // and `iceHasEverConnected` flips to true.
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'connected';
+      publisher['onIceConnectionStateChange']();
+      expect(publisher['iceHasEverConnected']).toBe(true);
+      expect(publisher['onReconnectionNeeded']).not.toHaveBeenCalled();
+    });
+
+    it(`isStable() returns false when ICE is 'new'`, () => {
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'new';
+      // default connectionState in mock is 'connected'
+      expect(publisher.isStable()).toBe(false);
+    });
+
+    it(`isStable() returns true when ICE is 'connected' and connectionState is 'connected'`, () => {
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'connected';
+      // @ts-expect-error private api
+      publisher['pc'].connectionState = 'connected';
+      expect(publisher.isStable()).toBe(true);
+    });
+
+    it(`isStable() returns true when ICE is 'completed' and connectionState is 'connected'`, () => {
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'completed';
+      // @ts-expect-error private api
+      publisher['pc'].connectionState = 'connected';
+      expect(publisher.isStable()).toBe(true);
+    });
+
+    it(`isStable() returns false when ICE is 'disconnected'`, () => {
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'disconnected';
+      // @ts-expect-error private api
+      publisher['pc'].connectionState = 'connected';
+      expect(publisher.isStable()).toBe(false);
+    });
+
+    it(`after connected→disconnected→connected cycle, subsequent 'failed' DOES trigger ICE restart (flag stays true)`, () => {
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'connected';
+      publisher['onIceConnectionStateChange']();
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'disconnected';
+      publisher['onIceConnectionStateChange']();
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'connected';
+      publisher['onIceConnectionStateChange']();
+
+      vi.spyOn(publisher, 'restartIce').mockResolvedValue();
+      publisher['onReconnectionNeeded'] = vi.fn();
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'failed';
+      publisher['onIceConnectionStateChange']();
+      expect(publisher.restartIce).toHaveBeenCalled();
+      // the reason here is the regular restart path, NOT 'ice_never_connected'
+      expect(publisher['onReconnectionNeeded']).not.toHaveBeenCalledWith(
+        WebsocketReconnectStrategy.REJOIN,
+        ReconnectReason.ICE_NEVER_CONNECTED,
+        PeerType.PUBLISHER_UNSPECIFIED,
+      );
+    });
+
+    it(`connection-state 'failed' (distinct from ICE state) still fires REJOIN even after ICE was connected`, () => {
+      // mark ICE as connected first
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'connected';
+      publisher['onIceConnectionStateChange']();
+
+      publisher['onReconnectionNeeded'] = vi.fn();
+      // @ts-expect-error private api
+      publisher['pc'].connectionState = 'failed';
+      publisher['onConnectionStateChange']();
+      expect(publisher['onReconnectionNeeded']).toHaveBeenCalledWith(
+        WebsocketReconnectStrategy.REJOIN,
+        ReconnectReason.CONNECTION_FAILED,
+        PeerType.PUBLISHER_UNSPECIFIED,
+      );
+    });
+
+    it(`'completed' state is treated as connectivity — subsequent 'failed' DOES trigger ICE restart`, () => {
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'completed';
+      publisher['onIceConnectionStateChange']();
+
+      vi.spyOn(publisher, 'restartIce').mockResolvedValue();
+      publisher['onReconnectionNeeded'] = vi.fn();
+      // @ts-expect-error private api
+      publisher['pc'].iceConnectionState = 'failed';
+      publisher['onIceConnectionStateChange']();
+      expect(publisher.restartIce).toHaveBeenCalled();
+      expect(publisher['onReconnectionNeeded']).not.toHaveBeenCalledWith(
+        WebsocketReconnectStrategy.REJOIN,
+        ReconnectReason.ICE_NEVER_CONNECTED,
+        PeerType.PUBLISHER_UNSPECIFIED,
+      );
     });
 
     it(`should schedule ICE restart but cancel it if connection recovers in the meantime`, () => {

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -88,6 +88,7 @@ describe('Publisher', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     vi.resetModules();
     publisher.dispose();

--- a/packages/client/src/rtc/__tests__/Subscriber.test.ts
+++ b/packages/client/src/rtc/__tests__/Subscriber.test.ts
@@ -64,6 +64,7 @@ describe('Subscriber', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     vi.resetModules();
     subscriber.dispose();

--- a/packages/client/src/rtc/__tests__/Subscriber.test.ts
+++ b/packages/client/src/rtc/__tests__/Subscriber.test.ts
@@ -11,8 +11,10 @@ import {
   ErrorCode,
   PeerType,
   TrackType,
+  WebsocketReconnectStrategy,
 } from '../../gen/video/sfu/models/models';
 import { NegotiationError } from '../NegotiationError';
+import { ReconnectReason } from '../types';
 import { IceTrickleBuffer } from '../IceTrickleBuffer';
 import { StreamClient } from '../../coordinator/connection/client';
 
@@ -97,7 +99,14 @@ describe('Subscriber', () => {
       });
     });
 
+    const simulatePriorIceConnected = () => {
+      // @ts-expect-error - private field
+      subscriber['pc'].iceConnectionState = 'connected';
+      subscriber['onIceConnectionStateChange']();
+    };
+
     it(`should perform ICE restart when connection state changes to 'failed'`, () => {
+      simulatePriorIceConnected();
       vi.spyOn(subscriber, 'restartIce').mockResolvedValue();
       // @ts-expect-error - private field
       subscriber['pc'].iceConnectionState = 'failed';
@@ -106,6 +115,7 @@ describe('Subscriber', () => {
     });
 
     it(`should perform ICE restart when connection state changes to 'disconnected'`, () => {
+      simulatePriorIceConnected();
       vi.spyOn(subscriber, 'restartIce').mockResolvedValue();
       vi.useFakeTimers();
       // @ts-expect-error - private field
@@ -113,6 +123,51 @@ describe('Subscriber', () => {
       subscriber['onIceConnectionStateChange']();
       vi.runOnlyPendingTimers();
       expect(subscriber.restartIce).toHaveBeenCalled();
+    });
+
+    it(`does NOT perform ICE restart when ICE never connected and state goes to 'failed' — emits REJOIN with 'ice_never_connected'`, () => {
+      vi.spyOn(subscriber, 'restartIce').mockResolvedValue();
+      subscriber['onReconnectionNeeded'] = vi.fn();
+      // @ts-expect-error - private field
+      subscriber['pc'].iceConnectionState = 'failed';
+      subscriber['onIceConnectionStateChange']();
+      expect(subscriber.restartIce).not.toHaveBeenCalled();
+      expect(subscriber['onReconnectionNeeded']).toHaveBeenCalledWith(
+        WebsocketReconnectStrategy.REJOIN,
+        ReconnectReason.ICE_NEVER_CONNECTED,
+        PeerType.SUBSCRIBER,
+      );
+    });
+
+    it(`isStable() returns true only when ICE is connected/completed and connectionState is connected`, () => {
+      // @ts-expect-error - private field
+      subscriber['pc'].iceConnectionState = 'connected';
+      // @ts-expect-error - private field
+      subscriber['pc'].connectionState = 'connected';
+      expect(subscriber.isStable()).toBe(true);
+
+      // @ts-expect-error - private field
+      subscriber['pc'].iceConnectionState = 'completed';
+      expect(subscriber.isStable()).toBe(true);
+
+      // @ts-expect-error - private field
+      subscriber['pc'].iceConnectionState = 'disconnected';
+      expect(subscriber.isStable()).toBe(false);
+
+      // @ts-expect-error - private field
+      subscriber['pc'].iceConnectionState = 'new';
+      expect(subscriber.isStable()).toBe(false);
+    });
+
+    it(`iceHasEverConnected tracks lifetime connectivity`, () => {
+      expect(subscriber['iceHasEverConnected']).toBe(false);
+      simulatePriorIceConnected();
+      expect(subscriber['iceHasEverConnected']).toBe(true);
+      // going disconnected does not reset the flag
+      // @ts-expect-error - private field
+      subscriber['pc'].iceConnectionState = 'disconnected';
+      subscriber['onIceConnectionStateChange']();
+      expect(subscriber['iceHasEverConnected']).toBe(true);
     });
 
     it(`should throw NegotiationError when SFU returns an error`, async () => {

--- a/packages/client/src/rtc/index.ts
+++ b/packages/client/src/rtc/index.ts
@@ -1,5 +1,6 @@
 export * from './codecs';
 export * from './Dispatcher';
+export * from './NegotiationError';
 export * from './IceTrickleBuffer';
 export * from './Publisher';
 export * from './Subscriber';

--- a/packages/client/src/rtc/types.ts
+++ b/packages/client/src/rtc/types.ts
@@ -13,8 +13,11 @@ import type { ClientPublishOptions } from '../types';
 /**
  * Canonical reasons the SDK uses to trigger a reconnection. Free-form strings
  * are still accepted at the callback boundary (e.g. when forwarding an SFU
- * error message), but the members below name the cases the SDK itself raises
- * and the cases consumers like `Call.reconnect` inspect programmatically.
+ * error message), but only the members below influence reconnect-loop
+ * behavior. In particular, `Call.reconnect` programmatically inspects
+ * `ICE_NEVER_CONNECTED` to drive the unsupported-network detector — pass a
+ * canonical member when you want the SDK to react to the reason; pass a
+ * free-form string when the value is purely diagnostic.
  */
 export const ReconnectReason = {
   /** ICE never reached `connected`/`completed`, escalate to REJOIN. */

--- a/packages/client/src/rtc/types.ts
+++ b/packages/client/src/rtc/types.ts
@@ -10,11 +10,44 @@ import { Dispatcher } from './Dispatcher';
 import type { OptimalVideoLayer } from './layers';
 import type { ClientPublishOptions } from '../types';
 
+/**
+ * Canonical reasons the SDK uses to trigger a reconnection. Free-form strings
+ * are still accepted at the callback boundary (e.g. when forwarding an SFU
+ * error message), but the members below name the cases the SDK itself raises
+ * and the cases consumers like `Call.reconnect` inspect programmatically.
+ */
+export const ReconnectReason = {
+  /** ICE never reached `connected`/`completed`, escalate to REJOIN. */
+  ICE_NEVER_CONNECTED: 'ice_never_connected',
+  /** RTCPeerConnection.connectionState became `failed`. */
+  CONNECTION_FAILED: 'connection_failed',
+  /** `restartIce()` rejected. */
+  RESTART_ICE_FAILED: 'restart_ice_failed',
+  /** SFU `goAway` event, migrate to a new SFU. */
+  GO_AWAY: 'go_away',
+  /** Network came back online after going offline. */
+  NETWORK_BACK_ONLINE: 'network_back_online',
+  /** SFU error event with no descriptive message. */
+  SFU_ERROR: 'sfu_error',
+} as const;
+
+export type ReconnectReason =
+  | (typeof ReconnectReason)[keyof typeof ReconnectReason]
+  | (string & {});
+
 export type OnReconnectionNeeded = (
   kind: WebsocketReconnectStrategy,
-  reason: string,
+  reason: ReconnectReason,
   peerType: PeerType,
 ) => void;
+
+/**
+ * Fires the first time a peer connection's ICE transport reaches
+ * `connected` or `completed` during its lifetime. Used by `Call` to reset
+ * the "ICE never connected" failure counter only when WebRTC has actually
+ * recovered, not merely when the SFU join handshake succeeded.
+ */
+export type OnIceConnected = (peerType: PeerType) => void;
 
 export type BasePeerConnectionOpts = {
   sfuClient: StreamSfuClient;
@@ -22,6 +55,7 @@ export type BasePeerConnectionOpts = {
   connectionConfig?: RTCConfiguration;
   dispatcher: Dispatcher;
   onReconnectionNeeded?: OnReconnectionNeeded;
+  onIceConnected?: OnIceConnected;
   tag: string;
   enableTracing: boolean;
   iceRestartDelay?: number;


### PR DESCRIPTION
### 💡 Overview

The SFU reconnection loop in `Call.ts` previously retried indefinitely.
On networks that can't actually do WebRTC, or when SDP negotiation keeps failing, the SDK churned `joinRequest`s and `restartICE` calls forever instead of surfacing a clear terminal state.

This PR introduces three stop conditions, a real backoff, an ICE-was-connected gate, and a FAST-reconnect optimisation that skips publisher ICE restart when the peer connection is still healthy. Aligned with the equivalent Swift change in https://github.com/GetStream/stream-video-swift/pull/1119 where applicable; the JS-only additions go further.

### 📝 Implementation notes

**Stop conditions** (terminal: call `this.leave({ message: <reason> })`, matching iOS/Android — JS doesn't expose `RECONNECTING_FAILED`):

- `rejoin_attempt_limit_exceeded` — rolling 10 rejoins per 120 s   (Swift parity), via a new generic `SlidingWindowRateLimiter`.
- `webrtc_unsupported_network` — N peer-connection failures with zero `connected` events (default 2). Counter resets only when ICE actually reaches `connected`/`completed`, **not** on SFU join alone.
- `repeated_negotiation_failures` — N consecutive `NegotiationError`s in the reconnect loop (default 3).

**ICE gating in `BasePeerConnection`:**
- pre-connect `failed` → escalate to REJOIN with `ice_never_connected`.
- pre-connect `disconnected` → transient, log only and wait (the browser may recover; if it ultimately fails, `failed` takes over).
- otherwise unchanged: `disconnected` schedules a delayed restart, `failed` restarts immediately.

**FAST reconnect publisher-skip:** if the publisher PC is still `isStable()` when only the signal WS dropped, FAST no longer issues a redundant `publisher.restartIce()`.

**Reconnect-state reset on `leave()`:** `reconnectStrategy`, `reconnectReason`, and `reconnectAttempts` are now cleared in `Call.leave()`. The success path at the end of `joinFlow` already cleared the first two, but `giveUpAndLeave()` bypasses that path, and `reconnectAttempts` was never reset. Without this, a Call instance reused after a terminal `giveUpAndLeave()` would send stale `ReconnectDetails` on the next fresh `join()`.

**SFU client teardown fixes:**

- `close()` now closes the WebSocket whether it's `OPEN` or still  `CONNECTING` (so an in-flight upgrade can't dispatch events into a torn-down Call).
- `dispose()` rejects a still-pending `joinResponseTask` so awaiters (`leaveAndClose`, `await joinTask`) don't hang. The promise is created via a small `makeJoinResponseTask` factory that attaches a no-op rejection handler; explicit awaiters still observe the rejection through their own `then`/`catch`.

🎫 Ticket: https://linear.app/stream/issue/REACT-959/improve-video-sdk-reconnects-and-ice-restart-behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced WebRTC reconnection with explicit attempt budgeting and configurable limits for ICE and negotiation failures
  * Added a rolling-window rate limiter to control reconnect attempts
  * Exposed negotiation error type for RTC consumers

* **Bug Fixes**
  * Fixed unhandled promise rejections during SFU/client teardown
  * Refined ICE state tracking and restart/restore behavior to reduce unnecessary reconnections

* **Documentation**
  * Added class-style conventions and examples

* **Tests**
  * New comprehensive tests covering reconnect, ICE, and rate-limiter behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->