### PR TITLE
feat(ios): audio route selection

### DIFF
--- a/packages/react-native-sdk/ios/StreamInCallManager.m
+++ b/packages/react-native-sdk/ios/StreamInCallManager.m
@@ -7,6 +7,11 @@ RCT_EXTERN_METHOD(setAudioRole:(NSString *)audioRole)
 
 RCT_EXTERN_METHOD(setDefaultAudioDeviceEndpointType:(NSString *)endpointType)
 
+RCT_EXTERN_METHOD(chooseAudioDeviceEndpoint:(NSString *)endpointName)
+
+RCT_EXTERN_METHOD(getAudioDeviceStatus:(RCTPromiseResolveBlock)resolve
+                             withRejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(setEnableStereoAudioOutput:(BOOL)enable)
 
 RCT_EXTERN_METHOD(setup)

--- a/packages/react-native-sdk/ios/StreamInCallManager.swift
+++ b/packages/react-native-sdk/ios/StreamInCallManager.swift
@@ -42,6 +42,7 @@ class StreamInCallManager: RCTEventEmitter {
     private var audioManagerActivated = false
     private var callAudioRole: CallAudioRole = .communicator
     private var defaultAudioDevice: DefaultAudioDevice = .speaker
+    private var selectedAudioDeviceEndpoint: String?
     private var enableStereo: Bool = false
     private var previousVolume: Float = 0.75
 
@@ -88,7 +89,92 @@ class StreamInCallManager: RCTEventEmitter {
             self.defaultAudioDevice = endpointType.lowercased() == "earpiece" ? .earpiece : .speaker
         }
     }
-    
+
+    @objc(getAudioDeviceStatus:withRejecter:)
+    func getAudioDeviceStatus(resolve: @escaping RCTPromiseResolveBlock,
+                              reject: @escaping RCTPromiseRejectBlock) {
+        audioSessionQueue.async { [self] in
+            let session = AVAudioSession.sharedInstance()
+
+            // "Speaker"/"Earpiece" are the always-available built-in routes; the
+            // built-in mic is already represented by "Earpiece" so it's skipped.
+            var devices: [String] = ["Speaker", "Earpiece"]
+            for input in session.availableInputs ?? [] where input.portType != .builtInMic {
+                devices.append(input.portName)
+            }
+
+            let currentEndpointType = endpointType(for: session.currentRoute.outputs.first?.portType)
+            let selectedDevice: String = {
+                if let input = session.currentRoute.inputs.first, input.portType != .builtInMic {
+                    return input.portName
+                }
+                return currentEndpointType
+            }()
+
+            DispatchQueue.main.async {
+                resolve([
+                    "devices": devices,
+                    "currentEndpointType": currentEndpointType,
+                    "selectedDevice": selectedDevice,
+                ])
+            }
+        }
+    }
+
+    @objc(chooseAudioDeviceEndpoint:)
+    func chooseAudioDeviceEndpoint(endpointName: String) {
+        audioSessionQueue.async { [weak self] in
+            guard let self else { return }
+            let rtcSession = RTCAudioSession.sharedInstance()
+            rtcSession.lockForConfiguration()
+            defer { rtcSession.unlockForConfiguration() }
+
+            let avSession = AVAudioSession.sharedInstance()
+            do {
+                // Record the choice before rebuilding config so makeAudioConfiguration()
+                // reflects it (adds/removes .defaultToSpeaker) and the route survives
+                // engine rebuilds. The sink owns setActive(); an override needs none.
+                self.selectedAudioDeviceEndpoint = endpointName
+                try rtcSession.setConfiguration(self.makeAudioConfiguration())
+
+                switch endpointName {
+                case "Speaker", "Earpiece":
+                    // Built-in routes: force the output and reset input to the built-in
+                    // mic so a previously preferred Bluetooth/wired mic is released.
+                    try avSession.overrideOutputAudioPort(endpointName == "Speaker" ? .speaker : .none)
+                    if let mic = avSession.availableInputs?.first(where: { $0.portType == .builtInMic }) {
+                        try avSession.setPreferredInput(mic)
+                    }
+                default:
+                    // Bluetooth/wired: prefer that port; iOS routes output to follow it.
+                    try avSession.overrideOutputAudioPort(.none)
+                    if let input = avSession.availableInputs?.first(where: { $0.portName == endpointName }) {
+                        try avSession.setPreferredInput(input)
+                    }
+                }
+                self.log("chooseAudioDeviceEndpoint: switched to \(endpointName)")
+            } catch {
+                self.log("chooseAudioDeviceEndpoint: error switching to \(endpointName): \(error)")
+            }
+        }
+    }
+
+    /// Output port type → the shared cross-platform AudioDeviceEndpointType label.
+    private func endpointType(for portType: AVAudioSession.Port?) -> String {
+        switch portType {
+        case .builtInReceiver:
+            return "Earpiece"
+        case .builtInSpeaker:
+            return "Speaker"
+        case .bluetoothA2DP, .bluetoothHFP, .bluetoothLE:
+            return "Bluetooth Device"
+        case .headphones, .usbAudio, .carAudio:
+            return "Wired Headset"
+        default:
+            return "Unknown"
+        }
+    }
+
     @objc(setEnableStereoAudioOutput:)
     func setEnableStereoAudioOutput(enabled: Bool) {
         audioSessionQueue.async { [self] in
@@ -138,7 +224,12 @@ class StreamInCallManager: RCTEventEmitter {
             #endif
             category = .playAndRecord
             mode = .voiceChat
-            options = defaultAudioDevice == .speaker ? [bluetoothOption, .defaultToSpeaker] : [bluetoothOption]
+            // Key .defaultToSpeaker off the active selection so engine rebuilds
+            // (interruption recovery) preserve the route; fall back to the start
+            // preference until the user picks a device.
+            let wantSpeaker = selectedAudioDeviceEndpoint == "Speaker"
+                || (selectedAudioDeviceEndpoint == nil && defaultAudioDevice == .speaker)
+            options = wantSpeaker ? [bluetoothOption, .defaultToSpeaker] : [bluetoothOption]
         }
 
         let rtcConfig = RTCAudioSessionConfiguration.webRTC()
@@ -168,6 +259,15 @@ class StreamInCallManager: RCTEventEmitter {
                 adm.setStereoPlayoutPreference(true)
             }
 
+            // If a Bluetooth/wired device is already connected at start and the user
+            // hasn't chosen a route, prefer it.
+            let startExternalInput = callAudioRole == .communicator && selectedAudioDeviceEndpoint == nil
+                ? AVAudioSession.sharedInstance().availableInputs?.first(where: { $0.portType != .builtInMic })
+                : nil
+            if let startExternalInput {
+                selectedAudioDeviceEndpoint = startExternalInput.portName
+            }
+
             let rtcConfig = makeAudioConfiguration()
             log("Setup with category: \(rtcConfig.category), mode: \(rtcConfig.mode), options: \(rtcConfig.categoryOptions)")
 
@@ -177,6 +277,9 @@ class StreamInCallManager: RCTEventEmitter {
             defer { session.unlockForConfiguration() }
             do {
                 try session.setConfiguration(rtcConfig)
+                if let startExternalInput {
+                    try AVAudioSession.sharedInstance().setPreferredInput(startExternalInput)
+                }
             } catch {
                 // String(describing:) shows the real error; localizedDescription prints a useless "error 0".
                 log("Error setting audio session: \(String(describing: error))")
@@ -313,6 +416,7 @@ class StreamInCallManager: RCTEventEmitter {
             stereoRefreshWorkItem = nil
             callAudioRole = .communicator
             defaultAudioDevice = .speaker
+            selectedAudioDeviceEndpoint = nil
             enableStereo = false
             audioManagerActivated = false
         }

--- a/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
+++ b/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
@@ -62,6 +62,25 @@ class IOSCallManager {
   };
 
   /**
+   * Get the current audio device status.
+   */
+  getAudioDeviceStatus = async (): Promise<AudioDeviceStatus> => {
+    invariant(Platform.OS === 'ios', 'Supported only on iOS');
+    return NativeManager.getAudioDeviceStatus();
+  };
+
+  /**
+   * Switches the audio device to the specified endpoint.
+   *
+   * @param endpointName the device name (e.g. "Speaker", "Earpiece", or a
+   * Bluetooth/wired device name as returned by getAudioDeviceStatus().devices).
+   */
+  selectAudioDevice = (endpointName: string): void => {
+    invariant(Platform.OS === 'ios', 'Supported only on iOS');
+    NativeManager.chooseAudioDeviceEndpoint(endpointName);
+  };
+
+  /**
    * Register a listener for iOS audio interruptions.
    *
    * @param onInterruption callback to be called when iOS reports an audio interruption.


### PR DESCRIPTION
### 💡 Overview

Implements iOS support for audio route selection.

Previously on iOS the only routing entry point was `showDeviceSelector`
(the system AVRoutePicker); there was no programmatic way to enumerate or
select the audio output device. The native methods
`chooseAudioDeviceEndpoint` and `getAudioDeviceStatus` are already
declared in the call-manager native module contract and implemented on
Android, but were unimplemented on iOS. This fills in the iOS half so the
existing JS API works on iOS too:

- `callManager.ios.getAudioDeviceStatus()`
- `callManager.ios.selectAudioDevice(endpointName)`

No new public API surface, this brings iOS to parity with Android.

### 🔍 Why this works on iOS

`overrideOutputAudioPort` only exposes speaker-vs-default, so output
selection can look impossible from the docs alone. The key: **output
follows the preferred input**.

- Under `.playAndRecord` + `.allowBluetoothHFP`, `setPreferredInput` on a
  Bluetooth-HFP/built-in port routes the *output* onto that device.
- `overrideOutputAudioPort(.speaker/.none)` handles the built-in
  speaker/receiver; `.defaultToSpeaker` is removed for non-speaker routes.
- Verified on-device: Speaker, Earpiece, Bluetooth (HFP), wired — incl.
  persistence across Siri/phone interruptions.

Refs:
[setPreferredInput](https://developer.apple.com/documentation/avfaudio/avaudiosession/setpreferredinput(_:)) ·
[overrideOutputAudioPort](https://developer.apple.com/documentation/avfaudio/avaudiosession/overrideoutputaudioport(_:))

### 📝 Implementation notes

- **`getAudioDeviceStatus`** enumerates the built-in routes (Speaker,
  Earpiece) plus any connected Bluetooth/wired inputs, and reports the
  current endpoint + selected device using the shared
  `AudioDeviceEndpointType` labels, so the shape matches Android.
- **`chooseAudioDeviceEndpoint`** applies the route inside the
  `RTCAudioSession` configuration lock and records the selection so
  `makeAudioConfiguration()` (the single source of truth) preserves it
  across engine rebuilds / interruption recovery. The engine sink remains
  the sole owner of `setActive()`.
  Built-in routes reset the preferred input to the built-in mic so a
  previously preferred Bluetooth/wired mic is released.
- A Bluetooth/wired device connected **at call start** is preferred
  automatically, matching typical phone-call behavior.
- Native additions in `ios/StreamInCallManager.swift` +
  `ios/StreamInCallManager.m`; JS surface added to `IOSCallManager`,
  mirroring the existing Android methods.

🎫 Ticket: N/A (community contribution)

📑 Docs: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iOS audio device controls in the call manager.
  * You can now check available audio outputs and the current selection.
  * You can also switch audio routing to a chosen endpoint such as speaker, earpiece, Bluetooth, or wired audio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->