### PR TITLE
feat(client): allow disabling client event reporter

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -101,6 +101,7 @@ export class StreamVideoClient {
     this.streamClient = createCoordinatorClient(apiKey, clientOptions);
     this.clientEventReporter = new ClientEventReporter({
       streamClient: this.streamClient,
+      enabled: !clientOptions?.disableClientEventReporting,
     });
 
     this.writeableStateStore = new StreamVideoWriteableStateStore();

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -101,7 +101,7 @@ export class StreamVideoClient {
     this.streamClient = createCoordinatorClient(apiKey, clientOptions);
     this.clientEventReporter = new ClientEventReporter({
       streamClient: this.streamClient,
-      enabled: !clientOptions?.disableClientEventReporting,
+      enabled: clientOptions?.clientEventsReportingEnabled ?? true,
     });
 
     this.writeableStateStore = new StreamVideoWriteableStateStore();

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -214,6 +214,13 @@ export type StreamClientOptions = Partial<AxiosRequestConfig> & {
   browser?: boolean;
 
   /**
+   * Disables the client-side event reporter (call lifecycle telemetry).
+   * Useful for non-interactive sessions such as egress/recording where the
+   * telemetry adds no value. Defaults to `false`.
+   */
+  disableClientEventReporting?: boolean;
+
+  /**
    *  @deprecated Use `logOptions` instead.
    *  Custom logger instance used to handle log messages.
    *  Will be removed in a future release.

--- a/packages/client/src/coordinator/connection/types.ts
+++ b/packages/client/src/coordinator/connection/types.ts
@@ -214,11 +214,11 @@ export type StreamClientOptions = Partial<AxiosRequestConfig> & {
   browser?: boolean;
 
   /**
-   * Disables the client-side event reporter (call lifecycle telemetry).
-   * Useful for non-interactive sessions such as egress/recording where the
-   * telemetry adds no value. Defaults to `false`.
+   * Enables the client-side event reporter (call lifecycle telemetry).
+   * Set to `false` for non-interactive sessions such as egress/recording
+   * where the telemetry adds no value. Defaults to `true`.
    */
-  disableClientEventReporting?: boolean;
+  clientEventsReportingEnabled?: boolean;
 
   /**
    *  @deprecated Use `logOptions` instead.

--- a/packages/client/src/reporting/ClientEventReporter.ts
+++ b/packages/client/src/reporting/ClientEventReporter.ts
@@ -64,6 +64,7 @@ export type CallReportContext = {
 
 export type ClientEventReporterOptions = {
   streamClient: StreamClient;
+  enabled?: boolean;
 };
 
 type StageError = {
@@ -94,6 +95,7 @@ export class ClientEventReporter {
   private readonly logger = videoLoggerSystem.getLogger('ClientEventReporter');
 
   private streamClient: StreamClient;
+  private enabled: boolean;
 
   private coordinatorConnectId?: string;
   private coordinatorConnectUserId?: string;
@@ -112,6 +114,7 @@ export class ClientEventReporter {
 
   constructor(options: ClientEventReporterOptions) {
     this.streamClient = options.streamClient;
+    this.enabled = options.enabled ?? true;
   }
 
   /**
@@ -731,6 +734,7 @@ export class ClientEventReporter {
   };
 
   private send = (body: Record<string, unknown>) => {
+    if (!this.enabled) return;
     void this.sendWithRetry(body);
   };
 

--- a/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
+++ b/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
@@ -618,3 +618,36 @@ describe('ClientEventReporter', () => {
     expect(ws2.every((e) => e.sfu_id === 'sfu-2')).toBe(true);
   });
 });
+
+describe('ClientEventReporter (disabled)', () => {
+  const cid = 'default:call-1';
+  let doAxiosRequest: ReturnType<typeof vi.fn>;
+  let reporter: ClientEventReporter;
+
+  beforeEach(() => {
+    doAxiosRequest = vi.fn().mockResolvedValue({});
+    const streamClient = fromPartial<StreamClient>({
+      userID: 'user-1',
+      doAxiosRequest,
+      getUserAgent: () => 'test-agent',
+      getSdkVersion: () => '1.0.0',
+    });
+    reporter = new ClientEventReporter({ streamClient, enabled: false });
+    reporter.startCoordinatorConnection('user-1');
+    reporter.registerCall(cid, {
+      callType: 'default',
+      callId: 'call-1',
+      getCallSessionId: () => 'session-1',
+      getSfuId: () => 'sfu-1',
+      getUserSessionId: () => 'user-session-1',
+    });
+  });
+
+  it('does not post any events when disabled', async () => {
+    reporter.startCorrelation(cid, 'first-attempt');
+    await reporter.track(cid, 'CoordinatorJoin', () => Promise.resolve('ok'));
+    await flush();
+
+    expect(doAxiosRequest).not.toHaveBeenCalled();
+  });
+});

--- a/sample-apps/react/egress-composite/src/hooks/useInitializeClient.ts
+++ b/sample-apps/react/egress-composite/src/hooks/useInitializeClient.ts
@@ -94,7 +94,7 @@ export const useInitializeClientAndCall = () => {
       baseURL,
       logLevel,
       maxConnectUserRetries: 25,
-      disableClientEventReporting: true,
+      clientEventsReportingEnabled: false,
     });
   }, [apiKey, baseURL, logLevel]);
 

--- a/sample-apps/react/egress-composite/src/hooks/useInitializeClient.ts
+++ b/sample-apps/react/egress-composite/src/hooks/useInitializeClient.ts
@@ -94,6 +94,7 @@ export const useInitializeClientAndCall = () => {
       baseURL,
       logLevel,
       maxConnectUserRetries: 25,
+      disableClientEventReporting: true,
     });
   }, [apiKey, baseURL, logLevel]);
 


### PR DESCRIPTION
### 💡 Overview
This PR introduces a `disableClientEventReporting` client option that turns off the client-side event reporter (call-lifecycle telemetry) for a given `StreamVideoClient` instance. It defaults to `false`, so existing behavior is unchanged for all callers.
The egress composite sample app now opts out via this flag.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1011/call-event-reporting-option-for-disabling-reporting-for-clients

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added `clientEventsReportingEnabled` option to control client-side call event reporting/telemetry. When set to `false`, the client suppresses event transmission; it remains enabled by default.

* **Bug Fixes / Changes in Behavior**
  * Event delivery is now skipped when reporting is disabled.

* **Tests**
  * Added coverage to verify no event requests are sent when reporting is turned off (including an egress composite sample setup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->