### PR TITLE
fix(client): stale local publishedTracks after mute and SFU reconnect

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -460,7 +460,8 @@ export class Publisher extends BasePeerConnection {
     const trackInfos: TrackInfo[] = [];
     for (const publishOption of this.publishOptions) {
       const bundle = this.transceiverCache.get(publishOption);
-      if (!bundle || !bundle.transceiver.sender.track) continue;
+      const track = bundle?.transceiver.sender.track;
+      if (!bundle || !track || track.readyState !== 'live') continue;
       trackInfos.push(this.toTrackInfo(bundle, sdp));
     }
     return trackInfos;


### PR DESCRIPTION
### 💡 Overview
Fix a stale "Audio is connecting…" spinner that appeared on the local participant's tile after muting the mic and going through a reconnect. The local `publishedTracks` was incorrectly being repopulated with AUDIO during reconnect even though the user was muted.    

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnection reliability by fixing incomplete validation checks during connection recovery. The application now properly verifies connection status before attempting to restore connections after network interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->