### PR TITLE
fix(client): Send call data in JoinInitiated event

### DIFF
--- a/packages/client/src/reporting/ClientEventReporter.ts
+++ b/packages/client/src/reporting/ClientEventReporter.ts
@@ -390,8 +390,13 @@ export class ClientEventReporter {
     const joinAttemptId = this.joinAttemptIds.get(cid);
     if (!joinAttemptId) return;
     const coordinatorConnectId = this.coordinatorConnectId;
+    const ctx = this.callContexts.get(cid);
+
     this.send({
       user_id: this.streamClient.userID,
+      type: ctx?.callType,
+      id: ctx?.callId,
+      call_cid: cid,
       stage: 'JoinInitiated',
       join_attempt_id: joinAttemptId,
       ...(coordinatorConnectId && {


### PR DESCRIPTION
### 💡 Overview
This PR adds `type`, `id`, and `call_cid` to the `JoinInitiated` event, matching the shape of all other per-call stages.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Join initiation events now include enhanced context information with additional call identifiers and metadata for more comprehensive event logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->