### PR TITLE
fix(react-dogfood): use list device selector on Safari and in active call

### DIFF
--- a/sample-apps/react/react-dogfood/components/ToggleCameraButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleCameraButton.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 
 import {
+  Browsers,
   DeviceSelectorVideo,
   Icon,
   MenuToggle,
@@ -35,7 +36,7 @@ const ToggleMenuButton = forwardRef<HTMLButtonElement, ToggleMenuButtonProps>(
 );
 
 export const ToggleCameraButton = () => {
-  const visualType = isMobile() ? 'list' : 'preview';
+  const visualType = isMobile() || Browsers.isSafari() ? 'list' : 'preview';
   return (
     <MenuToggle
       placement="top-start"

--- a/sample-apps/react/react-dogfood/components/ToggleDualCameraButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleDualCameraButton.tsx
@@ -4,18 +4,15 @@ import {
   Restricted,
   ToggleVideoPublishingButton,
 } from '@stream-io/video-react-sdk';
-import { isMobile } from '../helpers/isMobile';
 import { DegradedPerformanceNotification } from './DegradedPerformanceNotification';
 
 export const ToggleDualCameraButton = () => {
-  const visualType = isMobile() ? 'list' : 'preview';
-
   return (
     <Restricted requiredGrants={[OwnCapability.SEND_VIDEO]} hasPermissionsOnly>
       <div className="rd__dual-toggle">
         <DegradedPerformanceNotification className="rd__call-controls__notification" />
         <ToggleVideoPublishingButton
-          Menu={<DeviceSelectorVideo visualType={visualType} />}
+          Menu={<DeviceSelectorVideo visualType="list" />}
           menuPlacement="top"
         />
       </div>

--- a/sample-apps/react/react-dogfood/components/ToggleDualMicButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleDualMicButton.tsx
@@ -13,10 +13,7 @@ export const ToggleDualMicButton = () => {
         <ToggleAudioPublishingButton
           Menu={
             <>
-              <DeviceSelectorAudioInput
-                visualType="preview"
-                title="Microphone"
-              />
+              <DeviceSelectorAudioInput visualType="list" title="Microphone" />
               <DeviceSelectorAudioOutput visualType="list" title="Speaker" />
             </>
           }

--- a/sample-apps/react/react-dogfood/components/ToggleMicButton.tsx
+++ b/sample-apps/react/react-dogfood/components/ToggleMicButton.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 
 import {
+  Browsers,
   DeviceSelectorAudioInput,
   DeviceSelectorAudioOutput,
   Icon,
@@ -10,6 +11,7 @@ import {
   useCallStateHooks,
   useI18n,
 } from '@stream-io/video-react-sdk';
+import { isMobile } from '../helpers/isMobile';
 
 const ToggleMenuButton = forwardRef<HTMLButtonElement, ToggleMenuButtonProps>(
   function ToggleMenuButton(props, ref) {
@@ -35,13 +37,19 @@ const ToggleMenuButton = forwardRef<HTMLButtonElement, ToggleMenuButtonProps>(
 );
 
 export const ToggleMicButton = () => {
+  const inputVisualType =
+    isMobile() || Browsers.isSafari() ? 'list' : 'preview';
+
   return (
     <MenuToggle
       placement="top-start"
       ToggleButton={ToggleMenuButton}
       visualType={MenuVisualType.MENU}
     >
-      <DeviceSelectorAudioInput visualType="preview" title="Microphone" />
+      <DeviceSelectorAudioInput
+        visualType={inputVisualType}
+        title="Microphone"
+      />
       <DeviceSelectorAudioOutput visualType="list" title="Speaker" />
     </MenuToggle>
   );


### PR DESCRIPTION
### 💡 Overview
Safari behaves inconsistently when we open streams for each device causing audio issues. Use `list` device selector on Safari, additionally use preview mode only in Lobby.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/1255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced device selector interface for Safari and mobile devices—camera and microphone selectors now use list view for improved usability.
  * Standardized visual presentation of device selection across different browsers and platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->