### PR TITLE
fix: missing safe area insets usage

### DIFF
--- a/packages/react-native-sdk/src/components/Call/RingingCallContent/IncomingCall.tsx
+++ b/packages/react-native-sdk/src/components/Call/RingingCallContent/IncomingCall.tsx
@@ -45,17 +45,29 @@ export const IncomingCall = ({
 }: IncomingCallProps) => {
   const { t } = useI18n();
   const {
-    theme: { colors, incomingCall, typefaces },
+    theme: { colors, incomingCall, typefaces, variants },
   } = useTheme();
 
   const landscapeContentStyles: ViewStyle = {
     flexDirection: landscape ? 'row' : 'column',
   };
 
+  const insetStyles: ViewStyle = {
+    paddingTop: variants.insets.top,
+    paddingBottom: variants.insets.bottom,
+    paddingLeft: variants.insets.left,
+    paddingRight: variants.insets.right,
+  };
+
   return (
     <Background>
       <View
-        style={[styles.content, landscapeContentStyles, incomingCall.content]}
+        style={[
+          styles.content,
+          landscapeContentStyles,
+          insetStyles,
+          incomingCall.content,
+        ]}
       >
         <View style={[styles.topContainer, incomingCall.topContainer]}>
           <UserInfo />

--- a/packages/react-native-sdk/src/components/Call/RingingCallContent/OutgoingCall.tsx
+++ b/packages/react-native-sdk/src/components/Call/RingingCallContent/OutgoingCall.tsx
@@ -35,12 +35,19 @@ export const OutgoingCall = ({
   landscape,
 }: OutgoingCallProps) => {
   const {
-    theme: { colors, typefaces, outgoingCall },
+    theme: { colors, typefaces, outgoingCall, variants },
   } = useTheme();
   const { t } = useI18n();
 
   const landscapeContentStyles: ViewStyle = {
     flexDirection: landscape ? 'row' : 'column',
+  };
+
+  const insetStyles: ViewStyle = {
+    paddingTop: variants.insets.top,
+    paddingBottom: variants.insets.bottom,
+    paddingLeft: variants.insets.left,
+    paddingRight: variants.insets.right,
   };
 
   return (
@@ -53,7 +60,12 @@ export const OutgoingCall = ({
         ]}
       >
         <View
-          style={[styles.content, landscapeContentStyles, outgoingCall.content]}
+          style={[
+            styles.content,
+            landscapeContentStyles,
+            insetStyles,
+            outgoingCall.content,
+          ]}
         >
           <View style={[styles.topContainer, outgoingCall.topContainer]}>
             <UserInfo />

--- a/packages/react-native-sdk/src/components/Call/RingingCallContent/RingingCallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/RingingCallContent/RingingCallContent.tsx
@@ -68,12 +68,10 @@ const RingingCallPanel = ({
   CallPreparingIndicator = DefaultCallPreparingIndicator,
   landscape,
   onBackPress,
-}: RingingCallContentProps) => {
+  callingState,
+}: RingingCallContentProps & { callingState: CallingState }) => {
   const call = useCall();
   const isCallCreatedByMe = call?.isCreatedByMe;
-
-  const { useCallCallingState } = useCallStateHooks();
-  const callingState = useCallCallingState();
 
   switch (callingState) {
     case CallingState.RINGING:
@@ -102,15 +100,12 @@ export const RingingCallContent = (props: RingingCallContentProps) => {
   const {
     theme: { ringingCallContent },
   } = useTheme();
+  const { useCallCallingState } = useCallStateHooks();
+  const callingState = useCallCallingState();
+
   return (
-    <View style={[styles.container, ringingCallContent.container]}>
-      <RingingCallPanel {...props} />
+    <View style={[StyleSheet.absoluteFill, ringingCallContent.container]}>
+      <RingingCallPanel {...props} callingState={callingState} />
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    ...StyleSheet.absoluteFillObject,
-  },
-});

--- a/packages/react-native-sdk/src/components/Call/RingingCallContent/TextBasedIndicator.tsx
+++ b/packages/react-native-sdk/src/components/Call/RingingCallContent/TextBasedIndicator.tsx
@@ -13,12 +13,23 @@ export const TextBasedIndicator = (props: TextBasedIndicatorProps) => {
     theme: {
       colors,
       typefaces,
-      variants: { iconSizes },
+      variants: { iconSizes, insets },
     },
   } = useTheme();
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.sheetTertiary }]}>
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.sheetTertiary,
+          paddingTop: insets.top,
+          paddingBottom: insets.bottom,
+          paddingLeft: insets.left,
+          paddingRight: insets.right,
+        },
+      ]}
+    >
       {props.onBackPress && (
         <View style={styles.backContainer}>
           <Pressable

--- a/packages/react-native-sdk/src/components/Livestream/ViewerLivestream/ViewerLivestream.tsx
+++ b/packages/react-native-sdk/src/components/Livestream/ViewerLivestream/ViewerLivestream.tsx
@@ -148,11 +148,19 @@ export const ViewerLivestream = ({
   ]);
 
   if (endedAt != null) {
-    return <CallEndedView />;
+    return (
+      <View style={[styles.container, viewerLivestream.container]}>
+        <CallEndedView />
+      </View>
+    );
   }
 
   if (!canJoinLive || callingState !== CallingState.JOINED) {
-    return <ViewerLobby isLive={canJoinLive} />;
+    return (
+      <View style={[styles.container, viewerLivestream.container]}>
+        <ViewerLobby isLive={canJoinLive} />
+      </View>
+    );
   }
 
   return (

--- a/sample-apps/react-native/dogfood/android/gradle.properties
+++ b/sample-apps/react-native/dogfood/android/gradle.properties
@@ -41,4 +41,4 @@ hermesEnabled=true
 # Use this property to enable edge-to-edge display support.
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
-edgeToEdgeEnabled=false
+edgeToEdgeEnabled=true

--- a/sample-apps/react-native/dogfood/src/components/ActiveCall.tsx
+++ b/sample-apps/react-native/dogfood/src/components/ActiveCall.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   CallContent,
   NoiseCancellationProvider,
+  StreamTheme,
   useCall,
   useIsInPiPMode,
   useModeration,
@@ -31,6 +32,24 @@ type ActiveCallProps = {
   onCallEnded: () => void;
   onChatOpenHandler: () => void;
   unreadCountIndicator: number;
+};
+
+// Since we are adding CustomTopControls, we need to override the callContent container paddingTop to 0
+const CustomCallContentThemeOverride = ({
+  children,
+}: React.PropsWithChildren<{}>) => {
+  const { theme } = useTheme();
+  const customTheme = {
+    ...theme,
+    callContent: {
+      ...theme.callContent,
+      container: {
+        ...theme.callContent.container,
+        paddingTop: 0,
+      },
+    },
+  };
+  return <StreamTheme theme={customTheme}>{children}</StreamTheme>;
 };
 
 export const ActiveCall = ({
@@ -125,14 +144,16 @@ export const ActiveCall = ({
           barStyle={themeMode === 'light' ? 'dark-content' : 'light-content'}
         />
         {!isInPiPMode && <CustomTopControls />}
-        <CallContent
-          iOSPiPIncludeLocalParticipantVideo
-          onHangupCallHandler={onHangupCallHandler}
-          CallControls={CustomBottomControls}
-          ParticipantLabel={AudioConnectingParticipantLabel}
-          landscape={isLandscape}
-          layout={selectedLayout}
-        />
+        <CustomCallContentThemeOverride>
+          <CallContent
+            iOSPiPIncludeLocalParticipantVideo
+            onHangupCallHandler={onHangupCallHandler}
+            CallControls={CustomBottomControls}
+            ParticipantLabel={AudioConnectingParticipantLabel}
+            landscape={isLandscape}
+            layout={selectedLayout}
+          />
+        </CustomCallContentThemeOverride>
         <ParticipantsInfoListModal
           isCallParticipantsInfoVisible={isCallParticipantsVisible}
           setIsCallParticipantsInfoVisible={setIsCallParticipantsVisible}

--- a/sample-apps/react-native/dogfood/src/components/CallControlls/BottomControls.tsx
+++ b/sample-apps/react-native/dogfood/src/components/CallControlls/BottomControls.tsx
@@ -85,12 +85,20 @@ const SubtitleContainer = ({
     useCallStateHooks();
   const isCaptioningInProgress = useIsCallCaptioningInProgress();
   const { isSpeakingWhileMuted } = useMicrophoneState();
+  const {
+    theme: {
+      variants: { insets },
+    },
+  } = useTheme();
   if (!isCaptioningInProgress || !isSpeakingWhileMuted) {
     return null;
   }
   return (
     <View
-      style={[styles.subtitleContainer, { bottom: controlsContainerHeight }]}
+      style={[
+        styles.subtitleContainer,
+        { bottom: controlsContainerHeight + insets.bottom },
+      ]}
     >
       <ClosedCaptions />
       <View style={styles.speakingLabelContainer}>

--- a/sample-apps/react-native/dogfood/src/components/CallControlls/MoreActionsButton/AndroidAudioRoutePickerDrawer.tsx
+++ b/sample-apps/react-native/dogfood/src/components/CallControlls/MoreActionsButton/AndroidAudioRoutePickerDrawer.tsx
@@ -51,6 +51,11 @@ export const AndroidAudioRoutePickerDrawer: React.FC<
   const screenHeight = useWindowDimensions().height;
   const drawerHeight = screenHeight * 0.8;
   const styles = useStyles();
+  const {
+    theme: {
+      variants: { insets },
+    },
+  } = useTheme();
 
   const [audioDeviceStatus, setAudioDeviceStatus] =
     useState<AudioDeviceStatus>();
@@ -66,7 +71,7 @@ export const AndroidAudioRoutePickerDrawer: React.FC<
   const selectedAudioDeviceName = audioDeviceStatus?.selectedDevice;
 
   // negative offset is needed so the drawer component start above the bottom controls
-  const offset = -bottomControlsHeight;
+  const offset = -bottomControlsHeight - insets.bottom;
 
   const translateY = useRef<any>(
     new Animated.Value(drawerHeight + offset),

--- a/sample-apps/react-native/dogfood/src/components/CallControlls/MoreActionsButton/BottomControlsDrawer.tsx
+++ b/sample-apps/react-native/dogfood/src/components/CallControlls/MoreActionsButton/BottomControlsDrawer.tsx
@@ -53,12 +53,7 @@ export const BottomControlsDrawer: React.FC<DrawerProps> = ({
   const call = useCall();
 
   // negative offset to position the drawer component above the bottom controls
-  const {
-    theme: {
-      variants: { insets },
-    },
-  } = useTheme();
-  const callContentPaddingBottom = insets.bottom;
+  const callContentPaddingBottom = theme.variants.insets.bottom;
   const offset = -bottomControlsHeight - callContentPaddingBottom;
 
   const translateY = useRef<any>(

--- a/sample-apps/react-native/dogfood/src/components/CallControlls/MoreActionsButton/BottomControlsDrawer.tsx
+++ b/sample-apps/react-native/dogfood/src/components/CallControlls/MoreActionsButton/BottomControlsDrawer.tsx
@@ -53,7 +53,13 @@ export const BottomControlsDrawer: React.FC<DrawerProps> = ({
   const call = useCall();
 
   // negative offset to position the drawer component above the bottom controls
-  const offset = -bottomControlsHeight;
+  const {
+    theme: {
+      variants: { insets },
+    },
+  } = useTheme();
+  const callContentPaddingBottom = insets.bottom;
+  const offset = -bottomControlsHeight - callContentPaddingBottom;
 
   const translateY = useRef<any>(
     new Animated.Value(drawerHeight + offset),

--- a/sample-apps/react-native/dogfood/src/navigators/Call.tsx
+++ b/sample-apps/react-native/dogfood/src/navigators/Call.tsx
@@ -29,7 +29,7 @@ const Calls = () => {
   return (
     <StreamCall call={firstCall}>
       <CallLeaveOnUnmount call={firstCall} />
-      <View style={styles.container}>
+      <View style={StyleSheet.absoluteFill}>
         <RingingCallContent landscape={orientation === 'landscape'} />
       </View>
     </StreamCall>
@@ -61,9 +61,3 @@ export const Call = () => {
     </>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    ...StyleSheet.absoluteFillObject,
-  },
-});

--- a/sample-apps/react-native/dogfood/src/navigators/Call.tsx
+++ b/sample-apps/react-native/dogfood/src/navigators/Call.tsx
@@ -8,21 +8,16 @@ import {
   StreamCall,
   useCalls,
 } from '@stream-io/video-react-native-sdk';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { CallStackParamList } from '../../types';
 import { NavigationHeader } from '../components/NavigationHeader';
-import {
-  SafeAreaView,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
 import { useOrientation } from '../hooks/useOrientation';
 
 const CallStack = createNativeStackNavigator<CallStackParamList>();
 
 const Calls = () => {
   const calls = useCalls().filter((c) => c.ringing);
-  const { top } = useSafeAreaInsets();
   const orientation = useOrientation();
 
   const firstCall = calls.at(-1);
@@ -34,9 +29,9 @@ const Calls = () => {
   return (
     <StreamCall call={firstCall}>
       <CallLeaveOnUnmount call={firstCall} />
-      <SafeAreaView style={[styles.container, { top }]}>
+      <View style={styles.container}>
         <RingingCallContent landscape={orientation === 'landscape'} />
-      </SafeAreaView>
+      </View>
     </StreamCall>
   );
 };

--- a/sample-apps/react-native/dogfood/src/screens/Meeting/GuestMeetingScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Meeting/GuestMeetingScreen.tsx
@@ -10,6 +10,7 @@ import { MeetingStackParamList } from '../../../types';
 import { MeetingUI } from '../../components/MeetingUI';
 import { createToken } from '../../modules/helpers/createToken';
 import { useAppGlobalStoreValue } from '../../contexts/AppContext';
+import { useCustomTheme } from '../../theme';
 
 type Props = NativeStackScreenProps<
   MeetingStackParamList,
@@ -20,6 +21,8 @@ export const GuestMeetingScreen = (props: Props) => {
   const appEnvironment = useAppGlobalStoreValue(
     (store) => store.appEnvironment,
   );
+  const themeMode = useAppGlobalStoreValue((store) => store.themeMode);
+  const customTheme = useCustomTheme(themeMode);
   const [videoClient, setVideoClient] = useState<StreamVideoClient | undefined>(
     undefined,
   );
@@ -84,7 +87,7 @@ export const GuestMeetingScreen = (props: Props) => {
   }
 
   return (
-    <StreamVideo client={videoClient}>
+    <StreamVideo client={videoClient} style={customTheme}>
       <StreamCall call={call}>
         <MeetingUI callId={callId} {...props} />
       </StreamCall>

--- a/sample-apps/react-native/dogfood/src/theme.ts
+++ b/sample-apps/react-native/dogfood/src/theme.ts
@@ -48,7 +48,7 @@ export const useCustomTheme = (mode: ThemeMode): DeepPartial<Theme> => {
   };
 
   const callContent: DeepPartial<Theme['callContent']> = {
-    container: { paddingTop: 0, paddingBottom: 0, flexDirection: 'column' },
+    container: { paddingTop: 0, flexDirection: 'column' },
   };
 
   const lightThemeColors: DeepPartial<Theme['colors']> = {

--- a/sample-apps/react-native/dogfood/src/theme.ts
+++ b/sample-apps/react-native/dogfood/src/theme.ts
@@ -47,10 +47,6 @@ export const useCustomTheme = (mode: ThemeMode): DeepPartial<Theme> => {
     },
   };
 
-  const callContent: DeepPartial<Theme['callContent']> = {
-    container: { paddingTop: 0, flexDirection: 'column' },
-  };
-
   const lightThemeColors: DeepPartial<Theme['colors']> = {
     buttonPrimary: '#3399ff',
     buttonSecondary: '#eff0f1',
@@ -70,7 +66,6 @@ export const useCustomTheme = (mode: ThemeMode): DeepPartial<Theme> => {
 
   const baseTheme: DeepPartial<Theme> = {
     variants,
-    callContent,
   };
 
   if (mode === 'light') {

--- a/sample-apps/react-native/expo-video-sample/app.json
+++ b/sample-apps/react-native/expo-video-sample/app.json
@@ -16,6 +16,7 @@
       "appleTeamId": "EHV7XZLAHA"
     },
     "android": {
+      "edgeToEdgeEnabled": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"

--- a/sample-apps/react-native/expo-video-sample/app/_layout.tsx
+++ b/sample-apps/react-native/expo-video-sample/app/_layout.tsx
@@ -4,13 +4,16 @@ import { UsersList } from '../components/UsersList';
 import { VideoWrapper } from '../components/VideoWrapper';
 import { AppProvider, useAppContext } from '../context/AppContext';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 export default function Root() {
   // Set up the auth context and render our layout inside of it.
   return (
-    <AppProvider>
-      <Home />
-    </AppProvider>
+    <SafeAreaProvider>
+      <AppProvider>
+        <Home />
+      </AppProvider>
+    </SafeAreaProvider>
   );
 }
 

--- a/sample-apps/react-native/expo-video-sample/app/ringing.tsx
+++ b/sample-apps/react-native/expo-video-sample/app/ringing.tsx
@@ -6,8 +6,7 @@ import {
   useCalls,
 } from '@stream-io/video-react-native-sdk';
 import { useEffect } from 'react';
-import { StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet, View } from 'react-native';
 import { router } from 'expo-router';
 
 export default function JoinRingingCallScreen() {
@@ -28,9 +27,9 @@ export default function JoinRingingCallScreen() {
   return (
     <StreamCall call={firstCall}>
       <CallLeaveOnUnmount call={firstCall} />
-      <SafeAreaView style={styles.flexedContainer}>
+      <View style={styles.flexedContainer}>
         <RingingCallContent />
-      </SafeAreaView>
+      </View>
     </StreamCall>
   );
 }

--- a/sample-apps/react-native/expo-video-sample/components/CallControlsComponent.tsx
+++ b/sample-apps/react-native/expo-video-sample/components/CallControlsComponent.tsx
@@ -11,7 +11,6 @@ import {
 } from '@stream-io/video-react-native-sdk';
 import React from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Hearing from '../assets/Hearing';
 import AutoAwesome from '../assets/AutoAwesome';
 import { useCustomVideoFilters } from './hooks/useCustomVideoFilters';
@@ -57,12 +56,10 @@ const BackgroundFiltersButton = () => {
 };
 
 export const CallControlsComponent = ({ landscape }: CallControlProps) => {
-  const { bottom } = useSafeAreaInsets();
   const landscapeStyles: ViewStyle = {
     flexDirection: landscape ? 'column-reverse' : 'row',
     paddingHorizontal: landscape ? 12 : 0,
     paddingVertical: landscape ? 0 : 12,
-    paddingBottom: landscape ? 0 : Math.max(bottom, 16),
   };
 
   return (

--- a/sample-apps/react-native/expo-video-sample/components/MeetingUI.tsx
+++ b/sample-apps/react-native/expo-video-sample/components/MeetingUI.tsx
@@ -8,9 +8,7 @@ import {
   useCall,
   useCallStateHooks,
 } from '@stream-io/video-react-native-sdk';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { AuthProgressLoader } from './AuthProgressLoader';
-import { StyleSheet } from 'react-native';
 import { CallControlsComponent } from './CallControlsComponent';
 
 export const MeetingUI = () => {
@@ -34,21 +32,13 @@ export const MeetingUI = () => {
     return <AuthProgressLoader />;
   }
   return (
-    <SafeAreaView style={styles.container}>
-      <NoiseCancellationProvider>
-        <BackgroundFiltersProvider>
-          <CallContent
-            CallControls={CallControlsComponent}
-            iOSPiPIncludeLocalParticipantVideo={true}
-          />
-        </BackgroundFiltersProvider>
-      </NoiseCancellationProvider>
-    </SafeAreaView>
+    <NoiseCancellationProvider>
+      <BackgroundFiltersProvider>
+        <CallContent
+          CallControls={CallControlsComponent}
+          iOSPiPIncludeLocalParticipantVideo={true}
+        />
+      </BackgroundFiltersProvider>
+    </NoiseCancellationProvider>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});

--- a/sample-apps/react-native/expo-video-sample/components/VideoWrapper.tsx
+++ b/sample-apps/react-native/expo-video-sample/components/VideoWrapper.tsx
@@ -1,13 +1,17 @@
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 import {
+  DeepPartial,
   StreamVideo,
   StreamVideoClient,
+  Theme,
 } from '@stream-io/video-react-native-sdk';
 import { useAppContext } from '../context/AppContext';
 import { createToken } from '../utils/createToken';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export const VideoWrapper = ({ children }: PropsWithChildren<{}>) => {
   const { user } = useAppContext();
+  const customTheme = useCustomTheme();
   const [videoClient, setVideoClient] = useState<StreamVideoClient | undefined>(
     undefined,
   );
@@ -61,5 +65,26 @@ export const VideoWrapper = ({ children }: PropsWithChildren<{}>) => {
     return null;
   }
 
-  return <StreamVideo client={videoClient}>{children}</StreamVideo>;
+  return (
+    <StreamVideo client={videoClient} style={customTheme}>
+      {children}
+    </StreamVideo>
+  );
+};
+
+const useCustomTheme = (): DeepPartial<Theme> => {
+  const { top, right, bottom, left } = useSafeAreaInsets();
+
+  const variants: DeepPartial<Theme['variants']> = {
+    insets: {
+      top,
+      right,
+      bottom,
+      left,
+    },
+  };
+
+  return {
+    variants,
+  };
 };

--- a/sample-apps/react-native/ringing-tutorial/app.json
+++ b/sample-apps/react-native/ringing-tutorial/app.json
@@ -19,6 +19,7 @@
       "appleTeamId": "EHV7XZLAHA"
     },
     "android": {
+      "edgeToEdgeEnabled": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"

--- a/sample-apps/react-native/ringing-tutorial/app/(app)/ringing.tsx
+++ b/sample-apps/react-native/ringing-tutorial/app/(app)/ringing.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
-import { StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet, View } from 'react-native';
 import {
   RingingCallContent,
   StreamCall,
@@ -25,9 +24,9 @@ export default function Ringing() {
 
   return (
     <StreamCall call={call}>
-      <SafeAreaView style={styles.container}>
+      <View style={styles.container}>
         <RingingCallContent />
-      </SafeAreaView>
+      </View>
     </StreamCall>
   );
 }

--- a/sample-apps/react-native/ringing-tutorial/app/_layout.tsx
+++ b/sample-apps/react-native/ringing-tutorial/app/_layout.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { Slot } from 'expo-router';
 import { AuthenticationProvider } from '../contexts/authentication-provider';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 export default function Root() {
   return (
-    <AuthenticationProvider>
-      <GestureHandlerRootView style={{ flex: 1 }}>
-        <Slot />
-      </GestureHandlerRootView>
-    </AuthenticationProvider>
+    <SafeAreaProvider>
+      <AuthenticationProvider>
+        <GestureHandlerRootView style={{ flex: 1 }}>
+          <Slot />
+        </GestureHandlerRootView>
+      </AuthenticationProvider>
+    </SafeAreaProvider>
   );
 }

--- a/sample-apps/react-native/ringing-tutorial/contexts/authentication-provider.tsx
+++ b/sample-apps/react-native/ringing-tutorial/contexts/authentication-provider.tsx
@@ -6,12 +6,15 @@ import React, {
   useState,
 } from 'react';
 import {
+  DeepPartial,
   StreamVideo,
   StreamVideoClient,
   StreamVideoRN,
+  Theme,
 } from '@stream-io/video-react-native-sdk';
 import { Users, UserWithToken } from '../constants/Users';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const API_KEY = 'par8f5s3gn2j';
 
@@ -38,6 +41,7 @@ export function useAuthentication() {
 export function AuthenticationProvider({ children }: PropsWithChildren) {
   const [userId, setUserId] = useState<string>();
   const [isLoading, setIsLoading] = useState(true);
+  const customTheme = useCustomTheme();
 
   const userWithToken = Users.find((user) => user.id === userId);
   const client =
@@ -88,10 +92,29 @@ export function AuthenticationProvider({ children }: PropsWithChildren) {
       }}
     >
       {client ? (
-        <StreamVideo client={client}>{children}</StreamVideo>
+        <StreamVideo client={client} style={customTheme}>
+          {children}
+        </StreamVideo>
       ) : (
         <>{children}</>
       )}
     </AuthContext.Provider>
   );
 }
+
+const useCustomTheme = (): DeepPartial<Theme> => {
+  const { top, right, bottom, left } = useSafeAreaInsets();
+
+  const variants: DeepPartial<Theme['variants']> = {
+    insets: {
+      top,
+      right,
+      bottom,
+      left,
+    },
+  };
+
+  return {
+    variants,
+  };
+};


### PR DESCRIPTION
### 💡 Overview

The React Native sample apps did not handle Android edge-to-edge display correctly, and safe area insets were applied inconsistently — some screens used `SafeAreaView` wrappers around SDK components, others applied manual padding inside the app, and a few SDK components (`RingingCallContent`, `ViewerLivestream` pre-join/ended states) did not consume `theme.variants.insets` at all. The result was double padding in some places and content overlapping system bars in others.

This PR does the following:

1. Enables Android edge-to-edge across all RN sample apps.
2. Centralises inset handling through the SDK theme (`theme.variants.insets`) instead of per-screen `SafeAreaView` wrappers.
3. Fixes the two SDK components that previously ignored the theme insets.
4. Updates the user-facing docs to teach the same pattern.

### 📝 Implementation notes

Two things done: 

1. Make sure all full screen SDK components use the insets passed to theme
2. Make sure all sample apps do not use SafeAreaView in case the full screen SDK components are used in a screen

Also revamped  the docs https://github.com/GetStream/docs-content/pull/1300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safe-area handling across call, livestream, and meeting screens for more reliable layout on devices with notches and system insets.

* **Style**
  * Added theme-aware inset padding to call UI (incoming/outgoing/indicators), controls, and subtitle positioning for consistent spacing.
  * Enabled Android edge-to-edge rendering and updated app layouts to integrate safe-area providers for correct content insets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-js/pull/2250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->