### PR TITLE
fix(ios): joining a call muted may break remote audio playout

### DIFF
--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -84,11 +84,14 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
             if (ownCapabilities.includes(OwnCapability.SEND_AUDIO)) {
               const hasPermission = await this.hasPermission(permissionState);
               if (hasPermission && status !== 'enabled') {
+                this.setMutedRecordingPrepared(true);
                 await this.startSpeakingWhileMutedDetection(deviceId);
               } else {
+                this.setMutedRecordingPrepared(false);
                 await this.stopSpeakingWhileMutedDetection();
               }
             } else {
+              this.setMutedRecordingPrepared(false);
               await this.stopSpeakingWhileMutedDetection();
             }
           } catch (err) {
@@ -465,6 +468,18 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
     await soundDetectorCleanup().catch((err) => {
       this.logger.warn('Failed to stop speaking while muted detector', err);
     });
+  }
+
+  /**
+   * iOS-only: keep the mic-input chain prepared while muted
+   * so the `AVAudioEngine` stays full-duplex and remote audio renders on a
+   * muted join.
+   */
+  private setMutedRecordingPrepared(enabled: boolean): void {
+    if (!isReactNative()) return;
+    globalThis.streamRNVideoSDK?.callManager.setMutedRecordingPrepared?.(
+      enabled,
+    );
   }
 
   private async hasPermission(

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -76,6 +76,7 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
         ]) => {
           try {
             if (callingState === CallingState.LEFT) {
+              this.setMutedRecordingPrepared(false);
               await this.stopSpeakingWhileMutedDetection();
             }
             if (callingState !== CallingState.JOINED) return;

--- a/packages/client/src/devices/__tests__/MicrophoneManagerRN.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManagerRN.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MicrophoneManager } from '../MicrophoneManager';
 import { Call } from '../../Call';
 import { StreamClient } from '../../coordinator/connection/client';
-import { StreamVideoWriteableStateStore } from '../../store';
+import { CallingState, StreamVideoWriteableStateStore } from '../../store';
 import {
   mockAudioDevices,
   mockAudioStream,
@@ -262,6 +262,25 @@ describe('MicrophoneManager React Native', () => {
       timeout: 100,
     });
     expect(setMutedRecordingPreparedMock).not.toHaveBeenCalledWith(true);
+  });
+
+  it('should release prepared muted recording when the call is left', async () => {
+    await manager.disable();
+    await vi.waitUntil(
+      () =>
+        setMutedRecordingPreparedMock.mock.calls.some(([arg]) => arg === true),
+      { timeout: 100 },
+    );
+    setMutedRecordingPreparedMock.mockClear();
+
+    manager['call'].state.setCallingState(CallingState.LEFT);
+
+    await vi.waitUntil(
+      () =>
+        setMutedRecordingPreparedMock.mock.calls.some(([arg]) => arg === false),
+      { timeout: 100 },
+    );
+    expect(setMutedRecordingPreparedMock).toHaveBeenCalledWith(false);
   });
 
   afterEach(() => {

--- a/packages/client/src/devices/__tests__/MicrophoneManagerRN.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManagerRN.test.ts
@@ -54,11 +54,13 @@ describe('MicrophoneManager React Native', () => {
   let manager: MicrophoneManager;
   let checkPermissionMock: ReturnType<typeof vi.fn>;
   let subscribeMock: ReturnType<typeof vi.fn>;
+  let setMutedRecordingPreparedMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     speechActivityCallback = null;
     unsubscribeMocks = [];
     checkPermissionMock = vi.fn(async () => true);
+    setMutedRecordingPreparedMock = vi.fn();
     subscribeMock = vi.fn((cb) => {
       speechActivityCallback = cb;
       const unsub = vi.fn();
@@ -71,6 +73,7 @@ describe('MicrophoneManager React Native', () => {
         setup: vi.fn(),
         start: vi.fn(),
         stop: vi.fn(),
+        setMutedRecordingPrepared: setMutedRecordingPreparedMock,
       },
       permissions: {
         check: checkPermissionMock,
@@ -208,6 +211,57 @@ describe('MicrophoneManager React Native', () => {
 
     await vi.waitUntil(() => fn.mock.calls.length > 0, { timeout: 100 });
     expect(fn).toHaveBeenCalled();
+  });
+
+  it('should prepare muted recording when mic is disabled and user can send audio', async () => {
+    await manager.enable();
+    await manager.disable();
+
+    await vi.waitUntil(
+      () =>
+        setMutedRecordingPreparedMock.mock.calls.some(([arg]) => arg === true),
+      { timeout: 100 },
+    );
+    expect(setMutedRecordingPreparedMock).toHaveBeenCalledWith(true);
+  });
+
+  it('should release prepared muted recording when mic is enabled', async () => {
+    await manager.disable();
+    setMutedRecordingPreparedMock.mockClear();
+    await manager.enable();
+
+    await vi.waitUntil(
+      () =>
+        setMutedRecordingPreparedMock.mock.calls.some(([arg]) => arg === false),
+      { timeout: 100 },
+    );
+    expect(setMutedRecordingPreparedMock).toHaveBeenCalledWith(false);
+  });
+
+  it('should not prepare muted recording when user cannot send audio', async () => {
+    await manager.disable();
+    manager['call'].state.setOwnCapabilities([]);
+    setMutedRecordingPreparedMock.mockClear();
+    // toggle status to re-run the reactive subscription with no send-audio cap
+    await manager.enable();
+    await manager.disable();
+
+    await vi.waitUntil(
+      () => setMutedRecordingPreparedMock.mock.calls.length > 0,
+      { timeout: 100 },
+    );
+    expect(setMutedRecordingPreparedMock).not.toHaveBeenCalledWith(true);
+  });
+
+  it('should not prepare muted recording if native microphone permission is denied', async () => {
+    checkPermissionMock.mockResolvedValue(false);
+    await manager.enable();
+    await manager.disable();
+
+    await vi.waitUntil(() => checkPermissionMock.mock.calls.length > 0, {
+      timeout: 100,
+    });
+    expect(setMutedRecordingPreparedMock).not.toHaveBeenCalledWith(true);
   });
 
   afterEach(() => {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -480,6 +480,18 @@ export type StreamRNVideoSDKGlobals = {
      * Stops the in call manager.
      */
     stop({ isRingingTypeCall }: StreamRNVideoSDKCallManagerRingingParams): void;
+
+    /**
+     * iOS-only. Keeps the audio engine's microphone-input (voice-processing)
+     * chain prepared while the mic is muted, so the `AVAudioEngine` stays full-duplex
+     * meaning: mic going out and speaker coming in, simultaneously
+     *
+     * Without this, joining muted builds an output-only engine under the
+     * `PlayAndRecord`/`VoiceChat` (VPIO) session, which makes the remote audio
+     * not audible when joining muted. As echo cancellation expects the mic to be
+     * prepared.
+     */
+    setMutedRecordingPrepared?(enabled: boolean): void;
   };
   permissions: {
     /**

--- a/packages/react-native-callingx/ios/AudioSessionManager.swift
+++ b/packages/react-native-callingx/ios/AudioSessionManager.swift
@@ -67,9 +67,9 @@ enum DefaultAudioDevice {
     private func applyCallKitConfiguration() {
         let rtcSession = RTCAudioSession.sharedInstance()
 
-        // Relax to a pure-output (.playback) session when mic permission is
-        // missing — but only once CallKit has already activated the session.
-        let usePlaybackFallback = rtcSession.isActive && !micPermissionGranted()
+        // Relax to a pure-output (.playback) session when mic permission is missing
+        // same logic as in StreamInCallManager
+        let usePlaybackFallback = !micPermissionGranted()
 
         // webRTC() singleton hardcodes sampleRate=48000 / ioBufferDuration=0.02 — keep those.
         let rtcConfig = RTCAudioSessionConfiguration.webRTC()

--- a/packages/react-native-callingx/ios/AudioSessionManager.swift
+++ b/packages/react-native-callingx/ios/AudioSessionManager.swift
@@ -65,29 +65,44 @@ enum DefaultAudioDevice {
     // MARK: - Private
 
     private func applyCallKitConfiguration() {
-        let currentDevice = stateQueue.sync { defaultAudioDevice }
+        let rtcSession = RTCAudioSession.sharedInstance()
 
-        // XCode 16 and older don't expose .allowBluetoothHFP
-        // https://forums.swift.org/t/xcode-26-avaudiosession-categoryoptions-allowbluetooth-deprecated/80956
-        #if compiler(>=6.2) // For Xcode 26.0+
-            let bluetoothOption: AVAudioSession.CategoryOptions = .allowBluetoothHFP
-        #else
-            let bluetoothOption: AVAudioSession.CategoryOptions = .allowBluetooth
-        #endif
-
-        var categoryOptions: AVAudioSession.CategoryOptions = [bluetoothOption, .allowBluetoothA2DP]
-        if currentDevice == .speaker {
-            categoryOptions.insert(.defaultToSpeaker)
-        }
+        // Relax to a pure-output (.playback) session when mic permission is
+        // missing — but only once CallKit has already activated the session.
+        let usePlaybackFallback = rtcSession.isActive && !micPermissionGranted()
 
         // webRTC() singleton hardcodes sampleRate=48000 / ioBufferDuration=0.02 — keep those.
         let rtcConfig = RTCAudioSessionConfiguration.webRTC()
-        rtcConfig.category = AVAudioSession.Category.playAndRecord.rawValue
-        rtcConfig.mode = AVAudioSession.Mode.voiceChat.rawValue
-        rtcConfig.categoryOptions = categoryOptions
+        if usePlaybackFallback {
+            // Known gap: .playback can't route to the receiver (earpiece) — that route
+            // only exists under .playAndRecord.
+            rtcConfig.category = AVAudioSession.Category.playback.rawValue
+            rtcConfig.mode = AVAudioSession.Mode.spokenAudio.rawValue
+            rtcConfig.categoryOptions = []
+        } else {
+            let currentDevice = stateQueue.sync { defaultAudioDevice }
+
+            // XCode 16 and older don't expose .allowBluetoothHFP
+            // https://forums.swift.org/t/xcode-26-avaudiosession-categoryoptions-allowbluetooth-deprecated/80956
+            #if compiler(>=6.2) // For Xcode 26.0+
+                let bluetoothOption: AVAudioSession.CategoryOptions = .allowBluetoothHFP
+            #else
+                let bluetoothOption: AVAudioSession.CategoryOptions = .allowBluetooth
+            #endif
+
+            var categoryOptions: AVAudioSession.CategoryOptions = [bluetoothOption, .allowBluetoothA2DP]
+            if currentDevice == .speaker {
+                categoryOptions.insert(.defaultToSpeaker)
+            }
+
+            rtcConfig.category = AVAudioSession.Category.playAndRecord.rawValue
+            rtcConfig.mode = AVAudioSession.Mode.voiceChat.rawValue
+            rtcConfig.categoryOptions = categoryOptions
+        }
         RTCAudioSessionConfiguration.setWebRTC(rtcConfig)
 
-        let rtcSession = RTCAudioSession.sharedInstance()
+        CallingxLog.audio.debugPublic("[applyCallKitConfiguration] category=\(rtcConfig.category) mode=\(rtcConfig.mode)")
+
         rtcSession.lockForConfiguration()
         defer { rtcSession.unlockForConfiguration() }
 
@@ -95,6 +110,14 @@ enum DefaultAudioDevice {
             try rtcSession.setConfiguration(rtcConfig)
         } catch {
             CallingxLog.audio.errorPublic("[createAudioSessionIfNeeded] Error: \(error)")
+        }
+    }
+
+    private func micPermissionGranted() -> Bool {
+        if #available(iOS 17.0, *) {
+            return AVAudioApplication.shared.recordPermission == .granted
+        } else {
+            return AVAudioSession.sharedInstance().recordPermission == .granted
         }
     }
 }

--- a/packages/react-native-callingx/ios/AudioSessionManager.swift
+++ b/packages/react-native-callingx/ios/AudioSessionManager.swift
@@ -109,7 +109,7 @@ enum DefaultAudioDevice {
         do {
             try rtcSession.setConfiguration(rtcConfig)
         } catch {
-            CallingxLog.audio.errorPublic("[createAudioSessionIfNeeded] Error: \(error)")
+            CallingxLog.audio.errorPublic("[applyCallKitConfiguration] Error: \(error)")
         }
     }
 

--- a/packages/react-native-sdk/ios/StreamInCallManager.swift
+++ b/packages/react-native-sdk/ios/StreamInCallManager.swift
@@ -117,6 +117,15 @@ class StreamInCallManager: RCTEventEmitter {
             // TODO: for stereo we should disallow BluetoothHFP and allow only allowBluetoothA2DP
             // note: this is the behaviour of iOS native SDK, but fails here with (OSStatus error -50.)
             // options = self.enableStereo ? [.allowBluetoothA2DP] : []
+        } else if !micPermissionGranted() {
+            // Communicator without mic permission (denied or not yet asked): use a
+            // pure-output, no-VPIO session so the output-only AVAudioEngine renders
+            // remote audio. Mirrors stream-video-swift 
+            // (isRecordingEnabled ? .playAndRecord : .playback). We can't record anyway.
+            // Self-heals: granting permission + unmuting rebuilds the engine.
+            category = .playback
+            mode = .spokenAudio
+            options = []
         } else {
             // XCode 16 and older don't expose .allowBluetoothHFP
             // https://forums.swift.org/t/xcode-26-avaudiosession-categoryoptions-allowbluetooth-deprecated/80956
@@ -137,6 +146,14 @@ class StreamInCallManager: RCTEventEmitter {
         // Keep WebRTC's internal state consistent during interruptions/route changes.
         RTCAudioSessionConfiguration.setWebRTC(rtcConfig)
         return rtcConfig
+    }
+
+    private func micPermissionGranted() -> Bool {
+        if #available(iOS 17.0, *) {
+            return AVAudioApplication.shared.recordPermission == .granted
+        } else {
+            return AVAudioSession.sharedInstance().recordPermission == .granted
+        }
     }
 
     @objc

--- a/packages/react-native-sdk/ios/StreamInCallManager.swift
+++ b/packages/react-native-sdk/ios/StreamInCallManager.swift
@@ -120,9 +120,11 @@ class StreamInCallManager: RCTEventEmitter {
         } else if !micPermissionGranted() {
             // Communicator without mic permission (denied or not yet asked): use a
             // pure-output, no-VPIO session so the output-only AVAudioEngine renders
-            // remote audio. Mirrors stream-video-swift 
+            // remote audio. Mirrors stream-video-swift
             // (isRecordingEnabled ? .playAndRecord : .playback). We can't record anyway.
             // Self-heals: granting permission + unmuting rebuilds the engine.
+            // Known gap: .playback can't route to the receiver (earpiece) — that route
+            // only exists under .playAndRecord.
             category = .playback
             mode = .spokenAudio
             options = []

--- a/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
+++ b/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
@@ -85,7 +85,7 @@ const streamRNVideoSDKGlobals: StreamRNVideoSDKGlobals = {
         return;
       }
       if (enabled) {
-        // Mute via the voice-processing unit (its the default, fail safe config here) so the input chain
+        // Mute via the voice-processing unit (it's the default, fail safe config here) so the input chain
         // stays built while muted, rather than tearing the engine down.
         AudioDeviceModule.setMuteMode(
           AudioEngineMuteMode.VoiceProcessing,

--- a/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
+++ b/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
@@ -1,6 +1,10 @@
 import { StreamRNVideoSDKGlobals } from '@stream-io/video-client';
 import { NativeModules, PermissionsAndroid, Platform } from 'react-native';
-import { audioDeviceModuleEvents } from '@stream-io/react-native-webrtc';
+import {
+  AudioDeviceModule,
+  AudioEngineMuteMode,
+  audioDeviceModuleEvents,
+} from '@stream-io/react-native-webrtc';
 import { getCallingxLibIfAvailable } from '../push/libs/callingx';
 import {
   endCallingxCall,
@@ -70,6 +74,24 @@ const streamRNVideoSDKGlobals: StreamRNVideoSDKGlobals = {
         return;
       }
       StreamInCallManagerNativeModule.stop();
+    },
+    // iOS-only. Keep the AVAudioEngine mic-input (voice-processing) chain
+    // prepared while muted so the engine stays full-duplex and remote audio
+    // renders when joining muted. Intentionally NOT gated by
+    // `shouldBypassForCallKit`: it acts on the shared `RTCAudioDeviceModule`, so
+    // it must run for both the StreamInCallManager and CallKit/callingx paths.
+    setMutedRecordingPrepared: (enabled) => {
+      if (Platform.OS !== 'ios') {
+        return;
+      }
+      if (enabled) {
+        // Mute via the voice-processing unit (its the default, fail safe config here) so the input chain
+        // stays built while muted, rather than tearing the engine down.
+        AudioDeviceModule.setMuteMode(
+          AudioEngineMuteMode.VoiceProcessing,
+        ).catch(() => {});
+      }
+      AudioDeviceModule.setRecordingAlwaysPreparedMode(enabled).catch(() => {});
     },
   },
   permissions: {

--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Callingx (0.4.0):
+  - Callingx (0.5.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2392,7 +2392,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - stream-io-noise-cancellation-react-native (0.7.0):
+  - stream-io-noise-cancellation-react-native (0.8.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2416,7 +2416,7 @@ PODS:
     - stream-react-native-webrtc
     - StreamVideoNoiseCancellation
     - Yoga
-  - stream-io-video-filters-react-native (0.12.4):
+  - stream-io-video-filters-react-native (0.13.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2442,7 +2442,7 @@ PODS:
   - stream-react-native-webrtc (145.0.0):
     - React-Core
     - StreamWebRTC (= 145.10.0)
-  - stream-video-react-native (1.37.0):
+  - stream-video-react-native (1.38.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2829,7 +2829,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Callingx: e038835f5415fe4bd05e2fcb16c5c8c4ceb7d4fb
+  Callingx: 330847610b57c4fcaccaa7a708b372ee7473aadb
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: 2d0f6516440ca865b33146ac797ab69743686d86
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
@@ -2921,10 +2921,10 @@ SPEC CHECKSUMS:
   RNSVG: 8efa5ad14ceb98fe56c03793bd55bc4bd30ad84b
   RNWorklets: 4931990f73bc8f347586918b2e13f11dfadf3b75
   stream-chat-react-native: 2d735ccdddfcfc16727480d5784f089548b7fc9c
-  stream-io-noise-cancellation-react-native: d8e53f7e61750f066a25d34229b0e569e815b88b
-  stream-io-video-filters-react-native: 2b855ed39efd48c366b1c288704e205a6ccdff48
+  stream-io-noise-cancellation-react-native: e4894d912edb8de125957832c40f49a32e51de84
+  stream-io-video-filters-react-native: 030f5b873cbbb868f5209169c9a7ecc16aa5cca4
   stream-react-native-webrtc: af1423d12a18cd213fa1bd745241d1734c9a8235
-  stream-video-react-native: 7e3bc0428ee3feb8700e02e394be7e5cbe9569a4
+  stream-video-react-native: b9bb1ec8542941445c7efb78f5441d71d2b8eb7a
   StreamVideoNoiseCancellation: 41f5a712aba288f9636b64b17ebfbdff52c61490
   StreamWebRTC: ff3698ef9a94e7ca90dd54ce36991066323fd855
   Teleport: 58dccc8594d74a77cdc2a2191b60656f9aaac743


### PR DESCRIPTION
### 💡 Overview

1. If voice processing was enabled, but mic was muted and then call was joined.. remote audio did not play - [fix(ios): joining a call muted can break both sending and receiving a…](https://github.com/GetStream/stream-video-js/commit/dc252118646ab5398b8fdefc675514a4feb103fc) 
2. [fix: non-callingx if mic permission is not granted make sure remote-a…](https://github.com/GetStream/stream-video-js/commit/6f57440276f7b2f02b758d73ff765b69959001b0)
3. Same as 2 but for callkit - [fix: mirror playback fallback for callingx too](https://github.com/GetStream/stream-video-js/commit/40427133d30aa6a54f11611073eabff4d825f2e1)

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS / React Native: keep microphone input prepared while muted to preserve full‑duplex echo cancellation when joining muted.

* **Bug Fixes**
  * Better behavior when microphone permission is denied to avoid unintended recording or routing.
  * Refined audio session configuration for more consistent routing and improved call audio quality.

* **Tests**
  * Added React Native test coverage for the muted-recording preparation lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->