### PR TITLE
fix: adjusted voip notification gate for background ws events handling

### DIFF
--- a/packages/react-native-sdk/src/utils/push/internal/ios.ts
+++ b/packages/react-native-sdk/src/utils/push/internal/ios.ts
@@ -48,10 +48,9 @@ export const onVoipNotificationReceived = async (
   }
 
   const callingx = getCallingxLib();
-  if (callingx.isCallTracked(call_cid)) {
-    //same call_cid is already tracked, so we skip the notification
+  if (pushUnsubscriptionCallbacks.has(call_cid)) {
     logger.debug(
-      `the same call_cid ${call_cid} is already tracked, skipping the call.ring notification`,
+      `the same call_cid ${call_cid} is already being watched, skipping the call.ring notification`,
     );
     return;
   }
@@ -91,6 +90,7 @@ export const onVoipNotificationReceived = async (
           event,
         );
         unsubscribe();
+        pushUnsubscriptionCallbacks.delete(call_cid);
         return;
       }
       const _closed = closeCallIfNecessary();
@@ -100,6 +100,7 @@ export const onVoipNotificationReceived = async (
           event,
         );
         unsubscribe();
+        pushUnsubscriptionCallbacks.delete(call_cid);
       }
     });
 


### PR DESCRIPTION
### 💡 Overview

Fix for regression bug: dedup gate for voip notification handling becomes broken, since `isCallTracked` becomes sync, so currently there is no subscription for ws events in background due to that. Mostly it affects killed app state behavior (e.g. call was cancelled by the caller when the app is killed) but also may affect fg/bg state, depending on client lifecycle.

### 📝 Implementation notes

Removed `isCallTracked` check. Adjusted dedup check: now it will check unsub callbacks map.

🎫 Ticket: https://linear.app/stream/issue/RN-395/ios-killed-state-ws-events-listening-issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of iOS call notifications to prevent duplicate notifications and ensure proper subscription cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->