### PR TITLE
feat(client): add hasInterruptedTrack helper

### DIFF
--- a/packages/client/src/helpers/__tests__/participantUtils.test.ts
+++ b/packages/client/src/helpers/__tests__/participantUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   hasAudio,
+  hasInterruptedTrack,
   hasPausedTrack,
   hasScreenShare,
   hasScreenShareAudio,
@@ -117,6 +118,52 @@ describe('participantUtils', () => {
         pin: { isLocalPin: false, pinnedAt: 0 },
       });
       expect(isPinned(participant)).toBe(false);
+    });
+  });
+
+  describe('hasInterruptedTrack', () => {
+    it('returns true when the track is both interrupted and published', () => {
+      const participant = createMockParticipant({
+        publishedTracks: [TrackType.AUDIO],
+        interruptedTracks: [TrackType.AUDIO],
+      });
+      expect(hasInterruptedTrack(participant, TrackType.AUDIO)).toBe(true);
+    });
+
+    it('returns false when the track is interrupted but no longer published', () => {
+      const participant = createMockParticipant({
+        publishedTracks: [],
+        interruptedTracks: [TrackType.AUDIO],
+      });
+      expect(hasInterruptedTrack(participant, TrackType.AUDIO)).toBe(false);
+    });
+
+    it('returns false when the track is published but not interrupted', () => {
+      const participant = createMockParticipant({
+        publishedTracks: [TrackType.AUDIO],
+        interruptedTracks: [],
+      });
+      expect(hasInterruptedTrack(participant, TrackType.AUDIO)).toBe(false);
+    });
+
+    it('returns false when interruptedTracks is undefined', () => {
+      const participant = createMockParticipant({
+        publishedTracks: [TrackType.AUDIO],
+        interruptedTracks: undefined,
+      });
+      expect(hasInterruptedTrack(participant, TrackType.AUDIO)).toBe(false);
+    });
+
+    it('checks each track type independently', () => {
+      const participant = createMockParticipant({
+        publishedTracks: [TrackType.AUDIO, TrackType.VIDEO],
+        interruptedTracks: [TrackType.VIDEO],
+      });
+      expect(hasInterruptedTrack(participant, TrackType.AUDIO)).toBe(false);
+      expect(hasInterruptedTrack(participant, TrackType.VIDEO)).toBe(true);
+      expect(hasInterruptedTrack(participant, TrackType.SCREEN_SHARE)).toBe(
+        false,
+      );
     });
   });
 

--- a/packages/client/src/helpers/participantUtils.ts
+++ b/packages/client/src/helpers/participantUtils.ts
@@ -42,6 +42,21 @@ export const isPinned = (p: StreamVideoParticipant): boolean =>
   !!p.pin && (p.pin.isLocalPin || p.pin.pinnedAt > 0);
 
 /**
+ * Check if a participant has a track that is currently interrupted: the
+ * participant intends to publish it (it is in `publishedTracks`) but no
+ * media is flowing right now (it is in `interruptedTracks`).
+ *
+ * @param p the participant to check.
+ * @param trackType the track type to check.
+ */
+export const hasInterruptedTrack = (
+  p: StreamVideoParticipant,
+  trackType: TrackType,
+): boolean =>
+  !!p.interruptedTracks?.includes(trackType) &&
+  p.publishedTracks.includes(trackType);
+
+/**
  * Check if a participant has a paused track of the specified type.
  *
  * @param p the participant to check.

--- a/sample-apps/react/react-dogfood/components/Debug/DebugParticipantViewUI.tsx
+++ b/sample-apps/react/react-dogfood/components/Debug/DebugParticipantViewUI.tsx
@@ -5,6 +5,7 @@ import {
   GenericMenu,
   GenericMenuButtonItem,
   hasAudio,
+  hasInterruptedTrack,
   hasScreenShare,
   hasScreenShareAudio,
   hasVideo,
@@ -13,6 +14,7 @@ import {
   ParticipantActionsContextMenu,
   Restricted,
   SfuModels,
+  StreamVideoParticipant,
   useCall,
   useI18n,
   useMenuContext,
@@ -23,19 +25,18 @@ import { useIsDebugMode } from './useIsDebugMode';
 import { useIsDemoEnvironment } from '../../context/AppEnvironmentContext';
 
 const InterruptedTrackBadge = ({
-  interruptedTracks,
+  participant,
 }: {
-  interruptedTracks?: SfuModels.TrackType[];
+  participant: StreamVideoParticipant;
 }) => {
-  if (!interruptedTracks || interruptedTracks.length === 0) return null;
   const labels: string[] = [];
-  if (interruptedTracks.includes(SfuModels.TrackType.AUDIO))
+  if (hasInterruptedTrack(participant, SfuModels.TrackType.AUDIO))
     labels.push('audio');
-  if (interruptedTracks.includes(SfuModels.TrackType.VIDEO))
+  if (hasInterruptedTrack(participant, SfuModels.TrackType.VIDEO))
     labels.push('video');
-  if (interruptedTracks.includes(SfuModels.TrackType.SCREEN_SHARE))
+  if (hasInterruptedTrack(participant, SfuModels.TrackType.SCREEN_SHARE))
     labels.push('screen');
-  if (interruptedTracks.includes(SfuModels.TrackType.SCREEN_SHARE_AUDIO))
+  if (hasInterruptedTrack(participant, SfuModels.TrackType.SCREEN_SHARE_AUDIO))
     labels.push('screen audio');
   if (labels.length === 0) return null;
   return (
@@ -65,7 +66,7 @@ export const DebugParticipantViewUI = () => {
   const call = useCall();
   const { participant, participantViewElement, trackType } =
     useParticipantViewContext();
-  const { sessionId, userId, interruptedTracks } = participant;
+  const { sessionId, userId } = participant;
 
   const isDemoEnvironment = useIsDemoEnvironment();
   const participantContextMenuActions = isDemoEnvironment
@@ -98,7 +99,6 @@ export const DebugParticipantViewUI = () => {
         <DefaultParticipantViewUI
           ParticipantActionsContextMenu={participantContextMenuActions}
         />
-        <InterruptedTrackBadge interruptedTracks={interruptedTracks} />
       </div>
     );
   }
@@ -107,7 +107,7 @@ export const DebugParticipantViewUI = () => {
       <DefaultParticipantViewUI
         ParticipantActionsContextMenu={participantContextMenuActions}
       />
-      <InterruptedTrackBadge interruptedTracks={interruptedTracks} />
+      <InterruptedTrackBadge participant={participant} />
       <div className="rd__debug__extra">
         <DebugStatsView call={call!} sessionId={sessionId} userId={userId} />
       </div>


### PR DESCRIPTION
### 💡 Overview

Adds `hasInterruptedTrack(participant, trackType)` to `@stream-io/video-client` that returns `true` only when a track is in both `interruptedTracks` and `publishedTracks`. This avoids a stale "audio interrupted" indicator that lingers after a remote sender unpublishes the track while it was interrupted, because the receiver-side `unmute` event does not always fire for an unpublish.

📑 Docs: https://github.com/GetStream/docs-content/pull/1322