### PR TITLE
fix: renegotiate unacknowledged publisher transceivers on republish

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -187,6 +187,9 @@ export class Publisher extends BasePeerConnection {
     if (isAudioTrackType(trackType)) {
       await this.updateAudioPublishOptions(trackType, options);
     }
+    if (track && !bundle.negotiated) {
+      await this.negotiate();
+    }
   };
 
   /**
@@ -490,6 +493,10 @@ export class Publisher extends BasePeerConnection {
 
         const { sdp: answerSdp } = response;
         await this.pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
+
+        for (const bundle of this.transceiverCache.items()) {
+          if (bundle.transceiver.sender.track) bundle.negotiated = true;
+        }
       } catch (err) {
         // negotiation failed, rollback to the previous state
         if (this.pc.signalingState === 'have-local-offer') {

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -157,6 +157,7 @@ describe('Publisher', () => {
         publishOption: publisher['publishOptions'][0],
         transceiver,
         options: {},
+        negotiated: true,
       });
 
       await publisher.publish(track, TrackType.VIDEO);
@@ -165,6 +166,75 @@ describe('Publisher', () => {
       expect(publisher['pc'].addTransceiver).not.toHaveBeenCalled();
       expect(transceiver.sender.replaceTrack).toHaveBeenCalledWith(clone);
       expect(track.stop).toHaveBeenCalled();
+    });
+
+    it('should not renegotiate when reusing an already-negotiated transceiver', async () => {
+      const track = new MediaStreamTrack();
+      const clone = new MediaStreamTrack();
+      vi.spyOn(track, 'clone').mockReturnValue(clone);
+
+      const transceiver = new RTCRtpTransceiver();
+      // @ts-expect-error test setup
+      transceiver.sender.track = track;
+      publisher['transceiverCache'].add({
+        publishOption: publisher['publishOptions'][0],
+        transceiver,
+        options: {},
+        negotiated: true,
+      });
+
+      // @ts-expect-error - private method
+      const negotiateSpy = vi.spyOn(publisher, 'negotiate').mockResolvedValue();
+
+      await publisher.publish(track, TrackType.VIDEO);
+
+      expect(transceiver.sender.replaceTrack).toHaveBeenCalledWith(clone);
+      expect(negotiateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should renegotiate on republish when a previous negotiation never reached the SFU (SetPublisher timeout)', async () => {
+      const track = new MediaStreamTrack();
+      const transceiver = new RTCRtpTransceiver();
+      // @ts-expect-error test setup
+      transceiver.sender.track = track;
+      const bundle = {
+        publishOption: publisher['publishOptions'][0],
+        transceiver,
+        options: {},
+        negotiated: false,
+      };
+      publisher['transceiverCache'].add(bundle);
+
+      vi.spyOn(publisher['pc'], 'createOffer')
+        // @ts-expect-error TS picks up the wrong overload
+        .mockResolvedValue({ sdp: 'offer-sdp', type: 'offer' });
+      vi.spyOn(publisher['pc'], 'setLocalDescription').mockResolvedValue();
+      vi.spyOn(publisher['pc'], 'setRemoteDescription').mockResolvedValue();
+      vi.spyOn(publisher, 'getAnnouncedTracks').mockReturnValue([
+        // @ts-expect-error incomplete data
+        { trackId: '123' },
+      ]);
+
+      sfuClient.setPublisher = vi
+        .fn()
+        .mockRejectedValue(new Error('SetPublisherTimeout'));
+      await expect(publisher['negotiate']()).rejects.toThrow(
+        'SetPublisherTimeout',
+      );
+      expect(bundle.negotiated).toBe(false);
+
+      const clone = new MediaStreamTrack();
+      vi.spyOn(track, 'clone').mockReturnValue(clone);
+      sfuClient.setPublisher = vi
+        .fn()
+        .mockResolvedValue({ response: { sdp: 'answer-sdp' } });
+
+      await publisher.publish(track, TrackType.VIDEO);
+
+      expect(publisher['pc'].addTransceiver).not.toHaveBeenCalled();
+      expect(transceiver.sender.replaceTrack).toHaveBeenCalledWith(clone);
+      expect(sfuClient.setPublisher).toHaveBeenCalled();
+      expect(bundle.negotiated).toBe(true);
     });
   });
 
@@ -1457,6 +1527,7 @@ describe('Publisher', () => {
         publishOption: publisher['publishOptions'][0],
         transceiver,
         options: {},
+        negotiated: true,
       });
 
       // stopping seeds the bundle's videoSender from the current encoder
@@ -1515,11 +1586,13 @@ describe('Publisher', () => {
         publishOption: publisher['publishOptions'][0],
         transceiver: vp8Transceiver,
         options: {},
+        negotiated: true,
       });
       publisher['transceiverCache'].add({
         publishOption: publisher['publishOptions'][1],
         transceiver: vp9Transceiver,
         options: {},
+        negotiated: true,
       });
 
       await publisher.stopTracks(TrackType.VIDEO);
@@ -1589,6 +1662,7 @@ describe('Publisher', () => {
         publishOption,
         transceiver,
         options: {},
+        negotiated: true,
       });
 
       // SFU sends a changePublishQuality while we are not publishing.

--- a/packages/client/src/rtc/types.ts
+++ b/packages/client/src/rtc/types.ts
@@ -112,6 +112,7 @@ export type PublishBundle = {
   transceiver: RTCRtpTransceiver;
   options: TrackPublishOptions;
   videoSender?: VideoSender;
+  negotiated?: boolean;
 };
 
 export type TrackLayersCache = {


### PR DESCRIPTION
### 💡 Overview
This PR fixes an issue where republishing could reuse a cached publisher transceiver without renegotiating, even if the previous SetPublisher negotiation failed. Publisher transceivers are now marked as negotiated only after a successful SFU negotiation. If a cached transceiver was never acknowledged by the SFU republishing reuses it but triggers a new negotiation so the track is properly announced.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1020/republish-after-failed-publisher-negotiation

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media publishing reliability by avoiding unnecessary renegotiation when reusing an already connected track.
  * Fixed republish flows so previously published audio/video can resume more smoothly without extra setup.
  * Reduced delays in quality changes and unpublish/re-publish scenarios for some browser-specific cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->