### PR TITLE
fix(react-dogfood): add SRI to Mapbox GL stylesheet

### DIFF
--- a/sample-apps/react/react-dogfood/pages/_document.tsx
+++ b/sample-apps/react/react-dogfood/pages/_document.tsx
@@ -40,6 +40,8 @@ export default function Document() {
         <link
           href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css"
           rel="stylesheet"
+          integrity="sha384-SDYx9Nwa5fE1fRuBplOPejrcbPOK/ql0Uym6hsGsTvnlC784P5LZhBJIbo8O/O+0"
+          crossOrigin="anonymous"
         />
       </Head>
       <body>


### PR DESCRIPTION
## Summary
- Adds `integrity` + `crossOrigin` to the version-pinned Mapbox GL CSS `<link>` in `sample-apps/react/react-dogfood/pages/_document.tsx`.
- Closes the SecurityScorecard `unsafe_sri_v2` findings on `pronto.getstream.io` (issue `bbf5d990-2ebb-50e0-a3f6-2fc5c192ac55`) and `pronto-staging.getstream.io` (issue `6396fb24-ba6f-5da7-b0e2-a58248ca1851`). Both deploy from this app.
- Tracking: APPSEC-156.

## Why this is safe
- URL is **version-pinned** (`v2.15.0`) — the file is immutable, so the hash will not drift.
- Mapbox CDN serves `access-control-allow-origin: *` and `cache-control: max-age=31536000`, satisfying SRI's CORS requirement for `crossorigin="anonymous"`.
- Hash regenerable any time with:
  ```
  curl -s https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css \
    | openssl dgst -sha384 -binary | openssl base64 -A
  # -> SDYx9Nwa5fE1fRuBplOPejrcbPOK/ql0Uym6hsGsTvnlC784P5LZhBJIbo8O/O+0
  ```

## Test plan
- [ ] `yarn dev` in `sample-apps/react/react-dogfood`, open a page that uses Mapbox, confirm the map renders (stylesheet not blocked by SRI failure)
- [ ] DevTools → Network → `mapbox-gl.css` shows `200` and *not* a console error like `Failed to find a valid digest in the 'integrity' attribute`
- [ ] Deploy to staging (pronto-staging) and confirm the SecurityScorecard finding clears on the next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mapbox stylesheet loading configuration with additional resource attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-js/pull/2242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->