### PR TITLE
chore(ci): bump GitHub Actions to latest majors

### DIFF
--- a/.github/actions/rn-bootstrap/action.yml
+++ b/.github/actions/rn-bootstrap/action.yml
@@ -6,7 +6,7 @@ runs:
     - run: echo "IMAGE=${ImageOS}-${ImageVersion}" >> $GITHUB_ENV
       shell: bash
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       if: ${{ env.INSTALL_NODE == 'true' }}
       with:
         node-version: 24.x
@@ -23,7 +23,7 @@ runs:
       shell: bash
 
     - name: Cache pods
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: ${{ env.INSTALL_PODS == 'true' }}
       with:
         path: sample-apps/react-native/dogfood/ios/Pods
@@ -39,7 +39,7 @@ runs:
 
     - name: Cache Gradle
       if: ${{ env.INSTALL_JAVA == 'true' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: |
           ~/.gradle/caches
@@ -48,7 +48,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       if: ${{ env.INSTALL_JAVA == 'true' }}
       with:
         distribution: 'zulu'
@@ -62,7 +62,7 @@ runs:
       shell: bash
 
     # Retrieve the cached emulator snapshot
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       if: ${{ env.INSTALL_ANDROID_EMULATOR == 'true' }}
       id: avd-cache
       with:

--- a/.github/workflows/deploy-react-sample-apps.yml
+++ b/.github/workflows/deploy-react-sample-apps.yml
@@ -69,10 +69,10 @@ jobs:
       MODE: ${{ github.ref_name == 'main' && 'production' || 'preview' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: 'yarn'

--- a/.github/workflows/egress-composite-e2e.yml
+++ b/.github/workflows/egress-composite-e2e.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: 'yarn'
@@ -47,7 +47,7 @@ jobs:
         run: yarn build:react:deps
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -64,7 +64,7 @@ jobs:
         run: yarn workspace @stream-io/egress-composite test:e2e:prod
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,6 +8,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@v3
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/react-native-workflow.yml
+++ b/.github/workflows/react-native-workflow.yml
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/rn-bootstrap
         timeout-minutes: 15
@@ -81,7 +81,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.platform || github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both' }}
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select XCode version
         run: sudo xcode-select --switch /Applications/Xcode_26.1.1.app
@@ -98,7 +98,7 @@ jobs:
         run: bundle exec fastlane build_ios
 
       - name: Upload .ipa
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ipa
           path: |
@@ -112,7 +112,7 @@ jobs:
     if: ${{ (github.event_name != 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && (!github.event.inputs.platform || github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both')) }}
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select XCode version
         run: sudo xcode-select --switch /Applications/Xcode_26.1.1.app
@@ -121,7 +121,7 @@ jobs:
         timeout-minutes: 15
 
       - name: Download .ipa
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ipa
 
@@ -136,7 +136,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || !github.event.inputs.platform || github.event.inputs.platform == 'android' || github.event.inputs.platform == 'both' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/rn-bootstrap
         timeout-minutes: 15
@@ -168,13 +168,13 @@ jobs:
         run: bundle exec fastlane build_android_play_store
 
       - name: Upload .apk
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: apk
           path: '**/dist/*.apk'
 
       - name: Upload .aab
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: aab
           path: '**/dist/*.aab'
@@ -186,13 +186,13 @@ jobs:
     if: ${{ (github.event_name != 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && (!github.event.inputs.platform || github.event.inputs.platform == 'android' || github.event.inputs.platform == 'both')) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/rn-bootstrap
         timeout-minutes: 15
 
       - name: Download .aab
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: aab
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,16 +18,16 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: 'yarn'
 
       - name: ESLint Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: './.eslintcache'
           key: ${{ runner.os }}-eslintcache-${{ github.ref_name }}-${{ hashFiles('.eslintcache') }}

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -28,19 +28,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
       - name: ESLint Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: './.eslintcache'
           key: ${{ runner.os }}-eslintcache-${{ github.ref_name }}-${{ hashFiles('.eslintcache') }}


### PR DESCRIPTION
### 💡 Overview

Bumps all GitHub Actions used across CI workflows to their latest major versions, and replaces the unmaintained PR-title linter (`aslafy-z/conventional-pr-title-action`) with the more widely used `amannn/action-semantic-pull-request`.

### 📝 Implementation notes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `actions/cache` | v4 (one v3 in `rn-bootstrap`) | **v5** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `actions/setup-java` | v4 | **v5** |
| PR-title linter | `aslafy-z/conventional-pr-title-action@v3` | `amannn/action-semantic-pull-request@v6` |
| `ruby/setup-ruby` | v1 | unchanged (v1 is the floating major track) |

All major bumps require Actions Runner ≥ 2.327.1, which GitHub-hosted `ubuntu-latest` / `macos-15` already satisfy.

**Behavior notes worth flagging:**

- `download-artifact@v8`: hash mismatches now **error** by default (previously a warning). This is good security hygiene; if a legit mismatch ever shows up, we can opt out per-step via `digest-mismatch: warn`.
- `setup-node@v6`: auto-caching is now scoped to npm only. We use explicit `cache: 'yarn'` everywhere, so this is a no-op.
- `upload-artifact@v7` + `download-artifact@v8` share the same artifact backend and are designed to be paired; existing upload→download flows in `react-native-workflow.yml` are unchanged.
- `amannn/action-semantic-pull-request@v6` validates Conventional Commit-style PR titles by default, matching our existing convention.

🎫 Ticket: n/a (CI hygiene)