### PR TITLE
chore(react-dogfood): delete chat channel on call.session_ended

### DIFF
--- a/sample-apps/react/react-dogfood/helpers/chat.ts
+++ b/sample-apps/react/react-dogfood/helpers/chat.ts
@@ -1,0 +1,31 @@
+import { type CallSessionEndedEvent, StreamClient } from '@stream-io/node-sdk';
+
+export async function deleteCallChatChannel(
+  client: StreamClient,
+  event: CallSessionEndedEvent,
+) {
+  const callId = event.call?.id ?? event.call_cid.split(':')[1];
+  if (!callId) return;
+
+  const type = 'videocall';
+  try {
+    await client.chat.deleteChannel({ type, id: callId, hard_delete: true });
+    console.log(`Hard-deleted chat channel ${type}:${callId}`);
+  } catch (err) {
+    if (isChannelNotFound(err)) {
+      console.log(`Chat channel ${type}:${callId} already gone, skipping`);
+      return;
+    }
+    throw err;
+  }
+}
+
+function isChannelNotFound(err: unknown): boolean {
+  const CHANNEL_NOT_FOUND_CODE = 16;
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === CHANNEL_NOT_FOUND_CODE
+  );
+}

--- a/sample-apps/react/react-dogfood/helpers/chat.ts
+++ b/sample-apps/react/react-dogfood/helpers/chat.ts
@@ -4,17 +4,16 @@ export async function deleteCallChatChannel(
   client: StreamClient,
   event: CallSessionEndedEvent,
 ) {
-  const callIdFromCid = event.call_cid?.split(':')[1];
-  const callId = event.call?.id ?? callIdFromCid;
-  if (!callId) return;
+  const id = event.call?.id ?? event.call_cid?.split(':')[1];
+  if (!id) return;
 
   const type = 'videocall';
   try {
-    await client.chat.deleteChannel({ type, id: callId, hard_delete: true });
-    console.log(`Hard-deleted chat channel ${type}:${callId}`);
+    await client.chat.deleteChannel({ type, id, hard_delete: true });
+    console.log(`Hard-deleted chat channel ${type}:${id}`);
   } catch (err) {
     if (isChannelNotFound(err)) {
-      console.log(`Chat channel ${type}:${callId} already gone, skipping`);
+      console.log(`Chat channel ${type}:${id} already gone, skipping`);
       return;
     }
     throw err;

--- a/sample-apps/react/react-dogfood/helpers/chat.ts
+++ b/sample-apps/react/react-dogfood/helpers/chat.ts
@@ -4,7 +4,8 @@ export async function deleteCallChatChannel(
   client: StreamClient,
   event: CallSessionEndedEvent,
 ) {
-  const callId = event.call?.id ?? event.call_cid.split(':')[1];
+  const callIdFromCid = event.call_cid?.split(':')[1];
+  const callId = event.call?.id ?? callIdFromCid;
   if (!callId) return;
 
   const type = 'videocall';

--- a/sample-apps/react/react-dogfood/pages/api/webhook.ts
+++ b/sample-apps/react/react-dogfood/pages/api/webhook.ts
@@ -1,6 +1,7 @@
 import { StreamClient } from '@stream-io/node-sdk';
 import { NextApiRequest, NextApiResponse } from 'next';
 import getRawBody from 'raw-body';
+import { deleteCallChatChannel } from '../../helpers/chat';
 import { uploadCallRecording } from '../../helpers/gong';
 import { saveParticipantAsCallMember } from '../../helpers/participants';
 
@@ -56,6 +57,8 @@ const handleWebhook = (req: NextApiRequest, res: NextApiResponse) => {
       processor = uploadCallRecording;
     } else if (event.type === 'call.session_participant_joined') {
       processor = saveParticipantAsCallMember;
+    } else if (event.type === 'call.session_ended') {
+      processor = deleteCallChatChannel;
     }
 
     processor?.(client, event)


### PR DESCRIPTION
### 💡 Overview

Extend the demo app webhook handler with a `call.session_ended` branch that hard-deletes the corresponding Stream Chat channel. Chat channels in this app use type `videocall` with channel ID = call ID, and were previously never cleaned up after a call ended, so chat history persisted indefinitely. This change wipes the channel server-side as soon as the session ends, protecting user privacy.

Ref: #2222

🎫 Ticket: https://linear.app/stream/issue/AI-557/add-a-button-to-invite-an-agent-to-a-demo-call