### PR TITLE
fix(react-dogfood): only render VisionAgent button in demo environment

### DIFF
--- a/sample-apps/react/react-dogfood/components/ActiveCall.tsx
+++ b/sample-apps/react/react-dogfood/components/ActiveCall.tsx
@@ -324,14 +324,16 @@ export const ActiveCall = (props: ActiveCallProps) => {
               </WithTooltip>
             )}
             <RecordCallConfirmationButton />
-            <div className="str-video__call-controls__desktop rd__ai-agent-anchor">
-              <AskAIAgentButton
-                sessionId={agentSessionId}
-                onSessionCreated={setAgentSessionId}
-                onSessionCleared={() => setAgentSessionId(null)}
-              />
-              <AIAgentStatusPanel />
-            </div>
+            {isDemoEnvironment && (
+              <div className="str-video__call-controls__desktop rd__ai-agent-anchor">
+                <AskAIAgentButton
+                  sessionId={agentSessionId}
+                  onSessionCreated={setAgentSessionId}
+                  onSessionCleared={() => setAgentSessionId(null)}
+                />
+                <AIAgentStatusPanel />
+              </div>
+            )}
             <div className="str-video__call-controls__desktop">
               <CancelCallConfirmButton onLeave={onLeave} />
             </div>


### PR DESCRIPTION
### 💡 Overview

Gates the **Ask AI Agent** button (and its accompanying `AIAgentStatusPanel`) in `ActiveCall` behind `isDemoEnvironment`, so the Vision Agents flow is only surfaced in the `demo` environment and no longer appears in `pronto` or restricted builds.

### 📝 Implementation notes

- The `useIsDemoEnvironment()` hook was already being called in `ActiveCall.tsx`, so no new imports were needed.
- Wrapped the entire `rd__ai-agent-anchor` div (button + panel) rather than just the button, because the status panel is positionally anchored to the button. Outside `demo` there is no way to invite an agent anyway, so the panel has nothing to surface.

🎫 Ticket: https://linear.app/stream/issue/AI-557/add-a-button-to-invite-an-agent-to-a-demo-call

📑 Docs: n/a (sample app only, no public API change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - AI agent interface now displays conditionally based on deployment environment, appearing only in demo environments to prevent unintended feature exposure across different deployment contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->