### PR TITLE
fix(client): bail reconnects during in-flight lifecycles and clean up listeners

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -287,6 +287,7 @@ export class Call {
   private statsReportingIntervalInMs: number = 2000;
   private statsReporter?: StatsReporter;
   private sfuStatsReporter?: SfuStatsReporter;
+  private lastStatsOptions?: StatsOptions;
   private dropTimeout: ReturnType<typeof setTimeout> | undefined;
 
   private readonly clientStore: StreamVideoWriteableStateStore;
@@ -736,6 +737,7 @@ export class Call {
       this.sfuStatsReporter?.flush();
       this.sfuStatsReporter?.stop();
       this.sfuStatsReporter = undefined;
+      this.lastStatsOptions = undefined;
 
       this.subscriber?.dispose();
       this.subscriber = undefined;
@@ -1125,17 +1127,19 @@ export class Call {
     const performingFastReconnect =
       this.reconnectStrategy === WebsocketReconnectStrategy.FAST;
 
-    let statsOptions = this.sfuStatsReporter?.options;
+    let statsOptions = this.lastStatsOptions;
     if (
       !this.credentials ||
       !statsOptions ||
       performingRejoin ||
-      performingMigration
+      performingMigration ||
+      data?.migrating_from
     ) {
       try {
         const joinResponse = await this.doJoinRequest(data);
         this.credentials = joinResponse.credentials;
         statsOptions = joinResponse.stats_options;
+        this.lastStatsOptions = statsOptions;
       } catch (error) {
         // prevent triggering reconnect flow if the state is OFFLINE
         const avoidRestoreState =
@@ -1613,11 +1617,18 @@ export class Call {
     reason: ReconnectReason,
   ): Promise<void> => {
     if (
+      this.state.callingState === CallingState.JOINING ||
       this.state.callingState === CallingState.RECONNECTING ||
       this.state.callingState === CallingState.MIGRATING ||
       this.state.callingState === CallingState.RECONNECTING_FAILED
     )
       return;
+
+    // Drop redundant reconnect calls. If a reconnect is already queued or
+    // running for this Call, that entry will resolve whatever broke;
+    // queueing more entries just replays the full REJOIN cycle (one extra
+    // `POST /join` per entry) once the call is already healthy again.
+    if (hasPending(this.reconnectConcurrencyTag)) return;
 
     return withoutConcurrency(this.reconnectConcurrencyTag, async () => {
       const reconnectStartTime = Date.now();

--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -141,6 +141,10 @@ export abstract class BasePeerConnection {
       this.onIceConnectionStateChange,
     );
     pc.removeEventListener('icegatheringstatechange', this.onIceGatherChange);
+    pc.removeEventListener(
+      'connectionstatechange',
+      this.onConnectionStateChange,
+    );
     this.unsubscribeIceTrickle?.();
     this.subscriptions.forEach((unsubscribe) => unsubscribe());
     this.subscriptions = [];

--- a/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
+++ b/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
@@ -43,7 +43,7 @@ const makeCall = () => {
  */
 const primeForReconnect = (call: Call) => {
   // put the call in a non-terminal, non-JOINED state so the do-while iterates
-  call.state.setCallingState(CallingState.JOINING);
+  call.state.setCallingState(CallingState.IDLE);
   // force the strategy-decider in the catch block to always pick REJOIN,
   // so tests that care about the rejoin rate limiter don't bounce to FAST
   // based on wall-clock timing. Individual tests that want to exercise the
@@ -136,7 +136,7 @@ describe('Call reconnect stopping conditions', () => {
       });
 
       for (let i = 0; i < 5; i++) {
-        call.state.setCallingState(CallingState.JOINING);
+        call.state.setCallingState(CallingState.IDLE);
         await call['reconnect'](WebsocketReconnectStrategy.FAST, 'test');
       }
 
@@ -401,6 +401,125 @@ describe('Call reconnect stopping conditions', () => {
       expect(limiter.maxAttempts).toBe(1);
       expect(limiter.windowMs).toBe(1000);
     });
+  });
+});
+
+/**
+ * Entry-condition bails. `reconnect()` must drop new triggers when:
+ * - A join/reconnect/migrate lifecycle is already in progress.
+ * - A reconnect is already queued via `hasPending(reconnectConcurrencyTag)`.
+ * - The terminal `RECONNECTING_FAILED` state has been reached.
+ *
+ * These are pure short-circuits — none of the strategy implementations
+ * should be invoked.
+ */
+describe('Call reconnect entry-condition bails', () => {
+  let call: Call;
+
+  beforeEach(() => {
+    call = makeCall();
+    vi.spyOn(connectionUtils, 'sleep').mockResolvedValue(undefined);
+    vi.spyOn(call, 'leave').mockResolvedValue(undefined);
+    vi.spyOn(call, 'get').mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const stubAllStrategies = () => ({
+    fast: vi
+      .spyOn(
+        call as unknown as { reconnectFast: () => Promise<void> },
+        'reconnectFast',
+      )
+      .mockResolvedValue(undefined),
+    rejoin: vi
+      .spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      )
+      .mockResolvedValue(undefined),
+    migrate: vi
+      .spyOn(
+        call as unknown as { reconnectMigrate: () => Promise<void> },
+        'reconnectMigrate',
+      )
+      .mockResolvedValue(undefined),
+  });
+
+  it('bails immediately when state is JOINING — Call.join owns recovery during the initial join window', async () => {
+    const strategies = stubAllStrategies();
+    call.state.setCallingState(CallingState.JOINING);
+
+    await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+    expect(strategies.fast).not.toHaveBeenCalled();
+    expect(strategies.rejoin).not.toHaveBeenCalled();
+    expect(strategies.migrate).not.toHaveBeenCalled();
+  });
+
+  it('bails immediately when state is RECONNECTING — another reconnect is already running', async () => {
+    const strategies = stubAllStrategies();
+    call.state.setCallingState(CallingState.RECONNECTING);
+
+    await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+    expect(strategies.fast).not.toHaveBeenCalled();
+    expect(strategies.rejoin).not.toHaveBeenCalled();
+    expect(strategies.migrate).not.toHaveBeenCalled();
+  });
+
+  it('bails immediately when state is MIGRATING — reconnectMigrate is in flight', async () => {
+    const strategies = stubAllStrategies();
+    call.state.setCallingState(CallingState.MIGRATING);
+
+    await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+    expect(strategies.fast).not.toHaveBeenCalled();
+    expect(strategies.rejoin).not.toHaveBeenCalled();
+    expect(strategies.migrate).not.toHaveBeenCalled();
+  });
+
+  it('bails immediately when state is RECONNECTING_FAILED — terminal, no further attempts', async () => {
+    const strategies = stubAllStrategies();
+    call.state.setCallingState(CallingState.RECONNECTING_FAILED);
+
+    await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+    expect(strategies.fast).not.toHaveBeenCalled();
+    expect(strategies.rejoin).not.toHaveBeenCalled();
+    expect(strategies.migrate).not.toHaveBeenCalled();
+  });
+
+  it('drops duplicate reconnect calls while one is already pending', async () => {
+    let resolveFirst: () => void = () => {};
+    const firstStrategy = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const rejoinSpy = vi
+      .spyOn(
+        call as unknown as { reconnectRejoin: () => Promise<void> },
+        'reconnectRejoin',
+      )
+      .mockImplementationOnce(async () => {
+        await firstStrategy;
+        call.state.setCallingState(CallingState.JOINED);
+      });
+
+    primeForReconnect(call);
+
+    const firstCall = call['reconnect'](
+      WebsocketReconnectStrategy.REJOIN,
+      'first',
+    );
+    await Promise.resolve();
+    call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'second');
+
+    expect(rejoinSpy).toHaveBeenCalledTimes(1);
+
+    resolveFirst();
+    await firstCall;
   });
 });
 


### PR DESCRIPTION
### 💡 Overview
  Description
 
This PR hardens the reconnect logic in Call.ts against concurrent recovery paths, stale signals, and wasted network calls. 
Reconnect fixes:
 -  trigger fresh coord call when data.migrating_from is set 
  - bail when state is JOINING - external triggers (dispatcher error/goAway events) no longer kick off a parallel reconnect while Call.join's for-loop is still iterating. 
  - dedup queued reconnects via hasPending - when a reconnect is already queued or running for this Call, additional triggers are dropped. 
  - cache statsOptions across partial coord failures —-statsOptions is now persisted on the Call instance after each successful coord response

  Event listener cleanup:  
  - remove `connectionstatechange` listener on PC dispose - the listener was registered in createPeerConnection but missing from detachEventHandlers.


### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnect logic to prevent redundant reconnection attempts when duplicate calls are triggered
  * Enhanced call migration handling during join operations
  * Strengthened state validation for more reliable call state transitions

* **Performance**
  * Optimized statistics tracking and reporting configuration management during call initialization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-js/pull/2257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->