### PR TITLE
fix(client): prevent screen share audio loopback by default

### DIFF
--- a/packages/client/src/devices/ScreenShareState.ts
+++ b/packages/client/src/devices/ScreenShareState.ts
@@ -26,7 +26,7 @@ export class ScreenShareState extends AudioDeviceManagerState<DisplayMediaStream
    * Constructs a new ScreenShareState instance.
    */
   constructor() {
-    super('stop-tracks', undefined, AudioBitrateProfile.MUSIC_HIGH_QUALITY);
+    super('stop-tracks', undefined, AudioBitrateProfile.VOICE_HIGH_QUALITY);
   }
 
   /**

--- a/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
+++ b/packages/client/src/devices/__tests__/ScreenShareManager.test.ts
@@ -126,7 +126,7 @@ describe('ScreenShareManager', () => {
     expect(call.publish).toHaveBeenCalledWith(
       manager.state.mediaStream,
       TrackType.SCREEN_SHARE,
-      { audioBitrateProfile: AudioBitrateProfile.MUSIC_HIGH_QUALITY },
+      { audioBitrateProfile: AudioBitrateProfile.VOICE_HIGH_QUALITY },
     );
   });
 

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -357,7 +357,10 @@ export const getScreenShareStream = async (
           ? options.audio
           : {
               channelCount: { ideal: 2 },
-              echoCancellation: false,
+              // AEC on the captured system audio uses the local render path
+              // as reference, which removes remote participants' voices that
+              // would otherwise loop back to them through the screen share.
+              echoCancellation: true,
               autoGainControl: false,
               noiseSuppression: false,
               ...options?.audio,

--- a/packages/client/src/devices/devices.ts
+++ b/packages/client/src/devices/devices.ts
@@ -340,7 +340,6 @@ export const getScreenShareStream = async (
   const tag = `navigator.mediaDevices.getDisplayMedia.${getDisplayMediaExecId++}.`;
   try {
     const constraints: DisplayMediaStreamOptions = {
-      // @ts-expect-error - not present in types yet
       systemAudio: 'include',
       ...options,
       video:
@@ -357,9 +356,8 @@ export const getScreenShareStream = async (
           ? options.audio
           : {
               channelCount: { ideal: 2 },
-              // AEC on the captured system audio uses the local render path
-              // as reference, which removes remote participants' voices that
-              // would otherwise loop back to them through the screen share.
+              // @ts-expect-error not yet present in the types
+              restrictOwnAudio: true,
               echoCancellation: true,
               autoGainControl: false,
               noiseSuppression: false,


### PR DESCRIPTION
### 💡 Overview

When a user shares system audio while in a call, the OS-mixed system audio also includes the remote participants' voices coming out of the local speakers. This currently produces an unpleasant loopback for the remote speakers (they hear themselves played back through the screen share track).

This change updates the screen share audio defaults so AEC removes the call audio from the captured system audio by default, while preserving the rest (music, video, presentation audio).

### 📝 Implementation notes

- Flip `echoCancellation` to `true` in `getScreenShareStream`'s default audio constraints
- Adds `restrictOwnAudio` for browsers that support it
- Change `ScreenShareState`'s default `audioBitrateProfile` from `MUSIC_HIGH_QUALITY` to `VOICE_HIGH_QUALITY`. The previous default was inconsistent with what the capture path actually produces.
- The defaults still merge caller-supplied `options.audio` last, so any explicit override, including the constraints written by `setAudioBitrateProfile(MUSIC_HIGH_QUALITY)` continues to win, preserving HIFI music quality when the integrator opts in.

🎫 Ticket: https://linear.app/stream/issue/REACT-973/feedback-loop-issue-with-chromes-new-system-audio-sharing-feature