### PR TITLE
fix(client): propagate underlying WS connection error through connect timeout

### DIFF
--- a/packages/client/src/coordinator/connection/__tests__/connection.test.ts
+++ b/packages/client/src/coordinator/connection/__tests__/connection.test.ts
@@ -193,6 +193,53 @@ describe('StableWSConnection - silent handshake hang', () => {
     expect(outcome.kind).toBe('rejected');
   });
 
+  it('preserves an initial WS close reason when reconnect cannot get healthy', async () => {
+    const client = new StreamClient('test-key', {
+      browser: false,
+      defaultWsTimeout: 5000,
+      WebSocketImpl: ManualWebSocket as unknown as typeof WebSocket,
+      timeout: 1000,
+    });
+    vi.spyOn(client.tokenManager, 'tokenReady').mockResolvedValue('fake-token');
+    vi.spyOn(client.tokenManager, 'loadToken').mockResolvedValue('fake-token');
+    vi.spyOn(client.tokenManager, 'getToken').mockReturnValue('fake-token');
+
+    client._setUser({ id: 'test-user' });
+    client.userID = 'test-user';
+    client.clientID = 'test-user--abcdef';
+    client._setupConnectionIdPromise();
+
+    const wsConnection = new StableWSConnection(client);
+    client.wsConnection = wsConnection;
+
+    const connectAttemptOutcome = wsConnection.connect(5000).then(
+      () => ({ kind: 'resolved' as const }),
+      (error: Error) => ({ kind: 'rejected' as const, error }),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    const ws = ManualWebSocket.instances.at(-1)!;
+    expect(ws).toBeDefined();
+
+    ws.onclose?.({
+      code: 1006,
+      reason: 'specific ws close reason',
+      wasClean: false,
+      target: ws,
+    });
+
+    await vi.advanceTimersByTimeAsync(20000);
+    const outcome = await connectAttemptOutcome;
+
+    expect(outcome.kind).toBe('rejected');
+    if (outcome.kind === 'rejected') {
+      expect(outcome.error.message).toContain('specific ws close reason');
+      expect(outcome.error.message).not.toContain(
+        'initial WS connection could not be established',
+      );
+    }
+  });
+
   it('does not schedule a reconnect (and leaves connectionIdPromise rejected) on a permanent, non-WS failure', async () => {
     const client = new StreamClient('test-key', {
       browser: false,

--- a/packages/client/src/coordinator/connection/connection.ts
+++ b/packages/client/src/coordinator/connection/connection.ts
@@ -66,6 +66,7 @@ export class StableWSConnection {
   consecutiveFailures = 0;
   /** keep track of the total number of failures */
   totalFailures = 0;
+  lastConnectionError?: WSConnectionError;
 
   // Health-check pings + connection-staleness check.
   /** Send a health check message every 25 seconds */
@@ -102,6 +103,7 @@ export class StableWSConnection {
     }
 
     this.isDisconnected = false;
+    this.lastConnectionError = undefined;
 
     try {
       const healthCheck = await this._connect(timeout);
@@ -140,6 +142,7 @@ export class StableWSConnection {
         // _connect()'s catch) keeps a single failure from spawning two
         // parallel chains - one from this catch and one from _reconnect's
         // own catch when _connect was called from there.
+        this.lastConnectionError = error;
         this._reconnect();
       }
     }
@@ -179,14 +182,22 @@ export class StableWSConnection {
       (async () => {
         await sleep(timeout);
         this.isConnecting = false;
-        throw new Error(
-          JSON.stringify({
-            code: '',
-            StatusCode: '',
-            message: 'initial WS connection could not be established',
-            isWSFailure: true,
-          }),
-        );
+        const e = this.lastConnectionError;
+        const errorPayload = e
+          ? {
+              code: e.code,
+              StatusCode: e.StatusCode,
+              message: e.message,
+              isWSFailure: e.isWSFailure,
+            }
+          : {
+              code: '',
+              StatusCode: '',
+              message: 'initial WS connection could not be established',
+              isWSFailure: true,
+            };
+
+        throw new Error(JSON.stringify(errorPayload));
       })(),
     ]);
   };
@@ -376,6 +387,7 @@ export class StableWSConnection {
       return undefined;
     } catch (caught) {
       const err = caught as WSConnectionError;
+      this.lastConnectionError = err;
       this.isConnecting = false;
       this._log(`_connect() - Error - `, err);
       // Reject THIS attempt's connection-id promise (P1) directly via the


### PR DESCRIPTION
### 💡 Overview

This PR fixes an issue where `connectUser()` could hide the real initial WebSocket failure reason. When the initial WS connection failed with a transient error, the client started the reconnect flow and later threw the generic `"initial WS connection could not be established"` timeout error if reconnect did not become healthy. The original WS close/error reason was lost. The fix stores the latest WS connection error before starting reconnect and uses it when `_waitForHealthy()` times out. This preserves the real failure details while keeping the existing reconnect behavior.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1018/propagate-underlying-ws-connection-error

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection error messages so failed reconnects can surface the most recent close reason instead of only a generic timeout message.
  * Preserved the original close details when an initial connection cannot become healthy.

* **Tests**
  * Added coverage for reconnect failures to ensure the reported error includes the specific close reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->