### PR TITLE
fix(client): omit client telemetry events for unregistered calls

### DIFF
--- a/packages/client/src/reporting/ClientEventReporter.ts
+++ b/packages/client/src/reporting/ClientEventReporter.ts
@@ -219,7 +219,7 @@ export class ClientEventReporter {
       joinAttemptIdSnapshot: this.joinAttemptIds.get(cid),
     };
 
-    this.send({
+    this.sendForCall(cid, {
       ...this.buildCommon(cid, 'MediaDevicePermission', pair),
       ...this.sessionIdField(cid),
       microphone_permission_status: readPermissionStatus(
@@ -322,7 +322,7 @@ export class ClientEventReporter {
     };
 
     const resolvedSfuId = this.getSfuId(cid);
-    this.send({
+    this.sendForCall(cid, {
       ...this.buildCommon(cid, stage, pair),
       ...this.sessionIdField(cid),
       ...(resolvedSfuId && { sfu_id: resolvedSfuId }),
@@ -395,7 +395,7 @@ export class ClientEventReporter {
     const coordinatorConnectId = this.coordinatorConnectId;
     const ctx = this.callContexts.get(cid);
 
-    this.send({
+    this.sendForCall(cid, {
       user_id: this.streamClient.userID || this.coordinatorConnectUserId,
       type: ctx?.callType,
       id: ctx?.callId,
@@ -454,7 +454,7 @@ export class ClientEventReporter {
         joinReasonSnapshot: this.joinReasons.get(cid),
       };
       this.coordinatorPairs.set(cid, pair);
-      this.send({
+      this.sendForCall(cid, {
         ...this.buildCommon(cid, 'CoordinatorJoin', pair),
         ...(pair.joinReasonSnapshot && {
           join_reason: pair.joinReasonSnapshot,
@@ -469,7 +469,7 @@ export class ClientEventReporter {
   private succeedCoordinator = (cid: string) => {
     const pair = this.coordinatorPairs.get(cid);
     if (!pair) return;
-    this.send({
+    this.sendForCall(cid, {
       ...this.buildCommon(cid, 'CoordinatorJoin', pair),
       ...this.sessionIdField(cid),
       ...(pair.joinReasonSnapshot && { join_reason: pair.joinReasonSnapshot }),
@@ -488,7 +488,7 @@ export class ClientEventReporter {
       return;
     }
     const { reason, code } = pair.lastError;
-    this.send({
+    this.sendForCall(cid, {
       ...this.buildCommon(cid, 'CoordinatorJoin', pair),
       ...this.sessionIdField(cid),
       ...(pair.joinReasonSnapshot && { join_reason: pair.joinReasonSnapshot }),
@@ -513,7 +513,7 @@ export class ClientEventReporter {
       };
       this.wsPairs.set(cid, pair);
       const sfuId = this.getSfuId(cid);
-      this.send({
+      this.sendForCall(cid, {
         ...this.buildCommon(cid, 'WSJoin', pair),
         ...this.sessionIdField(cid),
         ...(sfuId && { sfu_id: sfuId }),
@@ -529,7 +529,7 @@ export class ClientEventReporter {
     const pair = this.wsPairs.get(cid);
     if (!pair) return;
     const sfuId = this.getSfuId(cid);
-    this.send({
+    this.sendForCall(cid, {
       ...this.buildCommon(cid, 'WSJoin', pair),
       ...this.sessionIdField(cid),
       ...(sfuId && { sfu_id: sfuId }),
@@ -552,7 +552,7 @@ export class ClientEventReporter {
     const { reason, code } = pair.lastError;
     const sfuId = this.getSfuId(cid);
 
-    this.send({
+    this.sendForCall(cid, {
       ...this.buildCommon(cid, 'WSJoin', pair),
       ...this.sessionIdField(cid),
       event_type: 'completed',
@@ -627,7 +627,7 @@ export class ClientEventReporter {
     };
     this.peerConnectionPairs.set(key, pair);
 
-    this.send({
+    this.sendForCall(cid, {
       ...this.buildCommon(cid, 'PeerConnectionConnect', pair),
       ...this.sessionIdField(cid),
       peer_connection: role,
@@ -648,7 +648,7 @@ export class ClientEventReporter {
     const pair = this.peerConnectionPairs.get(key);
     if (!pair) return;
 
-    this.send({
+    this.sendForCall(cid, {
       ...this.buildCommon(cid, 'PeerConnectionConnect', pair),
       ...this.sessionIdField(cid),
       peer_connection: role,
@@ -676,7 +676,7 @@ export class ClientEventReporter {
     const pair = this.peerConnectionPairs.get(key);
     if (!pair) return;
 
-    this.send({
+    this.sendForCall(cid, {
       ...this.buildCommon(cid, 'PeerConnectionConnect', pair),
       ...this.sessionIdField(cid),
       peer_connection: role,
@@ -736,6 +736,11 @@ export class ClientEventReporter {
   private send = (body: Record<string, unknown>) => {
     if (!this.enabled) return;
     void this.sendWithRetry(body);
+  };
+
+  private sendForCall = (cid: string, body: Record<string, unknown>) => {
+    if (!this.callContexts.has(cid)) return;
+    this.send(body);
   };
 
   private sendWithRetry = async (

--- a/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
+++ b/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
@@ -617,6 +617,58 @@ describe('ClientEventReporter', () => {
     expect(ws1.every((e) => e.sfu_id === 'sfu-1')).toBe(true);
     expect(ws2.every((e) => e.sfu_id === 'sfu-2')).toBe(true);
   });
+
+  describe('drops events for an unregistered call', () => {
+    it('does not emit stage events after the call is unregistered', async () => {
+      reporter.startCorrelation(cid, 'first-attempt');
+      reporter.unregisterCall(cid);
+      await flush();
+      doAxiosRequest.mockClear();
+
+      await reporter.track(cid, 'WSJoin', () => Promise.resolve('ok'));
+      reporter.reportFirstFrame(cid, TrackType.VIDEO, 'track-1');
+      await flush();
+
+      expect(doAxiosRequest).not.toHaveBeenCalled();
+    });
+
+    it('does not emit a stage completion when unregistered mid-flight', async () => {
+      reporter.startCorrelation(cid, 'first-attempt');
+      await flush();
+      doAxiosRequest.mockClear();
+
+      await reporter.track(cid, 'WSJoin', async () => {
+        reporter.unregisterCall(cid);
+        return 'ok';
+      });
+      await flush();
+
+      const completed = postedEvents().filter(
+        (e) => e.stage === 'WSJoin' && e.event_type === 'completed',
+      );
+      expect(completed).toHaveLength(0);
+    });
+
+    it('does not emit JoinInitiated for an unregistered call', async () => {
+      reporter.unregisterCall(cid);
+      reporter.startCorrelation(cid, 'first-attempt');
+      await flush();
+
+      const joinInitiated = postedEvents().filter(
+        (e) => e.stage === 'JoinInitiated',
+      );
+      expect(joinInitiated).toHaveLength(0);
+    });
+
+    it('still emits CoordinatorWS events (connection-scoped, not call-gated)', async () => {
+      reporter.unregisterCall(cid);
+      await reporter.trackCoordinatorWs(() => Promise.resolve('ok'));
+      await flush();
+
+      const ws = postedEvents().filter((e) => e.stage === 'CoordinatorWS');
+      expect(ws.length).toBeGreaterThan(0);
+    });
+  });
 });
 
 describe('ClientEventReporter (disabled)', () => {


### PR DESCRIPTION
### 💡 Overview

This PR fixes an issue where the client event reporter emits telemetry for a call that is no longer registered, producing events the backend rejects (400, code 4: type is required / join_attempt_id is required). When `leave()` races an in-flight join, the join flow keeps running after the call has been unregistered from the reporter. It then calls back into the reporter even though the call's context was already gone. 

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1012/call-event-reporting-callleave-unregisters-the-call-from-the-reporting

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented certain call-related events from being sent after a call has ended or been removed, reducing spurious reporting.
  * Improved consistency of event delivery so only active calls continue to emit call-scoped updates.
  * Preserved connection-level reporting where appropriate, even if the associated call is no longer active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->