### PR TITLE
feat(dogfood): enable video on outgoing ringing calls

### DIFF
--- a/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
+++ b/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
@@ -145,6 +145,7 @@ export const DialerPage = ({
       setRingingCall(call);
       await call.getOrCreate({
         ring: true,
+        video: true,
         data: {
           members,
           settings_override: {


### PR DESCRIPTION
### 💡 Overview

The dialer page created ringing calls without `video: true`, so outgoing rings weren't flagged as video calls. This adds `video: true` alongside the existing `ring: true` in `getOrCreate`.

### 📝 Implementation notes

One-line change in `DialerPage.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ringing now starts with video enabled by default, so calls initiated from the dialer can open with video support ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->