### PR TITLE
chore: add npm support links

### DIFF
--- a/packages/audio-filters-web/package.json
+++ b/packages/audio-filters-web/package.json
@@ -20,6 +20,10 @@
     "url": "https://github.com/GetStream/stream-video-js.git",
     "directory": "packages/audio-filters-web"
   },
+  "homepage": "https://github.com/GetStream/stream-video-js/tree/main/packages/audio-filters-web#readme",
+  "bugs": {
+    "url": "https://github.com/GetStream/stream-video-js/issues"
+  },
   "sideEffects": false,
   "files": [
     "dist",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,6 +21,10 @@
     "url": "https://github.com/GetStream/stream-video-js.git",
     "directory": "packages/client"
   },
+  "homepage": "https://github.com/GetStream/stream-video-js/tree/main/packages/client#readme",
+  "bugs": {
+    "url": "https://github.com/GetStream/stream-video-js/issues"
+  },
   "files": [
     "dist",
     "src",

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -20,6 +20,10 @@
     "url": "https://github.com/GetStream/stream-video-js.git",
     "directory": "packages/codemod"
   },
+  "homepage": "https://github.com/GetStream/stream-video-js/tree/main/packages/codemod#readme",
+  "bugs": {
+    "url": "https://github.com/GetStream/stream-video-js/issues"
+  },
   "dependencies": {
     "jscodeshift": "^17.3.0"
   },

--- a/packages/react-bindings/package.json
+++ b/packages/react-bindings/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/GetStream/stream-video-js.git",
     "directory": "packages/react-bindings"
   },
+  "homepage": "https://github.com/GetStream/stream-video-js/tree/main/packages/react-bindings#readme",
+  "bugs": {
+    "url": "https://github.com/GetStream/stream-video-js/issues"
+  },
   "files": [
     "dist",
     "src",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/GetStream/stream-video-js.git",
     "directory": "packages/react-native-sdk"
   },
+  "bugs": {
+    "url": "https://github.com/GetStream/stream-video-js/issues"
+  },
   "files": [
     "dist",
     "src",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -29,6 +29,10 @@
     "url": "https://github.com/GetStream/stream-video-js.git",
     "directory": "packages/react-sdk"
   },
+  "homepage": "https://github.com/GetStream/stream-video-js/tree/main/packages/react-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/GetStream/stream-video-js/issues"
+  },
   "files": [
     "dist",
     "src",

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -12,6 +12,10 @@
     "url": "https://github.com/GetStream/stream-video-js.git",
     "directory": "packages/styling"
   },
+  "homepage": "https://github.com/GetStream/stream-video-js/tree/main/packages/styling#readme",
+  "bugs": {
+    "url": "https://github.com/GetStream/stream-video-js/issues"
+  },
   "devDependencies": {
     "rimraf": "^6.1.3",
     "sass": "^1.100.0"

--- a/packages/video-filters-web/package.json
+++ b/packages/video-filters-web/package.json
@@ -15,6 +15,10 @@
     "url": "https://github.com/GetStream/stream-video-js.git",
     "directory": "packages/video-filters-web"
   },
+  "homepage": "https://github.com/GetStream/stream-video-js/tree/main/packages/video-filters-web#readme",
+  "bugs": {
+    "url": "https://github.com/GetStream/stream-video-js/issues"
+  },
   "sideEffects": false,
   "files": [
     "dist",


### PR DESCRIPTION
﻿### Overview

Adds missing npm support metadata to the public package manifests that did not expose it yet:

- adds package README `homepage` links where missing
- adds the shared GitHub issue tracker as `bugs.url`
- keeps existing repository metadata and existing intentional homepage links intact

This is metadata-only: no runtime code, dependencies, generated files, exports, or package entry points are changed.

### Implementation notes

Updated these package manifests:

- `packages/audio-filters-web/package.json`
- `packages/client/package.json`
- `packages/codemod/package.json`
- `packages/react-bindings/package.json`
- `packages/react-native-sdk/package.json`
- `packages/react-sdk/package.json`
- `packages/styling/package.json`
- `packages/video-filters-web/package.json`

Ticket: N/A

Docs: N/A

### Verification

- manifest check across public package manifests
- `git diff --cached --check`
- `npm pack --dry-run --json --ignore-scripts` for each updated package manifest
- `corepack yarn install --immutable --mode=skip-build`
- `corepack yarn prettier --check packages/audio-filters-web/package.json packages/client/package.json packages/codemod/package.json packages/react-bindings/package.json packages/react-native-sdk/package.json packages/react-sdk/package.json packages/styling/package.json packages/video-filters-web/package.json`
- WSL Ubuntu 26.04:
  - `npm pkg get homepage bugs --json` in `packages/client`
  - `npm pack --dry-run --json --ignore-scripts` in `packages/client`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata across multiple packages to include standardized homepage links and issue tracker URLs for improved discoverability on npm registries and enhanced access to documentation and support resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->