### PR TITLE
chore(egress-composite): upgrade layout to 1.0.21

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,3 +9,5 @@ nodeLinker: node-modules
 npmMinimalAgeGate: 3d
 npmPublishProvenance: true
 yarnPath: .yarn/releases/yarn-4.14.1.cjs
+npmPreapprovedPackages:
+  - "@skooldev/skool-stream-layout"

--- a/sample-apps/react/egress-composite/package.json
+++ b/sample-apps/react/egress-composite/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.5",
     "@sentry/react": "^10.30.0",
-    "@skooldev/skool-stream-layout": "1.0.20",
+    "@skooldev/skool-stream-layout": "1.0.21",
     "@stream-io/video-react-sdk": "workspace:^",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/sample-apps/react/egress-composite/package.json
+++ b/sample-apps/react/egress-composite/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.5",
     "@sentry/react": "^10.30.0",
-    "@skooldev/skool-stream-layout": "1.0.19",
+    "@skooldev/skool-stream-layout": "1.0.20",
     "@stream-io/video-react-sdk": "workspace:^",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8259,14 +8259,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skooldev/skool-stream-layout@npm:1.0.20":
-  version: 1.0.20
-  resolution: "@skooldev/skool-stream-layout@npm:1.0.20"
+"@skooldev/skool-stream-layout@npm:1.0.21":
+  version: 1.0.21
+  resolution: "@skooldev/skool-stream-layout@npm:1.0.21"
   peerDependencies:
     "@stream-io/video-react-sdk": ^1.37.0
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10/f939a6108ec6a53b6517bef53bfa97de7b5b78dd2cd8591a446f2a35288b5177ecc151b8a06bd3d50c570b9cf1affc03b14ebb5929684bfbae2ca96d6b1533e2
+  checksum: 10/71563f99d12d6875e1743bd946381ab212f152df142361aaa989171b9f1c20f418d214f6593c3fc7cf143cb5eb8536ef4b4d163f2d6aa0915acbd52b5de2ea10
   languageName: node
   linkType: hard
 
@@ -8325,7 +8325,7 @@ __metadata:
     "@playwright/test": "npm:^1.56.0"
     "@sentry/react": "npm:^10.30.0"
     "@sentry/vite-plugin": "npm:^4.6.1"
-    "@skooldev/skool-stream-layout": "npm:1.0.20"
+    "@skooldev/skool-stream-layout": "npm:1.0.21"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.1.17"
     "@types/react-dom": "npm:~19.1.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8259,14 +8259,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skooldev/skool-stream-layout@npm:1.0.19":
-  version: 1.0.19
-  resolution: "@skooldev/skool-stream-layout@npm:1.0.19"
+"@skooldev/skool-stream-layout@npm:1.0.20":
+  version: 1.0.20
+  resolution: "@skooldev/skool-stream-layout@npm:1.0.20"
   peerDependencies:
-    "@stream-io/video-react-sdk": ^1.34.2
+    "@stream-io/video-react-sdk": ^1.37.0
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10/b3d15124cf9b2489190e7b99e670afaac7dd386f0d885185e525376c1af79b73c924fd6e9d29d37e2479421c36cf04df31efcfef1ef4e3e75ec18bb62ad71dfe
+  checksum: 10/f939a6108ec6a53b6517bef53bfa97de7b5b78dd2cd8591a446f2a35288b5177ecc151b8a06bd3d50c570b9cf1affc03b14ebb5929684bfbae2ca96d6b1533e2
   languageName: node
   linkType: hard
 
@@ -8325,7 +8325,7 @@ __metadata:
     "@playwright/test": "npm:^1.56.0"
     "@sentry/react": "npm:^10.30.0"
     "@sentry/vite-plugin": "npm:^4.6.1"
-    "@skooldev/skool-stream-layout": "npm:1.0.19"
+    "@skooldev/skool-stream-layout": "npm:1.0.20"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.1.17"
     "@types/react-dom": "npm:~19.1.11"


### PR DESCRIPTION
### 💡 Overview
Upgrade @skooldev/skool-stream-layout from `1.0.19` to `1.0.20` in the egress-composite sample app. Add `@skooldev/skool-stream-layout` to npmPreapprovedPackages

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a bundled layout package to a newer version.
  * Added a preapproved package entry to the package manager configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-js/pull/2243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->