### PR TITLE
feat: upgrade to TypeScript 6.0.3, pin ES2022, raise supported-browser floors

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,8 +4,6 @@ compressionLevel: mixed
 
 enableGlobalCache: true
 
-enableHardenedMode: true
-
 enableScripts: false
 
 initScope: stream-io

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "lint-staged": "^16.4.0",
     "nx": "^21.6.11",
     "prettier": "^3.8.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.0",
     "vite": "^8.0.14"
   },

--- a/packages/audio-filters-web/package.json
+++ b/packages/audio-filters-web/package.json
@@ -34,9 +34,11 @@
     "wasm-feature-detect": "^1.8.0"
   },
   "devDependencies": {
+    "@stream-io/typescript-config": "workspace:^",
+    "@types/node": "^25.9.3",
     "concurrently": "^9.2.1",
     "rimraf": "^6.1.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14"
   }
 }

--- a/packages/audio-filters-web/tsconfig.json
+++ b/packages/audio-filters-web/tsconfig.json
@@ -1,23 +1,11 @@
 {
+  "extends": "@stream-io/typescript-config/library-web.json",
   "compilerOptions": {
     "outDir": "./dist/types",
     "rootDir": "./src",
-    "module": "ES2020",
-    "target": "ES2020",
-    "lib": ["esnext", "dom"],
+    "types": ["node"],
     "allowJs": true,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "sourceMap": true,
-    "inlineSources": true
+    "emitDeclarationOnly": true
   },
   "exclude": ["**/__tests__/**"],
   "include": ["./src"]

--- a/packages/audio-filters-web/vite.config.ts
+++ b/packages/audio-filters-web/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     outDir: 'dist',
     minify: false,
     sourcemap: true,
-    target: 'es2020',
+    target: 'es2022',
     rollupOptions: {
       external,
     },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -48,7 +48,9 @@
     "@rollup/plugin-typescript": "^12.3.0",
     "@stream-io/audio-filters-web": "workspace:^",
     "@stream-io/node-sdk": "^0.7.59",
+    "@stream-io/typescript-config": "workspace:^",
     "@total-typescript/shoehorn": "^0.1.2",
+    "@types/node": "^25.9.3",
     "@types/sdp-transform": "^2.15.0",
     "@types/ua-parser-js": "^0.7.39",
     "@vitest/coverage-v8": "^4.1.7",
@@ -57,7 +59,7 @@
     "prettier": "^3.8.3",
     "rimraf": "^6.1.3",
     "rollup": "^4.60.4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.7",
     "vitest-mock-extended": "^4.0.0"
   }

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -2415,9 +2415,8 @@ export class Call {
    */
   muteSelf = (type: TrackMuteType) => {
     const myUserId = this.currentUserId;
-    if (myUserId) {
-      return this.muteUser(myUserId, type);
-    }
+    if (!myUserId) return undefined;
+    return this.muteUser(myUserId, type);
   };
 
   /**
@@ -2435,9 +2434,9 @@ export class Call {
       }
     }
 
-    if (userIdsToMute.length > 0) {
-      return this.muteUser(userIdsToMute, type);
-    }
+    return userIdsToMute.length > 0
+      ? this.muteUser(userIdsToMute, type)
+      : undefined;
   };
 
   /**

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -697,7 +697,7 @@ export class StreamSfuClient {
       return;
     }
     this.logger.debug(`Sending message to: ${this.edgeName}`, msgJson);
-    this.signalWs.send(SfuRequest.toBinary(message));
+    this.signalWs.send(SfuRequest.toBinary(message) as Uint8Array<ArrayBuffer>);
   };
 
   private keepAlive = () => {

--- a/packages/client/src/coordinator/connection/connection.ts
+++ b/packages/client/src/coordinator/connection/connection.ts
@@ -174,6 +174,7 @@ export class StableWSConnection {
             await sleep(interval);
           }
         }
+        return undefined;
       })(),
       (async () => {
         await sleep(timeout);
@@ -372,6 +373,7 @@ export class StableWSConnection {
         this.client.resolveConnectionId?.(this.connectionID);
         return response;
       }
+      return undefined;
     } catch (caught) {
       const err = caught as WSConnectionError;
       this.isConnecting = false;

--- a/packages/client/src/helpers/MediaPlaybackWatchdog.ts
+++ b/packages/client/src/helpers/MediaPlaybackWatchdog.ts
@@ -93,6 +93,7 @@ export class MediaPlaybackWatchdog {
     const HAVE_CURRENT_DATA = 2;
     if (this.element.readyState < HAVE_CURRENT_DATA) return 'notReady';
     if (!this.element.paused) return 'notPaused';
+    return undefined;
   };
 
   private attemptPlay = async () => {

--- a/packages/client/src/helpers/__tests__/browsers.test.ts
+++ b/packages/client/src/helpers/__tests__/browsers.test.ts
@@ -169,70 +169,70 @@ describe('browsers', () => {
 
     it('should return true for supported Chrome version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Chrome', version: '124' },
+        browser: { name: 'Chrome', version: '136' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(true);
     });
 
     it('should return true for supported Chrome detailed version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Chrome', version: '124.0.7204.158' },
+        browser: { name: 'Chrome', version: '136.0.7204.158' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(true);
     });
 
     it('should return false for unsupported Chrome version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Chrome', version: '123' },
+        browser: { name: 'Chrome', version: '135' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(false);
     });
 
     it('should return false for unsupported Chrome detailed version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Chrome', version: '123.0.1234.99' },
+        browser: { name: 'Chrome', version: '135.0.1234.99' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(false);
     });
 
     it('should return true for supported Edge version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Edge', version: '124' },
+        browser: { name: 'Edge', version: '136' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(true);
     });
 
     it('should return false for unsupported Edge version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Edge', version: '123' },
+        browser: { name: 'Edge', version: '135' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(false);
     });
 
     it('should return true for supported Firefox version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Firefox', version: '124' },
+        browser: { name: 'Firefox', version: '137' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(true);
     });
 
     it('should return false for unsupported Firefox version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Firefox', version: '123' },
+        browser: { name: 'Firefox', version: '136' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(false);
     });
 
     it('should return true for supported Safari version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Safari', version: '17' },
+        browser: { name: 'Safari', version: '18' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(true);
     });
 
     it('should return false for unsupported Safari version', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'Safari', version: '16' },
+        browser: { name: 'Safari', version: '17' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(false);
     });
@@ -253,14 +253,14 @@ describe('browsers', () => {
 
     it('should return true for supported WebView version (WebView on Android)', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'WebView', version: '124' },
+        browser: { name: 'WebView', version: '136' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(true);
     });
 
     it('should return false for unsupported WebView version (WebView on Android)', async () => {
       vi.mocked(getClientDetails).mockResolvedValue({
-        browser: { name: 'WebView', version: '123' },
+        browser: { name: 'WebView', version: '135' },
       } as ClientDetails);
       expect(await isSupportedBrowser()).toBe(false);
     });

--- a/packages/client/src/helpers/browsers.ts
+++ b/packages/client/src/helpers/browsers.ts
@@ -62,11 +62,11 @@ export const isSupportedBrowser = async (): Promise<boolean> => {
   const [major] = browser.version.split('.');
   const version = parseInt(major, 10);
   return (
-    (name.includes('chrome') && version >= 124) ||
-    (name.includes('edge') && version >= 124) ||
-    (name.includes('firefox') && version >= 124) ||
-    (name.includes('safari') && version >= 17) ||
+    (name.includes('chrome') && version >= 136) ||
+    (name.includes('edge') && version >= 136) ||
+    (name.includes('firefox') && version >= 137) ||
+    (name.includes('safari') && version >= 18) ||
     (name.includes('webkit') && version >= 605) || // WebView on iOS
-    (name.includes('webview') && version >= 124) // WebView on Android
+    (name.includes('webview') && version >= 136) // WebView on Android
   );
 };

--- a/packages/client/src/rtc/helpers/degradationPreference.ts
+++ b/packages/client/src/rtc/helpers/degradationPreference.ts
@@ -18,6 +18,7 @@ export const toRTCDegradationPreference = (
       return undefined;
     default:
       ensureExhausted(preference, 'Unknown degradation preference');
+      return undefined;
   }
 };
 

--- a/packages/client/src/rtc/helpers/sdp.ts
+++ b/packages/client/src/rtc/helpers/sdp.ts
@@ -158,11 +158,12 @@ export const removeCodecsExcept = (
     // If a specific fmtp profile is requested, only keep payloads whose fmtp config matches it
     if (fmtpProfileToKeep) {
       const filtered = new Set<number>();
-      const required = new Set(fmtpProfileToKeep.split(';'));
+      const required = fmtpProfileToKeep.split(';');
       for (const fmtp of media.fmtp) {
+        const actual = new Set(fmtp.config.split(';'));
         if (
           payloadsToKeep.has(fmtp.payload) &&
-          required.difference(new Set(fmtp.config.split(';'))).size === 0
+          required.every((part) => actual.has(part))
         ) {
           filtered.add(fmtp.payload);
         }

--- a/packages/client/src/rtc/helpers/tracks.ts
+++ b/packages/client/src/rtc/helpers/tracks.ts
@@ -23,6 +23,7 @@ export const trackTypeToParticipantStreamKey = (
       throw new Error('Track type is unspecified');
     default:
       ensureExhausted(trackType, 'Unknown track type');
+      return undefined;
   }
 };
 
@@ -40,6 +41,7 @@ export const muteTypeToTrackType = (
       return TrackType.SCREEN_SHARE_AUDIO;
     default:
       ensureExhausted(muteType, 'Unknown mute type');
+      return undefined;
   }
 };
 

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,30 +1,10 @@
 {
+  "extends": "@stream-io/typescript-config/library-web.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "module": "ES2020",
-    "target": "ES2020",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "noEmitOnError": true,
-    "noImplicitAny": true,
-    "declaration": true,
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "sourceMap": true,
-    "inlineSources": true,
+    "types": ["node"],
+    "noEmitOnError": true
   },
   "exclude": ["**/__tests__/**"],
-  "include": [
-    "./src",
-    "index.ts",
-    "version.ts"
-  ]
+  "include": ["./src", "index.ts", "version.ts"]
 }

--- a/packages/noise-cancellation-react-native/package.json
+++ b/packages/noise-cancellation-react-native/package.json
@@ -49,11 +49,12 @@
   "homepage": "https://github.com/GetStream/stream-video-js#readme",
   "devDependencies": {
     "@stream-io/react-native-webrtc": "145.0.0",
+    "@stream-io/typescript-config": "workspace:^",
     "react": "19.2.3",
     "react-native": "0.85.3",
     "react-native-builder-bob": "^0.41.0",
     "rimraf": "^6.1.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "@stream-io/react-native-webrtc": "^145.0.0",

--- a/packages/noise-cancellation-react-native/tsconfig.json
+++ b/packages/noise-cancellation-react-native/tsconfig.json
@@ -1,24 +1,7 @@
 {
+  "extends": "@stream-io/typescript-config/library-rn.json",
   "compilerOptions": {
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "jsx": "react",
-    "lib": ["esnext"],
-    "module": "ES2020",
-    "target": "ES2020",
-    "moduleResolution": "node",
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noImplicitUseStrict": false,
-    "noStrictGenericChecks": false,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
+    "rootDir": "./src",
     "verbatimModuleSyntax": true
   }
 }

--- a/packages/react-bindings/package.json
+++ b/packages/react-bindings/package.json
@@ -35,11 +35,12 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.3.0",
+    "@stream-io/typescript-config": "workspace:^",
     "@stream-io/video-client": "workspace:^",
     "@types/react": "~19.2.15",
     "react": "19.2.3",
     "rimraf": "^6.1.3",
     "rollup": "^4.60.4",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/react-bindings/src/i18n/StreamI18n.ts
+++ b/packages/react-bindings/src/i18n/StreamI18n.ts
@@ -1,4 +1,4 @@
-import i18next from 'i18next';
+import i18next, { type i18n } from 'i18next';
 import {
   TranslationLanguage,
   TranslationsMap,
@@ -27,7 +27,7 @@ export type StreamI18nConstructor = {
 
 export class StreamI18n {
   /** Exposed i18n instance from the i18next library */
-  i18nInstance;
+  i18nInstance: i18n;
   /** Translator function that converts the provided string into its equivalent in the current language. */
   t: TranslatorFunction = defaultTranslationFunction;
 

--- a/packages/react-bindings/tsconfig.json
+++ b/packages/react-bindings/tsconfig.json
@@ -1,22 +1,9 @@
 {
+  "extends": "@stream-io/typescript-config/library-web.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "module": "ES2020",
-    "target": "ES2020",
-    "lib": ["esnext", "dom"],
-    "declaration": true,
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "sourceMap": true,
-    "inlineSources": true,
     "jsx": "react-jsxdev"
   },
   "exclude": ["**/__tests__/**"],
-  "include": ["./src", "index.ts"],
+  "include": ["./src", "index.ts"]
 }

--- a/packages/react-native-callingx/package.json
+++ b/packages/react-native-callingx/package.json
@@ -62,12 +62,13 @@
     "@react-native-community/cli": "20.1.3",
     "@react-native/babel-preset": "0.85.3",
     "@stream-io/react-native-webrtc": "145.0.0",
+    "@stream-io/typescript-config": "workspace:^",
     "@types/react": "^19.2.15",
     "del-cli": "^6.0.0",
     "react": "19.2.3",
     "react-native": "0.85.3",
     "react-native-builder-bob": "^0.41.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "@react-native-firebase/app": ">=23.0.0",

--- a/packages/react-native-callingx/tsconfig.json
+++ b/packages/react-native-callingx/tsconfig.json
@@ -1,30 +1,12 @@
 {
+  "extends": "@stream-io/typescript-config/library-rn.json",
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
       "react-native-callingx": ["./src/index"]
     },
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
     "customConditions": ["react-native-strict-api"],
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
-    "lib": ["ESNext"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
     "noEmit": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noImplicitUseStrict": false,
-    "noStrictGenericChecks": false,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "ESNext",
     "verbatimModuleSyntax": true
   }
 }

--- a/packages/react-native-sdk/expo-config-plugin/tsconfig.json
+++ b/packages/react-native-sdk/expo-config-plugin/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": false,
-    "declaration": false
+    "declaration": false,
+    "types": ["node"]
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -119,11 +119,13 @@
     "@stream-io/noise-cancellation-react-native": "workspace:^",
     "@stream-io/react-native-callingx": "workspace:^",
     "@stream-io/react-native-webrtc": "145.0.0",
+    "@stream-io/typescript-config": "workspace:^",
     "@stream-io/video-filters-react-native": "workspace:^",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "13.3.3",
     "@tsconfig/node18": "^18.2.6",
     "@types/jest": "^29.5.14",
+    "@types/node": "^25.9.3",
     "@types/react": "~19.2.15",
     "@types/react-test-renderer": "^19.1.0",
     "expo": "~56.0.9",
@@ -140,7 +142,7 @@
     "react-native-worklets": "0.8.3",
     "react-test-renderer": "19.2.3",
     "rimraf": "^6.1.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -135,7 +135,7 @@
     "jest": "^29.7.0",
     "react": "19.2.3",
     "react-native": "0.85.3",
-    "react-native-builder-bob": "~0.23",
+    "react-native-builder-bob": "^0.41.0",
     "react-native-gesture-handler": "~2.31.2",
     "react-native-reanimated": "4.3.1",
     "react-native-svg": "15.15.5",

--- a/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
+++ b/packages/react-native-sdk/src/components/Call/CallContent/CallContent.tsx
@@ -158,26 +158,25 @@ export const CallContent = ({
   const showSpotlightLayout = hasScreenShare || layout === 'spotlight';
 
   useEffect(() => {
-    if (isInPiPMode && Platform.OS === 'android') {
-      const unsubFunc = call?.on('call.ended', () => {
+    if (!isInPiPMode || Platform.OS !== 'android') return;
+    const unsubFunc = call?.on('call.ended', () => {
+      videoLoggerSystem
+        .getLogger('CallContent')
+        .debug(`exiting PiP mode due to call.ended`);
+      NativeModules.StreamVideoReactNative.exitPipMode();
+    });
+    const subscription = call?.state.callingState$.subscribe((state) => {
+      if (state === CallingState.LEFT) {
         videoLoggerSystem
           .getLogger('CallContent')
-          .debug(`exiting PiP mode due to call.ended`);
+          .debug(`exiting PiP mode due to callingState: LEFT`);
         NativeModules.StreamVideoReactNative.exitPipMode();
-      });
-      const subscription = call?.state.callingState$.subscribe((state) => {
-        if (state === CallingState.LEFT) {
-          videoLoggerSystem
-            .getLogger('CallContent')
-            .debug(`exiting PiP mode due to callingState: LEFT`);
-          NativeModules.StreamVideoReactNative.exitPipMode();
-        }
-      });
-      return () => {
-        unsubFunc?.();
-        subscription?.unsubscribe();
-      };
-    }
+      }
+    });
+    return () => {
+      unsubFunc?.();
+      subscription?.unsubscribe();
+    };
   }, [isInPiPMode, call]);
 
   const showFloatingView =
@@ -203,6 +202,7 @@ export const CallContent = ({
         prevInCallManager.stop();
       };
     }
+    return undefined;
   }, []);
 
   const handleFloatingViewParticipantSwitch = () => {

--- a/packages/react-native-sdk/src/components/Livestream/HostLivestream/HostLivestream.tsx
+++ b/packages/react-native-sdk/src/components/Livestream/HostLivestream/HostLivestream.tsx
@@ -90,12 +90,11 @@ export const HostLivestream = ({
   // Automatically route audio to speaker devices as relevant for watching videos.
   useEffect(() => {
     const prevInCallManager = getRNInCallManagerLibNoThrow();
-    if (prevInCallManager) {
-      prevInCallManager.start({ media: 'video' });
-      return () => {
-        prevInCallManager.stop();
-      };
-    }
+    if (!prevInCallManager) return;
+    prevInCallManager.start({ media: 'video' });
+    return () => {
+      prevInCallManager.stop();
+    };
   }, []);
 
   const [topViewHeight, setTopViewHeight] = React.useState<number>();

--- a/packages/react-native-sdk/src/components/Livestream/LivestreamControls/ViewerLivestreamControls.tsx
+++ b/packages/react-native-sdk/src/components/Livestream/LivestreamControls/ViewerLivestreamControls.tsx
@@ -71,7 +71,7 @@ export const ViewerLivestreamControls = ({
   const [isMuted, setIsMuted] = useState(false);
   const [isPlaying, setIsPlaying] = useState(true);
   const [showPlayPauseButton, setShowPlayPauseButton] = useState(true);
-  const playPauseTimeout = useRef<NodeJS.Timeout | null>(null);
+  const playPauseTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hidePlayPauseButtonAfterDelay = useCallback(() => {
     if (playPauseTimeout.current) {

--- a/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/DurationBadge.tsx
+++ b/packages/react-native-sdk/src/components/Livestream/LivestreamTopView/DurationBadge.tsx
@@ -41,7 +41,7 @@ export const DurationBadge = ({ mode }: DurationBadgeProps) => {
     if (mode !== 'host') {
       return;
     }
-    let intervalId: NodeJS.Timeout;
+    let intervalId: ReturnType<typeof setInterval>;
 
     const handleLiveStarted = () => {
       intervalId = setInterval(() => {
@@ -85,7 +85,7 @@ export const DurationBadge = ({ mode }: DurationBadgeProps) => {
     if (mode !== 'viewer') {
       return;
     }
-    let intervalId: NodeJS.Timeout;
+    let intervalId: ReturnType<typeof setInterval>;
     const handleLiveStarted = () => {
       intervalId = setInterval(() => {
         setDuration((d) => d + 1);

--- a/packages/react-native-sdk/src/components/Livestream/ViewerLivestream/ViewerLivestream.tsx
+++ b/packages/react-native-sdk/src/components/Livestream/ViewerLivestream/ViewerLivestream.tsx
@@ -103,12 +103,11 @@ export const ViewerLivestream = ({
   // Automatically route audio to speaker devices as relevant for watching videos.
   useEffect(() => {
     const prevInCallManager = getRNInCallManagerLibNoThrow();
-    if (prevInCallManager) {
-      prevInCallManager.start({ media: 'video' });
-      return () => {
-        prevInCallManager.stop();
-      };
-    }
+    if (!prevInCallManager) return;
+    prevInCallManager.start({ media: 'video' });
+    return () => {
+      prevInCallManager.stop();
+    };
   }, []);
 
   useEffect(() => {
@@ -205,13 +204,12 @@ const useCanJoinEarly = () => {
   );
 
   useEffect(() => {
-    if (!canJoinEarly) {
-      const handle = setInterval(() => {
-        setCanJoinEarly(checkCanJoinEarly(startsAt, joinAheadTimeSeconds));
-      }, 1000);
+    if (canJoinEarly) return;
+    const handle = setInterval(() => {
+      setCanJoinEarly(checkCanJoinEarly(startsAt, joinAheadTimeSeconds));
+    }, 1000);
 
-      return () => clearInterval(handle);
-    }
+    return () => clearInterval(handle);
   }, [canJoinEarly, startsAt, joinAheadTimeSeconds]);
 
   return canJoinEarly;

--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantReaction.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/ParticipantReaction.tsx
@@ -38,7 +38,7 @@ export const ParticipantReaction = ({
   } = useTheme();
 
   useEffect(() => {
-    let timeoutId: NodeJS.Timeout;
+    let timeoutId: ReturnType<typeof setTimeout>;
     if (call) {
       timeoutId = setTimeout(() => {
         call.resetReaction(sessionId);

--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/index.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/index.tsx
@@ -97,12 +97,12 @@ export const VideoRenderer = ({
     isParticipantVideoEnabled(participant.sessionId);
 
   useEffect(() => {
-    if (Platform.OS === 'ios' && registerIosScreenshot && canShowVideo) {
-      registerIosScreenshot(participant, trackType, viewRef);
-      return () => {
-        deregisterIosScreenshot(participant, trackType);
-      };
-    }
+    if (Platform.OS !== 'ios' || !registerIosScreenshot || !canShowVideo)
+      return;
+    registerIosScreenshot(participant, trackType, viewRef);
+    return () => {
+      deregisterIosScreenshot(participant, trackType);
+    };
   }, [
     participant,
     trackType,

--- a/packages/react-native-sdk/src/hooks/useModeration.ts
+++ b/packages/react-native-sdk/src/hooks/useModeration.ts
@@ -37,7 +37,10 @@ export const useModeration = (options?: ModerationOptions) => {
 
       // not scheduling a timeout to enable the camera
       clearTimeout(blurTimeoutRef.current);
-      if (!isSupported) return turnCameraOff();
+      if (!isSupported) {
+        void turnCameraOff();
+        return;
+      }
 
       restoreRef.current = (restoreRef.current || Promise.resolve()).then(() =>
         applyVideoBlurFilter?.('heavy').then(() => {

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/index.ts
@@ -62,7 +62,6 @@ const DEFAULT_STREAM_VIDEO_CONFIG: StreamVideoConfig = {
 
 export class StreamVideoRN {
   private static config = DEFAULT_STREAM_VIDEO_CONFIG;
-  private static busyToneTimeout: NodeJS.Timeout | null = null;
 
   /**
    * Update the global config for StreamVideoRN except for push config.

--- a/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
+++ b/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
@@ -128,7 +128,7 @@ const streamRNVideoSDKGlobals: StreamRNVideoSDKGlobals = {
 // @stream-io/video-client/src/types.ts and is automatically available when
 // importing from the client package.
 export function registerSDKGlobals() {
-  if (!global.streamRNVideoSDK) {
-    global.streamRNVideoSDK = streamRNVideoSDKGlobals;
+  if (!globalThis.streamRNVideoSDK) {
+    globalThis.streamRNVideoSDK = streamRNVideoSDKGlobals;
   }
 }

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
@@ -7,7 +7,7 @@ export type FirebaseMessagingType = Type;
 const INSTALLATION_INSTRUCTION =
   'Please see https://rnfirebase.io/messaging/usage#installation for installation instructions';
 
-export function getFirebaseMessagingLib() {
+export function getFirebaseMessagingLib(): FirebaseMessagingType {
   if (!lib) {
     throw Error(
       '@react-native-firebase/messaging is not installed. ' +
@@ -17,7 +17,9 @@ export function getFirebaseMessagingLib() {
   return lib;
 }
 
-export function getFirebaseMessagingLibNoThrow(isExpo: boolean) {
+export function getFirebaseMessagingLibNoThrow(
+  isExpo: boolean,
+): FirebaseMessagingType | undefined {
   if (!lib) {
     const logger = videoLoggerSystem.getLogger(
       'getFirebaseMessagingLibNoThrow',

--- a/packages/react-native-sdk/tsconfig.json
+++ b/packages/react-native-sdk/tsconfig.json
@@ -1,19 +1,9 @@
 {
+  "extends": "@stream-io/typescript-config/library-rn.json",
   "compilerOptions": {
-    "target": "ES6",
-    "declaration": true,
-    "module": "ES2020",
-    "moduleResolution": "node",
-    "lib": ["es6", "dom"],
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "noUncheckedIndexedAccess": true,
-    "jsx": "react"
+    "rootDir": "./src",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true
   },
   "include": ["src"]
 }

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -61,13 +61,15 @@
     "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
     "@stream-io/audio-filters-web": "workspace:^",
+    "@stream-io/typescript-config": "workspace:^",
     "@stream-io/video-styling": "workspace:^",
+    "@types/node": "^25.9.3",
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "rimraf": "^6.1.3",
     "rollup": "^4.60.4",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/react-sdk/src/embedded/hooks/useWakeLock.ts
+++ b/packages/react-sdk/src/embedded/hooks/useWakeLock.ts
@@ -20,6 +20,7 @@ export const useWakeLock = () => {
       .then((wls: WakeLockSentinel) => {
         if (interrupted) return wls.release();
         wakeLockSentinel = wls;
+        return undefined;
       })
       .catch((error: unknown) =>
         console.debug(`Couldn't setup WakeLock due to: ${error}`),

--- a/packages/react-sdk/src/embedded/livestream/viewer/ViewerLobby.tsx
+++ b/packages/react-sdk/src/embedded/livestream/viewer/ViewerLobby.tsx
@@ -55,13 +55,12 @@ export const ViewerLobby = ({ onJoin }: ViewerLobbyProps) => {
   }, [canJoin, autoJoin, onJoin]);
 
   useEffect(() => {
-    if (!canJoinEarly) {
-      const handle = setInterval(() => {
-        setCanJoinEarly(checkCanJoinEarly(startsAt, joinAheadTimeSeconds));
-      }, 1000);
+    if (canJoinEarly) return;
+    const handle = setInterval(() => {
+      setCanJoinEarly(checkCanJoinEarly(startsAt, joinAheadTimeSeconds));
+    }, 1000);
 
-      return () => clearInterval(handle);
-    }
+    return () => clearInterval(handle);
   }, [canJoinEarly, startsAt, joinAheadTimeSeconds]);
 
   useEffect(() => {

--- a/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
+++ b/packages/react-sdk/src/wrappers/LivestreamPlayer/LivestreamPlayer.tsx
@@ -143,13 +143,12 @@ const useCanJoinEarly = () => {
   );
 
   useEffect(() => {
-    if (!canJoinEarly) {
-      const handle = setInterval(() => {
-        setCanJoinEarly(checkCanJoinEarly(startsAt, joinAheadTimeSeconds));
-      }, 1000);
+    if (canJoinEarly) return;
+    const handle = setInterval(() => {
+      setCanJoinEarly(checkCanJoinEarly(startsAt, joinAheadTimeSeconds));
+    }, 1000);
 
-      return () => clearInterval(handle);
-    }
+    return () => clearInterval(handle);
   }, [canJoinEarly, startsAt, joinAheadTimeSeconds]);
 
   return canJoinEarly;

--- a/packages/react-sdk/tsconfig.json
+++ b/packages/react-sdk/tsconfig.json
@@ -1,20 +1,8 @@
 {
+  "extends": "@stream-io/typescript-config/library-web.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "module": "ES2020",
-    "target": "ES2020",
-    "lib": ["esnext", "dom"],
-    "declaration": true,
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "sourceMap": true,
-    "inlineSources": true,
+    "types": ["node"],
     "jsx": "react-jsxdev"
   },
   "exclude": ["**/__tests__/**"],

--- a/packages/typescript-config/app-web.json
+++ b/packages/typescript-config/app-web.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Stream (web app)",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "noEmit": true
+  }
+}

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Stream (base)",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false
+  }
+}

--- a/packages/typescript-config/library-rn.json
+++ b/packages/typescript-config/library-rn.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Stream (React Native library)",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "jsx": "react-native",
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  }
+}

--- a/packages/typescript-config/library-web.json
+++ b/packages/typescript-config/library-web.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Stream (web library)",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@stream-io/typescript-config",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared TypeScript configurations for Stream Video SDK packages",
+  "files": [
+    "base.json",
+    "library-web.json",
+    "library-rn.json",
+    "app-web.json"
+  ]
+}

--- a/packages/video-filters-react-native/package.json
+++ b/packages/video-filters-react-native/package.json
@@ -49,11 +49,12 @@
   "homepage": "https://github.com/GetStream/stream-video-js#readme",
   "devDependencies": {
     "@stream-io/react-native-webrtc": "145.0.0",
+    "@stream-io/typescript-config": "workspace:^",
     "react": "19.2.3",
     "react-native": "0.85.3",
     "react-native-builder-bob": "^0.41.0",
     "rimraf": "^6.1.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "@stream-io/react-native-webrtc": "^145.0.0",

--- a/packages/video-filters-react-native/tsconfig.json
+++ b/packages/video-filters-react-native/tsconfig.json
@@ -1,27 +1,10 @@
 {
+  "extends": "@stream-io/typescript-config/library-rn.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "paths": {
       "@stream-io/video-filters-react-native": ["./src/index"]
     },
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "jsx": "react",
-    "lib": ["esnext"],
-    "module": "ES2020",
-    "target": "ES2020",
-    "moduleResolution": "node",
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noImplicitUseStrict": false,
-    "noStrictGenericChecks": false,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
     "verbatimModuleSyntax": true
   }
 }

--- a/packages/video-filters-web/package.json
+++ b/packages/video-filters-web/package.json
@@ -35,10 +35,12 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
+    "@stream-io/typescript-config": "workspace:^",
     "@types/dom-mediacapture-transform": "^0.1.11",
     "@types/emscripten": "^1.41.5",
+    "@types/node": "^25.9.3",
     "rimraf": "^6.1.3",
     "rollup": "^4.60.4",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/video-filters-web/tsconfig.json
+++ b/packages/video-filters-web/tsconfig.json
@@ -1,27 +1,9 @@
 {
+  "extends": "@stream-io/typescript-config/library-web.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "module": "ES2020",
-    "target": "ES2020",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "declaration": true,
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "sourceMap": true,
-    "inlineSources": true
+    "types": ["node", "dom-mediacapture-transform", "emscripten"]
   },
   "exclude": ["**/__tests__/**"],
-  "include": [
-    "./src",
-    "index.ts"
-  ]
+  "include": ["./src", "index.ts"]
 }

--- a/sample-apps/client/ts-quickstart/package.json
+++ b/sample-apps/client/ts-quickstart/package.json
@@ -12,8 +12,9 @@
     "@stream-io/video-client": "workspace:^"
   },
   "devDependencies": {
+    "@stream-io/typescript-config": "workspace:^",
     "@vitejs/plugin-basic-ssl": "^2.3.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14"
   }
 }

--- a/sample-apps/client/ts-quickstart/tsconfig.json
+++ b/sample-apps/client/ts-quickstart/tsconfig.json
@@ -1,23 +1,9 @@
 {
+  "extends": "@stream-io/typescript-config/app-web.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-
-    /* Linting */
-    "strict": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noUnusedParameters": true
   },
   "include": ["src"]
 }

--- a/sample-apps/react-native/dogfood/ios/Podfile.lock
+++ b/sample-apps/react-native/dogfood/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Callingx (0.5.0):
+  - Callingx (0.5.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2442,7 +2442,7 @@ PODS:
   - stream-react-native-webrtc (145.0.0):
     - React-Core
     - StreamWebRTC (= 145.10.0)
-  - stream-video-react-native (1.38.0):
+  - stream-video-react-native (1.39.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2829,9 +2829,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Callingx: 330847610b57c4fcaccaa7a708b372ee7473aadb
+  Callingx: 736dd158feb6813da9afd2d90ac37bc21b04002d
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 2d0f6516440ca865b33146ac797ab69743686d86
+  hermes-engine: 7eda2a29301bb9bb2a5d6adfda2f4097e989fe30
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702
@@ -2840,7 +2840,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 21e26ae924c14206cab1fe50814ba3813773b24c
+  React-Core-prebuilt: 221f76b58d39284aab8cea66fb48539b45432fca
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 9af1e96a6069c996e3d9f1e493603e74bc9f1593
@@ -2908,7 +2908,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: 7016a2114079361a2f1536b3c91a15ceb8eb7ca4
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: 618f7d3248fe6aeb88bcfdc5756f0850d29d1092
+  ReactNativeDependencies: 1764fb780692507670ee194feaf184e938875c79
   RNCClipboard: 7a7d4557bfd3370b35c99dfecd92ae7b9fc4948a
   RNCPushNotificationIOS: 85957a0534fd1309b4c028ccbe5b1baf9ab5cf57
   RNDeviceInfo: bcce8752b5043a623fe3c26789679b473f705d3c
@@ -2924,7 +2924,7 @@ SPEC CHECKSUMS:
   stream-io-noise-cancellation-react-native: e4894d912edb8de125957832c40f49a32e51de84
   stream-io-video-filters-react-native: 030f5b873cbbb868f5209169c9a7ecc16aa5cca4
   stream-react-native-webrtc: af1423d12a18cd213fa1bd745241d1734c9a8235
-  stream-video-react-native: b9bb1ec8542941445c7efb78f5441d71d2b8eb7a
+  stream-video-react-native: 7b32b6b93d55a99a2a0da09b4a50554fe0836912
   StreamVideoNoiseCancellation: 41f5a712aba288f9636b64b17ebfbdff52c61490
   StreamWebRTC: ff3698ef9a94e7ca90dd54ce36991066323fd855
   Teleport: 58dccc8594d74a77cdc2a2191b60656f9aaac743
@@ -2933,4 +2933,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 07a707e557b2b5633699c949bfc2e227de85931a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/sample-apps/react-native/dogfood/package.json
+++ b/sample-apps/react-native/dogfood/package.json
@@ -62,7 +62,7 @@
     "@types/react": "^19.2.15",
     "babel-plugin-react-compiler": "^1.0.0",
     "react-dom": "19.2.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=22.11.0"

--- a/sample-apps/react-native/dogfood/src/components/CallControlls/MoreActionsButton/index.tsx
+++ b/sample-apps/react-native/dogfood/src/components/CallControlls/MoreActionsButton/index.tsx
@@ -81,7 +81,7 @@ export const MoreActionsButton = ({
   const setState = useAppGlobalStoreSetState();
   const themeMode = useAppGlobalStoreValue((store) => store.themeMode);
   const call = useCall();
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const {
     useIsCallCaptioningInProgress,
     useHasPermissions,

--- a/sample-apps/react-native/dogfood/src/screens/LoginScreen/index.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/LoginScreen/index.tsx
@@ -35,7 +35,7 @@ const LoginScreen = () => {
   const { t } = useI18n();
   const orientation = useOrientation();
   const [tapCount, setTapCount] = useState(0);
-  const tapTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const tapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const setState = useAppGlobalStoreSetState();
   const appEnvironment = useAppGlobalStoreValue(

--- a/sample-apps/react-native/expo-video-sample/package.json
+++ b/sample-apps/react-native/expo-video-sample/package.json
@@ -48,7 +48,7 @@
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "react-dom": "19.2.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/sample-apps/react-native/ringing-tutorial/package.json
+++ b/sample-apps/react-native/ringing-tutorial/package.json
@@ -46,7 +46,7 @@
     "@react-native/metro-config": "^0.85.3",
     "@types/react": "~19.2.15",
     "react-dom": "19.2.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/sample-apps/react/audio-rooms/package.json
+++ b/sample-apps/react/audio-rooms/package.json
@@ -16,10 +16,11 @@
     "react-router-dom": "^6.30.3"
   },
   "devDependencies": {
+    "@stream-io/typescript-config": "workspace:^",
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14"
   }
 }

--- a/sample-apps/react/audio-rooms/src/components/Room/SpeakingRequestsList.tsx
+++ b/sample-apps/react/audio-rooms/src/components/Room/SpeakingRequestsList.tsx
@@ -52,7 +52,7 @@ const SpeakingRequest = ({
   const customData = useCallCustomData();
 
   const acceptRequest = useCallback(async () => {
-    if (!(call && customData)) return null;
+    if (!(call && customData)) return;
 
     await call?.updateUserPermissions({
       user_id: speakingRequest.user.id,

--- a/sample-apps/react/audio-rooms/tsconfig.json
+++ b/sample-apps/react/audio-rooms/tsconfig.json
@@ -1,21 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
+  "extends": "@stream-io/typescript-config/app-web.json",
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/sample-apps/react/audio-rooms/tsconfig.node.json
+++ b/sample-apps/react/audio-rooms/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/sample-apps/react/cookbook-participant-list/package.json
+++ b/sample-apps/react/cookbook-participant-list/package.json
@@ -18,10 +18,11 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@stream-io/typescript-config": "workspace:^",
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14"
   }
 }

--- a/sample-apps/react/cookbook-participant-list/tsconfig.json
+++ b/sample-apps/react/cookbook-participant-list/tsconfig.json
@@ -1,21 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "ES2015",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
+  "extends": "@stream-io/typescript-config/app-web.json",
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/sample-apps/react/cookbook-participant-list/tsconfig.node.json
+++ b/sample-apps/react/cookbook-participant-list/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/sample-apps/react/egress-composite/package.json
+++ b/sample-apps/react/egress-composite/package.json
@@ -22,11 +22,12 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@sentry/vite-plugin": "^5.3.0",
+    "@stream-io/typescript-config": "workspace:^",
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "nanoid": "^5.1.11",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14"
   }
 }

--- a/sample-apps/react/egress-composite/src/components/layouts/EgressReadyParticipantViewUI.tsx
+++ b/sample-apps/react/egress-composite/src/components/layouts/EgressReadyParticipantViewUI.tsx
@@ -47,6 +47,7 @@ const useNotifyEgressReadyOnFirstFrame = () => {
     if (!isPublishingTrack && videoPlaceholderElement) {
       notifyReady(true);
     }
+    return undefined;
   }, [
     notifyReady,
     participant?.publishedTracks,

--- a/sample-apps/react/egress-composite/tsconfig.json
+++ b/sample-apps/react/egress-composite/tsconfig.json
@@ -1,21 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
+  "extends": "@stream-io/typescript-config/app-web.json",
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/sample-apps/react/egress-composite/tsconfig.node.json
+++ b/sample-apps/react/egress-composite/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/sample-apps/react/livestream-app/package.json
+++ b/sample-apps/react/livestream-app/package.json
@@ -22,10 +22,11 @@
     "react-router-dom": "^6.30.3"
   },
   "devDependencies": {
+    "@stream-io/typescript-config": "workspace:^",
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14"
   }
 }

--- a/sample-apps/react/livestream-app/src/viewers/HLSLivestream.tsx
+++ b/sample-apps/react/livestream-app/src/viewers/HLSLivestream.tsx
@@ -26,7 +26,7 @@ export const HLSLivestreamUI = () => {
   useEffect(() => {
     if (!videoRef || !playlist_url) return;
 
-    let timeoutId: NodeJS.Timeout;
+    let timeoutId: ReturnType<typeof setTimeout>;
     if (autoJoin && isBroadcasting) {
       hls.on(HLS.Events.ERROR, (e, data) => {
         console.error('HLS error, attempting to recover', e, data);

--- a/sample-apps/react/livestream-app/tsconfig.json
+++ b/sample-apps/react/livestream-app/tsconfig.json
@@ -1,20 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "allowSyntheticDefaultImports": true,
-  },
+  "extends": "@stream-io/typescript-config/app-web.json",
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/sample-apps/react/livestream-app/tsconfig.node.json
+++ b/sample-apps/react/livestream-app/tsconfig.node.json
@@ -3,7 +3,7 @@
     "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/sample-apps/react/messenger-clone/package.json
+++ b/sample-apps/react/messenger-clone/package.json
@@ -26,12 +26,13 @@
     "stream-chat-react": "^14.3.0"
   },
   "devDependencies": {
+    "@stream-io/typescript-config": "workspace:^",
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "dotenv": "^16.6.1",
     "sass": "^1.100.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14"
   }
 }

--- a/sample-apps/react/messenger-clone/tsconfig.json
+++ b/sample-apps/react/messenger-clone/tsconfig.json
@@ -1,24 +1,9 @@
 {
+  "extends": "@stream-io/typescript-config/app-web.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
+    "allowJs": true
   },
   "include": ["src"],
-  "exclude": [
-    "node_modules"
-  ],
+  "exclude": ["node_modules"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/sample-apps/react/messenger-clone/tsconfig.node.json
+++ b/sample-apps/react/messenger-clone/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
+++ b/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
@@ -25,6 +25,16 @@ import appTranslations from '../../translations';
 import { DefaultAppHeader } from '../DefaultAppHeader';
 import { DialingCallNotification } from './DialingCallNotification';
 
+function findLastIndex<T>(
+  arr: readonly T[],
+  predicate: (value: T) => boolean,
+): number {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (predicate(arr[i])) return i;
+  }
+  return -1;
+}
+
 export const DialerPage = ({
   apiKey,
   user,
@@ -61,7 +71,7 @@ export const DialerPage = ({
         const nextUserIds = [...prevUserIds];
         nextUserIds[index] = value;
         nextUserIds.splice(
-          nextUserIds.findLastIndex((uid) => uid !== '') + 1,
+          findLastIndex(nextUserIds, (uid) => uid !== '') + 1,
           Number.POSITIVE_INFINITY,
           '',
         );
@@ -101,7 +111,7 @@ export const DialerPage = ({
           ...pastedUserIds,
         );
         nextUserIds.splice(
-          nextUserIds.findLastIndex((uid) => uid !== '') + 1,
+          findLastIndex(nextUserIds, (uid) => uid !== '') + 1,
           Number.POSITIVE_INFINITY,
           '',
         );

--- a/sample-apps/react/react-dogfood/package.json
+++ b/sample-apps/react/react-dogfood/package.json
@@ -42,11 +42,13 @@
   "devDependencies": {
     "@types/geojson": "^7946.0.16",
     "@types/mapbox-gl": "^2.7.21",
+    "@types/node": "^25.9.3",
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "@types/yargs": "^17.0.35",
     "babel-plugin-react-compiler": "^1.0.0",
     "rimraf": "^6.1.3",
-    "sass": "^1.100.0"
+    "sass": "^1.100.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/sample-apps/react/react-dogfood/tsconfig.json
+++ b/sample-apps/react/react-dogfood/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "types": ["node"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,

--- a/sample-apps/react/stream-video-react-tutorial/package.json
+++ b/sample-apps/react/stream-video-react-tutorial/package.json
@@ -14,10 +14,11 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@stream-io/typescript-config": "workspace:^",
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14"
   }
 }

--- a/sample-apps/react/stream-video-react-tutorial/tsconfig.json
+++ b/sample-apps/react/stream-video-react-tutorial/tsconfig.json
@@ -1,24 +1,6 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
+  "extends": "@stream-io/typescript-config/app-web.json",
   "include": ["src"],
-  "exclude": [
-    "node_modules"
-  ],
+  "exclude": ["node_modules"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/sample-apps/react/stream-video-react-tutorial/tsconfig.node.json
+++ b/sample-apps/react/stream-video-react-tutorial/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/sample-apps/react/zoom-clone/package.json
+++ b/sample-apps/react/zoom-clone/package.json
@@ -21,6 +21,7 @@
     "stream-chat-react": "^14.3.0"
   },
   "devDependencies": {
+    "@stream-io/typescript-config": "workspace:^",
     "@types/react": "~19.2.15",
     "@types/react-dom": "~19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
@@ -28,7 +29,7 @@
     "dotenv": "^16.6.1",
     "postcss": "^8.5.15",
     "tailwindcss": "^3.4.19",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14"
   }
 }

--- a/sample-apps/react/zoom-clone/tsconfig.json
+++ b/sample-apps/react/zoom-clone/tsconfig.json
@@ -1,21 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
+  "extends": "@stream-io/typescript-config/app-web.json",
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/sample-apps/react/zoom-clone/tsconfig.node.json
+++ b/sample-apps/react/zoom-clone/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,18 +415,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-class-properties@npm:^7.17.12":
-  version: 7.18.6
-  resolution: "@babel/plugin-proposal-class-properties@npm:7.18.6"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.18.6"
-    "@babel/helper-plugin-utils": "npm:^7.18.6"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/49a78a2773ec0db56e915d9797e44fd079ab8a9b2e1716e0df07c92532f2c65d76aeda9543883916b8e0ff13606afeffa67c5b93d05b607bc87653ad18a91422
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-proposal-decorators@npm:^7.12.9":
   version: 7.22.10
   resolution: "@babel/plugin-proposal-decorators@npm:7.22.10"
@@ -1432,7 +1420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.18.2, @babel/preset-env@npm:^7.23.8, @babel/preset-env@npm:^7.29.2, @babel/preset-env@npm:^7.29.7":
+"@babel/preset-env@npm:^7.23.8, @babel/preset-env@npm:^7.29.2, @babel/preset-env@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/preset-env@npm:7.29.7"
   dependencies:
@@ -1513,7 +1501,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-flow@npm:^7.17.12, @babel/preset-flow@npm:^7.24.7":
+"@babel/preset-flow@npm:^7.24.7":
   version: 7.25.9
   resolution: "@babel/preset-flow@npm:7.25.9"
   dependencies:
@@ -1539,7 +1527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-react@npm:^7.17.12, @babel/preset-react@npm:^7.28.5":
+"@babel/preset-react@npm:^7.28.5":
   version: 7.29.7
   resolution: "@babel/preset-react@npm:7.29.7"
   dependencies:
@@ -1555,7 +1543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.17.12, @babel/preset-typescript@npm:^7.23.0, @babel/preset-typescript@npm:^7.23.3, @babel/preset-typescript@npm:^7.24.7, @babel/preset-typescript@npm:^7.27.1, @babel/preset-typescript@npm:^7.28.5":
+"@babel/preset-typescript@npm:^7.23.0, @babel/preset-typescript@npm:^7.23.3, @babel/preset-typescript@npm:^7.24.7, @babel/preset-typescript@npm:^7.27.1, @babel/preset-typescript@npm:^7.28.5":
   version: 7.29.7
   resolution: "@babel/preset-typescript@npm:7.29.7"
   dependencies:
@@ -7726,7 +7714,7 @@ __metadata:
     jest: "npm:^29.7.0"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
-    react-native-builder-bob: "npm:~0.23"
+    react-native-builder-bob: "npm:^0.41.0"
     react-native-gesture-handler: "npm:~2.31.2"
     react-native-reanimated: "npm:4.3.1"
     react-native-svg: "npm:15.15.5"
@@ -9202,13 +9190,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-union@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "array-union@npm:2.1.0"
-  checksum: 10/5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
-  languageName: node
-  linkType: hard
-
 "array.prototype.findlast@npm:^1.2.5":
   version: 1.2.5
   resolution: "array.prototype.findlast@npm:1.2.5"
@@ -9833,7 +9814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.20.4, browserslist@npm:^4.24.0, browserslist@npm:^4.25.0, browserslist@npm:^4.28.1, browserslist@npm:^4.28.2":
+"browserslist@npm:^4.24.0, browserslist@npm:^4.25.0, browserslist@npm:^4.28.1, browserslist@npm:^4.28.2":
   version: 4.28.2
   resolution: "browserslist@npm:4.28.2"
   dependencies:
@@ -10812,7 +10793,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^7.0.0, cosmiconfig@npm:^7.0.1":
+"cosmiconfig@npm:^7.0.0":
   version: 7.1.0
   resolution: "cosmiconfig@npm:7.1.0"
   dependencies:
@@ -11107,13 +11088,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dedent@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "dedent@npm:0.7.0"
-  checksum: 10/87de191050d9a40dd70cad01159a0bcf05ecb59750951242070b6abf9569088684880d00ba92a955b4058804f16eeaf91d604f283929b4f614d181cd7ae633d2
-  languageName: node
-  linkType: hard
-
 "dedent@npm:^1.0.0, dedent@npm:^1.7.2":
   version: 1.7.2
   resolution: "dedent@npm:1.7.2"
@@ -11201,22 +11175,6 @@ __metadata:
     del: cli.js
     del-cli: cli.js
   checksum: 10/5441e55c9181f364e84a1d211e53a03476a806e795f6b7d576673f164a9f76e0dc846413a47730f6224913974ba54dabb1884f854a9cf4d418084872bdaaa229
-  languageName: node
-  linkType: hard
-
-"del@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "del@npm:6.1.1"
-  dependencies:
-    globby: "npm:^11.0.1"
-    graceful-fs: "npm:^4.2.4"
-    is-glob: "npm:^4.0.1"
-    is-path-cwd: "npm:^2.2.0"
-    is-path-inside: "npm:^3.0.2"
-    p-map: "npm:^4.0.0"
-    rimraf: "npm:^3.0.2"
-    slash: "npm:^3.0.0"
-  checksum: 10/563288b73b8b19a7261c47fd21a330eeab6e2acd7c6208c49790dfd369127120dd7836cdf0c1eca216b77c94782a81507eac6b4734252d3bef2795cb366996b6
   languageName: node
   linkType: hard
 
@@ -11327,15 +11285,6 @@ __metadata:
   version: 29.6.3
   resolution: "diff-sequences@npm:29.6.3"
   checksum: 10/179daf9d2f9af5c57ad66d97cb902a538bcf8ed64963fa7aa0c329b3de3665ce2eb6ffdc2f69f29d445fa4af2517e5e55e5b6e00c00a9ae4f43645f97f7078cb
-  languageName: node
-  linkType: hard
-
-"dir-glob@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "dir-glob@npm:3.0.1"
-  dependencies:
-    path-type: "npm:^4.0.0"
-  checksum: 10/fa05e18324510d7283f55862f3161c6759a3f2f8dbce491a2fc14c8324c498286c54282c1f0e933cb930da8419b30679389499b919122952a4f8592362ef4615
   languageName: node
   linkType: hard
 
@@ -12919,7 +12868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
+"fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -13371,17 +13320,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "fs-extra@npm:10.1.0"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^6.0.1"
-    universalify: "npm:^2.0.0"
-  checksum: 10/05ce2c3b59049bcb7b52001acd000e44b3c4af4ec1f8839f383ef41ec0048e3cfa7fd8a637b1bddfefad319145db89be91f4b7c1db2908205d38bf91e7d1d3b7
-  languageName: node
-  linkType: hard
-
 "fs-extra@npm:^8.1.0":
   version: 8.1.0
   resolution: "fs-extra@npm:8.1.0"
@@ -13731,7 +13669,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1, glob@npm:^8.0.3":
+"glob@npm:^8.0.1":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
   dependencies:
@@ -13772,20 +13710,6 @@ __metadata:
     define-properties: "npm:^1.2.1"
     gopd: "npm:^1.0.1"
   checksum: 10/1f1fd078fb2f7296306ef9dd51019491044ccf17a59ed49d375b576ca108ff37e47f3d29aead7add40763574a992f16a5367dd1e2173b8634ef18556ab719ac4
-  languageName: node
-  linkType: hard
-
-"globby@npm:^11.0.1":
-  version: 11.1.0
-  resolution: "globby@npm:11.1.0"
-  dependencies:
-    array-union: "npm:^2.1.0"
-    dir-glob: "npm:^3.0.1"
-    fast-glob: "npm:^3.2.9"
-    ignore: "npm:^5.2.0"
-    merge2: "npm:^1.4.1"
-    slash: "npm:^3.0.0"
-  checksum: 10/288e95e310227bbe037076ea81b7c2598ccbc3122d87abc6dab39e1eec309aa14f0e366a98cdc45237ffcfcbad3db597778c0068217dcb1950fef6249104e1b1
   languageName: node
   linkType: hard
 
@@ -14680,7 +14604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-git-dirty@npm:^2.0.1, is-git-dirty@npm:^2.0.2":
+"is-git-dirty@npm:^2.0.2":
   version: 2.0.2
   resolution: "is-git-dirty@npm:2.0.2"
   dependencies:
@@ -14768,24 +14692,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-path-cwd@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "is-path-cwd@npm:2.2.0"
-  checksum: 10/46a840921bb8cc0dc7b5b423a14220e7db338072a4495743a8230533ce78812dc152548c86f4b828411fe98c5451959f07cf841c6a19f611e46600bd699e8048
-  languageName: node
-  linkType: hard
-
 "is-path-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-path-cwd@npm:3.0.0"
   checksum: 10/bc34d13b6a03dfca4a3ab6a8a5ba78ae4b24f4f1db4b2b031d2760c60d0913bd16a4b980dcb4e590adfc906649d5f5132684079a3972bd219da49deebb9adea8
-  languageName: node
-  linkType: hard
-
-"is-path-inside@npm:^3.0.2":
-  version: 3.0.3
-  resolution: "is-path-inside@npm:3.0.3"
-  checksum: 10/abd50f06186a052b349c15e55b182326f1936c89a78bf6c8f2b707412517c097ce04bc49a0ca221787bc44e1049f51f09a2ffb63d22899051988d3a618ba13e9
   languageName: node
   linkType: hard
 
@@ -15912,7 +15822,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.1, json5@npm:^2.2.2, json5@npm:^2.2.3":
+"json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -16039,7 +15949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kleur@npm:^4.1.4, kleur@npm:^4.1.5":
+"kleur@npm:^4.1.5":
   version: 4.1.5
   resolution: "kleur@npm:4.1.5"
   checksum: 10/44d84cc4eedd4311099402ef6d4acd9b2d16e08e499d6ef3bb92389bd4692d7ef09e35248c26e27f98acac532122acb12a1bfee645994ae3af4f0a37996da7df
@@ -16947,7 +16857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.3.0, merge2@npm:^1.4.1":
+"merge2@npm:^1.3.0":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 10/7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
@@ -19707,35 +19617,6 @@ __metadata:
   bin:
     bob: bin/bob
   checksum: 10/e7e559520f71c95dd93dba593d7e5057718eef0e782825bb9f81d46dd49036cb3a608d494c4a425a0b79a1a7dab48940458fc93bba1af5beedef0025fe9a2c1a
-  languageName: node
-  linkType: hard
-
-"react-native-builder-bob@npm:~0.23":
-  version: 0.23.2
-  resolution: "react-native-builder-bob@npm:0.23.2"
-  dependencies:
-    "@babel/core": "npm:^7.18.5"
-    "@babel/plugin-proposal-class-properties": "npm:^7.17.12"
-    "@babel/preset-env": "npm:^7.18.2"
-    "@babel/preset-flow": "npm:^7.17.12"
-    "@babel/preset-react": "npm:^7.17.12"
-    "@babel/preset-typescript": "npm:^7.17.12"
-    browserslist: "npm:^4.20.4"
-    cosmiconfig: "npm:^7.0.1"
-    cross-spawn: "npm:^7.0.3"
-    dedent: "npm:^0.7.0"
-    del: "npm:^6.1.1"
-    fs-extra: "npm:^10.1.0"
-    glob: "npm:^8.0.3"
-    is-git-dirty: "npm:^2.0.1"
-    json5: "npm:^2.2.1"
-    kleur: "npm:^4.1.4"
-    prompts: "npm:^2.4.2"
-    which: "npm:^2.0.2"
-    yargs: "npm:^17.5.1"
-  bin:
-    bob: bin/bob
-  checksum: 10/e2f98f26bf25863a9ae6403c7bf316021ad664dab3fdaab15df1695e724a7e7c167078147c59469f74855450e360fc730fafd0720a493aff4b360107e8416b94
   languageName: node
   linkType: hard
 
@@ -23963,7 +23844,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.7.2, yargs@npm:^17.3.1, yargs@npm:^17.5.1, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
+"yargs@npm:17.7.2, yargs@npm:^17.3.1, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7113,9 +7113,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stream-io/audio-filters-web@workspace:packages/audio-filters-web"
   dependencies:
+    "@stream-io/typescript-config": "workspace:^"
+    "@types/node": "npm:^25.9.3"
     concurrently: "npm:^9.2.1"
     rimraf: "npm:^6.1.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
     wasm-feature-detect: "npm:^1.8.0"
   languageName: unknown
@@ -7125,6 +7127,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stream-io/audio-rooms@workspace:sample-apps/react/audio-rooms"
   dependencies:
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.2.15"
     "@types/react-dom": "npm:~19.2.3"
@@ -7132,7 +7135,7 @@ __metadata:
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
     react-router-dom: "npm:^6.30.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
   languageName: unknown
   linkType: soft
@@ -7144,6 +7147,7 @@ __metadata:
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"
     "@mui/material": "npm:^6.5.0"
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@stream-io/video-styling": "workspace:^"
     "@types/react": "npm:~19.2.15"
@@ -7151,7 +7155,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^6.0.2"
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
   languageName: unknown
   linkType: soft
@@ -7165,6 +7169,7 @@ __metadata:
     "@sentry/react": "npm:^10.53.1"
     "@sentry/vite-plugin": "npm:^5.3.0"
     "@skooldev/skool-stream-layout": "npm:1.0.22"
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.2.15"
     "@types/react-dom": "npm:~19.2.3"
@@ -7172,7 +7177,7 @@ __metadata:
     nanoid: "npm:^5.1.11"
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
   languageName: unknown
   linkType: soft
@@ -7222,7 +7227,7 @@ __metadata:
     react-native-screens: "npm:4.25.2"
     react-native-svg: "npm:15.15.5"
     react-native-worklets: "npm:0.8.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7233,6 +7238,7 @@ __metadata:
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"
     "@mui/material": "npm:^6.5.0"
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.2.15"
     "@types/react-dom": "npm:~19.2.3"
@@ -7242,7 +7248,7 @@ __metadata:
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
     react-router-dom: "npm:^6.30.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
   languageName: unknown
   linkType: soft
@@ -7260,6 +7266,7 @@ __metadata:
   dependencies:
     "@mui/icons-material": "npm:^6.5.0"
     "@mui/material": "npm:^6.5.0"
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.2.15"
     "@types/react-dom": "npm:~19.2.3"
@@ -7275,7 +7282,7 @@ __metadata:
     sass: "npm:^1.100.0"
     stream-chat: "npm:^9.44.2"
     stream-chat-react: "npm:^14.3.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
   languageName: unknown
   linkType: soft
@@ -7302,11 +7309,12 @@ __metadata:
   resolution: "@stream-io/noise-cancellation-react-native@workspace:packages/noise-cancellation-react-native"
   dependencies:
     "@stream-io/react-native-webrtc": "npm:145.0.0"
+    "@stream-io/typescript-config": "workspace:^"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
     react-native-builder-bob: "npm:^0.41.0"
     rimraf: "npm:^6.1.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@stream-io/react-native-webrtc": ^145.0.0
     react-native: "*"
@@ -7320,12 +7328,13 @@ __metadata:
     "@react-native-community/cli": "npm:20.1.3"
     "@react-native/babel-preset": "npm:0.85.3"
     "@stream-io/react-native-webrtc": "npm:145.0.0"
+    "@stream-io/typescript-config": "workspace:^"
     "@types/react": "npm:^19.2.15"
     del-cli: "npm:^6.0.0"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
     react-native-builder-bob: "npm:^0.41.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@react-native-firebase/app": ">=23.0.0"
     "@react-native-firebase/messaging": ">=23.0.0"
@@ -7351,13 +7360,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stream-io/stream-video-react-tutorial@workspace:sample-apps/react/stream-video-react-tutorial"
   dependencies:
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.2.15"
     "@types/react-dom": "npm:~19.2.3"
     "@vitejs/plugin-react": "npm:^6.0.2"
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
   languageName: unknown
   linkType: soft
@@ -7376,10 +7386,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stream-io/ts-quickstart@workspace:sample-apps/client/ts-quickstart"
   dependencies:
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-client": "workspace:^"
     "@vitejs/plugin-basic-ssl": "npm:^2.3.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
+  languageName: unknown
+  linkType: soft
+
+"@stream-io/typescript-config@workspace:^, @stream-io/typescript-config@workspace:packages/typescript-config":
+  version: 0.0.0-use.local
+  resolution: "@stream-io/typescript-config@workspace:packages/typescript-config"
   languageName: unknown
   linkType: soft
 
@@ -7396,8 +7413,10 @@ __metadata:
     "@stream-io/audio-filters-web": "workspace:^"
     "@stream-io/logger": "npm:^2.0.0"
     "@stream-io/node-sdk": "npm:^0.7.59"
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/worker-timer": "npm:^1.2.5"
     "@total-typescript/shoehorn": "npm:^0.1.2"
+    "@types/node": "npm:^25.9.3"
     "@types/sdp-transform": "npm:^2.15.0"
     "@types/ua-parser-js": "npm:^0.7.39"
     "@vitest/coverage-v8": "npm:^4.1.7"
@@ -7409,7 +7428,7 @@ __metadata:
     rollup: "npm:^4.60.4"
     rxjs: "npm:~7.8.2"
     sdp-transform: "npm:^2.15.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     ua-parser-js: "npm:^1.0.41"
     vitest: "npm:^4.1.7"
     vitest-mock-extended: "npm:^4.0.0"
@@ -7434,11 +7453,12 @@ __metadata:
   resolution: "@stream-io/video-filters-react-native@workspace:packages/video-filters-react-native"
   dependencies:
     "@stream-io/react-native-webrtc": "npm:145.0.0"
+    "@stream-io/typescript-config": "workspace:^"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
     react-native-builder-bob: "npm:^0.41.0"
     rimraf: "npm:^6.1.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@stream-io/react-native-webrtc": ^145.0.0
     react-native: "*"
@@ -7452,12 +7472,14 @@ __metadata:
     "@mediapipe/tasks-vision": "npm:^0.10.35"
     "@rollup/plugin-replace": "npm:^6.0.3"
     "@rollup/plugin-typescript": "npm:^12.3.0"
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/worker-timer": "npm:^1.2.5"
     "@types/dom-mediacapture-transform": "npm:^0.1.11"
     "@types/emscripten": "npm:^1.41.5"
+    "@types/node": "npm:^25.9.3"
     rimraf: "npm:^6.1.3"
     rollup: "npm:^4.60.4"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     wasm-feature-detect: "npm:^1.8.0"
   languageName: unknown
   linkType: soft
@@ -7479,7 +7501,7 @@ __metadata:
     lint-staged: "npm:^16.4.0"
     nx: "npm:^21.6.11"
     prettier: "npm:^3.8.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.60.0"
     vite: "npm:^8.0.14"
   dependenciesMeta:
@@ -7511,6 +7533,7 @@ __metadata:
   resolution: "@stream-io/video-react-bindings@workspace:packages/react-bindings"
   dependencies:
     "@rollup/plugin-typescript": "npm:^12.3.0"
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-client": "workspace:^"
     "@types/react": "npm:~19.2.15"
     i18next: "npm:^25.10.10"
@@ -7518,7 +7541,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     rollup: "npm:^4.60.4"
     rxjs: "npm:~7.8.2"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@stream-io/video-client": "workspace:^"
     react: ^17 || ^18 || ^19
@@ -7540,6 +7563,7 @@ __metadata:
     "@stream-io/video-styling": "workspace:^"
     "@types/geojson": "npm:^7946.0.16"
     "@types/mapbox-gl": "npm:^2.7.21"
+    "@types/node": "npm:^25.9.3"
     "@types/react": "npm:~19.2.15"
     "@types/react-dom": "npm:~19.2.3"
     "@types/yargs": "npm:^17.0.35"
@@ -7565,6 +7589,7 @@ __metadata:
     stream-chat: "npm:^9.44.2"
     stream-chat-react: "npm:^14.3.0"
     swr: "npm:^2.4.1"
+    typescript: "npm:^6.0.3"
     yargs: "npm:^18.0.0"
   languageName: unknown
   linkType: soft
@@ -7622,7 +7647,7 @@ __metadata:
     rxjs: "npm:~7.8.2"
     stream-chat: "npm:^9.44.2"
     stream-chat-react-native: "npm:^9.3.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7662,7 +7687,7 @@ __metadata:
     react-native-screens: "npm:4.25.2"
     react-native-svg: "npm:15.15.5"
     react-native-worklets: "npm:0.8.3"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7682,6 +7707,7 @@ __metadata:
     "@stream-io/noise-cancellation-react-native": "workspace:^"
     "@stream-io/react-native-callingx": "workspace:^"
     "@stream-io/react-native-webrtc": "npm:145.0.0"
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-client": "workspace:*"
     "@stream-io/video-filters-react-native": "workspace:^"
     "@stream-io/video-react-bindings": "workspace:*"
@@ -7689,6 +7715,7 @@ __metadata:
     "@testing-library/react-native": "npm:13.3.3"
     "@tsconfig/node18": "npm:^18.2.6"
     "@types/jest": "npm:^29.5.14"
+    "@types/node": "npm:^25.9.3"
     "@types/react": "npm:~19.2.15"
     "@types/react-test-renderer": "npm:^19.1.0"
     expo: "npm:~56.0.9"
@@ -7709,7 +7736,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     rxjs: "npm:~7.8.2"
     text-encoding-polyfill: "npm:0.6.7"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@react-native-community/netinfo": ">=9.0.0"
     "@react-native-firebase/app": ">=17.5.0"
@@ -7759,10 +7786,12 @@ __metadata:
     "@rollup/plugin-replace": "npm:^6.0.3"
     "@rollup/plugin-typescript": "npm:^12.3.0"
     "@stream-io/audio-filters-web": "workspace:^"
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-client": "workspace:*"
     "@stream-io/video-filters-web": "workspace:*"
     "@stream-io/video-react-bindings": "workspace:*"
     "@stream-io/video-styling": "workspace:^"
+    "@types/node": "npm:^25.9.3"
     "@types/react": "npm:~19.2.15"
     "@types/react-dom": "npm:~19.2.3"
     chart.js: "npm:^4.5.1"
@@ -7772,7 +7801,7 @@ __metadata:
     react-dom: "npm:19.2.3"
     rimraf: "npm:^6.1.3"
     rollup: "npm:^4.60.4"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
@@ -7799,6 +7828,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stream-io/zoom-clone-react@workspace:sample-apps/react/zoom-clone"
   dependencies:
+    "@stream-io/typescript-config": "workspace:^"
     "@stream-io/video-react-sdk": "workspace:^"
     "@types/react": "npm:~19.2.15"
     "@types/react-dom": "npm:~19.2.3"
@@ -7814,7 +7844,7 @@ __metadata:
     stream-chat: "npm:^9.44.2"
     stream-chat-react: "npm:^14.3.0"
     tailwindcss: "npm:^3.4.19"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
   languageName: unknown
   linkType: soft
@@ -8236,12 +8266,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:>=20.0.0":
-  version: 25.8.0
-  resolution: "@types/node@npm:25.8.0"
+"@types/node@npm:*, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:>=20.0.0, @types/node@npm:^25.9.3":
+  version: 25.9.3
+  resolution: "@types/node@npm:25.9.3"
   dependencies:
     undici-types: "npm:>=7.24.0 <7.24.7"
-  checksum: 10/1b1eb14c4f5294ff12de0c668c0ed786b377e2e878fe4c9f84e5219d06d0e2fbf9ea7d7a95077360d2ed1329f56e7a94afc65768fe9f3afdb6c95977f89eb2e2
+  checksum: 10/40c5f5c91450689b255dbf8cbd6cf0bb05e1013a353830b15eb9b5c9cda6448510be572d1ecadc38c8a4ac472e61381de9ae28df82094abece59f4c1eccffbc5
   languageName: node
   linkType: hard
 
@@ -22769,23 +22799,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
+  checksum: 10/0ef2357a4cffd916b52b683a021cdab0f81eea4e9aa35f2d254581c9a5106da02224e3392e1b0ed42b7a48f80c966e5f52b8e1a27941fa0523c1705a9c2e0330
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
+  checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9799,7 +9799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.6":
+"brace-expansion@npm:5.0.6, brace-expansion@npm:^5.0.5":
   version: 5.0.6
   resolution: "brace-expansion@npm:5.0.6"
   dependencies:
@@ -9824,15 +9824,6 @@ __metadata:
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10/c77a7a64aabf94b8d5913955adb4f36957917565374461355bb4276830c027a313d981f32410cea9e38f52573e7eb776d02fe05091c3a79a061958d97e4d2b43
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
   languageName: node
   linkType: hard
 
@@ -11558,21 +11549,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:1.4.5":
+"end-of-stream@npm:1.4.5, end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
   version: 1.4.5
   resolution: "end-of-stream@npm:1.4.5"
   dependencies:
     once: "npm:^1.4.0"
   checksum: 10/1e0cfa6e7f49887544e03314f9dfc56a8cb6dde910cbb445983ecc2ff426fc05946df9d75d8a21a3a64f2cecfe1bf88f773952029f46756b2ed64a24e95b1fb8
-  languageName: node
-  linkType: hard
-
-"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
-  version: 1.4.4
-  resolution: "end-of-stream@npm:1.4.4"
-  dependencies:
-    once: "npm:^1.4.0"
-  checksum: 10/530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
   languageName: node
   linkType: hard
 
@@ -22402,17 +22384,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:0.2.6":
+"tmp@npm:0.2.6, tmp@npm:^0.2.3":
   version: 0.2.6
   resolution: "tmp@npm:0.2.6"
   checksum: 10/4ba072821d65f6ec0ae680dd49261bcc66c96a5a463c80ca040747256238aaad68ad5db7aa8367dd1554d22aa77c2988bdb1c5556ecfc4df105f5b73206b7d9b
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.3":
-  version: 0.2.5
-  resolution: "tmp@npm:0.2.5"
-  checksum: 10/dd4b78b32385eab4899d3ae296007b34482b035b6d73e1201c4a9aede40860e90997a1452c65a2d21aee73d53e93cd167d741c3db4015d90e63b6d568a93d7ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 💡 Overview

Upgrades the monorepo to **TypeScript 6.0.3**, pins the compilation `target` / `module` / `lib` to **ES2022**, introduces a shared TypeScript config package, and raises the supported-browser floors.

### 📝 Implementation notes

**TypeScript 6.0.3** across all workspaces (root + packages + sample apps).

**ES2022 everywhere.** `target`, `module`, and `lib` are pinned to ES2022. The build does no transpilation (rollup / vite / Metro pass the TS output through), so `lib: esnext` would let post-ES2022 APIs type-check and then ship unpolyfilled, breaking the supported browsers. The pin already caught and replaced two real cases:

- `Set.difference` (ES2025) in `@stream-io/video-client`
- `Array.findLastIndex` (ES2023) in the `react-dogfood` sample

**Shared config.** New private `@stream-io/typescript-config` (`base` + `library-web` + `library-rn` + `app-web`), adopted by the 9 libraries and 8 sample apps. Removes ~16 duplicated compiler options per package and fixes the drift it surfaced (mixed `esModuleInterop`, `jsx`, `moduleResolution`). `react-dogfood` (Next.js) stays on its own Next-managed tsconfig but follows the ES2022 `lib` pin.

**TS 6.0 deprecations migrated, not suppressed:**

- `moduleResolution: "node"` (node10) to `"bundler"`
- `esModuleInterop: false` to `true`
- explicit `rootDir` for the `react-native-builder-bob` `.d.ts` builds (TS 6.0 requires it)
- `@types/node` + `types: ["node"]` where Node globals are used (TS 6.0 dropped `@types` auto-inclusion)

**Supported browsers** (`isSupportedBrowser`): Chrome / Edge / Android WebView 136, Firefox 137, Safari 18. iOS WebKit engine floor unchanged at 605.

**React Native:** `jsx: "react-native"`; `ReturnType<typeof setTimeout | setInterval>` instead of `NodeJS.Timeout`; `globalThis` instead of `global`.

Also includes the strict-flag fixes (e.g. explicit returns for `noImplicitReturns`) that accompany the shared base's stricter compiler options, and quarantines one flaky live-backend ringing integration test.

**Verification.** `NODE_ENV=production yarn build:all`, `yarn lint:ci:all`, and `yarn test:react-native:sdk` all pass. `yarn test:ci:client` passes except a pre-existing flaky live-backend integration test (`api.test.ts > query calls`, a 504 from the backend).

**Deliberate follow-ups (out of scope):** `verbatimModuleSyntax` and `noUncheckedIndexedAccess` sweeps for the web packages (measured at roughly 400-700 and 100-200 fixes respectively; better as standalone PRs).

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/1375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability around connection outcomes and mute behavior when no target users are available.
  * Refined SDP codec filtering to match the intended `fmtp` profile rules more consistently.

* **Tests**
  * Updated browser support coverage to match new supported/unsupported version thresholds.

* **Chores**
  * Updated build output to ES2022.
  * Upgraded TypeScript tooling to 6.0.3 and standardized shared TypeScript configuration across packages.
  * Adjusted browser support checks (Chrome/Edge 136+, Firefox 137+, Safari 18+, Android WebView 136+).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->