### PR TITLE
fix: fixed ws reject event race condition

### DIFF
--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -193,13 +193,11 @@ export const firebaseDataHandler = async (
                   'debug',
                 );
                 callingx.endCallWithReason(call_cid, endCallReason);
-                callFromPush
-                  .leave({ reject: false, reason: 'cancel' })
-                  .catch((error) => {
-                    logger.error(
-                      `Failed to leave already-ended ringing call ${call_cid}: ${error}`,
-                    );
-                  });
+                callFromPush.leave({ reject: false }).catch((error) => {
+                  logger.error(
+                    `Failed to leave already-ended ringing call ${call_cid}: ${error}`,
+                  );
+                });
                 resolve(undefined);
                 return;
               }
@@ -330,7 +328,7 @@ export const firebaseDataHandler = async (
         `Removing incoming call notification immediately with callCid: ${call_cid} as it should be closed`,
       );
       callingx.endCallWithReason(call_cid, endCallReason);
-      callFromPush.leave({ reject: false, reason: 'cancel' }).catch((error) => {
+      callFromPush.leave({ reject: false }).catch((error) => {
         logger.error(
           `Failed to leave already-ended ringing call ${call_cid}: ${error}`,
         );

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -193,6 +193,13 @@ export const firebaseDataHandler = async (
                   'debug',
                 );
                 callingx.endCallWithReason(call_cid, endCallReason);
+                callFromPush
+                  .leave({ reject: false, reason: 'cancel' })
+                  .catch((error) => {
+                    logger.error(
+                      `Failed to leave already-ended ringing call ${call_cid}: ${error}`,
+                    );
+                  });
                 resolve(undefined);
                 return;
               }
@@ -323,6 +330,11 @@ export const firebaseDataHandler = async (
         `Removing incoming call notification immediately with callCid: ${call_cid} as it should be closed`,
       );
       callingx.endCallWithReason(call_cid, endCallReason);
+      callFromPush.leave({ reject: false, reason: 'cancel' }).catch((error) => {
+        logger.error(
+          `Failed to leave already-ended ringing call ${call_cid}: ${error}`,
+        );
+      });
     }
   } else {
     const notifeeLib = getNotifeeLibThrowIfNotInstalledForPush();


### PR DESCRIPTION
### 💡 Overview
This PR fixes race condition for the quick hang up from a caller side case. 
The problem is: when ws event for reject comes earlier than push notification call instance is moved to IDLE state and removed from calls. After that push notification comes new call instance is created within `onRingingCall`, which now again in RINGING state. After that moment call appear to be stuck in that state - no subsequent `leave` invocation will change its state.  

### 📝 Implementation notes
Fix for the issue is to invoke `leave` method during push notification handling, which will dismiss new instance of already rejected call (rejected during ws event). 

🎫 Ticket: https://linear.app/stream/issue/RN-387/quick-hang-up-case-race-condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android incoming call notification handling to ensure ringing calls are properly cleaned up when closed, preventing state inconsistencies and enhancing reliability across different service modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-js/pull/2239)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->