### PR TITLE
chore(egress-composite): bump layout to 1.0.22

### DIFF
--- a/sample-apps/react/egress-composite/package.json
+++ b/sample-apps/react/egress-composite/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.5",
     "@sentry/react": "^10.30.0",
-    "@skooldev/skool-stream-layout": "1.0.21",
+    "@skooldev/skool-stream-layout": "1.0.22",
     "@stream-io/video-react-sdk": "workspace:^",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8723,14 +8723,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@skooldev/skool-stream-layout@npm:1.0.21":
-  version: 1.0.21
-  resolution: "@skooldev/skool-stream-layout@npm:1.0.21"
+"@skooldev/skool-stream-layout@npm:1.0.22":
+  version: 1.0.22
+  resolution: "@skooldev/skool-stream-layout@npm:1.0.22"
   peerDependencies:
     "@stream-io/video-react-sdk": ^1.37.0
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10/71563f99d12d6875e1743bd946381ab212f152df142361aaa989171b9f1c20f418d214f6593c3fc7cf143cb5eb8536ef4b4d163f2d6aa0915acbd52b5de2ea10
+  checksum: 10/2a26a777be92a731397acb899eae2aa588a1ad6b3d6237537ca7db95136ce33dc785e3ad17696bca8493cc575ef9ad7d49596628fa3ec1ec885fc36f2812c728
   languageName: node
   linkType: hard
 
@@ -8789,7 +8789,7 @@ __metadata:
     "@playwright/test": "npm:^1.56.0"
     "@sentry/react": "npm:^10.30.0"
     "@sentry/vite-plugin": "npm:^4.6.1"
-    "@skooldev/skool-stream-layout": "npm:1.0.21"
+    "@skooldev/skool-stream-layout": "npm:1.0.22"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.1.17"
     "@types/react-dom": "npm:~19.1.11"


### PR DESCRIPTION
### 💡 Overview

Bumps the Skool layout from `1.0.21` to `1.0.22` in the `sample-apps/react/egress-composite` app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated stream layout component dependency to the latest version for improved stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-js/pull/2267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->