### PR TITLE
fix: made CXCallObserver static warm instance

### DIFF
--- a/packages/react-native-callingx/ios/CallingxImpl.swift
+++ b/packages/react-native-callingx/ios/CallingxImpl.swift
@@ -208,26 +208,15 @@ import stream_react_native_webrtc
     }
     
     @objc public static func canRegisterCall() -> Bool {
-        let hasCall = hasRegisteredCall()
         let shouldReject = Settings.getShouldRejectCallWhenBusy()
-        return !shouldReject || (shouldReject && !hasCall)
+        guard shouldReject else { return true }
+        return !hasRegisteredCall()
     }
-    
+
     @objc public static func hasRegisteredCall() -> Bool {
-        guard let storage = uuidStorage else { return false }
-      
-        let appUUIDs = storage.allUUIDs()
-        if appUUIDs.isEmpty { return false }
-        
-        let observer = CXCallObserver()
-        for call in observer.calls {
-            for uuid in appUUIDs {
-                if call.uuid == uuid {
-                    return true
-                }
-            }
-        }
-        return false
+        // Backed by the warm CXCallObserver maintained in UUIDStorage — no per-call observer
+        // construction and no cold-snapshot misses. Intersects our calls with CallKit's live set.
+        return uuidStorage?.hasRegisteredCall() ?? false
     }
     
     @objc public static func getAudioOutput() -> String? {
@@ -427,8 +416,12 @@ import stream_react_native_webrtc
 
         // This is mostly needed for very first setup, as we need to override the default
         // provider configuration which is set in the constructor.
-        // IMPORTANT: We override CXProvider instance only if there is no registered call, otherwise we may lose corrsponding call state/events from CallKit
-        if !CallingxImpl.hasRegisteredCall() {
+        // IMPORTANT: We override the CXProvider instance only when there are no calls in
+        // flight, otherwise we'd destroy CallKit state/events for a live call. We check our
+        // own storage rather than CXCallObserver here: the observer trails registration and
+        // can briefly report empty (e.g. a VoIP-push call reported just before setup runs),
+        // which would wrongly tear down the provider mid-call.
+        if (CallingxImpl.uuidStorage?.count() ?? 0) == 0 {
             let oldProvider = CallingxImpl.sharedProvider
             let newProvider = CXProvider(configuration: Settings.getProviderConfiguration())
             newProvider.setDelegate(self, queue: nil)
@@ -581,18 +574,9 @@ import stream_react_native_webrtc
     }
     
     @objc public func isCallTracked(_ callId: String) -> Bool {
-        guard let uuid = CallingxImpl.uuidStorage?.getUUID(forCid: callId) else {
-            CallingxLog.core.debugPublic("[isCallTracked] callId not found")
-            return false
-        }
-        
-        let observer = CXCallObserver()
-        for call in observer.calls {
-            if call.uuid == uuid {
-                return true
-            }
-        }
-        return false
+        // Backed by the warm CXCallObserver in UUIDStorage — no per-call observer construction
+        // and no cold-snapshot misses. True when the call is tracked AND confirmed live by CallKit.
+        return CallingxImpl.uuidStorage?.isCallTracked(forCid: callId) ?? false
     }
     
     @objc public func setCurrentCallActive(_ callId: String) -> Bool {

--- a/packages/react-native-callingx/ios/UUIDStorage.swift
+++ b/packages/react-native-callingx/ios/UUIDStorage.swift
@@ -1,14 +1,58 @@
 import Foundation
+import CallKit
 
-@objcMembers public class UUIDStorage: NSObject {
+@objcMembers public class UUIDStorage: NSObject, CXCallObserverDelegate {
     /// Primary storage: cid -> CallingxCall
     private var callsByCid: [String: CallingxCall] = [:]
     /// Reverse lookup: lowercased UUID string -> CallingxCall
     private var callsByUUID: [String: CallingxCall] = [:]
     private let queue = DispatchQueue(label: "com.stream.uuidstorage", attributes: [])
 
+    /// Warm, long-lived observer of CallKit's call state — a cold observer can report empty even for a
+    /// call that's been live for a while.
+    private let callObserver = CXCallObserver()
+    /// CallKit's live view, maintained from observer callbacks. NOTE: contains UUIDs of ALL
+    /// system calls. Only ever intersect it with our own UUIDs — never treat it as "our calls".
+    private var liveCallKitUUIDs: Set<UUID> = []
+
     public override init() {
         super.init()
+        callObserver.setDelegate(self, queue: queue)
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            self.liveCallKitUUIDs = Set(
+                self.callObserver.calls.filter { !$0.hasEnded }.map { $0.uuid }
+            )
+        }
+    }
+
+    // MARK: - CXCallObserverDelegate
+
+    /// IMPORTANT: delivered on `queue`, NEVER call the `queue.sync` helpers below —
+    /// re-entering the serial queue would deadlock.
+    public func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
+        if call.hasEnded {
+            liveCallKitUUIDs.remove(call.uuid)
+        } else {
+            liveCallKitUUIDs.insert(call.uuid)
+        }
+    }
+
+    // MARK: - CallKit liveness queries
+
+    public func hasRegisteredCall() -> Bool {
+        return queue.sync {
+            guard !callsByCid.isEmpty else { return false }
+            let ours = Set(callsByCid.values.map { $0.uuid })
+            return !ours.isDisjoint(with: liveCallKitUUIDs)
+        }
+    }
+
+    public func isCallTracked(forCid cid: String) -> Bool {
+        return queue.sync {
+            guard let call = callsByCid[cid] else { return false }
+            return liveCallKitUUIDs.contains(call.uuid)
+        }
     }
 
     // MARK: - CallingxCall-based API (new)


### PR DESCRIPTION
### 💡 Overview

Adjusted the way how we confirm registered calls in CallKit, prevented cold state async instantiation issue.
Loosen condition for CXProvider recreation on setup.

🎫 Ticket: https://linear.app/stream/issue/RN-401/callkit-cxcallobserver-improvements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call tracking so active calls are detected more reliably.
  * Fixed busy-state handling to better prevent new calls when an existing call is already in progress.
  * Reduced cases where call status could become out of sync with the app’s current call list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->