### PR TITLE
fix(client): send migrating_from after repeated rejoin failures

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1230,7 +1230,10 @@ export class Call {
       const isReconnecting =
         this.reconnectStrategy !== WebsocketReconnectStrategy.UNSPECIFIED;
       const reconnectDetails = isReconnecting
-        ? this.getReconnectDetails(data?.migrating_from, previousSessionId)
+        ? this.getReconnectDetails(
+            previousSfuClient?.edgeName,
+            previousSessionId,
+          )
         : undefined;
       const preferredPublishOptions = !isReconnecting
         ? this.getPreferredPublishOptions()

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1692,6 +1692,7 @@ export class Call {
       const reconnectStartTime = Date.now();
       this.reconnectStrategy = strategy;
       this.reconnectReason = reason;
+      const sfuRejoinFailures = new Map<string, number>();
 
       const markAsReconnectingFailed = async () => {
         try {
@@ -1764,8 +1765,8 @@ export class Call {
         if (this.reconnectStrategy !== WebsocketReconnectStrategy.FAST) {
           this.reconnectAttempts++;
         }
-        const currentStrategy =
-          WebsocketReconnectStrategy[this.reconnectStrategy];
+        const attemptedStrategy = this.reconnectStrategy;
+        const currentStrategy = WebsocketReconnectStrategy[attemptedStrategy];
         try {
           // wait until the network is available
           await this.networkAvailableTask?.promise;
@@ -1786,9 +1787,27 @@ export class Call {
             case WebsocketReconnectStrategy.FAST:
               await this.reconnectFast();
               break;
-            case WebsocketReconnectStrategy.REJOIN:
-              await this.reconnectRejoin();
+            case WebsocketReconnectStrategy.REJOIN: {
+              const currentSfu = this.credentials?.server.edge_name;
+              if (
+                this.joinCallData &&
+                currentSfu &&
+                (sfuRejoinFailures.get(currentSfu) ?? 0) >= 2
+              ) {
+                this.joinCallData.migrating_from = currentSfu;
+                this.joinCallData.migrating_from_list = Array.from(
+                  sfuRejoinFailures.keys(),
+                );
+              }
+
+              try {
+                await this.reconnectRejoin();
+              } finally {
+                delete this.joinCallData?.migrating_from;
+                delete this.joinCallData?.migrating_from_list;
+              }
               break;
+            }
             case WebsocketReconnectStrategy.MIGRATE:
               await this.reconnectMigrate();
               break;
@@ -1803,6 +1822,20 @@ export class Call {
           this.consecutiveNegotiationFailures = 0;
           break; // do-while loop, reconnection worked, exit the loop
         } catch (error) {
+          if (attemptedStrategy === WebsocketReconnectStrategy.REJOIN) {
+            const failedSfu = this.credentials?.server.edge_name;
+            if (failedSfu) {
+              const switchSfu =
+                error instanceof SfuJoinError &&
+                SfuJoinError.isJoinErrorCode(error.errorEvent);
+              const failures = (sfuRejoinFailures.get(failedSfu) ?? 0) + 1;
+              sfuRejoinFailures.set(
+                failedSfu,
+                switchSfu ? Math.max(failures, 2) : failures,
+              );
+            }
+          }
+
           if (this.state.callingState === CallingState.OFFLINE) {
             this.logger.debug(
               `[Reconnect] Can't reconnect while offline, stopping reconnection attempts`,

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1788,16 +1788,14 @@ export class Call {
               await this.reconnectFast();
               break;
             case WebsocketReconnectStrategy.REJOIN: {
-              const currentSfu = this.credentials?.server.edge_name;
-              if (
-                this.joinCallData &&
-                currentSfu &&
-                (sfuRejoinFailures.get(currentSfu) ?? 0) >= 2
-              ) {
-                this.joinCallData.migrating_from = currentSfu;
-                this.joinCallData.migrating_from_list = Array.from(
-                  sfuRejoinFailures.keys(),
-                );
+              const confirmedBadSfus = Array.from(sfuRejoinFailures)
+                .filter(([, failures]) => failures >= 2)
+                .map(([sfu]) => sfu);
+
+              if (this.joinCallData && confirmedBadSfus.length) {
+                this.joinCallData.migrating_from =
+                  confirmedBadSfus[confirmedBadSfus.length - 1];
+                this.joinCallData.migrating_from_list = confirmedBadSfus;
               }
 
               try {

--- a/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
+++ b/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../StreamSfuClient', () => ({
   StreamSfuClient: vi.fn(),
 }));
 
-const makeCall = ({ reportingEnabled = true } = {}) => {
+const makeCall = ({ reportingEnabled = false } = {}) => {
   const streamClient = new StreamClient('test-key');
   const clientStore = new StreamVideoWriteableStateStore();
   return new Call({
@@ -423,7 +423,7 @@ describe('Call reconnect rejoin SFU migration hints', () => {
   };
 
   beforeEach(() => {
-    call = makeCall({ reportingEnabled: false });
+    call = makeCall();
     call['credentials'] = credentials;
     call['joinCallData'] = { create: true };
     primeForReconnect(call);

--- a/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
+++ b/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
@@ -501,6 +501,56 @@ describe('Call reconnect rejoin SFU migration hints', () => {
     });
     expect(call['joinCallData']).toEqual({ create: true });
   });
+
+  it('gives every SFU two tries before excluding it (a once-failed SFU is re-served, not yet listed)', async () => {
+    call.setRejoinAttemptLimit(5, 60);
+    call['credentials'] = {
+      ...credentials,
+      server: { ...credentials.server, edge_name: 'sfu-a' },
+    };
+
+    const pool = ['sfu-a', 'sfu-b', 'sfu-c'];
+    const sent: Array<{
+      migrating_from?: string;
+      migrating_from_list?: string[];
+    }> = [];
+    vi.spyOn(
+      call as unknown as {
+        doJoinRequest: (data?: unknown) => Promise<unknown>;
+      },
+      'doJoinRequest',
+    ).mockImplementation(async (data?: unknown) => {
+      const clone = JSON.parse(JSON.stringify(data ?? {}));
+      sent.push(clone);
+      const excluded = new Set<string>(clone.migrating_from_list ?? []);
+      const assigned = pool.find((s) => !excluded.has(s)) ?? pool.at(-1)!;
+      call['credentials'] = {
+        ...credentials,
+        server: { ...credentials.server, edge_name: assigned },
+      };
+      throw new Error('connect failed');
+    });
+
+    await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+    expect(sent).toHaveLength(5);
+    expect(sent[0].migrating_from_list).toBeUndefined();
+    expect(sent[1].migrating_from_list).toBeUndefined();
+    expect(sent[2].migrating_from).toBe('sfu-a');
+    expect(sent[2].migrating_from_list).toEqual(['sfu-a']);
+    expect(sent[3].migrating_from).toBe('sfu-a');
+    expect(sent[3].migrating_from_list).toEqual(['sfu-a']);
+    expect(sent[3].migrating_from_list).not.toContain('sfu-b');
+    expect(sent[4].migrating_from).toBe('sfu-b');
+    expect(sent[4].migrating_from_list).toEqual(['sfu-a', 'sfu-b']);
+
+    for (const req of sent) {
+      if (req.migrating_from) {
+        expect(req.migrating_from_list).toContain(req.migrating_from);
+      }
+    }
+    expect(call['joinCallData']).toEqual({ create: true });
+  });
 });
 
 /**

--- a/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
+++ b/packages/client/src/rtc/__tests__/Call.reconnect.test.ts
@@ -19,19 +19,23 @@ import { Subscriber } from '../Subscriber';
 import { Dispatcher } from '../Dispatcher';
 import { StreamSfuClient } from '../../StreamSfuClient';
 import { IceTrickleBuffer } from '../IceTrickleBuffer';
+import { SfuJoinError } from '../../errors';
 
 vi.mock('../../StreamSfuClient', () => ({
   StreamSfuClient: vi.fn(),
 }));
 
-const makeCall = () => {
+const makeCall = ({ reportingEnabled = true } = {}) => {
   const streamClient = new StreamClient('test-key');
   const clientStore = new StreamVideoWriteableStateStore();
   return new Call({
     type: 'default',
     id: 'test-call',
     streamClient,
-    clientEventReporter: new ClientEventReporter({ streamClient }),
+    clientEventReporter: new ClientEventReporter({
+      streamClient,
+      enabled: reportingEnabled,
+    }),
     clientStore,
     ringing: false,
     watching: false,
@@ -403,6 +407,99 @@ describe('Call reconnect stopping conditions', () => {
       expect(limiter.maxAttempts).toBe(1);
       expect(limiter.windowMs).toBe(1000);
     });
+  });
+});
+
+describe('Call reconnect rejoin SFU migration hints', () => {
+  let call: Call;
+  const credentials = {
+    server: {
+      url: 'https://getstream.io/',
+      ws_endpoint: 'https://getstream.io/ws',
+      edge_name: 'sfu-1',
+    },
+    token: 'token',
+    ice_servers: [],
+  };
+
+  beforeEach(() => {
+    call = makeCall({ reportingEnabled: false });
+    call['credentials'] = credentials;
+    call['joinCallData'] = { create: true };
+    primeForReconnect(call);
+    call.setRejoinAttemptLimit(3, 60);
+    vi.spyOn(connectionUtils, 'sleep').mockResolvedValue(undefined);
+    vi.spyOn(call, 'leave').mockResolvedValue(undefined);
+    vi.spyOn(call, 'get').mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('asks the coordinator to avoid an SFU after repeated rejoin failures without leaking migration hints', async () => {
+    const doJoinRequestArgs: unknown[] = [];
+    const doJoinRequest = vi
+      .spyOn(
+        call as unknown as {
+          doJoinRequest: (data?: unknown) => Promise<unknown>;
+        },
+        'doJoinRequest',
+      )
+      .mockImplementation(async (data?: unknown) => {
+        doJoinRequestArgs.push(JSON.parse(JSON.stringify(data)));
+        throw new Error('rejoin failed');
+      });
+
+    await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+    expect(doJoinRequest).toHaveBeenCalledTimes(3);
+    expect(doJoinRequestArgs[0]).toEqual({ create: true });
+    expect(doJoinRequestArgs[1]).toEqual({ create: true });
+    expect(doJoinRequestArgs[2]).toEqual({
+      create: true,
+      migrating_from: 'sfu-1',
+      migrating_from_list: ['sfu-1'],
+    });
+    expect(call['joinCallData']).toEqual({ create: true });
+  });
+
+  it('asks the coordinator to avoid an SFU immediately after an SFU join error', async () => {
+    call.setRejoinAttemptLimit(2, 60);
+    const doJoinRequestArgs: unknown[] = [];
+    const sfuFullError = new SfuJoinError({
+      error: {
+        code: ErrorCode.SFU_FULL,
+        message: 'SFU is full',
+      },
+      reconnectStrategy: WebsocketReconnectStrategy.REJOIN,
+    } as never);
+    const doJoinRequest = vi
+      .spyOn(
+        call as unknown as {
+          doJoinRequest: (data?: unknown) => Promise<unknown>;
+        },
+        'doJoinRequest',
+      )
+      .mockImplementationOnce(async (data?: unknown) => {
+        doJoinRequestArgs.push(JSON.parse(JSON.stringify(data)));
+        throw sfuFullError;
+      })
+      .mockImplementation(async (data?: unknown) => {
+        doJoinRequestArgs.push(JSON.parse(JSON.stringify(data)));
+        throw new Error('rejoin failed');
+      });
+
+    await call['reconnect'](WebsocketReconnectStrategy.REJOIN, 'test');
+
+    expect(doJoinRequest).toHaveBeenCalledTimes(2);
+    expect(doJoinRequestArgs[0]).toEqual({ create: true });
+    expect(doJoinRequestArgs[1]).toEqual({
+      create: true,
+      migrating_from: 'sfu-1',
+      migrating_from_list: ['sfu-1'],
+    });
+    expect(call['joinCallData']).toEqual({ create: true });
   });
 });
 


### PR DESCRIPTION
### 💡 Overview
This PR fixes an issue where a reconnecting client could get stuck rejoining the same unhealthy SFU, because the coordinator's `/join` can hand back the same SFU that failed. Failed rejoins are counted per SFU during a reconnection, and once an SFU fails enough times we set `migrating_from` / `migrating_from_list` so the coordinator gives us a different SFU (the hint applies only to that one request, so a following FAST reconnect isn't affected).

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1013/enhance-reconnect-flow-with-migrating-from-option

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved call reconnection reliability by refining retry behavior and tracking repeated SFU join failures to make smarter rejoin decisions.
  * Enhanced reconnection handling to reliably include migration hints during rejoin retries, improving recovery after SFU capacity issues while keeping call join parameters unchanged.
  * Strengthened reconnection test coverage to validate the updated rejoin and SFU exclusion behavior across multiple retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->