### PR TITLE
fix(client): keep user_id populated in call event telemetry when a disconnect races an in-flight join

### DIFF
--- a/packages/client/src/reporting/ClientEventReporter.ts
+++ b/packages/client/src/reporting/ClientEventReporter.ts
@@ -393,7 +393,7 @@ export class ClientEventReporter {
     const ctx = this.callContexts.get(cid);
 
     this.send({
-      user_id: this.streamClient.userID,
+      user_id: this.streamClient.userID || this.coordinatorConnectUserId,
       type: ctx?.callType,
       id: ctx?.callId,
       call_cid: cid,
@@ -712,7 +712,7 @@ export class ClientEventReporter {
     const ctx = this.callContexts.get(cid);
     const coordinatorConnectId = this.coordinatorConnectId;
     return {
-      user_id: this.streamClient.userID,
+      user_id: this.streamClient.userID || this.coordinatorConnectUserId,
       type: ctx?.callType ?? '',
       id: ctx?.callId ?? '',
       call_cid: cid,


### PR DESCRIPTION
### 💡 Overview
This PR fixes client call-event telemetry being rejected by the backend with 400 `user_id is required` when `disconnectUser() `(or a fast unmount / StrictMode remount) races an in-flight join() so the orphaned join kept emitting events that read user_id live from the now-cleared streamClient.userID, so we now fall back to the connect-scope coordinatorConnectUserId (captured at connectUser() and not cleared on disconnect), keeping every report's user_id populated.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced event tracking reliability for join operations with improved user identification fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->