### PR TITLE
feat: made messaging service extendable

### DIFF
--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/StreamMessagingHelper.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/StreamMessagingHelper.kt
@@ -16,9 +16,17 @@ import com.google.firebase.messaging.RemoteMessage
  * ```
  * class AppMessagingService : ReactNativeFirebaseMessagingService() {
  *   override fun onMessageReceived(remoteMessage: RemoteMessage) {
- *     StreamMessagingHelper.handleMessage(applicationContext, remoteMessage)
- *     // ...forward to other push SDKs here...
- *     super.onMessageReceived(remoteMessage) // keeps RN-Firebase JS handler running
+ *     // pass remote message to React Native Firebase JS background handler
+ *     super.onMessageReceived(remoteMessage)
+ *
+ *     // Optional gate — provided for finer control over the forwarding flow.
+ *     // `handleMessage` is also safe to call unconditionally; it no-ops for
+ *     // payloads that aren't a Stream `call.ring`.
+ *     if (StreamMessagingHelper.isStreamCallRing(remoteMessage)) {
+ *       StreamMessagingHelper.handleMessage(applicationContext, remoteMessage)
+ *     } else {
+ *       // forward to other push SDKs
+ *     }
  *   }
  * }
  * ```
@@ -27,6 +35,10 @@ object StreamMessagingHelper {
 
   private const val TAG = "[Callingx] StreamMessagingHelper"
 
+  /**
+   * Returns `true` if [remoteMessage] is a Stream Video incoming `call.ring` push.
+   * Useful when you want to short-circuit other SDK forwarders for Stream pushes.
+   */
   @JvmStatic
   fun isStreamCallRing(remoteMessage: RemoteMessage): Boolean {
     val data = remoteMessage.data

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/StreamMessagingHelper.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/StreamMessagingHelper.kt
@@ -1,0 +1,59 @@
+package io.getstream.rn.callingx
+
+import android.content.Context
+import com.google.firebase.messaging.RemoteMessage
+
+/**
+ * Public entry point for consumer apps that host their own [com.google.firebase.messaging.FirebaseMessagingService].
+ *
+ * To opt out of the default [StreamMessagingService] registration, add to the app manifest:
+ * ```
+ * <service
+ *     android:name="io.getstream.rn.callingx.StreamMessagingService"
+ *     tools:node="remove" />
+ * ```
+ * then invoke [handleMessage] from the app's own messaging service:
+ * ```
+ * class AppMessagingService : ReactNativeFirebaseMessagingService() {
+ *   override fun onMessageReceived(remoteMessage: RemoteMessage) {
+ *     StreamMessagingHelper.handleMessage(applicationContext, remoteMessage)
+ *     // ...forward to other push SDKs here...
+ *     super.onMessageReceived(remoteMessage) // keeps RN-Firebase JS handler running
+ *   }
+ * }
+ * ```
+ */
+object StreamMessagingHelper {
+
+  private const val TAG = "[Callingx] StreamMessagingHelper"
+
+  @JvmStatic
+  fun isStreamCallRing(remoteMessage: RemoteMessage): Boolean {
+    val data = remoteMessage.data
+    return data["sender"] == "stream.video" && data["type"] == "call.ring"
+  }
+
+  /**
+   * Handles a Stream Video `call.ring` payload by starting the incoming call flow.
+   * No-op for any other payload, so it is safe to call unconditionally from a host
+   * messaging service.
+   */
+  @JvmStatic
+  fun handleMessage(context: Context, remoteMessage: RemoteMessage) {
+    val data = remoteMessage.data
+    debugLog(TAG, "handleMessage data = $data")
+
+    if (!isStreamCallRing(remoteMessage)) {
+      debugLog(TAG, "sender or type is not supported, skipping CallService start")
+      return
+    }
+
+    val callCid = data["call_cid"]
+    if (callCid.isNullOrEmpty()) {
+      debugLog(TAG, "missing call_cid for call.ring, skipping CallService start")
+      return
+    }
+
+    CallService.startIncomingCallFromPush(context.applicationContext, data)
+  }
+}

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/StreamMessagingService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/StreamMessagingService.kt
@@ -14,35 +14,17 @@ import io.invertase.firebase.messaging.ReactNativeFirebaseMessagingService
  * the merged manifest so this service is the single FCM handler
  */
 @SuppressLint("MissingFirebaseInstanceTokenRefresh")
-class StreamMessagingService : ReactNativeFirebaseMessagingService() {
+open class StreamMessagingService : ReactNativeFirebaseMessagingService() {
 
   companion object {
     const val TAG = "[Callingx] StreamMessagingService"
   }
 
   override fun onMessageReceived(remoteMessage: RemoteMessage) {
-    val data = remoteMessage.data
-    debugLog(TAG, "onMessageReceived data = $data")
+    debugLog(TAG, "onMessageReceived data=${remoteMessage.data}")
 
-    val isSupportedStreamVideoCallRing =
-      data["sender"] == "stream.video" && data["type"] == "call.ring"
+    StreamMessagingHelper.handleMessage(applicationContext, remoteMessage)
 
-    if (isSupportedStreamVideoCallRing) {
-      val callCid = data["call_cid"]
-      if (callCid.isNullOrEmpty()) {
-        debugLog(
-          TAG,
-          "missing call_cid for call.ring, skipping CallService start",
-        )
-      } else {
-        CallService.startIncomingCallFromPush(applicationContext, data)
-      }
-    } else {
-      debugLog(TAG, "sender or type is not supported, skipping CallService start")
-    }
-
-    // Let React Native Firebase continue its normal processing so
-    // setBackgroundMessageHandler() still runs in JS.
     super.onMessageReceived(remoteMessage)
   }
 }


### PR DESCRIPTION
### 💡 Overview

When Android consumer app contains custom FirebaseMessagingService implementation (either from 3rd party SDK or own) there is a conflict as only single service can be active in runtime. This PR contains callingx package adjustments, so that several FirebaseMessagingService overrides issue can be resolved.

### 📝 Implementation notes

Added a public API on @stream-io/react-native-callingx that lets consumer apps inject ringing push notifications handling logic into custom FirebaseMessagingService implementations. 
Made StreamMessagingService extendable as an alternative for resolving conflicting messaging services issue.

🎫 Ticket: https://linear.app/stream/issue/RN-388/firebase-messaging-service-overrides-issue

📑 Docs: [https://github.com/GetStream/docs-content/pull/<id>](https://github.com/GetStream/docs-content/pull/1294)
