### PR TITLE
fix(client): capture sessionId before await in updateLocalStreamState

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -2079,9 +2079,9 @@ export class Call {
     ...trackTypes: TrackType[]
   ) => {
     if (!this.sfuClient || !this.sfuClient.sessionId) return;
-    await this.notifyTrackMuteState(!mediaStream, ...trackTypes);
-
     const { sessionId } = this.sfuClient;
+
+    await this.notifyTrackMuteState(!mediaStream, ...trackTypes);
     for (const trackType of trackTypes) {
       const streamStateProp = trackTypeToParticipantStreamKey(trackType);
       if (!streamStateProp) continue;

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -2078,10 +2078,12 @@ export class Call {
     mediaStream: MediaStream | undefined,
     ...trackTypes: TrackType[]
   ) => {
-    if (!this.sfuClient || !this.sfuClient.sessionId) return;
-    const { sessionId } = this.sfuClient;
+    const sessionId = this.sfuClient?.sessionId;
+    if (!sessionId) return;
 
     await this.notifyTrackMuteState(!mediaStream, ...trackTypes);
+    if (this.sfuClient?.sessionId !== sessionId) return;
+
     for (const trackType of trackTypes) {
       const streamStateProp = trackTypeToParticipantStreamKey(trackType);
       if (!streamStateProp) continue;

--- a/packages/client/src/__tests__/Call.publishing.test.ts
+++ b/packages/client/src/__tests__/Call.publishing.test.ts
@@ -290,6 +290,31 @@ describe('Publishing and Unpublishing tracks', () => {
       expect(participant!.screenShareStream).toBeUndefined();
       expect(participant!.screenShareAudioStream).toBeUndefined();
     });
+
+    it('does not throw if sfuClient is cleared while the mute-state RPC is in flight', async () => {
+      let releaseMuteUpdate!: () => void;
+      let signalMuteUpdateEntered!: () => void;
+      const muteUpdateEntered = new Promise<void>(
+        (resolve) => (signalMuteUpdateEntered = resolve),
+      );
+      sfuClient.updateMuteStates = vi.fn().mockImplementation(() => {
+        signalMuteUpdateEntered();
+        return new Promise<void>((resolve) => (releaseMuteUpdate = resolve));
+      });
+
+      const track = new MediaStreamTrack() as MediaStreamAudioTrack;
+      const mediaStream = new MediaStream();
+      vi.spyOn(mediaStream, 'getAudioTracks').mockReturnValue([track]);
+
+      const inflight = call.publish(mediaStream, TrackType.AUDIO);
+
+      await muteUpdateEntered;
+
+      call['sfuClient'] = undefined;
+      releaseMuteUpdate();
+
+      await inflight;
+    });
   });
 
   describe('Deprecated methods', () => {

--- a/packages/client/src/__tests__/Call.publishing.test.ts
+++ b/packages/client/src/__tests__/Call.publishing.test.ts
@@ -315,6 +315,84 @@ describe('Publishing and Unpublishing tracks', () => {
 
       await inflight;
     });
+
+    it('updates local stream state when sfuClient is replaced with the same session id', async () => {
+      let releaseMuteUpdate!: () => void;
+      let signalMuteUpdateEntered!: () => void;
+      const muteUpdateEntered = new Promise<void>(
+        (resolve) => (signalMuteUpdateEntered = resolve),
+      );
+      sfuClient.updateMuteStates = vi.fn().mockImplementation(() => {
+        signalMuteUpdateEntered();
+        return new Promise<void>((resolve) => (releaseMuteUpdate = resolve));
+      });
+
+      const track = new MediaStreamTrack() as MediaStreamAudioTrack;
+      const mediaStream = new MediaStream();
+      vi.spyOn(mediaStream, 'getAudioTracks').mockReturnValue([track]);
+
+      const inflight = call.publish(mediaStream, TrackType.AUDIO);
+
+      await muteUpdateEntered;
+
+      const replacementSfuClient = vi.fn() as unknown as StreamSfuClient;
+      // @ts-expect-error sessionId is readonly
+      replacementSfuClient['sessionId'] = sessionId;
+      replacementSfuClient.updateMuteStates = vi.fn();
+      call['sfuClient'] = replacementSfuClient;
+      releaseMuteUpdate();
+
+      await inflight;
+
+      const participant = call.state.findParticipantBySessionId(sessionId);
+      expect(participant?.publishedTracks).toEqual([TrackType.AUDIO]);
+      expect(participant?.audioStream).toBe(mediaStream);
+    });
+
+    it('skips local stream state update when sfuClient is replaced with a new session id', async () => {
+      let releaseMuteUpdate!: () => void;
+      let signalMuteUpdateEntered!: () => void;
+      const muteUpdateEntered = new Promise<void>(
+        (resolve) => (signalMuteUpdateEntered = resolve),
+      );
+      sfuClient.updateMuteStates = vi.fn().mockImplementation(() => {
+        signalMuteUpdateEntered();
+        return new Promise<void>((resolve) => (releaseMuteUpdate = resolve));
+      });
+
+      const track = new MediaStreamTrack() as MediaStreamAudioTrack;
+      const mediaStream = new MediaStream();
+      vi.spyOn(mediaStream, 'getAudioTracks').mockReturnValue([track]);
+
+      const inflight = call.publish(mediaStream, TrackType.AUDIO);
+
+      await muteUpdateEntered;
+
+      const replacementSessionId = 'replacement-session-id';
+      // @ts-expect-error partial data
+      call.state.updateOrAddParticipant(replacementSessionId, {
+        sessionId: replacementSessionId,
+        publishedTracks: [],
+      });
+
+      const replacementSfuClient = vi.fn() as unknown as StreamSfuClient;
+      // @ts-expect-error sessionId is readonly
+      replacementSfuClient['sessionId'] = replacementSessionId;
+      replacementSfuClient.updateMuteStates = vi.fn();
+      call['sfuClient'] = replacementSfuClient;
+      releaseMuteUpdate();
+
+      await inflight;
+
+      const originalParticipant =
+        call.state.findParticipantBySessionId(sessionId);
+      const replacementParticipant =
+        call.state.findParticipantBySessionId(replacementSessionId);
+      expect(originalParticipant?.publishedTracks).toEqual([]);
+      expect(originalParticipant?.audioStream).toBeUndefined();
+      expect(replacementParticipant?.publishedTracks).toEqual([]);
+      expect(replacementParticipant?.audioStream).toBeUndefined();
+    });
   });
 
   describe('Deprecated methods', () => {

--- a/packages/client/src/rpc/retryable.ts
+++ b/packages/client/src/rpc/retryable.ts
@@ -44,7 +44,6 @@ export const retryable = async <
   let result: FinishedUnaryCall<I, O> | undefined = undefined;
   do {
     if (attempt > 0) await sleep(retryInterval(attempt));
-    if (signal?.aborted) throw new Error(signal.reason);
 
     try {
       result = await rpc({ attempt });


### PR DESCRIPTION
### 💡 Overview
Fixes a TOCTOU race in Call.updateLocalStreamState: this.sfuClient.sessionId is read after await           this.notifyTrackMuteState(...), and a reconnect/leave during the await clears this.sfuClient, throwing on the destructure.  Also drops the signal.aborted  check in retryable so in-flight SFU RPCs can finish after the WebSocket is closed

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness when muting/unmuting local tracks so updates skip if the session changes mid-operation.
  * Request cancellation now triggers immediately instead of waiting for RPC failures.

* **Tests**
  * Added coverage ensuring publishing completes cleanly if the client state is cleared while an operation is in-flight.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->