### PR TITLE
fix(client): prevent call.join() hang on silent WS handshake stall

### DIFF
--- a/packages/client/src/coordinator/connection/__tests__/connection.test.ts
+++ b/packages/client/src/coordinator/connection/__tests__/connection.test.ts
@@ -28,11 +28,11 @@ class StuckWebSocket {
     StuckWebSocket.instances.push(this);
   }
 
-  close() {
+  close = () => {
     this.readyState = StuckWebSocket.CLOSED;
-  }
+  };
 
-  send() {}
+  send = () => {};
 }
 
 // A drivable mock that lets the test fire onopen / onmessage / onclose
@@ -77,13 +77,13 @@ class ManualWebSocket {
     } as MessageEvent);
   };
 
-  close() {
+  close = () => {
     this.readyState = ManualWebSocket.CLOSED;
-  }
+  };
 
-  send(data: string) {
+  send = (data: string) => {
     this.sentMessages.push(data);
-  }
+  };
 }
 
 const buildClient = () => {

--- a/packages/client/src/coordinator/connection/__tests__/connection.test.ts
+++ b/packages/client/src/coordinator/connection/__tests__/connection.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StreamClient } from '../client';
+import { StableWSConnection } from '../connection';
+import type { WSConnectionError } from '../types';
+
+class StuckWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: StuckWebSocket[] = [];
+
+  // instance-level constants so consumers can read e.g. ws.CLOSED
+  CONNECTING = StuckWebSocket.CONNECTING;
+  OPEN = StuckWebSocket.OPEN;
+  CLOSING = StuckWebSocket.CLOSING;
+  CLOSED = StuckWebSocket.CLOSED;
+
+  readyState = StuckWebSocket.CONNECTING;
+  url: string;
+  onopen: ((ev?: unknown) => unknown) | null = null;
+  onclose: ((ev?: unknown) => unknown) | null = null;
+  onerror: ((ev?: unknown) => unknown) | null = null;
+  onmessage: ((ev?: unknown) => unknown) | null = null;
+
+  constructor(url: string | URL) {
+    this.url = url.toString();
+    StuckWebSocket.instances.push(this);
+  }
+
+  close() {
+    this.readyState = StuckWebSocket.CLOSED;
+  }
+
+  send() {}
+}
+
+// A drivable mock that lets the test fire onopen / onmessage / onclose
+// at chosen points so we can observe behavior between handshake events.
+class ManualWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: ManualWebSocket[] = [];
+
+  CONNECTING = ManualWebSocket.CONNECTING;
+  OPEN = ManualWebSocket.OPEN;
+  CLOSING = ManualWebSocket.CLOSING;
+  CLOSED = ManualWebSocket.CLOSED;
+
+  readyState = ManualWebSocket.CONNECTING;
+  url: string;
+  onopen: ((ev?: unknown) => unknown) | null = null;
+  onclose: ((ev?: unknown) => unknown) | null = null;
+  onerror: ((ev?: unknown) => unknown) | null = null;
+  onmessage: ((ev?: unknown) => unknown) | null = null;
+  sentMessages: string[] = [];
+
+  constructor(url: string | URL) {
+    this.url = url.toString();
+    ManualWebSocket.instances.push(this);
+  }
+
+  fireOpen = () => {
+    this.readyState = ManualWebSocket.OPEN;
+    this.onopen?.({});
+  };
+
+  fireConnectionOk = (connectionId: string) => {
+    this.onmessage?.({
+      data: JSON.stringify({
+        type: 'connection.ok',
+        connection_id: connectionId,
+        me: { id: 'test-user' },
+      }),
+    } as MessageEvent);
+  };
+
+  close() {
+    this.readyState = ManualWebSocket.CLOSED;
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+}
+
+const buildClient = () => {
+  const client = new StreamClient('test-key', {
+    browser: false,
+    defaultWsTimeout: 5000,
+    WebSocketImpl: StuckWebSocket as unknown as typeof WebSocket,
+    timeout: 1000,
+  });
+
+  vi.spyOn(client.tokenManager, 'tokenReady').mockResolvedValue('fake-token');
+  vi.spyOn(client.tokenManager, 'loadToken').mockResolvedValue('fake-token');
+  vi.spyOn(client.tokenManager, 'getToken').mockReturnValue('fake-token');
+
+  client._setUser({ id: 'test-user' });
+  client.userID = 'test-user';
+  client.clientID = 'test-user--abcdef';
+
+  // matches what StreamClient.openConnection does before kicking off connect()
+  client._setupConnectionIdPromise();
+
+  return client;
+};
+
+describe('StableWSConnection - silent handshake hang', () => {
+  beforeEach(() => {
+    StuckWebSocket.instances = [];
+    ManualWebSocket.instances = [];
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects in-flight connectionIdPromise within defaultWsTimeout when WS upgrade silently stalls', async () => {
+    const client = buildClient();
+
+    // capture the promise that doAxiosRequest (e.g. from Call.join) would
+    // already be awaiting before _connect runs to completion
+    const originalConnectionIdPromise = client.connectionIdPromise!;
+    expect(originalConnectionIdPromise).toBeDefined();
+
+    // track settlement deterministically. If the orphaning bug regresses,
+    // these stay false and the test fails via assertion (not a vitest
+    // test-timeout, which would only signal "hang somewhere").
+    let didResolve = false;
+    let rejectionError: WSConnectionError | undefined;
+    originalConnectionIdPromise.then(
+      () => {
+        didResolve = true;
+      },
+      (error: WSConnectionError) => {
+        rejectionError = error;
+      },
+    );
+
+    const wsConnection = new StableWSConnection(client);
+    client.wsConnection = wsConnection;
+    const connectAttempt = wsConnection.connect(5000);
+    // attach a no-op rejection handler so vitest does not surface it as
+    // unhandled while we orchestrate fake timers; we still assert below.
+    const connectAttemptOutcome = connectAttempt.then(
+      () => ({ kind: 'resolved' as const }),
+      (error: WSConnectionError) => ({
+        kind: 'rejected' as const,
+        error,
+      }),
+    );
+
+    // let the token mock resolve and the WS get instantiated
+    await vi.advanceTimersByTimeAsync(0);
+    expect(StuckWebSocket.instances.length).toBe(1);
+    expect(StuckWebSocket.instances[0].readyState).toBe(
+      StuckWebSocket.CONNECTING,
+    );
+    // before the watchdog fires, the original promise must still be pending
+    expect(didResolve).toBe(false);
+    expect(rejectionError).toBeUndefined();
+
+    // trip the handshake watchdog
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(didResolve).toBe(false);
+    expect(rejectionError).toBeInstanceOf(Error);
+    expect(rejectionError?.isWSFailure).toBe(true);
+    expect(rejectionError?.message).toMatch(/WS handshake timed out/);
+
+    // half-open WS should have been torn down by the catch block
+    expect(StuckWebSocket.instances[0].readyState).toBe(StuckWebSocket.CLOSED);
+
+    // isConnecting must be cleared so a subsequent reconnect can proceed
+    expect(wsConnection.isConnecting).toBe(false);
+
+    // and the connectionIdPromise must NOT have been replaced with a fresh
+    // pending one in the catch: it stays rejected so any awaiter captured
+    // between the catch and the _reconnect's retry interval fails fast
+    // instead of silently capturing a never-settling P2. _reconnect's
+    // entry guard (in _connect) will recreate it on the next attempt.
+    expect(client.isConnectionIsPromisePending).toBe(false);
+
+    // drain the outer connect()'s _waitForHealthy(5000) and assert it
+    // bubbles up an isWSFailure rejection (rather than hanging forever)
+    await vi.advanceTimersByTimeAsync(20000);
+    const outcome = await connectAttemptOutcome;
+    expect(outcome.kind).toBe('rejected');
+  });
+
+  it('does not schedule a reconnect (and leaves connectionIdPromise rejected) on a permanent, non-WS failure', async () => {
+    const client = new StreamClient('test-key', {
+      browser: false,
+      defaultWsTimeout: 5000,
+      WebSocketImpl: StuckWebSocket as unknown as typeof WebSocket,
+      timeout: 1000,
+    });
+    // tokenReady rejects to push us into loadToken; loadToken then throws
+    // to drive _connect into its catch with an error that has no
+    // isWSFailure flag (the same shape as a permanent server reject).
+    vi.spyOn(client.tokenManager, 'tokenReady').mockRejectedValue(
+      new Error('token provider failed previously'),
+    );
+    vi.spyOn(client.tokenManager, 'loadToken').mockRejectedValue(
+      new Error('permanent token error'),
+    );
+    vi.spyOn(client.tokenManager, 'getToken').mockReturnValue('fake-token');
+
+    client._setUser({ id: 'test-user' });
+    client.userID = 'test-user';
+    client.clientID = 'test-user--abcdef';
+    client._setupConnectionIdPromise();
+
+    const originalConnectionIdPromise = client.connectionIdPromise!;
+    let didResolve = false;
+    let rejectionError: Error | undefined;
+    originalConnectionIdPromise.then(
+      () => {
+        didResolve = true;
+      },
+      (error: Error) => {
+        rejectionError = error;
+      },
+    );
+
+    const wsConnection = new StableWSConnection(client);
+    // spy on _reconnect to assert directly that no retry chain is
+    // launched on permanent failures
+    const reconnectSpy = vi.spyOn(wsConnection, '_reconnect');
+    client.wsConnection = wsConnection;
+    const connectAttempt = wsConnection.connect(5000);
+    const connectAttemptOutcome = connectAttempt.then(
+      () => ({ kind: 'resolved' as const }),
+      (error: Error) => ({ kind: 'rejected' as const, error }),
+    );
+
+    // let the token mock rejections propagate through _connect's catch
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(didResolve).toBe(false);
+    expect(rejectionError).toBeInstanceOf(Error);
+    expect(rejectionError?.message).toMatch(/permanent token error/);
+
+    // Finding #2: catch must NOT recreate connectionIdPromise as a fresh
+    // pending one for permanent (non-isWSFailure) errors. Otherwise, a
+    // doAxiosRequest issued in this window would capture a P that nothing
+    // ever settles and would hang indefinitely.
+    expect(client.isConnectionIsPromisePending).toBe(false);
+
+    // and crucially, no reconnect chain was launched - the catch's
+    // _reconnect() call is gated on err.isWSFailure, which is absent here.
+    // drain a generous slice of fake time to be sure no retry sneaks in.
+    await vi.advanceTimersByTimeAsync(20000);
+    expect(reconnectSpy).not.toHaveBeenCalled();
+
+    const outcome = await connectAttemptOutcome;
+    expect(outcome.kind).toBe('rejected');
+  });
+
+  it('does not write resolveConnectionId when disconnect runs after the handshake completes', async () => {
+    const client = new StreamClient('test-key', {
+      browser: false,
+      defaultWsTimeout: 5000,
+      WebSocketImpl: ManualWebSocket as unknown as typeof WebSocket,
+      timeout: 1000,
+    });
+    vi.spyOn(client.tokenManager, 'tokenReady').mockResolvedValue('fake-token');
+    vi.spyOn(client.tokenManager, 'loadToken').mockResolvedValue('fake-token');
+    vi.spyOn(client.tokenManager, 'getToken').mockReturnValue('fake-token');
+
+    client._setUser({ id: 'test-user' });
+    client.userID = 'test-user';
+    client.clientID = 'test-user--abcdef';
+    client._setupConnectionIdPromise();
+
+    // observe whether resolveConnectionId is called by wrapping it
+    let resolveConnectionIdCalled = false;
+    const originalResolve = client.resolveConnectionId;
+    client.resolveConnectionId = (...args: unknown[]) => {
+      resolveConnectionIdCalled = true;
+      return (originalResolve as (...a: unknown[]) => unknown)?.(...args);
+    };
+
+    const wsConnection = new StableWSConnection(client);
+    client.wsConnection = wsConnection;
+    const connectAttempt = wsConnection.connect(5000);
+    const connectAttemptOutcome = connectAttempt.then(
+      () => ({ kind: 'resolved' as const }),
+      (error: Error) => ({ kind: 'rejected' as const, error }),
+    );
+
+    // let the token resolve and the WS get created
+    await vi.advanceTimersByTimeAsync(0);
+    const ws = ManualWebSocket.instances.at(-1)!;
+    expect(ws).toBeDefined();
+
+    // simulate a successful handshake: open, then connection.ok
+    ws.fireOpen();
+    ws.fireConnectionOk('stale-conn-id');
+
+    // SYNCHRONOUSLY mark the connection as disconnected (as
+    // closeConnection() / disconnectUser() would) BEFORE the await
+    // Promise.race continuation in _connect runs. The post-handshake
+    // isDisconnected guard in _connect must then short-circuit instead
+    // of writing stale connection_id into the client's resolver.
+    wsConnection.disconnect();
+
+    // flush microtasks so the await Promise.race in _connect resumes
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Finding #1: resolveConnectionId must NOT have been called and
+    // wsConnection.connectionID must remain unset.
+    expect(resolveConnectionIdCalled).toBe(false);
+    expect(wsConnection.connectionID).toBeUndefined();
+
+    // and the new ws must be torn down by the guard's destroy call
+    expect(ws.readyState).toBe(ManualWebSocket.CLOSED);
+
+    // drain any outer connect()/_waitForHealthy bookkeeping
+    await vi.advanceTimersByTimeAsync(20000);
+    await connectAttemptOutcome;
+  });
+});

--- a/packages/client/src/coordinator/connection/__tests__/connection.test.ts
+++ b/packages/client/src/coordinator/connection/__tests__/connection.test.ts
@@ -184,7 +184,7 @@ describe('StableWSConnection - silent handshake hang', () => {
     // between the catch and the _reconnect's retry interval fails fast
     // instead of silently capturing a never-settling P2. _reconnect's
     // entry guard (in _connect) will recreate it on the next attempt.
-    expect(client.isConnectionIsPromisePending).toBe(false);
+    expect(client.isConnectionIdPromisePending).toBe(false);
 
     // drain the outer connect()'s _waitForHealthy(5000) and assert it
     // bubbles up an isWSFailure rejection (rather than hanging forever)
@@ -250,7 +250,7 @@ describe('StableWSConnection - silent handshake hang', () => {
     // pending one for permanent (non-isWSFailure) errors. Otherwise, a
     // doAxiosRequest issued in this window would capture a P that nothing
     // ever settles and would hang indefinitely.
-    expect(client.isConnectionIsPromisePending).toBe(false);
+    expect(client.isConnectionIdPromisePending).toBe(false);
 
     // and crucially, no reconnect chain was launched - the catch's
     // _reconnect() call is gated on err.isWSFailure, which is absent here.
@@ -321,7 +321,161 @@ describe('StableWSConnection - silent handshake hang', () => {
     // and the new ws must be torn down by the guard's destroy call
     expect(ws.readyState).toBe(ManualWebSocket.CLOSED);
 
-    // drain any outer connect()/_waitForHealthy bookkeeping
+    // The post-handshake guard must surface the abort to the caller of
+    // connect() instead of silently returning. Otherwise _waitForHealthy
+    // would observe the already-resolved connectionOpen and resolve with
+    // a ConnectedEvent for a torn-down connection.
+    await vi.advanceTimersByTimeAsync(20000);
+    const outcome = await connectAttemptOutcome;
+    expect(outcome.kind).toBe('rejected');
+    if (outcome.kind === 'rejected') {
+      expect(outcome.error.message).toMatch(
+        /disconnect\(\) ran while connecting/,
+      );
+    }
+  });
+
+  it('rejects the captured client.connectionIdPromise when disconnect aborts a handshake (no reopen)', async () => {
+    const client = new StreamClient('test-key', {
+      browser: false,
+      defaultWsTimeout: 5000,
+      WebSocketImpl: ManualWebSocket as unknown as typeof WebSocket,
+      timeout: 1000,
+    });
+    vi.spyOn(client.tokenManager, 'tokenReady').mockResolvedValue('fake-token');
+    vi.spyOn(client.tokenManager, 'loadToken').mockResolvedValue('fake-token');
+    vi.spyOn(client.tokenManager, 'getToken').mockReturnValue('fake-token');
+
+    client._setUser({ id: 'test-user' });
+    client.userID = 'test-user';
+    client.clientID = 'test-user--abcdef';
+    client._setupConnectionIdPromise();
+
+    // capture the connection-id promise BEFORE the handshake races against
+    // disconnect. doAxiosRequest awaits this same promise before sending
+    // non-public REST calls, so if it never settles those callers hang
+    // forever (the regression Codex flagged).
+    const capturedPromise = client.connectionIdPromise!;
+    expect(capturedPromise).toBeDefined();
+    let capturedResolved = false;
+    let capturedRejected: Error | undefined;
+    capturedPromise.then(
+      () => {
+        capturedResolved = true;
+      },
+      (error: Error) => {
+        capturedRejected = error;
+      },
+    );
+
+    const wsConnection = new StableWSConnection(client);
+    client.wsConnection = wsConnection;
+    const connectAttempt = wsConnection.connect(5000);
+    const connectAttemptOutcome = connectAttempt.then(
+      () => ({ kind: 'resolved' as const }),
+      (error: Error) => ({ kind: 'rejected' as const, error }),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    const ws = ManualWebSocket.instances.at(-1)!;
+
+    // successful handshake then synchronous disconnect (closeConnection
+    // path - does NOT touch client.connectionIdPromise)
+    ws.fireOpen();
+    ws.fireConnectionOk('stale-conn-id');
+    wsConnection.disconnect();
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The captured connection-id promise must be rejected (not stuck
+    // pending), so any in-flight doAxiosRequest fails fast.
+    expect(capturedResolved).toBe(false);
+    expect(capturedRejected).toBeInstanceOf(Error);
+    expect(capturedRejected?.message).toMatch(
+      /disconnect\(\) ran while connecting/,
+    );
+
+    // drain outer connect() bookkeeping
+    await vi.advanceTimersByTimeAsync(20000);
+    await connectAttemptOutcome;
+  });
+
+  it('rejects only the original promise when openConnection rotates resolvers mid-abort', async () => {
+    const client = new StreamClient('test-key', {
+      browser: false,
+      defaultWsTimeout: 5000,
+      WebSocketImpl: ManualWebSocket as unknown as typeof WebSocket,
+      timeout: 1000,
+    });
+    vi.spyOn(client.tokenManager, 'tokenReady').mockResolvedValue('fake-token');
+    vi.spyOn(client.tokenManager, 'loadToken').mockResolvedValue('fake-token');
+    vi.spyOn(client.tokenManager, 'getToken').mockReturnValue('fake-token');
+
+    client._setUser({ id: 'test-user' });
+    client.userID = 'test-user';
+    client.clientID = 'test-user--abcdef';
+    client._setupConnectionIdPromise();
+
+    // P1: the promise the in-flight _connect attempt is supposed to settle.
+    const promiseP1 = client.connectionIdPromise!;
+    let p1Resolved = false;
+    let p1Rejected: Error | undefined;
+    promiseP1.then(
+      () => {
+        p1Resolved = true;
+      },
+      (error: Error) => {
+        p1Rejected = error;
+      },
+    );
+
+    const wsConnection = new StableWSConnection(client);
+    client.wsConnection = wsConnection;
+    const connectAttempt = wsConnection.connect(5000);
+    const connectAttemptOutcome = connectAttempt.then(
+      () => ({ kind: 'resolved' as const }),
+      (error: Error) => ({ kind: 'rejected' as const, error }),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    const ws = ManualWebSocket.instances.at(-1)!;
+
+    // synchronous chain: handshake completes, disconnect runs, and then
+    // a concurrent openConnection() rotates the client-level resolvers
+    // to a fresh P2 - all BEFORE the _connect catch runs.
+    ws.fireOpen();
+    ws.fireConnectionOk('stale-conn-id');
+    wsConnection.disconnect();
+    client._setupConnectionIdPromise();
+
+    // P2: the rotated promise that the (hypothetical) follow-up
+    // openConnection would own. The stale attempt's catch must NOT
+    // settle this one.
+    const promiseP2 = client.connectionIdPromise!;
+    let p2Resolved = false;
+    let p2Rejected: Error | undefined;
+    promiseP2.then(
+      () => {
+        p2Resolved = true;
+      },
+      (error: Error) => {
+        p2Rejected = error;
+      },
+    );
+
+    // microtask flush -> _connect catch runs -> ownRejectConnectionId
+    // (closure captured BEFORE rotation) settles P1. P2 is untouched.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(p1Resolved).toBe(false);
+    expect(p1Rejected).toBeInstanceOf(Error);
+    expect(p1Rejected?.message).toMatch(/disconnect\(\) ran while connecting/);
+
+    // P2 must still be pending - rotation isolation is the whole point
+    // of capturing the reject closure per attempt.
+    expect(p2Resolved).toBe(false);
+    expect(p2Rejected).toBeUndefined();
+
     await vi.advanceTimersByTimeAsync(20000);
     await connectAttemptOutcome;
   });

--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -423,7 +423,7 @@ export class StreamClient {
     return this.connectionIdPromiseSafe?.();
   }
 
-  get isConnectionIsPromisePending() {
+  get isConnectionIdPromisePending() {
     return this.connectionIdPromiseSafe?.checkPending() ?? false;
   }
 

--- a/packages/client/src/coordinator/connection/connection.ts
+++ b/packages/client/src/coordinator/connection/connection.ts
@@ -284,6 +284,15 @@ export class StableWSConnection {
   ): Promise<ConnectedEvent | undefined> => {
     if (this.isConnecting) return; // ignore _connect if it's currently trying to connect
     this.isConnecting = true;
+    // Snapshot of the connection-id reject closure owned by THIS attempt.
+    // Captured at function entry so that even early failures (e.g.,
+    // tokenManager.loadToken throwing before we reach the WS phase) can
+    // settle the promise the caller is awaiting. Re-captured below if
+    // _connect itself sets up a fresh promise. If a concurrent
+    // openConnection() rotates `client.rejectConnectionId` later, our
+    // captured closure still settles only the original promise (P1) and
+    // never poisons the newer one (P2).
+    let ownRejectConnectionId = this.client.rejectConnectionId;
     let isTokenReady = false;
     try {
       this._log(`_connect() - waiting for token`);
@@ -301,8 +310,11 @@ export class StableWSConnection {
         await this.client.tokenManager.loadToken();
       }
 
-      if (!this.client.isConnectionIsPromisePending) {
+      if (!this.client.isConnectionIdPromisePending) {
         this.client._setupConnectionIdPromise();
+        // recapture: we just rotated the resolver ourselves, the new
+        // closure is the one bound to the promise this attempt owns.
+        ownRejectConnectionId = this.client.rejectConnectionId;
       }
       this._setupConnectionPromise();
       const wsURL = this._buildUrl();
@@ -340,14 +352,19 @@ export class StableWSConnection {
 
       // If we were disconnected during the handshake (e.g. closeConnection()
       // ran while a background _reconnect's _connect was in flight), tear
-      // down the new WS and skip resolveConnectionId so we do not write a
-      // stale connection_id into a connectionIdPromise owned by a newer
-      // StableWSConnection instance.
+      // down the new WS and throw so the caller of connect() does not get
+      // a misleading "success" for a connection that has already been
+      // aborted. We must NOT skip the throw and just return undefined: the
+      // outer connect() would otherwise fall through to _waitForHealthy(),
+      // which would observe the already-resolved connectionOpen promise
+      // and resolve with a ConnectedEvent for a torn-down connection.
       if (this.isDisconnected) {
         if (this.ws && this.ws.readyState !== this.ws.CLOSED) {
           this._destroyCurrentWSConnection();
         }
-        return;
+        throw new Error(
+          'WS handshake aborted: disconnect() ran while connecting',
+        );
       }
 
       if (response) {
@@ -359,10 +376,15 @@ export class StableWSConnection {
       const err = caught as WSConnectionError;
       this.isConnecting = false;
       this._log(`_connect() - Error - `, err);
-      // reject the in-flight connectionIdPromise so any awaiter is unblocked
-      // instead of being orphaned
-      this.client.rejectConnectionId?.(err);
-      // settle connectionOpen too so the SafePromise does not linger pending
+      // Reject THIS attempt's connection-id promise (P1) directly via the
+      // captured closure. Whether or not a concurrent openConnection() has
+      // since rotated client.rejectConnectionId to a newer promise (P2),
+      // calling ownRejectConnectionId only settles P1 - P2 is untouched.
+      // P1's awaiters (e.g., doAxiosRequest awaiting connectionIdPromise)
+      // therefore fail fast instead of being orphaned.
+      ownRejectConnectionId?.(err);
+      // connectionOpen is per-instance and not subject to rotation, so
+      // calling it unconditionally is safe (and a no-op if already settled).
       this.rejectConnectionOpen?.(err);
       // tear down a half-open WS so it does not linger and fire a stale wsID later
       if (this.ws && this.ws.readyState !== this.ws.CLOSED) {

--- a/packages/client/src/coordinator/connection/connection.ts
+++ b/packages/client/src/coordinator/connection/connection.ts
@@ -93,9 +93,9 @@ export class StableWSConnection {
   /**
    * connect - Connect to the WS URL
    * the default 15s timeout allows between 2~3 tries
-   * @return {ConnectAPIResponse<ConnectedEvent>} Promise that completes once the first health check message is received
+   * @return Promise that completes once the first health check message is received
    */
-  async connect(timeout = 15000) {
+  connect = async (timeout = 15000): Promise<ConnectedEvent | undefined> => {
     if (this.isConnecting) {
       throw Error(
         `You've called connect twice, can only attempt 1 connection at the time`,
@@ -105,7 +105,7 @@ export class StableWSConnection {
     this.isDisconnected = false;
 
     try {
-      const healthCheck = await this._connect();
+      const healthCheck = await this._connect(timeout);
       this.consecutiveFailures = 0;
 
       this._log(
@@ -124,30 +124,36 @@ export class StableWSConnection {
           'connect() - WS failure due to expired token, so going to try to reload token and reconnect',
         );
         this._reconnect({ refreshToken: true });
+      } else if (!error.isWSFailure) {
+        // API rejected the connection and we should not retry
+        throw new Error(
+          JSON.stringify({
+            code: error.code,
+            StatusCode: error.StatusCode,
+            message: error.message,
+            isWSFailure: error.isWSFailure,
+          }),
+        );
       } else {
-        if (!error.isWSFailure) {
-          // API rejected the connection and we should not retry
-          throw new Error(
-            JSON.stringify({
-              code: error.code,
-              StatusCode: error.StatusCode,
-              message: error.message,
-              isWSFailure: error.isWSFailure,
-            }),
-          );
-        }
+        // Transient WS failure (e.g., handshake watchdog). Kick off a
+        // reconnect chain so _waitForHealthy(timeout) below has something
+        // to poll for. Owning the trigger here (rather than inside
+        // _connect()'s catch) keeps a single failure from spawning two
+        // parallel chains - one from this catch and one from _reconnect's
+        // own catch when _connect was called from there.
+        this._reconnect();
       }
     }
 
     return await this._waitForHealthy(timeout);
-  }
+  };
 
   /**
    * _waitForHealthy polls the promise connection to see if its resolved until it times out
    * the default 15s timeout allows between 2~3 tries
    * @param timeout duration(ms)
    */
-  async _waitForHealthy(timeout = 15000) {
+  _waitForHealthy = async (timeout = 15000) => {
     return Promise.race([
       (async () => {
         const interval = 50; // ms
@@ -183,7 +189,7 @@ export class StableWSConnection {
         );
       })(),
     ]);
-  }
+  };
 
   /**
    * Builds and returns the url for websocket.
@@ -202,7 +208,7 @@ export class StableWSConnection {
   /**
    * disconnect - Disconnect the connection and doesn't recover...
    */
-  disconnect(timeout?: number) {
+  disconnect = (timeout?: number) => {
     this._log(
       `disconnect() - Closing the websocket connection for wsID ${this.wsID}`,
     );
@@ -264,14 +270,19 @@ export class StableWSConnection {
     delete this.ws;
 
     return isClosedPromise;
-  }
+  };
 
   /**
    * _connect - Connect to the WS endpoint
    *
+   * @param timeoutMs handshake watchdog deadline in ms. Defaults to
+   *   `client.defaultWSTimeout` when not provided. Top-level `connect(timeout)`
+   *   passes its own timeout through so caller-supplied deadlines are honored.
    * @return Promise that completes once the first health check message is received
    */
-  async _connect(): Promise<ConnectedEvent | undefined> {
+  _connect = async (
+    timeoutMs?: number,
+  ): Promise<ConnectedEvent | undefined> => {
     if (this.isConnecting) return; // ignore _connect if it's currently trying to connect
     this.isConnecting = true;
     let isTokenReady = false;
@@ -306,7 +317,7 @@ export class StableWSConnection {
 
       // race the WS handshake against an explicit deadline so a silent
       // network drop (e.g., carrier NAT or firewall) cannot wedge _connect()
-      const { defaultWSTimeout } = this.client;
+      const handshakeTimeout = timeoutMs ?? this.client.defaultWSTimeout;
       const timers = getTimers();
       let handshakeTimeoutId: number | undefined;
       let response: ConnectedEvent | undefined;
@@ -316,11 +327,11 @@ export class StableWSConnection {
           new Promise<never>((_, reject) => {
             handshakeTimeoutId = timers.setTimeout(() => {
               const err: WSConnectionError = new Error(
-                `WS handshake timed out after ${defaultWSTimeout}ms`,
+                `WS handshake timed out after ${handshakeTimeout}ms`,
               );
               err.isWSFailure = true;
               reject(err);
-            }, defaultWSTimeout);
+            }, handshakeTimeout);
           }),
         ]);
       } finally {
@@ -358,13 +369,9 @@ export class StableWSConnection {
       if (this.ws && this.ws.readyState !== this.ws.CLOSED) {
         this._destroyCurrentWSConnection();
       }
-      // for transient WS failures (e.g., handshake watchdog) kick off a reconnect
-      if (err?.isWSFailure) {
-        this._reconnect();
-      }
       throw err;
     }
-  }
+  };
 
   /**
    * _reconnect - Retry the connection to WS endpoint

--- a/packages/client/src/coordinator/connection/connection.ts
+++ b/packages/client/src/coordinator/connection/connection.ts
@@ -7,7 +7,7 @@ import {
   retryInterval,
   sleep,
 } from './utils';
-import type { StreamVideoEvent, UR } from './types';
+import type { StreamVideoEvent, UR, WSConnectionError } from './types';
 import type { LogLevel } from '@stream-io/logger';
 import type {
   ConnectedEvent,
@@ -49,13 +49,7 @@ export class StableWSConnection {
   lastEvent: Date | null;
   connectionCheckTimeout: number;
   connectionCheckTimeoutRef?: NodeJS.Timeout;
-  rejectConnectionOpen?: (
-    reason?: Error & {
-      code?: string | number;
-      isWSFailure?: boolean;
-      StatusCode?: string | number;
-    },
-  ) => void;
+  rejectConnectionOpen?: (reason?: WSConnectionError) => void;
   resolveConnectionOpen?: (value: ConnectedEvent) => void;
   totalFailures: number;
   ws?: WebSocket;
@@ -88,7 +82,7 @@ export class StableWSConnection {
     addConnectionEventListeners(this.onlineStatusChanged);
   }
 
-  _log = (msg: string, extra: UR = {}, level: LogLevel = 'info') => {
+  _log = (msg: string, extra: UR | Error = {}, level: LogLevel = 'info') => {
     this.client.logger[level](`connection:${msg}`, extra);
   };
 
@@ -117,12 +111,12 @@ export class StableWSConnection {
       this._log(
         `connect() - Established ws connection with healthcheck: ${healthCheck}`,
       );
-    } catch (error) {
+    } catch (caught) {
+      const error = caught as WSConnectionError;
       this.isHealthy = false;
       this.consecutiveFailures += 1;
 
       if (
-        // @ts-expect-error type issue
         error.code === KnownCodes.TOKEN_EXPIRED &&
         !this.client.tokenManager.isStatic()
       ) {
@@ -131,18 +125,13 @@ export class StableWSConnection {
         );
         this._reconnect({ refreshToken: true });
       } else {
-        // @ts-expect-error type issue
         if (!error.isWSFailure) {
           // API rejected the connection and we should not retry
           throw new Error(
             JSON.stringify({
-              // @ts-expect-error type issue
               code: error.code,
-              // @ts-expect-error type issue
               StatusCode: error.StatusCode,
-              // @ts-expect-error type issue
               message: error.message,
-              // @ts-expect-error type issue
               isWSFailure: error.isWSFailure,
             }),
           );
@@ -165,7 +154,8 @@ export class StableWSConnection {
         for (let i = 0; i <= timeout; i += interval) {
           try {
             return await this.connectionOpen;
-          } catch (error: any) {
+          } catch (caught) {
+            const error = caught as WSConnectionError;
             if (i === timeout) {
               throw new Error(
                 JSON.stringify({
@@ -211,7 +201,6 @@ export class StableWSConnection {
 
   /**
    * disconnect - Disconnect the connection and doesn't recover...
-   *
    */
   disconnect(timeout?: number) {
     this._log(
@@ -280,9 +269,9 @@ export class StableWSConnection {
   /**
    * _connect - Connect to the WS endpoint
    *
-   * @return {ConnectAPIResponse<ConnectedEvent>} Promise that completes once the first health check message is received
+   * @return Promise that completes once the first health check message is received
    */
-  async _connect() {
+  async _connect(): Promise<ConnectedEvent | undefined> {
     if (this.isConnecting) return; // ignore _connect if it's currently trying to connect
     this.isConnecting = true;
     let isTokenReady = false;
@@ -314,20 +303,65 @@ export class StableWSConnection {
       this.ws.onclose = this.onclose.bind(this, this.wsID);
       this.ws.onerror = this.onerror.bind(this, this.wsID);
       this.ws.onmessage = this.onmessage.bind(this, this.wsID);
-      const response = await this.connectionOpen;
+
+      // race the WS handshake against an explicit deadline so a silent
+      // network drop (e.g., carrier NAT or firewall) cannot wedge _connect()
+      const { defaultWSTimeout } = this.client;
+      const timers = getTimers();
+      let handshakeTimeoutId: number | undefined;
+      let response: ConnectedEvent | undefined;
+      try {
+        response = await Promise.race<ConnectedEvent | undefined>([
+          this.connectionOpen as Promise<ConnectedEvent>,
+          new Promise<never>((_, reject) => {
+            handshakeTimeoutId = timers.setTimeout(() => {
+              const err: WSConnectionError = new Error(
+                `WS handshake timed out after ${defaultWSTimeout}ms`,
+              );
+              err.isWSFailure = true;
+              reject(err);
+            }, defaultWSTimeout);
+          }),
+        ]);
+      } finally {
+        timers.clearTimeout(handshakeTimeoutId);
+      }
       this.isConnecting = false;
+
+      // If we were disconnected during the handshake (e.g. closeConnection()
+      // ran while a background _reconnect's _connect was in flight), tear
+      // down the new WS and skip resolveConnectionId so we do not write a
+      // stale connection_id into a connectionIdPromise owned by a newer
+      // StableWSConnection instance.
+      if (this.isDisconnected) {
+        if (this.ws && this.ws.readyState !== this.ws.CLOSED) {
+          this._destroyCurrentWSConnection();
+        }
+        return;
+      }
 
       if (response) {
         this.connectionID = response.connection_id;
         this.client.resolveConnectionId?.(this.connectionID);
         return response;
       }
-    } catch (err) {
-      this.client._setupConnectionIdPromise();
+    } catch (caught) {
+      const err = caught as WSConnectionError;
       this.isConnecting = false;
-      // @ts-expect-error type issue
       this._log(`_connect() - Error - `, err);
+      // reject the in-flight connectionIdPromise so any awaiter is unblocked
+      // instead of being orphaned
       this.client.rejectConnectionId?.(err);
+      // settle connectionOpen too so the SafePromise does not linger pending
+      this.rejectConnectionOpen?.(err);
+      // tear down a half-open WS so it does not linger and fire a stale wsID later
+      if (this.ws && this.ws.readyState !== this.ws.CLOSED) {
+        this._destroyCurrentWSConnection();
+      }
+      // for transient WS failures (e.g., handshake watchdog) kick off a reconnect
+      if (err?.isWSFailure) {
+        this._reconnect();
+      }
       throw err;
     }
   }
@@ -388,7 +422,8 @@ export class StableWSConnection {
       this._log('_reconnect() - Finished recoverCallBack');
 
       this.consecutiveFailures = 0;
-    } catch (error: any) {
+    } catch (caught) {
+      const error = caught as WSConnectionError;
       this.isHealthy = false;
       this.consecutiveFailures += 1;
       if (
@@ -538,19 +573,14 @@ export class StableWSConnection {
     this._log('onclose() - onclose callback - ' + event.code, { event, wsID });
 
     if (event.code === KnownCodes.WS_CLOSED_SUCCESS) {
-      // this is a permanent error raised by stream..
+      // this is a permanent error raised by stream.
       // usually caused by invalid auth details
-      const error = new Error(
+      const error: WSConnectionError = new Error(
         `WS connection reject with error ${event.reason}`,
       );
-
-      // @ts-expect-error type issue
       error.reason = event.reason;
-      // @ts-expect-error type issue
       error.code = event.code;
-      // @ts-expect-error type issue
       error.wasClean = event.wasClean;
-      // @ts-expect-error type issue
       error.target = event.target;
 
       this.rejectConnectionOpen?.(error);
@@ -622,7 +652,7 @@ export class StableWSConnection {
   private _errorFromWSEvent = (
     event: CloseEvent | ConnectionErrorEvent,
     isWSFailure = true,
-  ) => {
+  ): WSConnectionError => {
     let code: number;
     let statusCode: number;
     let message: string;
@@ -639,11 +669,7 @@ export class StableWSConnection {
 
     const msg = `WS failed with code: ${code}: ${APIErrorCodes[code] || code} and reason: ${message}`;
     this._log(msg, { event }, 'warn');
-    const error = new Error(msg) as Error & {
-      code?: number;
-      isWSFailure?: boolean;
-      StatusCode?: number;
-    };
+    const error = new Error(msg) as WSConnectionError;
     error.code = code;
     /**
      * StatusCode does not exist on any event types but has been left

--- a/packages/client/src/coordinator/connection/connection.ts
+++ b/packages/client/src/coordinator/connection/connection.ts
@@ -36,49 +36,48 @@ import { APIErrorCodes } from './errors';
  * - if the servers fails to publish a message to the client, the WS connection is destroyed
  */
 export class StableWSConnection {
-  // local vars
+  // Parent client reference.
+  client: StreamClient;
+
+  // Underlying WebSocket. wsID is bumped on each new connection so stale
+  // event handlers from previous sockets can be ignored.
+  ws?: WebSocket;
+  /** Incremented when a new WS connection is made */
+  wsID = 1;
+
+  // Connection lifecycle flags.
+  /** We only make 1 attempt to reconnect at the same time.. */
+  isConnecting = false;
+  /** To avoid reconnect if client is disconnected */
+  isDisconnected = false;
+  /** Boolean that indicates if we have a working connection to the server */
+  isHealthy = false;
+
+  // Open-connection promise: resolves on `connection.ok`, rejects on close/error.
   connectionID?: string;
   private connectionOpenSafe?: SafePromise<ConnectedEvent>;
-  consecutiveFailures: number;
-  pingInterval: number;
-  healthCheckTimeoutRef?: number;
-  isConnecting: boolean;
-  isDisconnected: boolean;
-  isHealthy: boolean;
-  isConnectionOpenResolved?: boolean;
-  lastEvent: Date | null;
-  connectionCheckTimeout: number;
-  connectionCheckTimeoutRef?: NodeJS.Timeout;
-  rejectConnectionOpen?: (reason?: WSConnectionError) => void;
   resolveConnectionOpen?: (value: ConnectedEvent) => void;
-  totalFailures: number;
-  ws?: WebSocket;
-  wsID: number;
+  rejectConnectionOpen?: (reason?: WSConnectionError) => void;
+  /** Boolean that indicates if the connection promise is resolved */
+  isConnectionOpenResolved?: boolean = false;
 
-  client: StreamClient;
+  // Failure counters (drive retry/backoff scheduling).
+  /** consecutive failures influence the duration of the timeout */
+  consecutiveFailures = 0;
+  /** keep track of the total number of failures */
+  totalFailures = 0;
+
+  // Health-check pings + connection-staleness check.
+  /** Send a health check message every 25 seconds */
+  pingInterval = 25 * 1000;
+  healthCheckTimeoutRef?: number;
+  connectionCheckTimeout = this.pingInterval + 10 * 1000;
+  connectionCheckTimeoutRef?: NodeJS.Timeout;
+  /** Store the last event time for health checks */
+  lastEvent: Date | null = null;
 
   constructor(client: StreamClient) {
     this.client = client;
-    /** consecutive failures influence the duration of the timeout */
-    this.consecutiveFailures = 0;
-    /** keep track of the total number of failures */
-    this.totalFailures = 0;
-    /** We only make 1 attempt to reconnect at the same time.. */
-    this.isConnecting = false;
-    /** To avoid reconnect if client is disconnected */
-    this.isDisconnected = false;
-    /** Boolean that indicates if the connection promise is resolved */
-    this.isConnectionOpenResolved = false;
-    /** Boolean that indicates if we have a working connection to the server */
-    this.isHealthy = false;
-    /** Incremented when a new WS connection is made */
-    this.wsID = 1;
-    /** Store the last event time for health checks */
-    this.lastEvent = null;
-    /** Send a health check message every 25 seconds */
-    this.pingInterval = 25 * 1000;
-    this.connectionCheckTimeout = this.pingInterval + 10 * 1000;
-
     addConnectionEventListeners(this.onlineStatusChanged);
   }
 
@@ -458,7 +457,6 @@ export class StableWSConnection {
    * onlineStatusChanged - this function is called when the browser connects or disconnects from the internet.
    *
    * @param {Event} event Event with type online or offline
-   *
    */
   onlineStatusChanged = (event: Event) => {
     if (event.type === 'offline') {

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -42,6 +42,21 @@ export type APIErrorResponse = {
   unrecoverable?: boolean;
 };
 
+/**
+ * A standard `Error` augmented with the metadata that the coordinator
+ * WebSocket connection layer attaches to rejection causes.
+ * `isWSFailure: true` marks transient/retriable failures; absent or `false`
+ * indicates a permanent failure that should not be retried.
+ */
+export type WSConnectionError = Error & {
+  code?: string | number;
+  isWSFailure?: boolean;
+  StatusCode?: string | number;
+  reason?: string;
+  wasClean?: boolean;
+  target?: EventTarget | null;
+};
+
 export class ErrorFromResponse<T> extends Error {
   public code: number | null;
   public status: number;


### PR DESCRIPTION
### 💡 Overview

`call.join()` could hang indefinitely on flaky mobile networks where the WebSocket upgrade response was silently dropped mid-handshake (carrier NAT timeout, transparent firewall, etc.). Neither `onopen` nor `onclose` fired, and the in-flight `connectionIdPromise` that `doAxiosRequest` awaited was orphaned by the `_connect()` catch block before it could reject. This PR makes silent stalls surface deterministically within `defaultWSTimeout` and removes the orphaning bug, so `call.join()` either succeeds (after a transient retry) or rejects with a clear `isWSFailure` error.

While in the area, the inline `Error & { code?: ...; isWSFailure?: boolean; StatusCode?: ... }` shape that was repeated across the connection layer is extracted into a named `WSConnectionError` type, removing 12 `// @ts-expect-error type issue` comments along the way.

### 📝 Implementation notes

- Adds a handshake watchdog in `StableWSConnection._connect()` that races `await this.connectionOpen` against `defaultWSTimeout` through the connection-layer `getTimers()` abstraction (so it survives background-tab throttling).
- Reorders the catch to reject `connectionIdPromise` **before** anything else, and no longer recreates the promise on permanent failures - `_connect()`'s entry guard makes a fresh one on the next attempt, so callers fail fast in the meantime.
- Adds a post-handshake `isDisconnected` guard that prevents a stale `connection_id` from being written into the client when `closeConnection()` runs concurrently with an in-flight handshake.
- Triggers `_reconnect()` from the catch only when `err?.isWSFailure` is set, so `_waitForHealthy()`'s polling window can pick up a successful retry while permanent errors propagate immediately.
- Extracts `WSConnectionError` to `coordinator/connection/types.ts` (already part of the public surface via the `index.ts` wildcard re-export). Adopts it across `connection.ts` and the new tests, removing all 12 `// @ts-expect-error type issue` directives in `connection.ts`.

🎫 Ticket: https://linear.app/stream/issue/RN-386/calljoin-hanging-during-network-issues