### PR TITLE
fix(client): don't tear down the SFU socket on a network blip during an in-flight reconnect

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -2093,10 +2093,17 @@ export class Call {
         } else {
           if (!this.networkAvailableTask) return;
           this.logger.debug('[Reconnect] Going online');
-          this.sfuClient?.close(
-            StreamSfuClient.DISPOSE_OLD_SOCKET,
-            'Closing WS to reconnect after going online',
-          );
+          // Only discard the socket when no reconnect is already in flight. A
+          // running reconnect owns the SFU-client lifecycle (`doJoin` closes
+          // the previous client once the new session is up). Closing here would
+          // tear down the socket it's mid-join on, leaving the in-flight rejoin
+          // to spin on SIGNAL_LOST.
+          if (!hasPending(this.reconnectConcurrencyTag)) {
+            this.sfuClient?.close(
+              StreamSfuClient.DISPOSE_OLD_SOCKET,
+              'Closing WS to reconnect after going online',
+            );
+          }
           // we went online, release the previous waiters and reset the state
           this.networkAvailableTask?.resolve();
           this.networkAvailableTask = undefined;


### PR DESCRIPTION
### 💡 Overview
This PR fixes an issue where a network offline / online transition could interfere with an ongoing SFU reconnect. In some cases, the network recovery handler would close the newly created SFU signaling socket while the rejoin was still in progress. The fix ensures the socket is only closed when no reconnect is already running, allowing the reconnect flow to manage the SFU client lifecycle correctly.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1014/network-change-closes-sfu-socket

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket reconnection handling when returning online to prevent unnecessary disconnections when a reconnect is already in progress, resulting in more reliable connection stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->