### PR TITLE
fix(client): avoid SFU socket close when online fires without offline recovery

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -2057,6 +2057,7 @@ export class Call {
           this.sfuStatsReporter?.stop();
           this.state.setCallingState(CallingState.OFFLINE);
         } else {
+          if (!this.networkAvailableTask) return;
           this.logger.debug('[Reconnect] Going online');
           this.sfuClient?.close(
             StreamSfuClient.DISPOSE_OLD_SOCKET,


### PR DESCRIPTION
### 💡 Overview
This PR fixes an issue where a `network: online` event could close the SFU WebSocket even though the call had not entered offline recovery. This can happen when `network: offline` fires before the call has successfully joined, so no networkAvailableTask is created. When `network: online` later fires, the SDK should ignore it instead of closing the active SFU socket with `4100`.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1014/network-change-closes-sfu-socket

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network reconnection handling to prevent unnecessary operations when transitioning back online, ensuring more reliable connectivity restoration during network changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->