### PR TITLE
fix(client): reliably deliver delta-compressed WebRTC stats

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -740,7 +740,9 @@ export class Call {
 
       const leaveReason = message ?? reason ?? 'user is leaving the call';
       this.tracer.trace('call.leaveReason', leaveReason);
-      this.sfuStatsReporter?.flush();
+      // await the final sample so it's captured from the still-live peer
+      // connections (disposed below); the send itself stays best-effort.
+      await this.sfuStatsReporter?.flush();
       this.sfuStatsReporter?.stop();
       this.sfuStatsReporter = undefined;
       this.lastStatsOptions = undefined;
@@ -1506,6 +1508,11 @@ export class Call {
       enable_rtc_stats: enableTracing,
       reporting_interval_ms: reportingIntervalMs,
     } = statsOptions;
+    // Flush the previous reporter's final sample while its peer connections are
+    // still alive, before we dispose them below. Awaits only the sampling step.
+    await this.sfuStatsReporter?.flush();
+    this.sfuStatsReporter?.stop();
+    this.sfuStatsReporter = undefined;
     if (closePreviousInstances && this.subscriber) {
       await this.subscriber.dispose();
     }
@@ -1568,8 +1575,6 @@ export class Call {
     }
 
     this.tracer.setEnabled(enableTracing);
-    this.sfuStatsReporter?.flush();
-    this.sfuStatsReporter?.stop();
     if (statsOptions?.reporting_interval_ms > 0) {
       this.sfuStatsReporter = new SfuStatsReporter(sfuClient, {
         clientDetails,

--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -346,7 +346,7 @@ export abstract class BasePeerConnection {
         // Sample stats into the delivery chain at connect/fail. The reporter
         // ships and commits the un-acked chain, so we must not trace the delta
         // separately here (that would double-send it and corrupt the chain).
-        await this.stats.get();
+        await this.stats.takeSample();
       } catch (err) {
         this.tracer.trace('getstatsOnFailure', (err as Error).toString());
       }

--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -343,8 +343,10 @@ export abstract class BasePeerConnection {
     });
     if (this.tracer && (state === 'connected' || state === 'failed')) {
       try {
-        const stats = await this.stats.get();
-        this.tracer.trace('getstats', stats.delta);
+        // Sample stats into the delivery chain at connect/fail. The reporter
+        // ships and commits the un-acked chain, so we must not trace the delta
+        // separately here (that would double-send it and corrupt the chain).
+        await this.stats.get();
       } catch (err) {
         this.tracer.trace('getstatsOnFailure', (err as Error).toString());
       }

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -162,14 +162,17 @@ export class SfuStatsReporter {
   };
 
   /**
-   * Samples both peer connections. Each `StatsTracer.get()` is serialized
+   * Samples both peer connections. Each `StatsTracer.takeSample()` is serialized
    * internally, so this is safe even if it overlaps another sample (e.g. the
    * connection-state-change handler). Kept separate from `send()` so an
    * explicit flush can capture the sample from live peer connections before
    * they are disposed, without waiting for an in-flight send.
    */
   private sample = (): Promise<[ComputedStats, ComputedStats | undefined]> =>
-    Promise.all([this.subscriber.stats.get(), this.publisher?.stats.get()]);
+    Promise.all([
+      this.subscriber.stats.takeSample(),
+      this.publisher?.stats.takeSample(),
+    ]);
 
   private send = (
     subscriberStats: ComputedStats,

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -6,6 +6,7 @@ import { ComputedStats, PendingDelta, Tracer, TraceRecord } from './rtc';
 import { flatten, getSdkName, getSdkVersion } from './utils';
 import { getDeviceState, getWebRTCInfo } from '../helpers/client-details';
 import { hasPending, withoutConcurrency } from '../helpers/concurrency';
+import { timeboxed } from '../coordinator/connection/utils';
 import {
   ClientDetails,
   InputDevices,
@@ -314,18 +315,25 @@ export class SfuStatsReporter {
   };
 
   /**
-   * Explicit/final flush (leave, migration, re-init). Awaits only the fast
-   * sampling step so callers can capture the final sample from live peer
-   * connections before disposing of them, then fires the send-best-effort. The
-   * returned promise resolves once the sample is taken, not when the sending
-   * completes. No-op once the reporter has been stopped.
+   * Explicit/final flush (leave, migration, re-init). Time-boxes the sampling
+   * step and swallows its failures, so a slow or failing `getStats()` on a
+   * degraded or closing peer connection can never block or reject call teardown
+   * or reconnect setup. On a successful sample it fires the send best-effort;
+   * the returned promise resolves once the sample is taken (or the time-box
+   * elapses / sampling fails), never when the sending completes. No-op once the
+   * reporter has been stopped.
    */
   flush = async (): Promise<void> => {
     if (this.isStopped) return;
-    const [subscriberStats, publisherStats] = await this.sample();
-    this.send(subscriberStats, publisherStats).catch((err) => {
-      this.logger.warn('Failed to flush report stats', err);
-    });
+    try {
+      const [sample] = await timeboxed([this.sample()], 2000);
+      const [subscriberStats, publisherStats] = sample;
+      this.send(subscriberStats, publisherStats).catch((err) => {
+        this.logger.warn('Failed to flush report stats', err);
+      });
+    } catch (err) {
+      this.logger.warn('Failed to sample stats for the final flush', err);
+    }
   };
 
   /**

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -2,9 +2,10 @@ import { combineLatest } from 'rxjs';
 import { StreamSfuClient } from '../StreamSfuClient';
 import { OwnCapability, StatsOptions } from '../gen/coordinator';
 import { Publisher, Subscriber } from '../rtc';
-import { Tracer, TraceRecord } from './rtc';
+import { ComputedStats, PendingDelta, Tracer, TraceRecord } from './rtc';
 import { flatten, getSdkName, getSdkVersion } from './utils';
 import { getDeviceState, getWebRTCInfo } from '../helpers/client-details';
+import { hasPending, withoutConcurrency } from '../helpers/concurrency';
 import {
   ClientDetails,
   InputDevices,
@@ -51,6 +52,8 @@ export class SfuStatsReporter {
   private readonly sdkVersion: string;
   private readonly webRTCVersion: string;
   private readonly inputDevices = new Map<'mic' | 'camera', InputDevices>();
+  private readonly statsConcurrencyTag = Symbol('sfuStatsReporter');
+  private isStopped = false;
 
   constructor(
     sfuClient: StreamSfuClient,
@@ -158,69 +161,122 @@ export class SfuStatsReporter {
     });
   };
 
+  /**
+   * Samples both peer connections. Each `StatsTracer.get()` is serialized
+   * internally, so this is safe even if it overlaps another sample (e.g. the
+   * connection-state-change handler). Kept separate from `send()` so an
+   * explicit flush can capture the sample from live peer connections before
+   * they are disposed, without waiting for an in-flight send.
+   */
+  private sample = (): Promise<[ComputedStats, ComputedStats | undefined]> =>
+    Promise.all([this.subscriber.stats.get(), this.publisher?.stats.get()]);
+
+  private send = (
+    subscriberStats: ComputedStats,
+    publisherStats: ComputedStats | undefined,
+    telemetry?: Telemetry,
+  ) => {
+    // serialize sends so overlapping ones can't race on the trace buffers or
+    // deliver an older delta after a newer one already succeeded. Not gated by
+    // `isStopped`: an explicit final flush must still deliver after stop().
+    return withoutConcurrency(this.statsConcurrencyTag, async () => {
+      // The delta chain is delivered only when delta tracing is enabled
+      // (the peer-connection tracer exists). Otherwise we drop the chain so it
+      // can't grow unbounded.
+      const subTracer = this.subscriber.tracer;
+      const pubTracer = this.publisher?.tracer;
+      let subPending: PendingDelta[] = [];
+      if (subTracer) {
+        subPending = this.subscriber.stats.getPendingDeltas();
+      } else {
+        this.subscriber.stats.clearPendingDeltas();
+      }
+      let pubPending: PendingDelta[] = [];
+      if (pubTracer && publisherStats) {
+        pubPending = this.publisher?.stats.getPendingDeltas() ?? [];
+      } else {
+        this.publisher?.stats.clearPendingDeltas();
+      }
+
+      const subscriberTrace = subTracer?.take();
+      const publisherTrace = pubTracer?.take();
+      const tracer = this.tracer.take();
+      const sfuTrace = this.sfuClient.getTrace();
+      const traces: TraceRecord[] = [
+        ...tracer.snapshot,
+        ...(sfuTrace?.snapshot ?? []),
+        ...(publisherTrace?.snapshot ?? []),
+        ...(subscriberTrace?.snapshot ?? []),
+        ...toGetStatsRecords(subPending, subTracer?.traceId),
+        ...toGetStatsRecords(pubPending, pubTracer?.traceId),
+      ];
+
+      try {
+        const { response } = await this.sfuClient.sendStats({
+          sdk: this.sdkName,
+          sdkVersion: this.sdkVersion,
+          webrtcVersion: this.webRTCVersion,
+          subscriberStats: JSON.stringify(flatten(subscriberStats.stats)),
+          publisherStats: publisherStats
+            ? JSON.stringify(flatten(publisherStats.stats))
+            : '[]',
+          subscriberRtcStats: '',
+          publisherRtcStats: '',
+          rtcStats: JSON.stringify(traces),
+          encodeStats: publisherStats?.performanceStats ?? [],
+          decodeStats: subscriberStats.performanceStats,
+          audioDevices: this.inputDevices.get('mic'),
+          videoDevices: this.inputDevices.get('camera'),
+          unifiedSessionId: this.unifiedSessionId,
+          deviceState: getDeviceState(),
+          telemetry,
+        });
+        // An SFU application-layer error means the stats were not accepted.
+        // Treat it like a transport failure: retain the chain and roll back the
+        // RTC traces (handled by the catch below) instead of committing.
+        if (response?.error) {
+          throw new Error(`SFU rejected stats: ${response.error.message}`);
+        }
+        // delivery confirmed: advance the delivery baseline for each chain.
+        if (subTracer) this.subscriber.stats.commitDeltas(subPending);
+        if (pubTracer && publisherStats) {
+          this.publisher?.stats.commitDeltas(pubPending);
+        }
+      } catch (err) {
+        // keep the delta chains (re-sent next interval); only the append-only
+        // RTC event traces are rolled back so they aren't lost.
+        publisherTrace?.rollback();
+        subscriberTrace?.rollback();
+        tracer.rollback();
+        sfuTrace?.rollback();
+        throw err;
+      }
+    });
+  };
+
+  /**
+   * Samples and sends one report. Used by the scheduler and the telemetry path.
+   * Bails if the reporter has been stopped so it never samples disposed peer
+   * connections.
+   */
   private run = async (telemetry?: Telemetry) => {
-    const [subscriberStats, publisherStats] = await Promise.all([
-      this.subscriber.stats.get(),
-      this.publisher?.stats.get(),
-    ]);
-
-    this.subscriber.tracer?.trace('getstats', subscriberStats.delta);
-    if (publisherStats) {
-      this.publisher?.tracer?.trace('getstats', publisherStats.delta);
-    }
-
-    const subscriberTrace = this.subscriber.tracer?.take();
-    const publisherTrace = this.publisher?.tracer?.take();
-    const tracer = this.tracer.take();
-    const sfuTrace = this.sfuClient.getTrace();
-    const traces: TraceRecord[] = [
-      ...tracer.snapshot,
-      ...(sfuTrace?.snapshot ?? []),
-      ...(publisherTrace?.snapshot ?? []),
-      ...(subscriberTrace?.snapshot ?? []),
-    ];
-
-    try {
-      await this.sfuClient.sendStats({
-        sdk: this.sdkName,
-        sdkVersion: this.sdkVersion,
-        webrtcVersion: this.webRTCVersion,
-        subscriberStats: JSON.stringify(flatten(subscriberStats.stats)),
-        publisherStats: publisherStats
-          ? JSON.stringify(flatten(publisherStats.stats))
-          : '[]',
-        subscriberRtcStats: '',
-        publisherRtcStats: '',
-        rtcStats: JSON.stringify(traces),
-        encodeStats: publisherStats?.performanceStats ?? [],
-        decodeStats: subscriberStats.performanceStats,
-        audioDevices: this.inputDevices.get('mic'),
-        videoDevices: this.inputDevices.get('camera'),
-        unifiedSessionId: this.unifiedSessionId,
-        deviceState: getDeviceState(),
-        telemetry,
-      });
-    } catch (err) {
-      publisherTrace?.rollback();
-      subscriberTrace?.rollback();
-      tracer.rollback();
-      sfuTrace?.rollback();
-      throw err;
-    }
+    if (this.isStopped) return;
+    const [subscriberStats, publisherStats] = await this.sample();
+    await this.send(subscriberStats, publisherStats, telemetry);
   };
 
   private scheduleNextReport = () => {
     const intervals = [1500, 3000, 3000, 5000];
     if (this.reportCount < intervals.length) {
       this.timeoutId = setTimeout(() => {
-        this.flush();
+        this.scheduledFlush();
         this.reportCount++;
         this.scheduleNextReport();
       }, intervals[this.reportCount]);
     } else {
       clearInterval(this.intervalId);
       this.intervalId = setInterval(() => {
-        this.flush();
+        this.scheduledFlush();
       }, this.options.reporting_interval_ms);
     }
   };
@@ -231,6 +287,7 @@ export class SfuStatsReporter {
     this.observeDevice(this.microphone, 'mic');
     this.observeDevice(this.camera, 'camera');
 
+    this.isStopped = false;
     this.reportCount = 0;
     clearInterval(this.intervalId);
     clearTimeout(this.timeoutId);
@@ -239,6 +296,7 @@ export class SfuStatsReporter {
   };
 
   stop = () => {
+    this.isStopped = true;
     this.unsubscribeDevicePermissionsSubscription?.();
     this.unsubscribeDevicePermissionsSubscription = undefined;
     this.unsubscribeListDevicesSubscription?.();
@@ -252,9 +310,40 @@ export class SfuStatsReporter {
     this.reportCount = 0;
   };
 
-  flush = () => {
+  /**
+   * Explicit/final flush (leave, migration, re-init). Awaits only the fast
+   * sampling step so callers can capture the final sample from live peer
+   * connections before disposing of them, then fires the send-best-effort. The
+   * returned promise resolves once the sample is taken, not when the sending
+   * completes. No-op once the reporter has been stopped.
+   */
+  flush = async (): Promise<void> => {
+    if (this.isStopped) return;
+    const [subscriberStats, publisherStats] = await this.sample();
+    this.send(subscriberStats, publisherStats).catch((err) => {
+      this.logger.warn('Failed to flush report stats', err);
+    });
+  };
+
+  /**
+   * Flush entry for the periodic scheduler. Skips when the reporter is stopped
+   * or a send is already in flight so ticks can't pile up under slow sends (the
+   * next sample's delta spans the skipped interval).
+   */
+  private scheduledFlush = () => {
+    if (this.isStopped || hasPending(this.statsConcurrencyTag)) return;
     this.run().catch((err) => {
       this.logger.warn('Failed to flush report stats', err);
     });
   };
 }
+
+/**
+ * Wraps un-acked, delta-compressed samples into the legacy `getstats` trace
+ * record shape so the chain rides inside `rtcStats`, wire-compatible with the
+ * server's existing decoder.
+ */
+const toGetStatsRecords = (
+  pending: PendingDelta[],
+  id: string | null = null,
+): TraceRecord[] => pending.map(({ delta, ts }) => ['getstats', id, delta, ts]);

--- a/packages/client/src/stats/SfuStatsReporter.ts
+++ b/packages/client/src/stats/SfuStatsReporter.ts
@@ -211,8 +211,8 @@ export class SfuStatsReporter {
         ...(sfuTrace?.snapshot ?? []),
         ...(publisherTrace?.snapshot ?? []),
         ...(subscriberTrace?.snapshot ?? []),
-        ...toGetStatsRecords(subPending, subTracer?.traceId),
-        ...toGetStatsRecords(pubPending, pubTracer?.traceId),
+        ...toGetStatsRecords(subPending, subTracer?.id),
+        ...toGetStatsRecords(pubPending, pubTracer?.id),
       ];
 
       try {

--- a/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
+++ b/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
@@ -148,6 +148,38 @@ describe('SfuStatsReporter delta delivery', () => {
     expect(resolved).toBe(true); // resolves after the sample, not the send
   });
 
+  it('does not reject (and skips the send) when the final sample fails', async () => {
+    const t = build();
+    t.subStats.takeSample.mockRejectedValue(new Error('getStats failed'));
+
+    await expect(t.reporter.flush()).resolves.toBeUndefined();
+    expect(t.sendStats).not.toHaveBeenCalled();
+  });
+
+  it('does not block teardown when the final sample hangs past the time-box', async () => {
+    vi.useFakeTimers();
+    try {
+      const t = build();
+      // sampling never settles (e.g. getStats() wedged on a closing connection)
+      t.subStats.takeSample.mockReturnValue(
+        promiseWithResolvers<object>().promise,
+      );
+
+      let settled = false;
+      const flushed = t.reporter.flush().then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(2000); // time-box elapses
+      await flushed;
+
+      expect(settled).toBe(true);
+      expect(t.sendStats).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('samples on an explicit flush even while a previous send is in flight', async () => {
     const t = build();
     const d = promiseWithResolvers<object>();

--- a/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
+++ b/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
@@ -9,8 +9,7 @@ const okResponse = { response: {} };
 const makeSlice = () => ({ snapshot: [] as unknown[], rollback: vi.fn() });
 
 const makeStats = (pending: Array<{ delta: object; ts: number }>) => ({
-  get: vi.fn().mockResolvedValue({
-    delta: {},
+  takeSample: vi.fn().mockResolvedValue({
     performanceStats: [],
     stats: new Map(),
   }),
@@ -133,7 +132,7 @@ describe('SfuStatsReporter delta delivery', () => {
   it('flush() resolves once the sample is taken, without awaiting the send', async () => {
     const t = build();
     const dGet = promiseWithResolvers<object>();
-    t.subStats.get.mockReturnValue(dGet.promise); // sampling hangs
+    t.subStats.takeSample.mockReturnValue(dGet.promise); // sampling hangs
     t.sendStats.mockReturnValue(promiseWithResolvers<object>().promise); // send would hang too
 
     let resolved = false;
@@ -158,7 +157,7 @@ describe('SfuStatsReporter delta delivery', () => {
     await vi.waitFor(() => expect(t.sendStats).toHaveBeenCalledTimes(1));
 
     await t.reporter.flush(); // flush #2: must sample now, not wait for send #1
-    expect(t.subStats.get).toHaveBeenCalledTimes(2);
+    expect(t.subStats.takeSample).toHaveBeenCalledTimes(2);
 
     d.resolve(okResponse);
   });
@@ -167,7 +166,7 @@ describe('SfuStatsReporter delta delivery', () => {
     const t = build();
     t.reporter.stop();
     await t.reporter.flush();
-    expect(t.subStats.get).not.toHaveBeenCalled();
+    expect(t.subStats.takeSample).not.toHaveBeenCalled();
   });
 
   it('skips overlapping scheduled reports while a run is in flight', async () => {
@@ -179,10 +178,10 @@ describe('SfuStatsReporter delta delivery', () => {
 
       t.reporter.start();
       await vi.advanceTimersByTimeAsync(1500); // first scheduled tick -> run in flight
-      expect(t.subStats.get).toHaveBeenCalledTimes(1);
+      expect(t.subStats.takeSample).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(3000); // next tick must be skipped
-      expect(t.subStats.get).toHaveBeenCalledTimes(1);
+      expect(t.subStats.takeSample).toHaveBeenCalledTimes(1);
 
       d.resolve(okResponse);
       t.reporter.stop();

--- a/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
+++ b/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BehaviorSubject } from 'rxjs';
+import { SfuStatsReporter } from '../SfuStatsReporter';
+
+// A FinishedUnaryCall-shaped success (no application-layer error).
+const okResponse = { response: {} };
+
+const deferred = <T>() => {
+  let resolve!: (v: T) => void;
+  let reject!: (e?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const makeSlice = () => ({ snapshot: [] as unknown[], rollback: vi.fn() });
+
+const makeStats = (pending: Array<{ delta: object; ts: number }>) => ({
+  get: vi.fn().mockResolvedValue({
+    delta: {},
+    performanceStats: [],
+    stats: new Map(),
+  }),
+  getPendingDeltas: vi.fn(() => pending),
+  commitDeltas: vi.fn(),
+  clearPendingDeltas: vi.fn(),
+});
+
+const makeTracer = (id: string) => ({
+  take: vi.fn(makeSlice),
+  trace: vi.fn(),
+  traceId: id,
+});
+
+const build = (opts: { withTracer?: boolean; withPublisher?: boolean } = {}) => {
+  const withTracer = opts.withTracer ?? true;
+  const subPending = [{ delta: { sub: 1 }, ts: 111 }];
+  const pubPending = [{ delta: { pub: 1 }, ts: 222 }];
+
+  const subStats = makeStats(subPending);
+  const subTracer = withTracer ? makeTracer('sub-id') : undefined;
+  const subscriber = { stats: subStats, tracer: subTracer };
+
+  let publisher: unknown;
+  let pubStats: ReturnType<typeof makeStats> | undefined;
+  if (opts.withPublisher) {
+    pubStats = makeStats(pubPending);
+    publisher = {
+      stats: pubStats,
+      tracer: withTracer ? makeTracer('pub-id') : undefined,
+    };
+  }
+
+  const sendStats = vi.fn().mockResolvedValue(okResponse);
+  const sfuClient = { sendStats, getTrace: vi.fn(() => undefined) };
+  const callTracer = { take: vi.fn(makeSlice), setEnabled: vi.fn() };
+
+  // device permission is 'denied' so observeDevice() doesn't reach listDevices()
+  const microphone = { state: { browserPermissionState$: new BehaviorSubject('denied') } };
+  const camera = { state: { browserPermissionState$: new BehaviorSubject('denied') } };
+  const state = { ownCapabilities$: new BehaviorSubject([]) };
+
+  const reporter = new SfuStatsReporter(sfuClient as never, {
+    options: { reporting_interval_ms: 1000, enable_rtc_stats: true } as never,
+    clientDetails: { sdk: undefined, browser: undefined } as never,
+    subscriber: subscriber as never,
+    publisher: publisher as never,
+    microphone: microphone as never,
+    camera: camera as never,
+    state: state as never,
+    tracer: callTracer as never,
+    unifiedSessionId: 'unified',
+  });
+
+  return {
+    reporter,
+    sendStats,
+    subStats,
+    subTracer,
+    pubStats,
+    callTracer,
+    subPending,
+    pubPending,
+  };
+};
+
+describe('SfuStatsReporter delta delivery', () => {
+  it('commits the un-acked chain after a successful send', async () => {
+    const t = build();
+    t.reporter.flush();
+    await vi.waitFor(() => expect(t.subStats.commitDeltas).toHaveBeenCalled());
+    expect(t.subStats.commitDeltas).toHaveBeenCalledWith(t.subPending);
+  });
+
+  it('does not re-trace the delta into the peer-connection tracer', async () => {
+    const t = build();
+    t.reporter.flush();
+    await vi.waitFor(() => expect(t.sendStats).toHaveBeenCalled());
+    expect(t.subTracer!.trace).not.toHaveBeenCalled();
+  });
+
+  it('ships the un-acked chain as getstats records inside rtcStats', async () => {
+    const t = build();
+    t.reporter.flush();
+    await vi.waitFor(() => expect(t.sendStats).toHaveBeenCalled());
+    const traces = JSON.parse(t.sendStats.mock.calls[0][0].rtcStats);
+    expect(traces).toContainEqual(['getstats', 'sub-id', { sub: 1 }, 111]);
+  });
+
+  it('retains the chain and rolls back generic traces on send failure', async () => {
+    const t = build();
+    const slice = makeSlice();
+    t.callTracer.take.mockReturnValue(slice);
+    t.sendStats.mockRejectedValue(new Error('network down'));
+
+    t.reporter.flush();
+    await vi.waitFor(() => expect(slice.rollback).toHaveBeenCalled());
+    expect(t.subStats.commitDeltas).not.toHaveBeenCalled();
+  });
+
+  it('treats an SFU application error as a failed send (no commit, rolls back)', async () => {
+    const t = build();
+    const slice = makeSlice();
+    t.callTracer.take.mockReturnValue(slice);
+    t.sendStats.mockResolvedValue({
+      response: { error: { code: 1, message: 'rejected', shouldRetry: false } },
+    });
+
+    t.reporter.flush();
+    await vi.waitFor(() => expect(slice.rollback).toHaveBeenCalled());
+    expect(t.subStats.commitDeltas).not.toHaveBeenCalled();
+  });
+
+  it('flush() resolves once the sample is taken, without awaiting the send', async () => {
+    const t = build();
+    const dGet = deferred<object>();
+    t.subStats.get.mockReturnValue(dGet.promise); // sampling hangs
+    t.sendStats.mockReturnValue(deferred<object>().promise); // send would hang too
+
+    let resolved = false;
+    const flushed = Promise.resolve(t.reporter.flush()).then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false); // still sampling -> flush not resolved
+
+    dGet.resolve({ delta: {}, performanceStats: [], stats: new Map() });
+    await flushed;
+    expect(resolved).toBe(true); // resolves after the sample, not the send
+  });
+
+  it('samples on an explicit flush even while a previous send is in flight', async () => {
+    const t = build();
+    const d = deferred<object>();
+    t.sendStats.mockReturnValueOnce(d.promise).mockResolvedValue(okResponse);
+
+    t.reporter.flush(); // flush #1: samples, fires the slow send
+    await vi.waitFor(() => expect(t.sendStats).toHaveBeenCalledTimes(1));
+
+    await t.reporter.flush(); // flush #2: must sample now, not wait for send #1
+    expect(t.subStats.get).toHaveBeenCalledTimes(2);
+
+    d.resolve(okResponse);
+  });
+
+  it('does not sample after stop()', async () => {
+    const t = build();
+    t.reporter.stop();
+    await t.reporter.flush();
+    expect(t.subStats.get).not.toHaveBeenCalled();
+  });
+
+  it('skips overlapping scheduled reports while a run is in flight', async () => {
+    vi.useFakeTimers();
+    try {
+      const t = build();
+      const d = deferred<object>();
+      t.sendStats.mockReturnValue(d.promise); // first scheduled send hangs
+
+      t.reporter.start();
+      await vi.advanceTimersByTimeAsync(1500); // first scheduled tick -> run in flight
+      expect(t.subStats.get).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(3000); // next tick must be skipped
+      expect(t.subStats.get).toHaveBeenCalledTimes(1);
+
+      d.resolve(okResponse);
+      t.reporter.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the chain instead of sending it when delta tracing is disabled', async () => {
+    const t = build({ withTracer: false });
+    t.reporter.flush();
+    await vi.waitFor(() => expect(t.sendStats).toHaveBeenCalled());
+
+    expect(t.subStats.clearPendingDeltas).toHaveBeenCalled();
+    expect(t.subStats.commitDeltas).not.toHaveBeenCalled();
+    const traces = JSON.parse(t.sendStats.mock.calls[0][0].rtcStats);
+    expect(traces.some((r: unknown[]) => r[0] === 'getstats')).toBe(false);
+  });
+});

--- a/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
+++ b/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
@@ -21,7 +21,7 @@ const makeStats = (pending: Array<{ delta: object; ts: number }>) => ({
 const makeTracer = (id: string) => ({
   take: vi.fn(makeSlice),
   trace: vi.fn(),
-  traceId: id,
+  id,
 });
 
 const build = (

--- a/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
+++ b/packages/client/src/stats/__tests__/SfuStatsReporter.test.ts
@@ -1,19 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
 import { SfuStatsReporter } from '../SfuStatsReporter';
+import { promiseWithResolvers } from '../../helpers/promise';
 
 // A FinishedUnaryCall-shaped success (no application-layer error).
 const okResponse = { response: {} };
-
-const deferred = <T>() => {
-  let resolve!: (v: T) => void;
-  let reject!: (e?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-};
 
 const makeSlice = () => ({ snapshot: [] as unknown[], rollback: vi.fn() });
 
@@ -34,7 +25,9 @@ const makeTracer = (id: string) => ({
   traceId: id,
 });
 
-const build = (opts: { withTracer?: boolean; withPublisher?: boolean } = {}) => {
+const build = (
+  opts: { withTracer?: boolean; withPublisher?: boolean } = {},
+) => {
   const withTracer = opts.withTracer ?? true;
   const subPending = [{ delta: { sub: 1 }, ts: 111 }];
   const pubPending = [{ delta: { pub: 1 }, ts: 222 }];
@@ -58,8 +51,12 @@ const build = (opts: { withTracer?: boolean; withPublisher?: boolean } = {}) => 
   const callTracer = { take: vi.fn(makeSlice), setEnabled: vi.fn() };
 
   // device permission is 'denied' so observeDevice() doesn't reach listDevices()
-  const microphone = { state: { browserPermissionState$: new BehaviorSubject('denied') } };
-  const camera = { state: { browserPermissionState$: new BehaviorSubject('denied') } };
+  const microphone = {
+    state: { browserPermissionState$: new BehaviorSubject('denied') },
+  };
+  const camera = {
+    state: { browserPermissionState$: new BehaviorSubject('denied') },
+  };
   const state = { ownCapabilities$: new BehaviorSubject([]) };
 
   const reporter = new SfuStatsReporter(sfuClient as never, {
@@ -135,9 +132,9 @@ describe('SfuStatsReporter delta delivery', () => {
 
   it('flush() resolves once the sample is taken, without awaiting the send', async () => {
     const t = build();
-    const dGet = deferred<object>();
+    const dGet = promiseWithResolvers<object>();
     t.subStats.get.mockReturnValue(dGet.promise); // sampling hangs
-    t.sendStats.mockReturnValue(deferred<object>().promise); // send would hang too
+    t.sendStats.mockReturnValue(promiseWithResolvers<object>().promise); // send would hang too
 
     let resolved = false;
     const flushed = Promise.resolve(t.reporter.flush()).then(() => {
@@ -154,7 +151,7 @@ describe('SfuStatsReporter delta delivery', () => {
 
   it('samples on an explicit flush even while a previous send is in flight', async () => {
     const t = build();
-    const d = deferred<object>();
+    const d = promiseWithResolvers<object>();
     t.sendStats.mockReturnValueOnce(d.promise).mockResolvedValue(okResponse);
 
     t.reporter.flush(); // flush #1: samples, fires the slow send
@@ -177,7 +174,7 @@ describe('SfuStatsReporter delta delivery', () => {
     vi.useFakeTimers();
     try {
       const t = build();
-      const d = deferred<object>();
+      const d = promiseWithResolvers<object>();
       t.sendStats.mockReturnValue(d.promise); // first scheduled send hangs
 
       t.reporter.start();

--- a/packages/client/src/stats/rtc/StatsTracer.ts
+++ b/packages/client/src/stats/rtc/StatsTracer.ts
@@ -60,10 +60,9 @@ export class StatsTracer {
   }
 
   /**
-   * Get the stats from the RTCPeerConnection.
-   * When called, it will return the stats for the current connection.
-   * It will also return the delta between the current stats and the previous stats.
-   * This is used to track the performance of the connection.
+   * Samples the RTCPeerConnection: returns the current stats report and the
+   * derived performance stats, and appends the delta-compressed sample to the
+   * un-acked delivery chain (retrieved via `getPendingDeltas`).
    *
    * @internal
    */
@@ -99,7 +98,7 @@ export class StatsTracer {
       this.frameTimeHistory = this.frameTimeHistory.slice(-2);
       this.fpsHistory = this.fpsHistory.slice(-2);
 
-      return { performanceStats, delta, stats };
+      return { performanceStats, stats };
     });
 
   /**

--- a/packages/client/src/stats/rtc/StatsTracer.ts
+++ b/packages/client/src/stats/rtc/StatsTracer.ts
@@ -5,7 +5,8 @@ import {
   TrackType,
 } from '../../gen/video/sfu/models/models';
 import type { RTCCodecStats, RTCMediaSourceStats } from '../types';
-import type { ComputedStats } from './types';
+import type { ComputedStats, PendingDelta } from './types';
+import { withoutConcurrency } from '../../helpers/concurrency';
 
 /**
  * StatsTracer is a class that collects and processes WebRTC stats.
@@ -20,12 +21,26 @@ export class StatsTracer {
   private readonly peerType: PeerType;
   private readonly trackIdToTrackType: Map<string, TrackType>;
   private readonly driftThresholdMs: number;
+  private readonly maxPendingDeltas: number;
+  // serializes get() so overlapping callers (the reporter and the
+  // connection-state-change handler) can't interleave their getStats() and
+  // corrupt the previousSample/pendingDeltas read-modify-write.
+  private readonly sampleTag = Symbol('statsTracerSample');
 
   private costOverrides?: Map<TrackType, number>;
 
-  private previousStats: Record<string, RTCStats> = {};
+  private previousSample: Record<string, RTCStats> = {};
   private frameTimeHistory: number[] = [];
   private fpsHistory: number[] = [];
+
+  /**
+   * The un-acked, delta-compressed samples awaiting delivery confirmation.
+   * Each entry's delta is computed against the immediately preceding sample,
+   * so the list forms a chain the server applies in order. The delivery
+   * baseline advances only when the reporter calls `commitDeltas` after a
+   * successful send; until then the chain is re-sent in full.
+   */
+  private pendingDeltas: PendingDelta[] = [];
 
   /**
    * Creates a new StatsTracer instance.
@@ -35,11 +50,13 @@ export class StatsTracer {
     peerType: PeerType,
     trackIdToTrackType: Map<string, TrackType>,
     statsTimestampDriftThresholdMs: number = 0,
+    maxPendingDeltas: number = 50,
   ) {
     this.pc = pc;
     this.peerType = peerType;
     this.trackIdToTrackType = trackIdToTrackType;
     this.driftThresholdMs = statsTimestampDriftThresholdMs;
+    this.maxPendingDeltas = maxPendingDeltas;
   }
 
   /**
@@ -50,28 +67,69 @@ export class StatsTracer {
    *
    * @internal
    */
-  get = async (): Promise<ComputedStats> => {
-    const stats = await this.pc.getStats();
-    const currentStats = toObjectWithCorrectedTimestamp(
-      stats,
-      Date.now(),
-      this.driftThresholdMs,
-    );
+  get = (): Promise<ComputedStats> =>
+    withoutConcurrency(this.sampleTag, async () => {
+      const stats = await this.pc.getStats();
+      const now = Date.now();
+      const currentStats = toObjectWithCorrectedTimestamp(
+        stats,
+        now,
+        this.driftThresholdMs,
+      );
 
-    const performanceStats = this.withOverrides(
-      this.peerType === PeerType.SUBSCRIBER
-        ? this.getDecodeStats(currentStats)
-        : this.getEncodeStats(currentStats),
-    );
+      // Sustained delivery failure: drop the stale un-acked chain and re-anchor
+      // so the next delta is a full snapshot. A full snapshot overwrites the
+      // server's accumulator, re-syncing it, and keeps the payload bounded.
+      if (this.pendingDeltas.length >= this.maxPendingDeltas) {
+        this.pendingDeltas = [];
+        this.previousSample = {};
+      }
 
-    const delta = deltaCompression(this.previousStats, currentStats);
+      const performanceStats = this.withOverrides(
+        this.peerType === PeerType.SUBSCRIBER
+          ? this.getDecodeStats(currentStats)
+          : this.getEncodeStats(currentStats),
+      );
 
-    // store the current data for the next iteration
-    this.previousStats = currentStats;
-    this.frameTimeHistory = this.frameTimeHistory.slice(-2);
-    this.fpsHistory = this.fpsHistory.slice(-2);
+      const delta = deltaCompression(this.previousSample, currentStats);
 
-    return { performanceStats, delta, stats };
+      // store the current data for the next iteration
+      this.previousSample = currentStats;
+      this.pendingDeltas.push({ delta, ts: now });
+      this.frameTimeHistory = this.frameTimeHistory.slice(-2);
+      this.fpsHistory = this.fpsHistory.slice(-2);
+
+      return { performanceStats, delta, stats };
+    });
+
+  /**
+   * Returns a stable copy of the un-acked delta chain to transmit, oldest first.
+   *
+   * @internal
+   */
+  getPendingDeltas = (): PendingDelta[] => this.pendingDeltas.slice();
+
+  /**
+   * Advances the delivery baseline by dropping exactly the deltas that were
+   * confirmed delivered. Matching is by object identity, so a stale commit
+   * that arrives after a re-anchor (which replaced the chain) is a safe no-op.
+   *
+   * @internal
+   */
+  commitDeltas = (sent: PendingDelta[]): void => {
+    if (sent.length === 0) return;
+    const committed = new Set(sent);
+    this.pendingDeltas = this.pendingDeltas.filter((d) => !committed.has(d));
+  };
+
+  /**
+   * Drops the un-acked chain without sending it. Used when delta reporting is
+   * disabled so the chain can't grow unbounded.
+   *
+   * @internal
+   */
+  clearPendingDeltas = (): void => {
+    this.pendingDeltas = [];
   };
 
   /**
@@ -97,8 +155,8 @@ export class StatsTracer {
         mediaSourceId,
       } = rtp as RTCOutboundRtpStreamStats;
 
-      if (kind === 'audio' || !this.previousStats[id]) continue;
-      const prevRtp = this.previousStats[id] as RTCOutboundRtpStreamStats;
+      if (kind === 'audio' || !this.previousSample[id]) continue;
+      const prevRtp = this.previousSample[id] as RTCOutboundRtpStreamStats;
 
       const deltaTotalEncodeTime =
         totalEncodeTime - (prevRtp.totalEncodeTime || 0);
@@ -150,8 +208,8 @@ export class StatsTracer {
       }
     }
 
-    if (!rtp || !this.previousStats[rtp.id]) return [];
-    const prevRtp = this.previousStats[rtp.id] as RTCInboundRtpStreamStats;
+    if (!rtp || !this.previousSample[rtp.id]) return [];
+    const prevRtp = this.previousSample[rtp.id] as RTCInboundRtpStreamStats;
 
     const {
       framesDecoded = 0,

--- a/packages/client/src/stats/rtc/StatsTracer.ts
+++ b/packages/client/src/stats/rtc/StatsTracer.ts
@@ -22,7 +22,7 @@ export class StatsTracer {
   private readonly trackIdToTrackType: Map<string, TrackType>;
   private readonly driftThresholdMs: number;
   private readonly maxPendingDeltas: number;
-  // serializes get() so overlapping callers (the reporter and the
+  // serializes takeSample() so overlapping callers (the reporter and the
   // connection-state-change handler) can't interleave their getStats() and
   // corrupt the previousSample/pendingDeltas read-modify-write.
   private readonly sampleTag = Symbol('statsTracerSample');
@@ -66,8 +66,8 @@ export class StatsTracer {
    *
    * @internal
    */
-  get = (): Promise<ComputedStats> =>
-    withoutConcurrency(this.sampleTag, async () => {
+  takeSample = (): Promise<ComputedStats> => {
+    return withoutConcurrency(this.sampleTag, async () => {
       const stats = await this.pc.getStats();
       const now = Date.now();
       const currentStats = toObjectWithCorrectedTimestamp(
@@ -100,6 +100,7 @@ export class StatsTracer {
 
       return { performanceStats, stats };
     });
+  };
 
   /**
    * Returns a stable copy of the un-acked delta chain to transmit, oldest first.

--- a/packages/client/src/stats/rtc/Tracer.ts
+++ b/packages/client/src/stats/rtc/Tracer.ts
@@ -10,10 +10,19 @@ export class Tracer {
   private buffer: TraceRecord[] = [];
   private enabled = true;
   private readonly id: string | null;
+  private readonly maxBuffer: number;
   private keys?: Map<TraceKey, boolean>;
 
-  constructor(id: string | null) {
+  constructor(id: string | null, maxBuffer: number = 2500) {
     this.id = id;
+    this.maxBuffer = maxBuffer;
+  }
+
+  /**
+   * The id stamped onto every trace record produced by this tracer.
+   */
+  get traceId(): string | null {
+    return this.id;
   }
 
   setEnabled = (enabled: boolean) => {
@@ -25,6 +34,7 @@ export class Tracer {
   trace: Trace = (tag, data) => {
     if (!this.enabled) return;
     this.buffer.push([tag, this.id, data, Date.now()]);
+    this.capBuffer();
   };
 
   traceOnce = (key: TraceKey, tag: string, data: RTCStatsDataType) => {
@@ -44,6 +54,7 @@ export class Tracer {
       snapshot,
       rollback: () => {
         this.buffer.unshift(...snapshot);
+        this.capBuffer();
       },
     };
   };
@@ -51,5 +62,23 @@ export class Tracer {
   dispose = () => {
     this.buffer = [];
     this.keys?.clear();
+  };
+
+  /**
+   * Bounds the buffer to `maxBuffer` records by dropping the oldest ones,
+   * leaving a single `tracebufferoverflow` breadcrumb at the front so the
+   * consumer knows records were dropped. Prevents unbounded growth (and the
+   * eventual oversized, un-sendable payload) under sustained delivery failure.
+   */
+  private capBuffer = () => {
+    const overflow = this.buffer.length - this.maxBuffer;
+    if (overflow <= 0) return;
+    this.buffer.splice(0, overflow);
+    this.buffer[0] = [
+      'tracebufferoverflow',
+      this.id,
+      { dropped: overflow },
+      Date.now(),
+    ];
   };
 }

--- a/packages/client/src/stats/rtc/Tracer.ts
+++ b/packages/client/src/stats/rtc/Tracer.ts
@@ -9,20 +9,13 @@ import type {
 export class Tracer {
   private buffer: TraceRecord[] = [];
   private enabled = true;
-  private readonly id: string | null;
+  readonly id: string | null;
   private readonly maxBuffer: number;
   private keys?: Map<TraceKey, boolean>;
 
   constructor(id: string | null, maxBuffer: number = 2500) {
     this.id = id;
     this.maxBuffer = maxBuffer;
-  }
-
-  /**
-   * The id stamped onto every trace record produced by this tracer.
-   */
-  get traceId(): string | null {
-    return this.id;
   }
 
   setEnabled = (enabled: boolean) => {
@@ -65,17 +58,16 @@ export class Tracer {
   };
 
   /**
-   * Bounds the buffer to `maxBuffer` records by dropping the oldest ones,
-   * leaving a single `tracebufferoverflow` breadcrumb at the front so the
-   * consumer knows records were dropped. Prevents unbounded growth (and the
-   * eventual oversized, un-sendable payload) under sustained delivery failure.
+   * Bounds the buffer to 2500 records by dropping the oldest ones,
+   * leaving a single `traceBufferOverflow` breadcrumb at the front so the
+   * consumer knows records were dropped.
    */
   private capBuffer = () => {
     const overflow = this.buffer.length - this.maxBuffer;
     if (overflow <= 0) return;
     this.buffer.splice(0, overflow);
     this.buffer[0] = [
-      'tracebufferoverflow',
+      'traceBufferOverflow',
       this.id,
       { dropped: overflow },
       Date.now(),

--- a/packages/client/src/stats/rtc/__tests__/StatsTracer.test.ts
+++ b/packages/client/src/stats/rtc/__tests__/StatsTracer.test.ts
@@ -43,7 +43,8 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    const { delta } = await tracer.get();
+    await tracer.get();
+    const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta.timestamp).toBe(WALL_NOW + 2000);
   });
@@ -60,7 +61,8 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    const { delta } = await tracer.get();
+    await tracer.get();
+    const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta.timestamp).toBe(WALL_NOW);
   });
@@ -77,7 +79,8 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    const { delta } = await tracer.get();
+    await tracer.get();
+    const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta['b'].timestamp).toBe(WALL_NOW);
     expect(delta.timestamp).toBe(WALL_NOW + 2000);
@@ -95,7 +98,8 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    const { delta } = await tracer.get();
+    await tracer.get();
+    const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta.timestamp).toBe(WALL_NOW + THRESHOLD_MS);
   });
@@ -127,7 +131,8 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    const { delta } = await tracer.get();
+    await tracer.get();
+    const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     // both stale and future drift get clamped to wall time, while the
     // within-threshold anchor stays the delta's top-level timestamp.
@@ -148,7 +153,8 @@ describe('StatsTracer timestamp drift correction', () => {
       0,
     );
 
-    const { delta } = await tracer.get();
+    await tracer.get();
+    const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta.timestamp).toBe(WALL_NOW + 99_999);
   });

--- a/packages/client/src/stats/rtc/__tests__/StatsTracer.test.ts
+++ b/packages/client/src/stats/rtc/__tests__/StatsTracer.test.ts
@@ -43,7 +43,7 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    await tracer.get();
+    await tracer.takeSample();
     const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta.timestamp).toBe(WALL_NOW + 2000);
@@ -61,7 +61,7 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    await tracer.get();
+    await tracer.takeSample();
     const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta.timestamp).toBe(WALL_NOW);
@@ -79,7 +79,7 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    await tracer.get();
+    await tracer.takeSample();
     const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta['b'].timestamp).toBe(WALL_NOW);
@@ -98,7 +98,7 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    await tracer.get();
+    await tracer.takeSample();
     const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta.timestamp).toBe(WALL_NOW + THRESHOLD_MS);
@@ -131,7 +131,7 @@ describe('StatsTracer timestamp drift correction', () => {
       THRESHOLD_MS,
     );
 
-    await tracer.get();
+    await tracer.takeSample();
     const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     // both stale and future drift get clamped to wall time, while the
@@ -153,7 +153,7 @@ describe('StatsTracer timestamp drift correction', () => {
       0,
     );
 
-    await tracer.get();
+    await tracer.takeSample();
     const { delta } = tracer.getPendingDeltas().at(-1)!;
 
     expect(delta.timestamp).toBe(WALL_NOW + 99_999);
@@ -215,8 +215,8 @@ describe('StatsTracer pending delta chain', () => {
     ]);
     const tracer = new StatsTracer(pc, PeerType.SUBSCRIBER, new Map(), 0);
 
-    await tracer.get();
-    await tracer.get();
+    await tracer.takeSample();
+    await tracer.takeSample();
 
     expect(tracer.getPendingDeltas()).toHaveLength(2);
   });
@@ -228,8 +228,8 @@ describe('StatsTracer pending delta chain', () => {
     ]);
     const tracer = new StatsTracer(pc, PeerType.SUBSCRIBER, new Map(), 0);
 
-    await tracer.get();
-    await tracer.get();
+    await tracer.takeSample();
+    await tracer.takeSample();
     const sent = tracer.getPendingDeltas();
     tracer.commitDeltas(sent.slice(0, 1));
 
@@ -245,8 +245,8 @@ describe('StatsTracer pending delta chain', () => {
     ]);
     const tracer = new StatsTracer(pc, PeerType.SUBSCRIBER, new Map(), 0);
 
-    await tracer.get();
-    await tracer.get();
+    await tracer.takeSample();
+    await tracer.takeSample();
     tracer.clearPendingDeltas();
 
     expect(tracer.getPendingDeltas()).toHaveLength(0);
@@ -263,9 +263,9 @@ describe('StatsTracer pending delta chain', () => {
       0,
     );
 
-    await tracer.get();
-    await tracer.get();
-    await tracer.get();
+    await tracer.takeSample();
+    await tracer.takeSample();
+    await tracer.takeSample();
     const chain = tracer.getPendingDeltas().map((p) => p.delta);
 
     expect(applyChain({}, chain)).toEqual({
@@ -285,9 +285,9 @@ describe('StatsTracer pending delta chain', () => {
       2, // maxPendingDeltas
     );
 
-    await tracer.get();
-    await tracer.get(); // chain now at the cap
-    await tracer.get(); // exceeds cap -> re-anchor
+    await tracer.takeSample();
+    await tracer.takeSample(); // chain now at the cap
+    await tracer.takeSample(); // exceeds cap -> re-anchor
 
     const chain = tracer.getPendingDeltas();
     expect(chain).toHaveLength(1);
@@ -309,10 +309,10 @@ describe('StatsTracer pending delta chain', () => {
       2,
     );
 
-    await tracer.get();
-    await tracer.get();
+    await tracer.takeSample();
+    await tracer.takeSample();
     const sent = tracer.getPendingDeltas(); // captured before re-anchor
-    await tracer.get(); // re-anchors, dropping `sent`
+    await tracer.takeSample(); // re-anchors, dropping `sent`
     tracer.commitDeltas(sent); // stale commit, must be a no-op
 
     expect(tracer.getPendingDeltas()).toHaveLength(1);
@@ -338,8 +338,8 @@ describe('StatsTracer concurrent sampling', () => {
     const pc = { getStats } as unknown as RTCPeerConnection;
     const tracer = new StatsTracer(pc, PeerType.SUBSCRIBER, new Map(), 0);
 
-    const pA = tracer.get();
-    const pB = tracer.get();
+    const pA = tracer.takeSample();
+    const pB = tracer.takeSample();
 
     // the second sample must not start until the first completes
     expect(getStats).toHaveBeenCalledTimes(1);

--- a/packages/client/src/stats/rtc/__tests__/StatsTracer.test.ts
+++ b/packages/client/src/stats/rtc/__tests__/StatsTracer.test.ts
@@ -153,3 +153,204 @@ describe('StatsTracer timestamp drift correction', () => {
     expect(delta.timestamp).toBe(WALL_NOW + 99_999);
   });
 });
+
+// Builds an RTCStatsReport from rich per-report fields (id is added for you).
+const richReport = (
+  entries: Record<string, Record<string, unknown>>,
+): RTCStatsReport => {
+  const map = new Map<string, RTCStats>();
+  for (const [id, fields] of Object.entries(entries)) {
+    map.set(id, { id, ...fields } as unknown as RTCStats);
+  }
+  return map as unknown as RTCStatsReport;
+};
+
+// A pc mock whose getStats() returns a different report on each successive call.
+const makeSeqPc = (reports: RTCStatsReport[]): RTCPeerConnection => {
+  const getStats = vi.fn();
+  for (const r of reports) getStats.mockResolvedValueOnce(r);
+  return { getStats } as unknown as RTCPeerConnection;
+};
+
+// Mirrors the server-side accumulator: applies chained deltas in order,
+// un-zeroing each report's hoisted timestamp.
+const applyChain = (
+  baseline: Record<string, any>,
+  deltas: Array<Record<string, any>>,
+): Record<string, any> => {
+  const acc: Record<string, any> = JSON.parse(JSON.stringify(baseline));
+  for (const delta of deltas) {
+    const top = delta.timestamp;
+    for (const [id, report] of Object.entries(delta)) {
+      if (id === 'timestamp') continue;
+      const target = (acc[id] ??= {});
+      for (const [k, v] of Object.entries(report as Record<string, unknown>)) {
+        target[k] = k === 'timestamp' && v === 0 ? top : v;
+      }
+    }
+  }
+  return acc;
+};
+
+describe('StatsTracer pending delta chain', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(WALL_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('accumulates one delta per get() in the pending chain', async () => {
+    const pc = makeSeqPc([
+      makeReport([{ id: 'a', timestamp: WALL_NOW }]),
+      makeReport([{ id: 'a', timestamp: WALL_NOW + 1000 }]),
+    ]);
+    const tracer = new StatsTracer(pc, PeerType.SUBSCRIBER, new Map(), 0);
+
+    await tracer.get();
+    await tracer.get();
+
+    expect(tracer.getPendingDeltas()).toHaveLength(2);
+  });
+
+  it('commitDeltas removes exactly the committed deltas by identity', async () => {
+    const pc = makeSeqPc([
+      makeReport([{ id: 'a', timestamp: WALL_NOW }]),
+      makeReport([{ id: 'a', timestamp: WALL_NOW + 1000 }]),
+    ]);
+    const tracer = new StatsTracer(pc, PeerType.SUBSCRIBER, new Map(), 0);
+
+    await tracer.get();
+    await tracer.get();
+    const sent = tracer.getPendingDeltas();
+    tracer.commitDeltas(sent.slice(0, 1));
+
+    const remaining = tracer.getPendingDeltas();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toBe(sent[1]);
+  });
+
+  it('clearPendingDeltas empties the chain', async () => {
+    const pc = makeSeqPc([
+      makeReport([{ id: 'a', timestamp: WALL_NOW }]),
+      makeReport([{ id: 'a', timestamp: WALL_NOW + 1000 }]),
+    ]);
+    const tracer = new StatsTracer(pc, PeerType.SUBSCRIBER, new Map(), 0);
+
+    await tracer.get();
+    await tracer.get();
+    tracer.clearPendingDeltas();
+
+    expect(tracer.getPendingDeltas()).toHaveLength(0);
+  });
+
+  it('reconstructs every sample by applying the un-acked chain in order', async () => {
+    const s0 = richReport({ a: { timestamp: WALL_NOW, bytes: 100 } });
+    const s1 = richReport({ a: { timestamp: WALL_NOW + 1000, bytes: 200 } });
+    const s2 = richReport({ a: { timestamp: WALL_NOW + 2000, bytes: 350 } });
+    const tracer = new StatsTracer(
+      makeSeqPc([s0, s1, s2]),
+      PeerType.SUBSCRIBER,
+      new Map(),
+      0,
+    );
+
+    await tracer.get();
+    await tracer.get();
+    await tracer.get();
+    const chain = tracer.getPendingDeltas().map((p) => p.delta);
+
+    expect(applyChain({}, chain)).toEqual({
+      a: { timestamp: WALL_NOW + 2000, bytes: 350 },
+    });
+  });
+
+  it('re-anchors with a full snapshot when the chain exceeds the cap', async () => {
+    const s0 = richReport({ a: { timestamp: WALL_NOW, bytes: 100 } });
+    const s1 = richReport({ a: { timestamp: WALL_NOW + 1000, bytes: 200 } });
+    const s2 = richReport({ a: { timestamp: WALL_NOW + 2000, bytes: 350 } });
+    const tracer = new StatsTracer(
+      makeSeqPc([s0, s1, s2]),
+      PeerType.SUBSCRIBER,
+      new Map(),
+      0,
+      2, // maxPendingDeltas
+    );
+
+    await tracer.get();
+    await tracer.get(); // chain now at the cap
+    await tracer.get(); // exceeds cap -> re-anchor
+
+    const chain = tracer.getPendingDeltas();
+    expect(chain).toHaveLength(1);
+    // the single re-anchored delta is a full snapshot of S2
+    expect(applyChain({}, [chain[0].delta])).toEqual({
+      a: { timestamp: WALL_NOW + 2000, bytes: 350 },
+    });
+  });
+
+  it('keeps a re-anchored keyframe when a stale commit lands afterwards', async () => {
+    const s0 = richReport({ a: { timestamp: WALL_NOW, bytes: 100 } });
+    const s1 = richReport({ a: { timestamp: WALL_NOW + 1000, bytes: 200 } });
+    const s2 = richReport({ a: { timestamp: WALL_NOW + 2000, bytes: 350 } });
+    const tracer = new StatsTracer(
+      makeSeqPc([s0, s1, s2]),
+      PeerType.SUBSCRIBER,
+      new Map(),
+      0,
+      2,
+    );
+
+    await tracer.get();
+    await tracer.get();
+    const sent = tracer.getPendingDeltas(); // captured before re-anchor
+    await tracer.get(); // re-anchors, dropping `sent`
+    tracer.commitDeltas(sent); // stale commit, must be a no-op
+
+    expect(tracer.getPendingDeltas()).toHaveLength(1);
+  });
+});
+
+const deferred = <T>() => {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+describe('StatsTracer concurrent sampling', () => {
+  it('serializes overlapping get() calls so the chain stays in call order', async () => {
+    const dA = deferred<RTCStatsReport>();
+    const dB = deferred<RTCStatsReport>();
+    const getStats = vi
+      .fn()
+      .mockReturnValueOnce(dA.promise)
+      .mockReturnValueOnce(dB.promise);
+    const pc = { getStats } as unknown as RTCPeerConnection;
+    const tracer = new StatsTracer(pc, PeerType.SUBSCRIBER, new Map(), 0);
+
+    const pA = tracer.get();
+    const pB = tracer.get();
+
+    // the second sample must not start until the first completes
+    expect(getStats).toHaveBeenCalledTimes(1);
+
+    // resolve the first sample; only then should the second getStats fire
+    dA.resolve(richReport({ a: { timestamp: 1000, bytes: 100 } }));
+    await pA;
+    expect(getStats).toHaveBeenCalledTimes(2);
+
+    dB.resolve(richReport({ a: { timestamp: 2000, bytes: 200 } }));
+    await pB;
+
+    // chain applied in call order reconstructs the second (newer) sample
+    const chain = tracer.getPendingDeltas().map((p) => p.delta);
+    expect(chain).toHaveLength(2);
+    expect(applyChain({}, chain)).toEqual({
+      a: { timestamp: 2000, bytes: 200 },
+    });
+  });
+});

--- a/packages/client/src/stats/rtc/__tests__/Tracer.test.ts
+++ b/packages/client/src/stats/rtc/__tests__/Tracer.test.ts
@@ -55,9 +55,9 @@ describe('Tracer', () => {
     expect(slice.snapshot.length).toBe(0);
   });
 
-  it('exposes its id via traceId', () => {
-    expect(new Tracer('abc').traceId).toBe('abc');
-    expect(new Tracer(null).traceId).toBeNull();
+  it('exposes its id via .id', () => {
+    expect(new Tracer('abc').id).toBe('abc');
+    expect(new Tracer(null).id).toBeNull();
   });
 
   it('caps the buffer, dropping oldest and leaving an overflow marker', () => {
@@ -69,7 +69,7 @@ describe('Tracer', () => {
 
     const slice = capped.take();
     expect(slice.snapshot.length).toBe(3);
-    expect(slice.snapshot[0][0]).toBe('tracebufferoverflow');
+    expect(slice.snapshot[0][0]).toBe('traceBufferOverflow');
     // newest record is retained
     expect(slice.snapshot[slice.snapshot.length - 1][2]).toEqual({ n: 4 });
   });
@@ -86,6 +86,6 @@ describe('Tracer', () => {
 
     const after = capped.take();
     expect(after.snapshot.length).toBe(3);
-    expect(after.snapshot[0][0]).toBe('tracebufferoverflow');
+    expect(after.snapshot[0][0]).toBe('traceBufferOverflow');
   });
 });

--- a/packages/client/src/stats/rtc/__tests__/Tracer.test.ts
+++ b/packages/client/src/stats/rtc/__tests__/Tracer.test.ts
@@ -54,4 +54,38 @@ describe('Tracer', () => {
     const slice = tracer.take();
     expect(slice.snapshot.length).toBe(0);
   });
+
+  it('exposes its id via traceId', () => {
+    expect(new Tracer('abc').traceId).toBe('abc');
+    expect(new Tracer(null).traceId).toBeNull();
+  });
+
+  it('caps the buffer, dropping oldest and leaving an overflow marker', () => {
+    const capped = new Tracer('id', 3);
+    capped.trace('e', { n: 1 });
+    capped.trace('e', { n: 2 });
+    capped.trace('e', { n: 3 });
+    capped.trace('e', { n: 4 }); // overflows the cap of 3
+
+    const slice = capped.take();
+    expect(slice.snapshot.length).toBe(3);
+    expect(slice.snapshot[0][0]).toBe('tracebufferoverflow');
+    // newest record is retained
+    expect(slice.snapshot[slice.snapshot.length - 1][2]).toEqual({ n: 4 });
+  });
+
+  it('caps the buffer on rollback too', () => {
+    const capped = new Tracer('id', 3);
+    capped.trace('e', { n: 1 });
+    const slice = capped.take();
+
+    capped.trace('e', { n: 2 });
+    capped.trace('e', { n: 3 });
+    capped.trace('e', { n: 4 }); // buffer now at the cap of 3
+    slice.rollback(); // prepends the old record, exceeding the cap
+
+    const after = capped.take();
+    expect(after.snapshot.length).toBe(3);
+    expect(after.snapshot[0][0]).toBe('tracebufferoverflow');
+  });
 });

--- a/packages/client/src/stats/rtc/types.ts
+++ b/packages/client/src/stats/rtc/types.ts
@@ -49,3 +49,14 @@ export type ComputedStats = {
    */
   performanceStats: PerformanceStats[];
 };
+
+/**
+ * A single, not-yet-delivered delta-compressed stats sample.
+ * The `delta` is computed against the immediately preceding sample, so a
+ * sequence of `PendingDelta`s forms a chain that the server applies in order
+ * onto its running accumulator. `ts` is the wall-clock time the sample was taken.
+ */
+export type PendingDelta = {
+  delta: Record<any, any>;
+  ts: number;
+};

--- a/packages/client/src/stats/rtc/types.ts
+++ b/packages/client/src/stats/rtc/types.ts
@@ -41,10 +41,6 @@ export type ComputedStats = {
    */
   stats: RTCStatsReport;
   /**
-   * Delta between the current stats and the previous stats.
-   */
-  delta: Record<any, any>;
-  /**
    * The current iteration of the stats.
    */
   performanceStats: PerformanceStats[];


### PR DESCRIPTION
### 💡 Overview

Improves delivery reliability of the delta-compressed WebRTC stats (`rtcStats`) that `SfuStatsReporter` sends to the SFU. The delta chain assumed in-order, exactly-once delivery, but `sendStats` is a loose, no-retry HTTP call, so under bad network conditions deltas were dropped or applied out of order, producing gaps / misleading server-side data.

The chain is now **baseline-on-ack**: un-acked deltas are persisted and re-sent until a send is confirmed, then committed by identity.

### 📝 Implementation notes

- `StatsTracer`: persist un-acked deltas as a chain (`getPendingDeltas` / `commitDeltas` by identity / `clearPendingDeltas`); re-anchor to a full snapshot past `maxPendingDeltas`. `takeSample()` (renamed from `get()`) now advertises that it samples *and* advances the chain, and is serialized per instance; the unused `ComputedStats.delta` return field was dropped.
- `SfuStatsReporter`: split `sample()` from `send()`; ship the chain as `getstats` records in `rtcStats`; serialize sends; commit on success, retain on failure (transport **or** `response.error`); skip overlapping scheduled reports; `isStopped` guard so nothing samples after teardown.
- Teardown safety: the final flush (leave / reconnect / migration) time-boxes the sample to 2s and swallows failures, so a slow or failing `getStats()` on a closing connection can never block or break `call.leave()`. `Call` awaits that flush so the last sample is taken from live peer connections before they are disposed.
- `Tracer`: public `id` field + bounded buffer (drop-oldest, leaving a `traceBufferOverflow` breadcrumb).
- Wire-compatible (still `getstats` records in `rtcStats`); no proto/server changes; no public API change.

Validated: 33 targeted stats unit tests (`StatsTracer` / `Tracer` / `SfuStatsReporter`) plus the broader `stats` / `rtc` suite, no regressions; types + lint clean; confirmed live in a real call (chain retains 2 → 4 → 6 → 8 under injected failure, delivers the backlog on recovery, drains to baseline).

🎫 Ticket: https://linear.app/stream/issue/REACT-1017/reliably-deliver-delta-compressed-webrtc-stats-baseline-on-ack

📑 Docs: n/a (internal telemetry)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SFU stats reporting to capture final metrics before teardown and prevent overlapping/duplicate sampling during slow sends.
  * Refined getstats sampling and trace handling so deltas commit only after successful delivery, with proper rollback on failures.
  * Ensured consistent stats sampling timing when peer connections transition into key states.
* **New Features**
  * Added ordered pending-delta delivery with improved recovery and safer handling of delayed or failed sends.
* **Tests**
  * Expanded coverage for delta delivery, flush/scheduling behavior, concurrency serialization, and capped trace buffering (including overflow/rollback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
