### PR TITLE
perf(react-sdk): reduce re-renders and event-listener churn

### DIFF
--- a/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListingItem.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/CallParticipantListingItem.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { ComponentProps, ComponentType, forwardRef } from 'react';
+import { ComponentProps, ComponentType, forwardRef, memo } from 'react';
 import { useConnectedUser, useI18n } from '@stream-io/video-react-bindings';
 import {
   hasAudio,
@@ -20,60 +20,64 @@ type CallParticipantListingItemProps = {
   /** Custom component used to display participant's name */
   DisplayName?: ComponentType<{ participant: StreamVideoParticipant }>;
 };
-export const CallParticipantListingItem = ({
-  participant,
-  DisplayName = DefaultDisplayName,
-}: CallParticipantListingItemProps) => {
-  const isAudioOn = hasAudio(participant);
-  const isVideoOn = hasVideo(participant);
-  const isPinnedOn = isPinned(participant);
+export const CallParticipantListingItem = memo(
+  function CallParticipantListingItem({
+    participant,
+    DisplayName = DefaultDisplayName,
+  }: CallParticipantListingItemProps) {
+    const isAudioOn = hasAudio(participant);
+    const isVideoOn = hasVideo(participant);
+    const isPinnedOn = isPinned(participant);
 
-  const { t } = useI18n();
+    const { t } = useI18n();
 
-  return (
-    <div className="str-video__participant-listing-item">
-      <Avatar name={participant.name} imageSrc={participant.image} />
-      <DisplayName participant={participant} />
-      <div className="str-video__participant-listing-item__media-indicator-group">
-        <MediaIndicator
-          title={isAudioOn ? t('Microphone on') : t('Microphone off')}
-          className={clsx(
-            'str-video__participant-listing-item__icon',
-            `str-video__participant-listing-item__icon-${
-              isAudioOn ? 'mic' : 'mic-off'
-            }`,
-          )}
-        />
-        <MediaIndicator
-          title={isVideoOn ? t('Camera on') : t('Camera off')}
-          className={clsx(
-            'str-video__participant-listing-item__icon',
-            `str-video__participant-listing-item__icon-${
-              isVideoOn ? 'camera' : 'camera-off'
-            }`,
-          )}
-        />
-        {isPinnedOn && (
+    return (
+      <div className="str-video__participant-listing-item">
+        <Avatar name={participant.name} imageSrc={participant.image} />
+        <DisplayName participant={participant} />
+        <div className="str-video__participant-listing-item__media-indicator-group">
           <MediaIndicator
-            title={t('Pinned')}
+            title={isAudioOn ? t('Microphone on') : t('Microphone off')}
             className={clsx(
               'str-video__participant-listing-item__icon',
-              'str-video__participant-listing-item__icon-pinned',
+              `str-video__participant-listing-item__icon-${
+                isAudioOn ? 'mic' : 'mic-off'
+              }`,
             )}
           />
-        )}
+          <MediaIndicator
+            title={isVideoOn ? t('Camera on') : t('Camera off')}
+            className={clsx(
+              'str-video__participant-listing-item__icon',
+              `str-video__participant-listing-item__icon-${
+                isVideoOn ? 'camera' : 'camera-off'
+              }`,
+            )}
+          />
+          {isPinnedOn && (
+            <MediaIndicator
+              title={t('Pinned')}
+              className={clsx(
+                'str-video__participant-listing-item__icon',
+                'str-video__participant-listing-item__icon-pinned',
+              )}
+            />
+          )}
 
-        <MenuToggle placement="bottom-end" ToggleButton={ToggleButton}>
-          <ParticipantViewContext.Provider
-            value={{ participant, trackType: 'none' }}
-          >
-            <ParticipantActionsContextMenu />
-          </ParticipantViewContext.Provider>
-        </MenuToggle>
+          <MenuToggle placement="bottom-end" ToggleButton={ToggleButton}>
+            <ParticipantViewContext.Provider
+              value={{ participant, trackType: 'none' }}
+            >
+              <ParticipantActionsContextMenu />
+            </ParticipantViewContext.Provider>
+          </MenuToggle>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  },
+);
+
+CallParticipantListingItem.displayName = 'CallParticipantListingItem';
 
 const MediaIndicator = (props: ComponentProps<'div'>) => (
   <WithTooltip {...props} />

--- a/packages/react-sdk/src/components/CallParticipantsList/CallParticipantsList.tsx
+++ b/packages/react-sdk/src/components/CallParticipantsList/CallParticipantsList.tsx
@@ -3,6 +3,7 @@ import {
   forwardRef,
   SetStateAction,
   useCallback,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -150,13 +151,21 @@ const ActiveUsersSearchResults = ({
   const { useParticipants } = useCallStateHooks();
   const participants = useParticipants({ sortBy: name });
 
+  // cache: each distinct name is normalized once
+  const normalizedNameCache = useRef<Map<string, string> | null>(null);
+
   const activeUsersSearchFn = useCallback(
     async (queryString: string) => {
       const normalizedQuery = normalizeString(queryString);
-      const queryRegExp = new RegExp(normalizedQuery, 'i');
-      return participants.filter((p) =>
-        normalizeString(p.name).match(queryRegExp),
-      );
+      const cache = (normalizedNameCache.current ??= new Map<string, string>());
+      return participants.filter((p) => {
+        let normalizedName = cache.get(p.name);
+        if (normalizedName === undefined) {
+          normalizedName = normalizeString(p.name);
+          cache.set(p.name, normalizedName);
+        }
+        return normalizedName.includes(normalizedQuery);
+      });
     },
     [participants],
   );
@@ -191,8 +200,10 @@ const BlockedUsersSearchResults = ({
 
   const blockedUsersSearchFn = useCallback(
     async (queryString: string) => {
-      const queryRegExp = new RegExp(queryString, 'i');
-      return blockedUsers.filter((userId) => userId.match(queryRegExp));
+      const normalizedQuery = queryString.toLowerCase();
+      return blockedUsers.filter((userId) =>
+        userId.toLowerCase().includes(normalizedQuery),
+      );
     },
     [blockedUsers],
   );

--- a/packages/react-sdk/src/components/DeviceSettings/AudioVolumeIndicator.tsx
+++ b/packages/react-sdk/src/components/DeviceSettings/AudioVolumeIndicator.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { createSoundDetector } from '@stream-io/video-client';
 import { useCallStateHooks } from '@stream-io/video-react-bindings';
 import { Icon } from '../Icon';
@@ -6,13 +6,17 @@ import { Icon } from '../Icon';
 export const AudioVolumeIndicator = () => {
   const { useMicrophoneState } = useCallStateHooks();
   const { isEnabled, mediaStream } = useMicrophoneState();
-  const [audioLevel, setAudioLevel] = useState(0);
+  const barRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!isEnabled || !mediaStream) return;
     const disposeSoundDetector = createSoundDetector(
       mediaStream,
-      ({ audioLevel: al }) => setAudioLevel(al),
+      ({ audioLevel: al }) => {
+        if (barRef.current) {
+          barRef.current.style.transform = `scaleX(${al / 100})`;
+        }
+      },
       { detectionFrequencyInMs: 80, destroyStreamOnStop: false },
     );
     return () => {
@@ -25,8 +29,8 @@ export const AudioVolumeIndicator = () => {
       <Icon icon={isEnabled ? 'mic' : 'mic-off'} />
       <div className="str-video__audio-volume-indicator__bar">
         <div
+          ref={barRef}
           className="str-video__audio-volume-indicator__bar-value"
-          style={{ transform: `scaleX(${audioLevel / 100})` }}
         />
       </div>
     </div>

--- a/packages/react-sdk/src/components/Search/SearchInput.tsx
+++ b/packages/react-sdk/src/components/Search/SearchInput.tsx
@@ -1,4 +1,5 @@
 import { ComponentProps, useEffect, useState } from 'react';
+import { useEffectEvent } from '@stream-io/video-react-bindings';
 import clsx from 'clsx';
 
 type SearchInputProps = ComponentProps<'input'> & {
@@ -20,11 +21,12 @@ export const SearchInput = ({
   const [inputElement, setInputElement] = useState<HTMLInputElement | null>(
     null,
   );
+  const onExitSearch = useEffectEvent(exitSearch);
   useEffect(() => {
     if (!inputElement) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key.toLowerCase() === 'escape') exitSearch();
+      if (e.key.toLowerCase() === 'escape') onExitSearch();
     };
 
     inputElement.addEventListener('keydown', handleKeyDown);
@@ -32,7 +34,7 @@ export const SearchInput = ({
     return () => {
       inputElement.removeEventListener('keydown', handleKeyDown);
     };
-  }, [exitSearch, inputElement]);
+  }, [inputElement]);
 
   return (
     <div

--- a/packages/react-sdk/src/core/components/Audio/Audio.tsx
+++ b/packages/react-sdk/src/core/components/Audio/Audio.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, useEffect, useState } from 'react';
+import { ComponentPropsWithoutRef, memo, useEffect, useState } from 'react';
 import {
   AudioTrackType,
   StreamVideoParticipant,
@@ -18,11 +18,11 @@ export type AudioProps = ComponentPropsWithoutRef<'audio'> & {
   trackType?: AudioTrackType;
 };
 
-export const Audio = ({
+export const Audio = memo(function Audio({
   participant,
   trackType = 'audioTrack',
   ...rest
-}: AudioProps) => {
+}: AudioProps) {
   const call = useCall();
   const [audioElement, setAudioElement] = useState<HTMLAudioElement | null>(
     null,
@@ -47,6 +47,6 @@ export const Audio = ({
       data-track-type={trackType}
     />
   );
-};
+});
 
 Audio.displayName = 'Audio';

--- a/packages/react-sdk/src/core/components/ParticipantView/ParticipantView.tsx
+++ b/packages/react-sdk/src/core/components/ParticipantView/ParticipantView.tsx
@@ -1,6 +1,7 @@
 import {
   ComponentType,
   forwardRef,
+  memo,
   ReactElement,
   useMemo,
   useState,
@@ -70,8 +71,8 @@ export type ParticipantViewProps = {
   className?: string;
 } & Pick<VideoProps, 'VideoPlaceholder' | 'PictureInPicturePlaceholder'>;
 
-export const ParticipantView = forwardRef<HTMLDivElement, ParticipantViewProps>(
-  function ParticipantView(
+export const ParticipantView = memo(
+  forwardRef<HTMLDivElement, ParticipantViewProps>(function ParticipantView(
     {
       participant,
       trackType = 'videoTrack',
@@ -195,7 +196,7 @@ export const ParticipantView = forwardRef<HTMLDivElement, ParticipantViewProps>(
         </ParticipantViewContext.Provider>
       </div>
     );
-  },
+  }),
 );
 
 ParticipantView.displayName = 'ParticipantView';

--- a/packages/react-sdk/src/core/components/Video/BaseVideo.tsx
+++ b/packages/react-sdk/src/core/components/Video/BaseVideo.tsx
@@ -22,9 +22,10 @@ export const BaseVideo = forwardRef<HTMLVideoElement, BaseVideoProps>(
       if (stream === videoElement.srcObject) return;
 
       videoElement.srcObject = stream;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
       if (Browsers.isSafari() || Browsers.isFirefox()) {
         // Firefox and Safari have some timing issue
-        setTimeout(() => {
+        timeoutId = setTimeout(() => {
           videoElement.srcObject = stream;
           videoElement.play().catch((e) => {
             console.error(`Failed to play stream`, e);
@@ -33,6 +34,7 @@ export const BaseVideo = forwardRef<HTMLVideoElement, BaseVideoProps>(
       }
 
       return () => {
+        clearTimeout(timeoutId);
         videoElement.pause();
         videoElement.srcObject = null;
       };

--- a/packages/react-sdk/src/core/components/Video/Video.tsx
+++ b/packages/react-sdk/src/core/components/Video/Video.tsx
@@ -1,6 +1,7 @@
 import {
   ComponentPropsWithoutRef,
   ComponentType,
+  CSSProperties,
   useEffect,
   useLayoutEffect,
   useState,
@@ -24,6 +25,8 @@ import {
   DefaultPictureInPicturePlaceholder,
   PictureInPicturePlaceholderProps,
 } from './DefaultPictureInPicturePlaceholder';
+
+const ABSOLUTE_POSITION_STYLE: CSSProperties = { position: 'absolute' };
 
 export type VideoProps = ComponentPropsWithoutRef<'video'> & {
   /**
@@ -203,14 +206,14 @@ export const Video = ({
       )}
       {isPiP && PictureInPicturePlaceholder && (
         <PictureInPicturePlaceholder
-          style={{ position: 'absolute' }}
+          style={ABSOLUTE_POSITION_STYLE}
           participant={participant}
         />
       )}
       {/* TODO: add condition to "hold" the placeholder until track unmutes as well */}
       {(hasNoVideoOrInvisible || isVideoPaused) && VideoPlaceholder && (
         <VideoPlaceholder
-          style={{ position: 'absolute' }}
+          style={ABSOLUTE_POSITION_STYLE}
           participant={participant}
           ref={refs?.setVideoPlaceholderElement}
         />

--- a/packages/react-sdk/src/hooks/useDragToScroll.ts
+++ b/packages/react-sdk/src/hooks/useDragToScroll.ts
@@ -33,6 +33,13 @@ export function useDragToScroll(
   element: HTMLElement | null,
   options: DragToScrollOptions = {},
 ) {
+  const {
+    enabled,
+    decay = 0.95,
+    minVelocity = 0.5,
+    dragThreshold = 5,
+  } = options;
+
   const stateRef = useRef<DragScrollState>({
     isDragging: false,
     isPointerActive: false,
@@ -46,9 +53,7 @@ export function useDragToScroll(
   });
 
   useEffect(() => {
-    if (!element || !options.enabled) return;
-
-    const { decay = 0.95, minVelocity = 0.5, dragThreshold = 5 } = options;
+    if (!element || !enabled) return;
 
     const state = stateRef.current;
 
@@ -158,5 +163,5 @@ export function useDragToScroll(
 
       stopMomentum();
     };
-  }, [element, options]);
+  }, [element, enabled, decay, minVelocity, dragThreshold]);
 }

--- a/packages/react-sdk/src/hooks/useScrollPosition.ts
+++ b/packages/react-sdk/src/hooks/useScrollPosition.ts
@@ -40,7 +40,7 @@ export const useVerticalScrollPosition = (
     const resizeObserver = new ResizeObserver(scrollHandler);
     resizeObserver.observe(scrollElement);
 
-    scrollElement.addEventListener('scroll', scrollHandler);
+    scrollElement.addEventListener('scroll', scrollHandler, { passive: true });
     return () => {
       scrollElement.removeEventListener('scroll', scrollHandler);
       resizeObserver.disconnect();
@@ -84,7 +84,7 @@ export const useHorizontalScrollPosition = (
     const resizeObserver = new ResizeObserver(scrollHandler);
     resizeObserver.observe(scrollElement);
 
-    scrollElement.addEventListener('scroll', scrollHandler);
+    scrollElement.addEventListener('scroll', scrollHandler, { passive: true });
     return () => {
       scrollElement.removeEventListener('scroll', scrollHandler);
       resizeObserver.disconnect();

--- a/packages/styling/src/DeviceSettings/DeviceSettings-layout.scss
+++ b/packages/styling/src/DeviceSettings/DeviceSettings-layout.scss
@@ -129,6 +129,8 @@
     background: var(--str-video__primary-color);
     border-radius: var(--str-video__border-radius-xs);
     transform-origin: left center;
+    // resting state; the live level is written inline by AudioVolumeIndicator
+    transform: scaleX(0);
   }
 }
 


### PR DESCRIPTION
### 💡 Overview

Performance and hygiene fixes for `@stream-io/video-react-sdk`, from a structured performance audit. Three focus areas: re-render reduction on hot paths, event-listener hygiene, and one use-after-cleanup correctness fix. No public API changes.

### 📝 Implementation notes

- **`React.memo` on hot-path components** (`ParticipantView`, `Audio`, `CallParticipantListingItem`): the participants array emits a fresh reference on every speaking/mute/connection-quality tick, so these rows/tiles reconciled on every emission even when their own props were unchanged. Memoizing stops the cascade (`ParticipantView` is wrapped as `memo(forwardRef(...))`).
- **Passive `scroll` listeners** (`useScrollPosition`): both handlers only read scroll geometry and never call `preventDefault`, so `{ passive: true }` lets the browser composite scroll frames without waiting on JS. Listener removal is unaffected.
- **`useDragToScroll` dependencies**: the sole caller passes an inline options object, so the effect re-subscribed all four pointer listeners on every render. Now depends on destructured primitives (`enabled`, `decay`, `minVelocity`, `dragThreshold`). The `pointermove` listener stays non-passive (it calls `preventDefault`).
- **`AudioVolumeIndicator`**: replaced a ~12.5 Hz `setState` (driving one CSS transform) with a direct ref write; the SCSS now sets a `scaleX(0)` resting state.
- **Participant search** (`CallParticipantsList`): the per-keystroke `normalizeString(p.name)` over all participants plus `new RegExp(userInput)` is replaced with a component-scoped, lazily-created normalized-name cache and an `includes()` substring match (also removes a latent ReDoS / invalid-pattern smell). The cache is released when the list unmounts, so user-controlled names are not retained across calls.
- **`SearchInput`**: the escape-key handler is stabilized with `useEffectEvent`, so the `keydown` listener is no longer re-subscribed when `exitSearch` identity changes.
- **`Video`**: hoisted the static `{ position: 'absolute' }` style object so it does not defeat memoized custom placeholders.
- **`BaseVideo` (correctness fix)**: the Safari/Firefox `setTimeout(..., 0)` that re-assigns `srcObject` and calls `play()` was never cleared. A `stream`/element change or unmount within the same tick fired it on an element the cleanup had just nulled, producing `play() interrupted` / `AbortError` noise. The timeout is now cleared in cleanup.

Verified: ESLint and `tsc --noEmit` clean on the touched files.

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: N/A (no public API change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search functionality with more efficient substring matching for participant names and user IDs.

* **Bug Fixes**
  * Fixed timeout cleanup in video streaming to prevent issues after component unmount.
  * Enhanced audio volume indicator with proper resting state styling.

* **Performance**
  * Optimized component rendering with memoization to reduce unnecessary re-renders.
  * Improved scroll event handling efficiency with passive listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->