### PR TITLE
feat(react-dogfood,egress-composite): add CSP frame-ancestors 'none'

### DIFF
--- a/sample-apps/react/egress-composite/vercel.json
+++ b/sample-apps/react/egress-composite/vercel.json
@@ -1,0 +1,10 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Content-Security-Policy", "value": "frame-ancestors 'none';" }
+      ]
+    }
+  ]
+}

--- a/sample-apps/react/react-dogfood/next.config.ts
+++ b/sample-apps/react/react-dogfood/next.config.ts
@@ -13,6 +13,12 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: '/(.*)',
+        headers: [
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'none';" },
+        ],
+      },
+      {
         source: '/.well-known/apple-app-site-association',
         headers: [{ key: 'content-type', value: 'application/json' }],
       },


### PR DESCRIPTION
## Summary
- Adds a minimal `Content-Security-Policy: frame-ancestors 'none';` header to both Vercel-deployed demo apps in this monorepo.
- Closes **3 of the 9** open SecurityScorecard `csp_no_policy_v2` findings:
  - `pronto.getstream.io` (react-dogfood)
  - `pronto-staging.getstream.io` (react-dogfood, staging deploy)
  - `video-layout.getstream.io` (egress-composite)
- Tracking: [APPSEC-160](https://linear.app/stream/issue/APPSEC-160) (parent: [APPSEC-156](https://linear.app/stream/issue/APPSEC-156)).

## Why this header / why this value
- `frame-ancestors 'none'` only blocks the page from being embedded in iframes (clickjacking protection). It does **not** restrict `script-src`, `img-src`, `connect-src`, `font-src`, etc., so no risk of breaking the demos.
- Same value already in use on `dashboard.getstream.io` and `demo-moderation.getstream.io`.
- Minimum needed to satisfy SCC's `csp_no_policy_v2` check.

## Changes

**`sample-apps/react/react-dogfood/next.config.ts`** — extend existing `async headers()` with a catch-all entry (keeps the existing `/.well-known/apple-app-site-association` and `/api/*` entries):

```diff
   async headers() {
     return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'none';" },
+        ],
+      },
       {
         source: '/.well-known/apple-app-site-association',
         headers: [{ key: 'content-type', value: 'application/json' }],
       },
       ...
```

**`sample-apps/react/egress-composite/vercel.json`** — new file (none existed before):

```json
{
  "headers": [
    {
      "source": "/(.*)",
      "headers": [
        { "key": "Content-Security-Policy", "value": "frame-ancestors 'none';" }
      ]
    }
  ]
}
```

## Test plan
- [ ] CI green
- [ ] Deploy to Vercel preview, then `curl -sI https://<preview-url>/` shows `content-security-policy: frame-ancestors 'none';`
- [ ] Open the rendered page in a browser, confirm no broken resources / no CSP violations in DevTools console
- [ ] After merge: `curl -sI https://pronto.getstream.io/` and `https://video-layout.getstream.io/` show the new header
- [ ] Confirm SCC findings clear on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced security protections across sample applications to prevent unauthorized frame embedding and protect against clickjacking attacks. These security updates ensure applications cannot be embedded in external websites, providing improved safeguards and better protecting users from potential cross-site framing vulnerabilities, clickjacking attempts, and related exploitation risks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-js/pull/2248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->