### PR TITLE
fix(client): preserve captured stage error in call event reporting

### DIFF
--- a/packages/client/src/reporting/ClientEventReporter.ts
+++ b/packages/client/src/reporting/ClientEventReporter.ts
@@ -347,8 +347,8 @@ export class ClientEventReporter {
       const { code, reason } = opts;
       const stageError: StageError = { code, reason };
 
-      applyError(this.coordinatorPairs.get(cid), stageError);
-      applyError(this.wsPairs.get(cid), stageError);
+      applyErrorIfAbsent(this.coordinatorPairs.get(cid), stageError);
+      applyErrorIfAbsent(this.wsPairs.get(cid), stageError);
 
       this.failCoordinator(cid);
       this.failWs(cid);
@@ -422,11 +422,17 @@ export class ClientEventReporter {
     stage: 'CoordinatorJoin' | 'WSJoin',
     err: unknown,
   ) => {
-    if (stage === 'CoordinatorJoin') {
-      applyError(this.coordinatorPairs.get(cid), mapCoordinatorHttpError(err));
-    } else {
-      applyError(this.wsPairs.get(cid), mapWsJoinError(err));
-    }
+    const pair =
+      stage === 'CoordinatorJoin'
+        ? this.coordinatorPairs.get(cid)
+        : this.wsPairs.get(cid);
+
+    applyErrorIfAbsent(
+      pair,
+      stage === 'CoordinatorJoin'
+        ? mapCoordinatorHttpError(err)
+        : mapWsJoinError(err),
+    );
   };
 
   private beginCoordinatorAttempt = (cid: string) => {
@@ -448,6 +454,7 @@ export class ClientEventReporter {
         event_type: 'initiated',
       });
     }
+    pair.lastError = undefined;
     pair.attempts++;
   };
 
@@ -506,6 +513,7 @@ export class ClientEventReporter {
       });
     }
 
+    pair.lastError = undefined;
     pair.attempts++;
   };
 
@@ -783,10 +791,16 @@ const readPermissionStatus = (
 const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err);
 
-// a pair reports the most recent error it saw - the most proximate
-// cause of the stage failure
 const applyError = (pair: StagePairState | undefined, next: StageError) => {
   if (!pair) return;
+  pair.lastError = next;
+};
+
+const applyErrorIfAbsent = (
+  pair: StagePairState | undefined,
+  next: StageError,
+) => {
+  if (!pair || pair.lastError) return;
   pair.lastError = next;
 };
 
@@ -832,7 +846,7 @@ const mapWsJoinError = (err: unknown): StageError => {
 
     return {
       reason: sfuError?.message || err.message,
-      code: sfuError ? ErrorCode[sfuError.code] : 'SFU_ERROR',
+      code: (sfuError && ErrorCode[sfuError.code]) || 'SFU_ERROR',
     };
   }
 

--- a/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
+++ b/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
@@ -329,6 +329,88 @@ describe('ClientEventReporter', () => {
     });
   });
 
+  it('keeps the captured SFU error over CLIENT_ABORTED on abort', async () => {
+    reporter.startCorrelation(cid, 'first-attempt');
+    void reporter.track(cid, 'WSJoin', () => new Promise(() => {}));
+    reporter.captureWsError(cid, {
+      code: 'SFU_ERROR',
+      reason: 'sfu disconnect',
+    });
+    reporter.abort(cid, {
+      code: 'CLIENT_ABORTED',
+      reason: 'SFU instructed to disconnect',
+    });
+    await flush();
+
+    const completed = postedEvents().filter(
+      (e) => e.stage === 'WSJoin' && e.event_type === 'completed',
+    );
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      outcome: 'failure',
+      retry_failure_code: 'SFU_ERROR',
+      retry_failure_reason: 'sfu disconnect',
+    });
+  });
+
+  it('keeps a captured SFU error over a later WSJoin timeout', async () => {
+    reporter.startCorrelation(cid, 'first-attempt');
+    await expect(
+      reporter.track(cid, 'WSJoin', async () => {
+        reporter.captureWsError(cid, {
+          code: 'SFU_ERROR',
+          reason: 'unauthenticated',
+        });
+        throw new SfuTimeoutError(
+          'SFU WS connection failed to open after 5000ms',
+        );
+      }),
+    ).rejects.toThrow();
+    reporter.close(cid);
+    await flush();
+
+    const completed = postedEvents().filter(
+      (e) => e.stage === 'WSJoin' && e.event_type === 'completed',
+    );
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      outcome: 'failure',
+      retry_failure_code: 'SFU_ERROR',
+      retry_failure_reason: 'unauthenticated',
+    });
+  });
+
+  it('lets a later WSJoin attempt override a previous attempt captured error', async () => {
+    reporter.startCorrelation(cid, 'first-attempt');
+    await expect(
+      reporter.track(cid, 'WSJoin', async () => {
+        reporter.captureWsError(cid, {
+          code: 'SFU_ERROR',
+          reason: 'attempt 1 sfu error',
+        });
+        throw new SfuTimeoutError('attempt 1 timeout');
+      }),
+    ).rejects.toThrow();
+    await expect(
+      reporter.track(cid, 'WSJoin', () =>
+        Promise.reject(new SfuTimeoutError('attempt 2 timeout')),
+      ),
+    ).rejects.toThrow();
+    reporter.close(cid);
+    await flush();
+
+    const completed = postedEvents().filter(
+      (e) => e.stage === 'WSJoin' && e.event_type === 'completed',
+    );
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      outcome: 'failure',
+      retry_count_attempt: 1,
+      retry_failure_code: 'REQUEST_TIMEOUT',
+      retry_failure_reason: 'attempt 2 timeout',
+    });
+  });
+
   it('reports a WSJoin timeout as REQUEST_TIMEOUT', async () => {
     reporter.startCorrelation(cid, 'first-attempt');
     await expect(


### PR DESCRIPTION
### 💡 Overview
This PR fixes an issue where the captured WS SFU error was overwritten with a generic one before it was reported, so WSJoin failures were misattributed in telemetry. The overwrite came from two places: 
- abort writing `CLIENT_ABORTED` when a `call.leave` was triggered
- stage handler writing the join's terminal rejection - `REQUEST_TIMEOUT` on a stalled join
  

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error tracking to preserve the first error encountered per connection attempt.
  * Improved error state management across retry attempts.

* **Tests**
  * Added test coverage for error prioritization and handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->