### PR TITLE
fix(react-bindings): declare @stream-io/video-client as a runtime dependency

### DIFF
--- a/packages/react-bindings/package.json
+++ b/packages/react-bindings/package.json
@@ -26,16 +26,15 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
+    "@stream-io/video-client": "workspace:*",
     "i18next": "^25.10.10",
     "rxjs": "~7.8.2"
   },
   "peerDependencies": {
-    "@stream-io/video-client": "workspace:^",
     "react": "^17 || ^18 || ^19"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.3.0",
-    "@stream-io/video-client": "workspace:^",
     "@types/react": "~19.2.15",
     "react": "19.2.3",
     "rimraf": "^6.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7511,7 +7511,7 @@ __metadata:
   resolution: "@stream-io/video-react-bindings@workspace:packages/react-bindings"
   dependencies:
     "@rollup/plugin-typescript": "npm:^12.3.0"
-    "@stream-io/video-client": "workspace:^"
+    "@stream-io/video-client": "workspace:*"
     "@types/react": "npm:~19.2.15"
     i18next: "npm:^25.10.10"
     react: "npm:19.2.3"
@@ -7520,7 +7520,6 @@ __metadata:
     rxjs: "npm:~7.8.2"
     typescript: "npm:^5.9.3"
   peerDependencies:
-    "@stream-io/video-client": "workspace:^"
     react: ^17 || ^18 || ^19
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### 💡 Overview

`@stream-io/video-react-bindings` imports `@stream-io/video-client` at runtime, but the package only declared it under `peerDependencies` and `devDependencies`; it was missing from `dependencies`. This declares it as a regular `workspace:*` runtime dependency.

### 📝 Implementation notes

- Added `@stream-io/video-client: "workspace:*"` to `dependencies`.
- Removed the redundant `@stream-io/video-client` entries from `peerDependencies` and `devDependencies`.
- Matches how `@stream-io/video-react-sdk` and `@stream-io/video-react-native-sdk` already declare `@stream-io/video-client`.
- `yarn.lock` updated accordingly; no new peer-dependency warnings (verified via `yarn explain peer-requirements`).

🎫 Ticket: N/A

📑 Docs: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal package dependencies to improve installation and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->