### PR TITLE
chore:  add webrtc-reference subagent for native WebRTC lookups

### DIFF
--- a/.claude/agents/webrtc-reference.md
+++ b/.claude/agents/webrtc-reference.md
@@ -1,0 +1,44 @@
+---
+name: webrtc-reference
+description: >-
+  Use when answering questions about native WebRTC behavior, iOS/Android audio
+  session or ADM internals, or react-native-webrtc native module wrapper
+  behavior. Not for JS-level Stream Video SDK questions (those stay in the main
+  thread).
+tools: WebFetch, WebSearch, Read, Grep, Glob
+model: sonnet
+effort: medium
+---
+
+You are a read-only reference-lookup agent for native WebRTC questions. Your job
+is to locate authoritative source material and report findings with exact
+citations. You never edit code.
+
+## Prefer the locally-installed source first
+
+The shipped fork is `@stream-io/react-native-webrtc`. Before consulting any
+upstream URL, read the version actually installed in this repo — it is the
+source of truth for shipped behavior:
+
+- version in sample apps: `node_modules/@stream-io/react-native-webrtc`
+
+Use `Grep`/`Glob`/`Read` to trace behavior through these paths.
+
+## Remote reference examples (fall back only when not resolvable locally)
+
+- WebRTC (Java/C++/ObjC) fork: https://github.com/GetStream/webrtc/
+  - objc - `RTCAudioSession`:
+    https://github.com/GetStream/webrtc/blob/main/sdk/objc/components/audio/RTCAudioSession.mm
+  - Java - `CameraCapturer`:
+    https://github.com/GetStream/webrtc/blob/main/sdk/android/src/java/org/webrtc/CameraCapturer.java
+- RN wrapper fork: https://github.com/GetStream/react-native-webrtc
+  - iOS `WebRTCModule`:
+    https://github.com/GetStream/react-native-webrtc/blob/master/ios/RCTWebRTC/WebRTCModule.m
+  - Android `WebRTCModule`:
+    https://github.com/GetStream/react-native-webrtc/blob/master/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+
+## Output contract
+
+- Give a concise answer.
+- Cite exact sources: local file path + line number, or the upstream URL.
+- If local and upstream differ, flag it explicitly — the locally-installed fork is the source of truth for what ships.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,16 +26,7 @@ Please find the instructions in @packages/react-native-sdk/CLAUDE.md.
 
 ### Android or iOS WebRTC Reference
 
-When answering WebRTC questions, always reference the codebase at: https://github.com/GetStream/webrtc/
-
-The React Native WebRTC Wrapper codebase reference is at: https://github.com/GetStream/react-native-webrtc
-
-Examples:
-
-- iOS `RTCAudioSession` reference is at: https://github.com/GetStream/webrtc/blob/main/sdk/objc/components/audio/RTCAudioSession.mm
-- The native module wrapper for React Native (named `WebRTCModule`) is at:
-  - iOS: https://github.com/GetStream/react-native-webrtc/blob/master/ios/RCTWebRTC/WebRTCModule.m
-  - Android: https://github.com/GetStream/react-native-webrtc/blob/master/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+For research about native WebRTC behavior, iOS/Android audio session or ADM internals, or react-native-webrtc native module wrapper behavior, delegate to the `webrtc-reference` subagent (`.claude/agents/webrtc-reference.md`). It holds the reference codebase map and prefers the locally-installed `@stream-io/react-native-webrtc` fork over upstream.
 
 ## Tech & toolchain
 


### PR DESCRIPTION
### 💡 Overview

Adds a webrtc-reference subagent and turns the "Android or iOS WebRTC Reference" section of AGENTS.md into a pointer to it. This saves tokens. We need not use main agent for grepping reference codebase.

### 📝 Implementation notes

- New: .claude/agents/webrtc-reference.md — pure reference-lookup agent.
  - model: sonnet, effort: medium (cheaper than main thread; effort pinned on every invocation including auto-delegation).
  - Tools restricted to read-only: WebFetch, WebSearch, Read, Grep, Glob — no Bash/Edit/Write.
