### PR TITLE
fix: leave call when it was cancelled during bg

### DIFF
--- a/packages/react-native-sdk/src/utils/push/internal/ios.ts
+++ b/packages/react-native-sdk/src/utils/push/internal/ios.ts
@@ -75,6 +75,11 @@ export const onVoipNotificationReceived = async (
         `callingx.endCallWithReason for call_cid: ${call_cid} endCallReason: ${endCallReason}`,
       );
       callingx.endCallWithReason(call_cid, endCallReason);
+      callFromPush.leave({ reject: false }).catch((error) => {
+        logger.error(
+          `Failed to leave already-ended ringing call ${call_cid}: ${error}`,
+        );
+      });
       return true;
     }
     return false;


### PR DESCRIPTION
### 💡 Overview

In case of killed iOS app, when call is cancelled on a caller side, call might stuck in a stale ringing state. The fix is to leave the call on ws event during bg state (killed app case).

🎫 Ticket: https://linear.app/stream/issue/RN-395/ios-killed-state-ws-events-listening-issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced iOS push notification handling to ensure ringing calls that have already ended properly clean up and release their state, with improved error logging to help diagnose any cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->