### PR TITLE
fix(react-native-sdk): subscribe to remote video when the participant appears after mount

### DIFF
--- a/packages/react-native-sdk/__tests__/components/ParticipantView.test.tsx
+++ b/packages/react-native-sdk/__tests__/components/ParticipantView.test.tsx
@@ -28,7 +28,7 @@ describe('ParticipantView', () => {
     });
     render(
       <ParticipantView
-        reactions={defaultEmojiReactions}
+        supportedReactions={defaultEmojiReactions}
         participant={testParticipant}
         trackType="videoTrack"
         isVisible={false}

--- a/packages/react-native-sdk/__tests__/components/TrackSubscriber.test.tsx
+++ b/packages/react-native-sdk/__tests__/components/TrackSubscriber.test.tsx
@@ -1,0 +1,67 @@
+import React, { createRef } from 'react';
+import { LayoutChangeEvent } from 'react-native';
+import { act, render } from '@testing-library/react-native';
+import { CallingState, SfuModels } from '@stream-io/video-client';
+import TrackSubscriber, {
+  TrackSubscriberHandle,
+} from '../../src/components/Participant/ParticipantView/VideoRenderer/TrackSubscriber';
+import mockParticipant from '../mocks/participant';
+import { mockCall } from '../mocks/call';
+import { mockClientWithUser } from '../mocks/client';
+
+jest.useFakeTimers();
+
+const layoutEvent = (width: number, height: number) =>
+  ({
+    nativeEvent: { layout: { width, height, x: 0, y: 0 } },
+  }) as unknown as LayoutChangeEvent;
+
+describe('TrackSubscriber', () => {
+  it('requests the video track when the participant appears in state after the subscriber mounted', () => {
+    const client = mockClientWithUser({ id: 'test-user-id' });
+    // The subscriber mounts before the remote participant is present in call
+    // state (the initial-join / reconnect race).
+    const call = mockCall(client, []);
+    call.state.setCallingState(CallingState.JOINED);
+
+    const sessionId = 'remote-session-1';
+    const ref = createRef<TrackSubscriberHandle>();
+
+    render(
+      <TrackSubscriber
+        ref={ref}
+        call={call}
+        participantSessionId={sessionId}
+        trackType="videoTrack"
+        isVisible={true}
+      />,
+    );
+
+    // Nothing to subscribe to yet: the participant is not in state.
+    expect(call.trackSubscriptionManager.subscriptions).toHaveLength(0);
+
+    // The remote participant now appears, publishing video ("state looks good").
+    act(() => {
+      call.state.setParticipants([
+        mockParticipant({
+          sessionId,
+          publishedTracks: [SfuModels.TrackType.VIDEO],
+        }),
+      ]);
+    });
+
+    // The view lays out and reports its dimensions.
+    act(() => {
+      ref.current?.onLayoutUpdate(layoutEvent(200, 200));
+    });
+
+    // The client must now request the participant's video track. Before the fix
+    // the subscription stream was terminated at mount time, so this stayed empty.
+    expect(call.trackSubscriptionManager.subscriptions).toContainEqual(
+      expect.objectContaining({
+        sessionId,
+        trackType: SfuModels.TrackType.VIDEO,
+      }),
+    );
+  });
+});

--- a/packages/react-native-sdk/__tests__/mocks/client.ts
+++ b/packages/react-native-sdk/__tests__/mocks/client.ts
@@ -3,9 +3,9 @@ import { OwnUserResponse, StreamVideoClient } from '@stream-io/video-client';
 const apiKey = 'API_KEY';
 const simulateUserConnection = (
   client: StreamVideoClient,
-  user: OwnUserResponse,
+  user: Partial<OwnUserResponse>,
 ) => {
-  client.streamClient._setUser(user);
+  client.streamClient._setUser(user as OwnUserResponse);
 };
 
 export const mockClientWithUser = (
@@ -20,6 +20,7 @@ export const mockClientWithUser = (
         id: '123',
         created_at: '',
         push_provider: '',
+        user_id: '',
       },
     ],
     role: '',

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -17,6 +17,7 @@
     "build": "yarn copy-version && bob build && yarn build:expo-plugin",
     "test:expo-plugin": "jest --config=expo-config-plugin/jest.config.js --coverage",
     "test": "yarn copy-version && jest --coverage && yarn test:expo-plugin",
+    "test:types": "yarn copy-version && tsc -p tsconfig.spec.json",
     "copy-version": "echo \"export const version = '$npm_package_version';\" > ./src/version.ts"
   },
   "repository": {

--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/TrackSubscriber.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/TrackSubscriber.tsx
@@ -7,6 +7,7 @@ import {
   hasScreenShare,
   hasVideo,
   SfuModels,
+  type StreamVideoParticipant,
   type VideoTrackType,
 } from '@stream-io/video-client';
 import {
@@ -14,8 +15,8 @@ import {
   combineLatest,
   distinctUntilChanged,
   distinctUntilKeyChanged,
+  filter,
   map,
-  takeWhile,
 } from 'rxjs';
 export type TrackSubscriberHandle = {
   onLayoutUpdate: (event: LayoutChangeEvent) => void;
@@ -67,7 +68,7 @@ const TrackSubscriber = forwardRef<TrackSubscriberHandle, TrackSubscriberProps>(
       };
       const isPublishingTrack$ = call.state.participants$.pipe(
         map((ps) => ps.find((p) => p.sessionId === participantSessionId)),
-        takeWhile((p) => !!p),
+        filter((p): p is StreamVideoParticipant => !!p),
         distinctUntilKeyChanged('publishedTracks'),
         map((p) =>
           trackType === 'videoTrack' ? hasVideo(p) : hasScreenShare(p),

--- a/packages/react-native-sdk/tsconfig.spec.json
+++ b/packages/react-native-sdk/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declaration": false,
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src", "__tests__", "jest-setup.ts"]
+}


### PR DESCRIPTION
### 💡 Overview

Fixes a React Native bug where a remote participant's video is never subscribed to on the first session, even though the participant and its published video track are present in call state. No `updateSubscriptions` call is sent for that participant at all, and only a manual rejoin recovers.

Root cause: in `TrackSubscriber`, `isPublishingTrack$` was derived from the global `participants$` with `takeWhile((p) => !!p)`. `takeWhile` **terminates** the stream the first time the participant is transiently missing from a `participants$` snapshot (an initial-join / reconnect race). Once terminated, the `combineLatest` that drives subscriptions can never emit again, so `updateSubscriptions` is never called for that participant even after it reappears publishing video. A full remount (manual rejoin) is the only recovery, which matches the reported "works after retry" behavior.

Fix: replace the terminal `takeWhile` with a non-terminal `filter`, so absent snapshots are skipped instead of ending the stream. It emits as soon as the participant is present and survives transient absence, preserving the reconnection resilience the component was designed for (the same code was originally added in https://github.com/GetStream/stream-video-js/pull/1964 to handle remote reconnect).

### 📝 Implementation notes

Commit 1 (fix + regression test):
- `TrackSubscriber.tsx`: `takeWhile((p) => !!p)` -> `filter((p): p is StreamVideoParticipant => !!p)`.
- `TrackSubscriber.test.tsx`: mounts the subscriber before the participant exists in state, then adds it publishing video and reports a layout; asserts the real `trackSubscriptionManager.subscriptions` contains the video track. Fails on the old code (`Received array: []`), passes with the fix. No mock of the code under test (drives real `CallState` + `TrackSubscriptionManager`).

Commit 2 (test type-checking):
- Post TS 6, test files outside the build tsconfig no longer auto-discover jest ambient types. Adds `tsconfig.spec.json` (type-check only, does not affect the shipped `bob` build) plus a `test:types` script.
- Surfaced and fixed two pre-existing, test-only type errors: `mocks/client.ts` incomplete `OwnUserResponse`, and `ParticipantView.test.tsx` stale `reactions` prop (-> `supportedReactions`).

🎫 Ticket: https://linear.app/stream/issue/RN-408/rn-client-does-not-request-video-on-first-user-session

📑 Docs: _N/A (internal bug fix, no public API change)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant video loading so subscriptions wait until the participant is available and layout is reported, reducing missed video starts.
  * Fixed reaction handling in participant views to use the supported reactions setting consistently.
* **Tests**
  * Added coverage for delayed track subscription behavior.
  * Expanded test support for participant connection and type-checking.
* **Chores**
  * Added a TypeScript spec-check script to help catch typing issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->