### PR TITLE
fix(audio-filters-web): recover AudioContext after iOS interruption

### DIFF
--- a/packages/audio-filters-web/src/AudioContextRecovery.ts
+++ b/packages/audio-filters-web/src/AudioContextRecovery.ts
@@ -5,14 +5,16 @@ export type AudioContextRecoveryOptions = {
   tracer?: Tracer;
 };
 
+// Only "suspended". Calling resume() during "interrupted" can leave the
+// destination zombied (state="running", currentTime frozen, unrecoverable
+// from JS). Wait for iOS to settle, then act.
 const needsRecovery = (state: AudioContextState): boolean => {
-  return state === 'suspended' || state === 'interrupted';
+  return state === 'suspended';
 };
 
 /**
- * Watches an {@link AudioContext} and brings it back to `running` after the
- * platform moves it into `suspended` or `interrupted` (e.g., iOS phone call,
- * Siri, screen lock, tab hidden on WebKit).
+ * Watches an {@link AudioContext} and brings it back to `running` after an
+ * iOS AVAudioSession interruption or cold-start autoplay-policy suspend.
  */
 export class AudioContextRecovery {
   private readonly audioContext: AudioContext;


### PR DESCRIPTION
### 💡 Overview
Fixes audio dying permanently after iOS audio session interruptions (Siri, phone calls, screen lock) in calls with Noise Cancellation. Calling `resume()` while state is `interrupted` fails with `InvalidStateError` and transitions the state to `suspended` — but a subsequent `resume()` then leaves the AudioContext in an invalid state (state="running" with frozen `currentTime`). Narrows recovery to act only on `suspended`.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-986/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized audio context recovery to activate only when the context enters a suspended state, eliminating unnecessary recovery attempts during audio interruptions and improving system efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-js/pull/2249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->