### PR TITLE
fix: android callingx calls should handle audio through through telecom

### DIFF
--- a/packages/react-native-callingx/README.md
+++ b/packages/react-native-callingx/README.md
@@ -66,7 +66,6 @@ Call events:
 - `didDisplayIncomingCall`
 - `didToggleHoldCallAction`
 - `didPerformSetMutedCallAction`
-- `didChangeAudioRoute`
 - `didReceiveStartCallAction`
 - `didActivateAudioSession`
 - `didDeactivateAudioSession`

--- a/packages/react-native-callingx/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-callingx/android/src/main/AndroidManifest.xml
@@ -45,7 +45,6 @@
         <action android:name="io.getstream.CALL_INACTIVE" />
         <action android:name="io.getstream.CALL_ACTIVE" />
         <action android:name="io.getstream.CALL_MUTED" />
-        <action android:name="io.getstream.CALL_ENDPOINT_CHANGED" />
         <action android:name="io.getstream.CALL_AUDIO_ENDPOINTS_CHANGED" />
         <action android:name="io.getstream.CALL_END" />
         <action android:name="io.getstream.CALL_REGISTRATION_FAILED" />

--- a/packages/react-native-callingx/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-callingx/android/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
         <action android:name="io.getstream.CALL_ACTIVE" />
         <action android:name="io.getstream.CALL_MUTED" />
         <action android:name="io.getstream.CALL_ENDPOINT_CHANGED" />
+        <action android:name="io.getstream.CALL_AUDIO_ENDPOINTS_CHANGED" />
         <action android:name="io.getstream.CALL_END" />
         <action android:name="io.getstream.CALL_REGISTRATION_FAILED" />
       </intent-filter>

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/AudioEndpointStore.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/AudioEndpointStore.kt
@@ -1,0 +1,47 @@
+package io.getstream.rn.callingx
+
+import io.getstream.rn.callingx.utils.AudioEndpointUtils
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Shared, process-wide store for Telecom audio-endpoint state.
+ *
+ * [CallService] owns the Telecom repository and writes endpoint snapshots here whenever they
+ * change; [CallingxModuleImpl] reads them to answer synchronous JS queries
+ * without cross-component coupling.
+ *
+ * Also holds the sticky default-endpoint preference, which is applied at call registration time by
+ * resolving it against the pre-call endpoints and passing it as
+ * `CallAttributesCompat.preferredStartingCallEndpoint`.
+ */
+object AudioEndpointStore {
+
+    /** Last serialized endpoints snapshot per callId (see [AudioEndpointUtils.snapshotJson]). */
+    private val snapshotByCallId = ConcurrentHashMap<String, String>()
+
+    /** Sticky default preference: "speaker" or "earpiece". Null means "let Telecom decide". */
+    @Volatile
+    private var defaultEndpointPref: String? = null
+
+    fun setSnapshot(callId: String, snapshotJson: String) {
+        snapshotByCallId[callId] = snapshotJson
+    }
+
+    fun getSnapshot(callId: String): String =
+        snapshotByCallId[callId] ?: AudioEndpointUtils.EMPTY_SNAPSHOT_JSON
+
+    fun setDefaultEndpointPref(endpointType: String?) {
+        defaultEndpointPref = endpointType
+    }
+
+    fun getDefaultEndpointPref(): String? = defaultEndpointPref
+
+    fun clear(callId: String) {
+        snapshotByCallId.remove(callId)
+    }
+
+    fun clearAll() {
+        snapshotByCallId.clear()
+        defaultEndpointPref = null
+    }
+}

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallRegistrationStore.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallRegistrationStore.kt
@@ -113,6 +113,10 @@ object CallRegistrationStore {
         return trackedCallIds.isNotEmpty()
     }
 
+    fun getTrackedCallIds(): List<String> {
+        return trackedCallIds.toList()
+    }
+
     /**
      * Queues an action for a call that is not yet registered.
      * Pending actions are drained and executed once registration completes.

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -421,13 +421,6 @@ class CallService : Service(), CallRepository.Listener {
         }
     }
 
-    override fun onCallEndpointChanged(callId: String, endpoint: String) {
-        sendBroadcastEvent(CallingxModuleImpl.CALL_ENDPOINT_CHANGED_ACTION) {
-            putExtra(CallingxModuleImpl.EXTRA_CALL_ID, callId)
-            putExtra(CallingxModuleImpl.EXTRA_AUDIO_ENDPOINT, endpoint)
-        }
-    }
-
     override fun onCallAudioEndpointsChanged(callId: String) {
         val call = callRepository.getCall(callId) ?: return
         val snapshotJson =

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -23,6 +23,7 @@ import io.getstream.rn.callingx.notifications.NotificationChannelsManager
 import io.getstream.rn.callingx.notifications.NotificationsConfig
 import io.getstream.rn.callingx.repo.CallRepository
 import io.getstream.rn.callingx.repo.CallRepositoryFactory
+import io.getstream.rn.callingx.utils.AudioEndpointUtils
 import io.getstream.rn.callingx.utils.SettingsStore
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -347,6 +348,7 @@ class CallService : Service(), CallRepository.Listener {
                 }
             }
             is Call.None, is Call.Unregistered -> {
+                AudioEndpointStore.clear(callId)
                 repromoteForegroundIfNeeded(callId)
                 if (!callRepository.hasRingingCall()) notificationManager.stopRingtone()
 
@@ -422,6 +424,21 @@ class CallService : Service(), CallRepository.Listener {
         sendBroadcastEvent(CallingxModuleImpl.CALL_ENDPOINT_CHANGED_ACTION) {
             putExtra(CallingxModuleImpl.EXTRA_CALL_ID, callId)
             putExtra(CallingxModuleImpl.EXTRA_AUDIO_ENDPOINT, endpoint)
+        }
+    }
+
+    override fun onCallAudioEndpointsChanged(callId: String) {
+        val call = callRepository.getCall(callId) ?: return
+        val snapshotJson =
+                AudioEndpointUtils.snapshotJson(
+                        call.currentCallEndpoint,
+                        call.availableCallEndpoints,
+                )
+        AudioEndpointStore.setSnapshot(callId, snapshotJson)
+
+        sendBroadcastEvent(CallingxModuleImpl.CALL_AUDIO_ENDPOINTS_CHANGED_ACTION) {
+            putExtra(CallingxModuleImpl.EXTRA_CALL_ID, callId)
+            putExtra(CallingxModuleImpl.EXTRA_AUDIO_ENDPOINTS_SNAPSHOT, snapshotJson)
         }
     }
 

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -348,6 +348,7 @@ class CallService : Service(), CallRepository.Listener {
                 }
             }
             is Call.None, is Call.Unregistered -> {
+                CallRegistrationStore.removeTrackedCall(callId)
                 AudioEndpointStore.clear(callId)
                 repromoteForegroundIfNeeded(callId)
                 if (!callRepository.hasRingingCall()) notificationManager.stopRingtone()

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
@@ -1,7 +1,9 @@
 package io.getstream.rn.callingx
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.os.ParcelUuid
 import android.telecom.DisconnectCause
 import android.util.Log
 import androidx.core.content.ContextCompat
@@ -34,6 +36,7 @@ class CallingxModuleImpl(
         const val EXTRA_ON_HOLD = "hold"
         const val EXTRA_DISCONNECT_CAUSE = "disconnect_cause"
         const val EXTRA_AUDIO_ENDPOINT = "audio_endpoint"
+        const val EXTRA_AUDIO_ENDPOINTS_SNAPSHOT = "audio_endpoints_snapshot"
         const val EXTRA_SOURCE = "source"
         const val EXTRA_ACTION = "action_name"
 
@@ -45,6 +48,7 @@ class CallingxModuleImpl(
         const val CALL_ACTIVE_ACTION = "io.getstream.CALL_ACTIVE"
         const val CALL_MUTED_ACTION = "io.getstream.CALL_MUTED"
         const val CALL_ENDPOINT_CHANGED_ACTION = "io.getstream.CALL_ENDPOINT_CHANGED"
+        const val CALL_AUDIO_ENDPOINTS_CHANGED_ACTION = "io.getstream.CALL_AUDIO_ENDPOINTS_CHANGED"
         const val CALL_END_ACTION = "io.getstream.CALL_END"
         const val CALL_REGISTRATION_FAILED_ACTION = "io.getstream.CALL_REGISTRATION_FAILED"
         const val CALL_OPTIMISTIC_ACCEPT_ACTION = "io.getstream.ACCEPT_CALL_OPTIMISTIC"
@@ -72,6 +76,7 @@ class CallingxModuleImpl(
 
         LifecycleListener.unregister()
         CallRegistrationStore.clearAll()
+        AudioEndpointStore.clearAll()
         CallEventBus.unsubscribe(this)
 
         isModuleInitialized = false
@@ -192,12 +197,7 @@ class CallingxModuleImpl(
 
     fun answerIncomingCall(callId: String, promise: Promise) {
         debugLog(TAG, "[module] answerIncomingCall: Answering call: $callId")
-        // TODO: get the call type from the call attributes
-        val isAudioCall = true // TODO: get the call type from the call attributes
-        // registeredCall.callAttributes.callType ==
-        //         CallAttributesCompat.CALL_TYPE_AUDIO_CALL
-        // currentCall?.processAction(TelecomCallAction.Answer(isAudioCall))
-        executeServiceAction(callId, CallAction.Answer(isAudioCall), promise)
+        executeServiceAction(callId, CallAction.Answer, promise)
     }
 
     fun startCall(
@@ -289,6 +289,35 @@ class CallingxModuleImpl(
 
     fun hasRegisteredCall(): Boolean {
         return CallRegistrationStore.hasRegisteredCall()
+    }
+
+    /** Android backs Telecom audio routing only when the Jetpack Telecom repository is used (API 26+). */
+    fun isTelecomBacked(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+
+    fun getAvailableAudioEndpoints(callId: String, promise: Promise) {
+        promise.resolve(AudioEndpointStore.getSnapshot(callId))
+    }
+
+    fun requestAudioEndpointChange(callId: String, endpointId: String, promise: Promise) {
+        debugLog(TAG, "[module] requestAudioEndpointChange: $callId -> $endpointId")
+        val parcelUuid =
+                try {
+                    ParcelUuid.fromString(endpointId)
+                } catch (e: IllegalArgumentException) {
+                    promise.reject("INVALID_ENDPOINT_ID", "Invalid endpoint id: $endpointId", e)
+                    return
+                }
+        executeServiceAction(callId, CallAction.SwitchAudioEndpoint(parcelUuid), promise)
+    }
+
+    fun setDefaultAudioDeviceEndpointType(endpointType: String?) {
+        debugLog(TAG, "[module] setDefaultAudioDeviceEndpointType: $endpointType")
+        AudioEndpointStore.setDefaultEndpointPref(endpointType)
+        SettingsStore.setDefaultDeviceEndpointType(reactApplicationContext, endpointType)
+    }
+
+    fun getRegisteredCallIds(): WritableArray {
+        return Arguments.fromList(CallRegistrationStore.getTrackedCallIds())
     }
 
     fun setMutedCall(callId: String, isMuted: Boolean, promise: Promise) {
@@ -493,6 +522,17 @@ class CallingxModuleImpl(
                     params.putString("output", extras.getString(EXTRA_AUDIO_ENDPOINT))
                 }
                 sendJSEvent("didChangeAudioRoute", params)
+            }
+            CALL_AUDIO_ENDPOINTS_CHANGED_ACTION -> {
+                // The snapshot (a JSON string with endpoints + currentEndpoint) is parsed on the
+                // JS side. Carried as a single string field to survive event param flattening.
+                if (extras.containsKey(EXTRA_AUDIO_ENDPOINTS_SNAPSHOT)) {
+                    params.putString(
+                            "snapshot",
+                            extras.getString(EXTRA_AUDIO_ENDPOINTS_SNAPSHOT),
+                    )
+                }
+                sendJSEvent("didChangeAudioEndpoints", params)
             }
         }
     }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
@@ -35,7 +35,6 @@ class CallingxModuleImpl(
         const val EXTRA_MUTED = "is_muted"
         const val EXTRA_ON_HOLD = "hold"
         const val EXTRA_DISCONNECT_CAUSE = "disconnect_cause"
-        const val EXTRA_AUDIO_ENDPOINT = "audio_endpoint"
         const val EXTRA_AUDIO_ENDPOINTS_SNAPSHOT = "audio_endpoints_snapshot"
         const val EXTRA_SOURCE = "source"
         const val EXTRA_ACTION = "action_name"
@@ -47,7 +46,6 @@ class CallingxModuleImpl(
         const val CALL_INACTIVE_ACTION = "io.getstream.CALL_INACTIVE"
         const val CALL_ACTIVE_ACTION = "io.getstream.CALL_ACTIVE"
         const val CALL_MUTED_ACTION = "io.getstream.CALL_MUTED"
-        const val CALL_ENDPOINT_CHANGED_ACTION = "io.getstream.CALL_ENDPOINT_CHANGED"
         const val CALL_AUDIO_ENDPOINTS_CHANGED_ACTION = "io.getstream.CALL_AUDIO_ENDPOINTS_CHANGED"
         const val CALL_END_ACTION = "io.getstream.CALL_END"
         const val CALL_REGISTRATION_FAILED_ACTION = "io.getstream.CALL_REGISTRATION_FAILED"
@@ -516,12 +514,6 @@ class CallingxModuleImpl(
                     params.putBoolean("muted", extras.getBoolean(EXTRA_MUTED, false))
                 }
                 sendJSEvent("didPerformSetMutedCallAction", params)
-            }
-            CALL_ENDPOINT_CHANGED_ACTION -> {
-                if (extras.containsKey(EXTRA_AUDIO_ENDPOINT)) {
-                    params.putString("output", extras.getString(EXTRA_AUDIO_ENDPOINT))
-                }
-                sendJSEvent("didChangeAudioRoute", params)
             }
             CALL_AUDIO_ENDPOINTS_CHANGED_ACTION -> {
                 // The snapshot (a JSON string with endpoints + currentEndpoint) is parsed on the

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/model/CallAction.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/model/CallAction.kt
@@ -14,7 +14,7 @@ import kotlinx.parcelize.Parcelize
  */
 sealed interface CallAction : Parcelable {
     @Parcelize
-    data class Answer(val isAudioCall: Boolean) : CallAction
+    object Answer : CallAction
 
     @Parcelize
     data class Disconnect(val cause: DisconnectCause) : CallAction

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/CallRepository.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/CallRepository.kt
@@ -37,7 +37,6 @@ abstract class CallRepository(protected val context: Context) {
     fun onIsCallActive(callId: String)
     fun onCallRegistered(callId: String, incoming: Boolean)
     fun onMuteCallChanged(callId: String, isMuted: Boolean)
-    fun onCallEndpointChanged(callId: String, endpoint: String)
 
     /**
      * Fired when the current endpoint or the set of available endpoints changes.

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/CallRepository.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/CallRepository.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.telecom.DisconnectCause
 import android.util.Log
 import androidx.core.telecom.CallAttributesCompat
+import androidx.core.telecom.CallEndpointCompat
 import io.getstream.rn.callingx.model.Call
 import io.getstream.rn.callingx.model.CallAction
 import io.getstream.rn.callingx.CallService
@@ -37,6 +38,11 @@ abstract class CallRepository(protected val context: Context) {
     fun onCallRegistered(callId: String, incoming: Boolean)
     fun onMuteCallChanged(callId: String, isMuted: Boolean)
     fun onCallEndpointChanged(callId: String, endpoint: String)
+
+    /**
+     * Fired when the current endpoint or the set of available endpoints changes.
+     */
+    fun onCallAudioEndpointsChanged(callId: String) {}
   }
 
   protected val _calls: MutableStateFlow<Map<String, Call.Registered>> = MutableStateFlow(emptyMap())
@@ -143,7 +149,8 @@ abstract class CallRepository(protected val context: Context) {
     displayName: String,
     address: Uri,
     isIncoming: Boolean,
-    isVideo: Boolean
+    isVideo: Boolean,
+    preferredStartingCallEndpoint: CallEndpointCompat? = null,
   ): CallAttributesCompat {
     return CallAttributesCompat(
       displayName = displayName,
@@ -164,6 +171,7 @@ abstract class CallRepository(protected val context: Context) {
         CallAttributesCompat.SUPPORTS_SET_INACTIVE or
           CallAttributesCompat.SUPPORTS_STREAM or
           CallAttributesCompat.SUPPORTS_TRANSFER,
+      preferredStartingCallEndpoint = preferredStartingCallEndpoint,
     )
   }
 

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/TelecomCallRepository.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/TelecomCallRepository.kt
@@ -10,20 +10,28 @@ import androidx.annotation.RequiresApi
 import androidx.core.telecom.CallAttributesCompat
 import androidx.core.telecom.CallControlResult
 import androidx.core.telecom.CallControlScope
+import androidx.core.telecom.CallEndpointCompat
 import androidx.core.telecom.CallsManager
+import io.getstream.rn.callingx.AudioEndpointStore
 import io.getstream.rn.callingx.debugLog
 import io.getstream.rn.callingx.model.Call
 import io.getstream.rn.callingx.model.CallAction
+import io.getstream.rn.callingx.utils.AudioEndpointUtils
+import io.getstream.rn.callingx.utils.SettingsStore
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -48,6 +56,9 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
 
     companion object {
         private const val TAG = "[Callingx] TelecomCallRepository"
+
+        /** Max time to wait for the pre-call endpoints to populate before registering the call. */
+        private const val PRE_CALL_ENDPOINTS_TIMEOUT_MS = 1500L
     }
 
     @Volatile
@@ -122,6 +133,15 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
             return
         }
 
+        // Resolve the preferred starting endpoint from the sticky default preference (if any).
+        // We must keep the pre-call endpoints flow subscribed until the in-call session has
+        // registered its endpoints, otherwise the resolved endpoint's (session-scoped) identifier
+        // is dropped by CallEndpointUuidTracker and no longer matches inside the call scope.
+        var preCallEndpointsJob: Job? = null
+        val preferredStartingEndpoint = resolvePreferredStartingEndpoint { job ->
+            preCallEndpointsJob = job
+        }
+
         // Hold the mutex only for the dedup check — release before entering the long-lived call scope
         val attributes: CallAttributesCompat
         val actionSource: Channel<CallAction>
@@ -139,6 +159,7 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
                         TAG,
                         "[repository] registerCall: Call $callId already registered, ignoring duplicate"
                 )
+                preCallEndpointsJob?.cancel()
                 return
             }
 
@@ -147,7 +168,13 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
                     "[repository] registerCall: Call $callId not found in map, proceeding with registration"
             )
 
-            attributes = createCallAttributes(displayName, address, isIncoming, isVideo)
+            attributes = createCallAttributes(
+                    displayName,
+                    address,
+                    isIncoming,
+                    isVideo,
+                    preferredStartingEndpoint,
+            )
             actionSource = Channel<CallAction>()
             flags = CallActionFlags()
             actionFlags[callId] = flags
@@ -204,6 +231,12 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
                         updateCallById(callId) { copy(availableCallEndpoints = it) }
                     }
                 }
+                // Once this in-call session has registered its endpoints, the preferred endpoint's
+                // identifier has been reused by it, so the pre-call subscription can be released.
+                launch {
+                    availableEndpoints.first { it.isNotEmpty() }
+                    preCallEndpointsJob?.cancel()
+                }
                 launch {
                     isMuted.collect {
                         updateCallById(callId) { copy(isMuted = it) }
@@ -231,9 +264,65 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
             // - The Call.actionSource channel is no longer referenced and can be garbage-collected;
             //   we do not explicitly close it because callers use trySend(), which never suspends.
             debugLog(TAG, "[repository] registerCall: Cleaning up call $callId")
+            preCallEndpointsJob?.cancel()
             removeCall(callId)
             actionFlags.remove(callId)
         }
+    }
+
+    /**
+     * Resolves the preferred starting audio endpoint from the sticky default preference, mirroring
+     * the AndroidX-recommended pattern: read [CallsManager.getAvailableStartingCallEndpoints], pick
+     * the endpoint matching the preference by type, and pass it as
+     * [CallAttributesCompat.preferredStartingCallEndpoint].
+     *
+     * The pre-call endpoints flow is kept subscribed (its [Job] handed back via [onJobStarted]) so
+     * that the endpoint's session-scoped identifier remains valid into the in-call session; the
+     * caller cancels it once the in-call session has registered its own endpoints.
+     *
+     * Returns null (and does not keep a subscription) when there is no preference, no matching
+     * endpoint, or a wired/bluetooth device is present (which must not be overridden).
+     */
+    private suspend fun resolvePreferredStartingEndpoint(
+            onJobStarted: (Job) -> Unit,
+    ): CallEndpointCompat? {
+        // In-memory pref is set by JS setup; fall back to the persisted value for the native
+        // cold-start push path where the call is registered before JS setup runs.
+        val pref =
+                AudioEndpointStore.getDefaultEndpointPref()
+                        ?: SettingsStore.getDefaultDeviceEndpointType(context)
+                        ?: return null
+        val prefType = when (pref) {
+            AudioEndpointUtils.TYPE_EARPIECE -> CallEndpointCompat.TYPE_EARPIECE
+            AudioEndpointUtils.TYPE_SPEAKER -> CallEndpointCompat.TYPE_SPEAKER
+            else -> return null
+        }
+
+        val latestPreCallEndpoints = MutableStateFlow<List<CallEndpointCompat>>(emptyList())
+        // Collected on Main: the underlying audio-device/bluetooth listeners expect a Looper.
+        val job = scope.launch(Dispatchers.Main) {
+            callsManager.getAvailableStartingCallEndpoints().collect {
+                latestPreCallEndpoints.value = it
+            }
+        }
+
+        val endpoints =
+                withTimeoutOrNull(PRE_CALL_ENDPOINTS_TIMEOUT_MS) {
+                    latestPreCallEndpoints.first { it.isNotEmpty() }
+                } ?: emptyList()
+
+        // Never override a physically-connected wired/bluetooth device.
+        val hasWiredOrBt = endpoints.any { AudioEndpointUtils.isWiredOrBluetooth(it.type) }
+        val preferred =
+                if (hasWiredOrBt) null else endpoints.firstOrNull { it.type == prefType }
+
+        if (preferred == null) {
+            job.cancel()
+            return null
+        }
+        debugLog(TAG, "[repository] resolvePreferredStartingEndpoint: preferring '$pref'")
+        onJobStarted(job)
+        return preferred
     }
 
     override fun updateCall(
@@ -276,6 +365,10 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
                                     _listener?.onCallEndpointChanged(callId, it.name.toString())
                                 }
                             }
+                            if (previous.currentCallEndpoint != call.currentCallEndpoint ||
+                                    previous.availableCallEndpoints != call.availableCallEndpoints) {
+                                _listener?.onCallAudioEndpointsChanged(callId)
+                            }
                         }
                         _listener?.onCallStateChanged(callId, call)
                     }
@@ -302,7 +395,7 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
             debugLog(TAG, "[repository] processCallActions[$callId]: action: ${action::class.simpleName}")
             when (action) {
                 is CallAction.Answer -> {
-                    doAnswer(callId, flags, action.isAudioCall)
+                    doAnswer(callId, flags)
                 }
                 is CallAction.Disconnect -> {
                     doDisconnect(callId, flags, action)
@@ -402,11 +495,11 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
         onIsCallDisconnected(callId, flags)(action.cause)
     }
 
-    private suspend fun CallControlScope.doAnswer(callId: String, flags: CallActionFlags, isAudioCall: Boolean) {
+    private suspend fun CallControlScope.doAnswer(callId: String, flags: CallActionFlags) {
         flags.isSelfAnswered.set(true)
         val callType =
-                if (isAudioCall) CallAttributesCompat.CALL_TYPE_AUDIO_CALL
-                else CallAttributesCompat.CALL_TYPE_VIDEO_CALL
+                _calls.value[callId]?.callAttributes?.callType
+                        ?: CallAttributesCompat.CALL_TYPE_VIDEO_CALL
 
         when (val result = answer(callType)) {
             is CallControlResult.Success -> {

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/TelecomCallRepository.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/repo/TelecomCallRepository.kt
@@ -360,11 +360,6 @@ class TelecomCallRepository(context: Context) : CallRepository(context) {
                                 debugLog(TAG, "[repository] observeCalls: Mute changed for $callId: ${call.isMuted}")
                                 _listener?.onMuteCallChanged(callId, call.isMuted)
                             }
-                            if (previous.currentCallEndpoint != call.currentCallEndpoint) {
-                                call.currentCallEndpoint?.let {
-                                    _listener?.onCallEndpointChanged(callId, it.name.toString())
-                                }
-                            }
                             if (previous.currentCallEndpoint != call.currentCallEndpoint ||
                                     previous.availableCallEndpoints != call.availableCallEndpoints) {
                                 _listener?.onCallAudioEndpointsChanged(callId)

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/utils/AudioEndpointUtils.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/utils/AudioEndpointUtils.kt
@@ -1,0 +1,57 @@
+package io.getstream.rn.callingx.utils
+
+import androidx.core.telecom.CallEndpointCompat
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Serialization helpers to bridge Telecom [CallEndpointCompat] values across the
+ * native <-> JS boundary. The JS SDK adapts these generic endpoint primitives into
+ * its own audio-device status shape.
+ */
+object AudioEndpointUtils {
+
+    /** Stable string type names shared with the JS layer. */
+    const val TYPE_EARPIECE = "earpiece"
+    const val TYPE_SPEAKER = "speaker"
+    const val TYPE_WIRED_HEADSET = "wired_headset"
+    const val TYPE_BLUETOOTH = "bluetooth"
+    const val TYPE_UNKNOWN = "unknown"
+
+    fun endpointTypeToString(type: Int): String = when (type) {
+        CallEndpointCompat.TYPE_EARPIECE -> TYPE_EARPIECE
+        CallEndpointCompat.TYPE_SPEAKER -> TYPE_SPEAKER
+        CallEndpointCompat.TYPE_WIRED_HEADSET -> TYPE_WIRED_HEADSET
+        CallEndpointCompat.TYPE_BLUETOOTH -> TYPE_BLUETOOTH
+        else -> TYPE_UNKNOWN
+    }
+
+    fun isWiredOrBluetooth(type: Int): Boolean =
+        type == CallEndpointCompat.TYPE_WIRED_HEADSET ||
+            type == CallEndpointCompat.TYPE_BLUETOOTH
+
+    fun toJson(endpoint: CallEndpointCompat): JSONObject = JSONObject().apply {
+        put("id", endpoint.identifier.toString())
+        put("name", endpoint.name.toString())
+        put("type", endpointTypeToString(endpoint.type))
+    }
+
+    /** Serialize a current/available endpoints snapshot into a JSON string. */
+    fun snapshotJson(
+        current: CallEndpointCompat?,
+        available: List<CallEndpointCompat>,
+    ): String {
+        val endpointsArray = JSONArray()
+        available.forEach { endpointsArray.put(toJson(it)) }
+        return JSONObject().apply {
+            put("endpoints", endpointsArray)
+            put("currentEndpoint", current?.let { toJson(it) } ?: JSONObject.NULL)
+        }.toString()
+    }
+
+    val EMPTY_SNAPSHOT_JSON: String =
+        JSONObject().apply {
+            put("endpoints", JSONArray())
+            put("currentEndpoint", JSONObject.NULL)
+        }.toString()
+}

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/utils/SettingsStore.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/utils/SettingsStore.kt
@@ -10,6 +10,7 @@ object SettingsStore {
     private const val KEY_OPTIMISTIC_ACCEPTING_TEXT = "optimistic_accepting_text"
     private const val KEY_OPTIMISTIC_REJECTING_TEXT = "optimistic_rejecting_text"
     private const val KEY_SKIP_INCOMING_PUSH_IN_FOREGROUND = "skip_incoming_push_in_foreground"
+    private const val KEY_DEFAULT_DEVICE_ENDPOINT_TYPE = "default_device_endpoint_type"
 
     private const val DEFAULT_OPTIMISTIC_ACCEPTING_TEXT = "Connecting..."
     private const val DEFAULT_OPTIMISTIC_REJECTING_TEXT = "Declining..."
@@ -58,5 +59,25 @@ object SettingsStore {
     fun shouldSkipIncomingPushInForeground(context: Context): Boolean {
         val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
         return prefs.getBoolean(KEY_SKIP_INCOMING_PUSH_IN_FOREGROUND, false)
+    }
+
+    /**
+     * Persisted so it survives process death: the native cold-start push path
+     * (startIncomingCallFromPush) registers calls before JS setup runs.
+     */
+    fun setDefaultDeviceEndpointType(context: Context, endpointType: String?) {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        prefs.edit {
+            if (endpointType != null) {
+                putString(KEY_DEFAULT_DEVICE_ENDPOINT_TYPE, endpointType)
+            } else {
+                remove(KEY_DEFAULT_DEVICE_ENDPOINT_TYPE)
+            }
+        }
+    }
+
+    fun getDefaultDeviceEndpointType(context: Context): String? {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        return prefs.getString(KEY_DEFAULT_DEVICE_ENDPOINT_TYPE, null)
     }
 }

--- a/packages/react-native-callingx/android/src/newarch/java/io/getstream/rn/callingx/CallingxModule.kt
+++ b/packages/react-native-callingx/android/src/newarch/java/io/getstream/rn/callingx/CallingxModule.kt
@@ -38,7 +38,23 @@ class CallingxModule(reactContext: ReactApplicationContext) :
     }
 
     override fun setDefaultAudioDeviceEndpointType(endpointType: String?) {
-        // leave empty
+        impl.setDefaultAudioDeviceEndpointType(endpointType)
+    }
+
+    override fun isTelecomBacked(): Boolean {
+        return impl.isTelecomBacked()
+    }
+
+    override fun getRegisteredCallIds(): WritableArray {
+        return impl.getRegisteredCallIds()
+    }
+
+    override fun getAvailableAudioEndpoints(callId: String, promise: Promise) {
+        impl.getAvailableAudioEndpoints(callId, promise)
+    }
+
+    override fun requestAudioEndpointChange(callId: String, endpointId: String, promise: Promise) {
+        impl.requestAudioEndpointChange(callId, endpointId, promise)
     }
 
     override fun setupAndroid(options: ReadableMap) {

--- a/packages/react-native-callingx/android/src/oldarch/java/io/getstream/rn/callingx/CallingxModule.kt
+++ b/packages/react-native-callingx/android/src/oldarch/java/io/getstream/rn/callingx/CallingxModule.kt
@@ -46,7 +46,27 @@ class CallingxModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun setDefaultAudioDeviceEndpointType(endpointType: String?) {
-        // leave empty
+        impl.setDefaultAudioDeviceEndpointType(endpointType)
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    fun isTelecomBacked(): Boolean {
+        return impl.isTelecomBacked()
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    fun getRegisteredCallIds(): WritableArray {
+        return impl.getRegisteredCallIds()
+    }
+
+    @ReactMethod
+    fun getAvailableAudioEndpoints(callId: String, promise: Promise) {
+        impl.getAvailableAudioEndpoints(callId, promise)
+    }
+
+    @ReactMethod
+    fun requestAudioEndpointChange(callId: String, endpointId: String, promise: Promise) {
+        impl.requestAudioEndpointChange(callId, endpointId, promise)
     }
 
     @ReactMethod

--- a/packages/react-native-callingx/ios/Callingx.mm
+++ b/packages/react-native-callingx/ios/Callingx.mm
@@ -416,6 +416,67 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(hasRegisteredCall) {
 }
 #endif
 
+#pragma mark - isTelecomBacked
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (NSNumber *)isTelecomBacked {
+  // Android-only Telecom routing; iOS uses the CallKit bypass instead.
+  return @NO;
+}
+#else
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isTelecomBacked) {
+  return @NO;
+}
+#endif
+
+#pragma mark - getRegisteredCallIds
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (NSArray<NSString *> *)getRegisteredCallIds {
+  return @[];
+}
+#else
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getRegisteredCallIds) {
+  return @[];
+}
+#endif
+
+#pragma mark - getAvailableAudioEndpoints
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)getAvailableAudioEndpoints:(nonnull NSString *)callId
+                           resolve:(nonnull RCTPromiseResolveBlock)resolve
+                            reject:(nonnull RCTPromiseRejectBlock)reject {
+  resolve(@"{\"endpoints\":[],\"currentEndpoint\":null}");
+}
+#else
+RCT_EXPORT_METHOD(getAvailableAudioEndpoints:(NSString *)callId
+                           resolve:(RCTPromiseResolveBlock)resolve
+                            reject:(RCTPromiseRejectBlock)reject) {
+  resolve(@"{\"endpoints\":[],\"currentEndpoint\":null}");
+}
+#endif
+
+#pragma mark - requestAudioEndpointChange
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)requestAudioEndpointChange:(nonnull NSString *)callId
+                        endpointId:(nonnull NSString *)endpointId
+                           resolve:(nonnull RCTPromiseResolveBlock)resolve
+                            reject:(nonnull RCTPromiseRejectBlock)reject {
+  // Not implemented on iOS
+  resolve(@YES);
+}
+#else
+RCT_EXPORT_METHOD(requestAudioEndpointChange:(NSString *)callId
+                        endpointId:(NSString *)endpointId
+                           resolve:(RCTPromiseResolveBlock)resolve
+                            reject:(RCTPromiseRejectBlock)reject) {
+  // Not implemented on iOS
+  resolve(@YES);
+}
+#endif
+
 #pragma mark - setCurrentCallActive
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-callingx/ios/CallingxImpl.swift
+++ b/packages/react-native-callingx/ios/CallingxImpl.swift
@@ -10,7 +10,6 @@ import stream_react_native_webrtc
     public static let didReceiveStartCallAction = "didReceiveStartCallAction"
     public static let didToggleHoldAction = "didToggleHoldCallAction"
     public static let didPerformSetMutedCallAction = "didPerformSetMutedCallAction"
-    public static let didChangeAudioRoute = "didChangeAudioRoute"
     public static let didAudioInterruption = "didAudioInterruption"
     public static let didDisplayIncomingCall = "didDisplayIncomingCall"
     public static let didActivateAudioSession = "didActivateAudioSession"
@@ -27,7 +26,7 @@ import stream_react_native_webrtc
 }
 
 // MARK: - Callingx Implementation
-@objc public class CallingxImpl: NSObject, CXProviderDelegate, RTCAudioSessionDelegate {
+@objc public class CallingxImpl: NSObject, CXProviderDelegate {
 
     // MARK: - Shared State
     @objc public static var sharedProvider: CXProvider?
@@ -89,10 +88,6 @@ import stream_react_native_webrtc
         isSetup = false
         canSendEvents = false
 
-        // Route changes go through RTCAudioSessionDelegate (fires after WebRTC's
-        // internal bookkeeping, so we don't need to defensively re-read currentRoute).
-        RTCAudioSession.sharedInstance().add(self)
-
         // Interruptions stay on NSNotificationCenter: the delegate's
         // `audioSessionDidBeginInterruption:` callback doesn't carry userInfo, and
         // `AVAudioSessionInterruptionReasonKey` (which we branch on for hardware
@@ -120,7 +115,6 @@ import stream_react_native_webrtc
     }
     
     deinit {
-        RTCAudioSession.sharedInstance().remove(self)
         NotificationCenter.default.removeObserver(self)
         engineSubscription?.cancel()
         engineSubscription = nil
@@ -217,14 +211,6 @@ import stream_react_native_webrtc
         // Backed by the warm CXCallObserver maintained in UUIDStorage — no per-call observer
         // construction and no cold-snapshot misses. Intersects our calls with CallKit's live set.
         return uuidStorage?.hasRegisteredCall() ?? false
-    }
-    
-    @objc public static func getAudioOutput() -> String? {
-        let outputs = AVAudioSession.sharedInstance().currentRoute.outputs
-        if !outputs.isEmpty {
-            return outputs[0].portType.rawValue
-        }
-        return nil
     }
     
     @objc public static func endCall(_ callId: String, reason: Int) {
@@ -329,23 +315,6 @@ import stream_react_native_webrtc
         }
     }
     
-    // MARK: - RTCAudioSessionDelegate
-
-    public func audioSessionDidChangeRoute(_ session: RTCAudioSession,
-                                           reason: AVAudioSession.RouteChangeReason,
-                                           previousRoute: AVAudioSessionRouteDescription) {
-        guard let output = CallingxImpl.getAudioOutput() else {
-            return
-        }
-
-        let params: [String: Any] = [
-            "output": output,
-            "reason": reason.rawValue
-        ]
-
-        sendEvent(CallingxEvents.didChangeAudioRoute, body: params)
-    }
-
     // MARK: - Audio Session Interruption
 
     // Observability + JS-event only; audio recovery is WebRTC's: AudioEngineDevice

--- a/packages/react-native-callingx/src/CallingxModule.ts
+++ b/packages/react-native-callingx/src/CallingxModule.ts
@@ -17,6 +17,7 @@ import {
   type EventParams,
   type CallingExpOptions,
   type DefaultDeviceEndpointType,
+  type AudioEndpointsSnapshot,
   type VoipEventName,
   type VoipEventParams,
   type VoipEventData,
@@ -63,6 +64,13 @@ class CallingxModule implements ICallingxModule {
     return this._isSetup;
   }
 
+  get isTelecomBacked(): boolean {
+    if (Platform.OS !== 'android') {
+      return false;
+    }
+    return NativeCallingModule.isTelecomBacked();
+  }
+
   setup(options: CallingExpOptions): void {
     if (this._isSetup) {
       return;
@@ -90,6 +98,7 @@ class CallingxModule implements ICallingxModule {
         ongoingChannel,
         notificationTexts,
         skipIncomingPushInForeground = false,
+        defaultDeviceEndpointType,
       } = options.android ?? {};
 
       this.titleTransformer =
@@ -117,6 +126,12 @@ class CallingxModule implements ICallingxModule {
 
       NativeCallingModule.setupAndroid(notificationsConfig);
 
+      if (defaultDeviceEndpointType) {
+        NativeCallingModule.setDefaultAudioDeviceEndpointType(
+          defaultDeviceEndpointType,
+        );
+      }
+
       registerHeadlessTask();
     }
 
@@ -130,8 +145,42 @@ class CallingxModule implements ICallingxModule {
   setDefaultAudioDeviceEndpointType(
     endpointType: DefaultDeviceEndpointType,
   ): void {
-    if (Platform.OS !== 'ios') return;
     NativeCallingModule.setDefaultAudioDeviceEndpointType(endpointType);
+  }
+
+  getRegisteredCallIds(): string[] {
+    if (Platform.OS !== 'android') {
+      return [];
+    }
+    return NativeCallingModule.getRegisteredCallIds();
+  }
+
+  async getAvailableAudioEndpoints(
+    callId: string,
+  ): Promise<AudioEndpointsSnapshot> {
+    const empty: AudioEndpointsSnapshot = {
+      endpoints: [],
+      currentEndpoint: null,
+    };
+    if (Platform.OS !== 'android') {
+      return empty;
+    }
+    try {
+      const json = await NativeCallingModule.getAvailableAudioEndpoints(callId);
+      return JSON.parse(json) as AudioEndpointsSnapshot;
+    } catch {
+      return empty;
+    }
+  }
+
+  requestAudioEndpointChange(
+    callId: string,
+    endpointId: string,
+  ): Promise<void> {
+    if (Platform.OS !== 'android') {
+      return Promise.resolve();
+    }
+    return NativeCallingModule.requestAudioEndpointChange(callId, endpointId);
   }
 
   getInitialEvents(): EventData[] {

--- a/packages/react-native-callingx/src/EventManager.ts
+++ b/packages/react-native-callingx/src/EventManager.ts
@@ -7,8 +7,33 @@ import type {
   VoipEventName,
 } from './types';
 import { isVoipEvent, isTurboModuleEnabled } from './utils/utils';
+import type { AudioEndpointsSnapshot } from './types';
 
 type EventListener<T> = (params: T) => void;
+
+/**
+ * Native carries the audio-endpoints snapshot as a single JSON string (`snapshot`) to survive
+ * event-param flattening across the bridge. Expand it into the structured public shape here.
+ */
+const normalizeEventParams = (event: EventData | VoipEventData): unknown => {
+  if (event.eventName !== 'didChangeAudioEndpoints') {
+    return event.params;
+  }
+  const raw = event.params as { callId?: string; snapshot?: string };
+  const fallback: AudioEndpointsSnapshot = {
+    endpoints: [],
+    currentEndpoint: null,
+  };
+  let snapshot = fallback;
+  if (raw.snapshot) {
+    try {
+      snapshot = JSON.parse(raw.snapshot) as AudioEndpointsSnapshot;
+    } catch {
+      snapshot = fallback;
+    }
+  }
+  return { callId: raw.callId, ...snapshot };
+};
 
 class EventManager<Name extends EventName | VoipEventName, Params> {
   private listenersCount: number = 0;
@@ -28,7 +53,8 @@ class EventManager<Name extends EventName | VoipEventName, Params> {
       const eventHandler = (event: EventData | VoipEventData) => {
         const eventListeners =
           this.eventListeners.get(event.eventName as Name) || [];
-        eventListeners.forEach((listener) => listener(event.params as Params));
+        const params = normalizeEventParams(event);
+        eventListeners.forEach((listener) => listener(params as Params));
       };
 
       if (isTurboModuleEnabled) {

--- a/packages/react-native-callingx/src/spec/NativeCallingx.ts
+++ b/packages/react-native-callingx/src/spec/NativeCallingx.ts
@@ -45,6 +45,25 @@ export interface Spec extends TurboModule {
 
   canPostNotifications(): boolean;
 
+  /**
+   * Whether audio routing is backed by the Jetpack Telecom stack on this device.
+   * Android: true on API 26+. iOS: always false (CallKit path uses its own bypass).
+   */
+  isTelecomBacked(): boolean;
+
+  /** Call ids currently registered with Telecom (Android). Empty on iOS. */
+  getRegisteredCallIds(): Array<string>;
+
+  /**
+   * Resolves a JSON string snapshot `{ endpoints: [{id,name,type}], currentEndpoint }`
+   * of the Telecom audio endpoints for the given call (Android). Resolves an empty
+   * snapshot on iOS / when the call is unknown.
+   */
+  getAvailableAudioEndpoints(callId: string): Promise<string>;
+
+  /** Requests a Telecom audio-endpoint change by endpoint id (Android). */
+  requestAudioEndpointChange(callId: string, endpointId: string): Promise<void>;
+
   getInitialEvents(): Array<{
     eventName: string;
     params: {
@@ -56,6 +75,8 @@ export interface Spec extends TurboModule {
       phase?: string;
       reason?: string;
       shouldResume?: boolean;
+      output?: string;
+      snapshot?: string;
     };
   }>;
 
@@ -158,6 +179,8 @@ export interface Spec extends TurboModule {
       phase?: string;
       reason?: string;
       shouldResume?: boolean;
+      output?: string;
+      snapshot?: string;
     };
   }>;
 

--- a/packages/react-native-callingx/src/spec/NativeCallingx.ts
+++ b/packages/react-native-callingx/src/spec/NativeCallingx.ts
@@ -75,7 +75,6 @@ export interface Spec extends TurboModule {
       phase?: string;
       reason?: string;
       shouldResume?: boolean;
-      output?: string;
       snapshot?: string;
     };
   }>;
@@ -179,7 +178,6 @@ export interface Spec extends TurboModule {
       phase?: string;
       reason?: string;
       shouldResume?: boolean;
-      output?: string;
       snapshot?: string;
     };
   }>;

--- a/packages/react-native-callingx/src/types.ts
+++ b/packages/react-native-callingx/src/types.ts
@@ -3,6 +3,27 @@ import type { ManagableTask } from './utils/headlessTask';
 
 export type DefaultDeviceEndpointType = 'speaker' | 'earpiece';
 
+/** Generic Telecom audio endpoint type names (Android). */
+export type AudioEndpointType =
+  | 'earpiece'
+  | 'speaker'
+  | 'wired_headset'
+  | 'bluetooth'
+  | 'unknown';
+
+/** A single Telecom audio endpoint. `id` is opaque and passed back to select it. */
+export type AudioEndpoint = {
+  id: string;
+  name: string;
+  type: AudioEndpointType;
+};
+
+/** Snapshot of the Telecom audio endpoints for a call. */
+export type AudioEndpointsSnapshot = {
+  endpoints: AudioEndpoint[];
+  currentEndpoint: AudioEndpoint | null;
+};
+
 export interface ICallingxModule {
   /**
    * Whether the module can post call notifications. Android only. iOS always returns true.
@@ -16,6 +37,11 @@ export interface ICallingxModule {
   get canPostNotifications(): boolean;
   get isOngoingCallsEnabled(): boolean;
   get isSetup(): boolean;
+  /**
+   * Whether audio routing on this device is backed by the Jetpack Telecom stack.
+   * Android: true on API 26+. iOS: always false.
+   */
+  get isTelecomBacked(): boolean;
 
   /**
    * Setup the module. This method must be called before any other method.
@@ -34,12 +60,32 @@ export interface ICallingxModule {
   setShouldRejectCallWhenBusy(shouldReject: boolean): void;
 
   /**
-   * Set the default audio endpoint for CallKit-managed calls (iOS only; no-op on Android).
-   * Sticky preference applied next time CallKit activates the session.
+   * Set the default audio endpoint applied when the OS activates the call's audio session.
+   * - iOS: applied next time CallKit activates the session.
+   * - Android (Telecom): applied once when the call becomes active and no wired/bluetooth
+   *   device is connected.
+   * Sticky preference.
    */
   setDefaultAudioDeviceEndpointType(
     endpointType: DefaultDeviceEndpointType,
   ): void;
+
+  /**
+   * Call ids currently registered with the native calling module (Android Telecom).
+   * Empty on iOS.
+   */
+  getRegisteredCallIds(): string[];
+
+  /**
+   * Get the current Telecom audio endpoints for a call (Android). On iOS / unknown call,
+   * resolves an empty snapshot.
+   */
+  getAvailableAudioEndpoints(callId: string): Promise<AudioEndpointsSnapshot>;
+
+  /**
+   * Request a Telecom audio-endpoint change by endpoint id (Android). No-op on iOS.
+   */
+  requestAudioEndpointChange(callId: string, endpointId: string): Promise<void>;
   /**
    * Get the initial events. This method is used to get the initial events from the app launch.
    * The events are queued and can be retrieved after the module is setup.
@@ -270,6 +316,13 @@ export type InternalAndroidOptions = {
    * @default false
    */
   skipIncomingPushInForeground?: boolean;
+  /**
+   * Default audio endpoint for Telecom-managed calls on Android.
+   * Applied at call registration as `CallAttributesCompat.preferredStartingCallEndpoint`
+   * Note: Works only before the call is registered.
+   * @default 'speaker'
+   */
+  defaultDeviceEndpointType?: DefaultDeviceEndpointType;
 };
 type AndroidOptions = InternalAndroidOptions & NotificationTransformers;
 
@@ -305,6 +358,7 @@ export type EventName =
   | 'didDisplayIncomingCall'
   | 'didToggleHoldCallAction'
   | 'didChangeAudioRoute'
+  | 'didChangeAudioEndpoints'
   | 'didAudioInterruption'
   | 'didReceiveStartCallAction'
   | 'didPerformSetMutedCallAction'
@@ -343,6 +397,9 @@ export type EventParams = {
     callId: string;
     output: string;
   };
+  didChangeAudioEndpoints: {
+    callId: string;
+  } & AudioEndpointsSnapshot;
   didAudioInterruption: IOSAudioInterruptionEvent;
   didReceiveStartCallAction: {
     callId: string;

--- a/packages/react-native-callingx/src/types.ts
+++ b/packages/react-native-callingx/src/types.ts
@@ -357,7 +357,6 @@ export type EventName =
   | 'endCall'
   | 'didDisplayIncomingCall'
   | 'didToggleHoldCallAction'
-  | 'didChangeAudioRoute'
   | 'didChangeAudioEndpoints'
   | 'didAudioInterruption'
   | 'didReceiveStartCallAction'
@@ -392,10 +391,6 @@ export type EventParams = {
   didPerformSetMutedCallAction: {
     callId: string;
     muted: boolean;
-  };
-  didChangeAudioRoute: {
-    callId: string;
-    output: string;
   };
   didChangeAudioEndpoints: {
     callId: string;

--- a/packages/react-native-callingx/src/utils/constants.ts
+++ b/packages/react-native-callingx/src/utils/constants.ts
@@ -21,7 +21,9 @@ export const defaultiOSOptions: Required<InternalIOSOptions> = {
 
 export const defaultAndroidOptions: Omit<
   DeepRequired<InternalAndroidOptions>,
-  'notificationTexts' | 'skipIncomingPushInForeground'
+  | 'notificationTexts'
+  | 'skipIncomingPushInForeground'
+  | 'defaultDeviceEndpointType'
 > = {
   incomingChannel: {
     id: 'stream_incoming_calls_channel',

--- a/packages/react-native-sdk/__tests__/call-manager/CallManager.test.ts
+++ b/packages/react-native-sdk/__tests__/call-manager/CallManager.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the Android Telecom (callingx) audio-routing branch in CallManager.
+ * The SDK delegates routing to callingx when a call is Telecom-managed, adapting callingx's
+ * generic endpoint primitives to the unchanged AudioDeviceStatus shape.
+ */
+
+type Snapshot = {
+  endpoints: { id: string; name: string; type: string }[];
+  currentEndpoint: { id: string; name: string; type: string } | null;
+};
+
+const makeNativeManager = () => ({
+  setTelecomManagedMode: jest.fn(),
+  setAudioRole: jest.fn(),
+  setDefaultAudioDeviceEndpointType: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+  setup: jest.fn(),
+  chooseAudioDeviceEndpoint: jest.fn(),
+  getAudioDeviceStatus: jest.fn(),
+  setForceSpeakerphoneOn: jest.fn(),
+});
+
+const makeCallingx = (overrides: Partial<any> = {}) => ({
+  isSetup: true,
+  isTelecomBacked: true,
+  isOngoingCallsEnabled: false,
+  hasRegisteredCall: jest.fn().mockReturnValue(true),
+  getRegisteredCallIds: jest.fn().mockReturnValue(['type:id']),
+  getAvailableAudioEndpoints: jest.fn(),
+  requestAudioEndpointChange: jest.fn().mockResolvedValue(undefined),
+  setDefaultAudioDeviceEndpointType: jest.fn(),
+  addEventListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
+  ...overrides,
+});
+
+/** Load CallManager with the given platform + mocked native/callingx modules. */
+const loadCallManager = ({
+  os,
+  nativeManager,
+  callingx,
+}: {
+  os: 'android' | 'ios';
+  nativeManager: ReturnType<typeof makeNativeManager>;
+  callingx: ReturnType<typeof makeCallingx> | undefined;
+}) => {
+  let mod!: typeof import('../../src/modules/call-manager/CallManager');
+  jest.isolateModules(() => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: os, select: (o: any) => o[os] },
+      NativeModules: { StreamInCallManager: nativeManager },
+      NativeEventEmitter: class {
+        addListener() {
+          return { remove: jest.fn() };
+        }
+      },
+    }));
+    jest.doMock('../../src/utils/push/libs/callingx', () => ({
+      getCallingxLibIfAvailable: () => callingx,
+    }));
+    mod = require('../../src/modules/call-manager/CallManager');
+  });
+  return mod;
+};
+
+const speakerSnapshot: Snapshot = {
+  endpoints: [
+    { id: 'ear', name: 'Earpiece', type: 'earpiece' },
+    { id: 'spk', name: 'Speaker', type: 'speaker' },
+    { id: 'bt1', name: 'Sony WH', type: 'bluetooth' },
+  ],
+  currentEndpoint: { id: 'spk', name: 'Speaker', type: 'speaker' },
+};
+
+describe('CallManager Android Telecom branch', () => {
+  afterEach(() => jest.resetModules());
+
+  it('adapts a callingx snapshot to AudioDeviceStatus', async () => {
+    const nativeManager = makeNativeManager();
+    const callingx = makeCallingx({
+      getAvailableAudioEndpoints: jest.fn().mockResolvedValue(speakerSnapshot),
+    });
+    const { CallManager } = loadCallManager({
+      os: 'android',
+      nativeManager,
+      callingx,
+    });
+    const status = await new CallManager().android.getAudioDeviceStatus();
+
+    expect(callingx.getAvailableAudioEndpoints).toHaveBeenCalledWith('type:id');
+    expect(nativeManager.getAudioDeviceStatus).not.toHaveBeenCalled();
+    expect(status).toEqual({
+      devices: ['Earpiece', 'Speaker', 'Sony WH'],
+      currentEndpointType: 'Speaker',
+      selectedDevice: 'Speaker',
+    });
+  });
+
+  it('selectAudioDevice resolves name -> id and routes via Telecom', async () => {
+    const nativeManager = makeNativeManager();
+    const callingx = makeCallingx({
+      getAvailableAudioEndpoints: jest.fn().mockResolvedValue(speakerSnapshot),
+    });
+    const { CallManager } = loadCallManager({
+      os: 'android',
+      nativeManager,
+      callingx,
+    });
+    new CallManager().android.selectAudioDevice('Sony WH');
+    await new Promise((r) => setImmediate(r));
+
+    expect(callingx.requestAudioEndpointChange).toHaveBeenCalledWith(
+      'type:id',
+      'bt1',
+    );
+    expect(nativeManager.chooseAudioDeviceEndpoint).not.toHaveBeenCalled();
+  });
+
+  it('setForceSpeakerphoneOn(true) routes to the speaker endpoint', async () => {
+    const nativeManager = makeNativeManager();
+    const callingx = makeCallingx({
+      getAvailableAudioEndpoints: jest.fn().mockResolvedValue(speakerSnapshot),
+    });
+    const { CallManager } = loadCallManager({
+      os: 'android',
+      nativeManager,
+      callingx,
+    });
+    new CallManager().speaker.setForceSpeakerphoneOn(true);
+    await new Promise((r) => setImmediate(r));
+
+    expect(callingx.requestAudioEndpointChange).toHaveBeenCalledWith(
+      'type:id',
+      'spk',
+    );
+    expect(nativeManager.setForceSpeakerphoneOn).not.toHaveBeenCalled();
+  });
+
+  it('setForceSpeakerphoneOn(false) prefers wired > bluetooth > earpiece', async () => {
+    const nativeManager = makeNativeManager();
+    // No wired device present -> should pick bluetooth over earpiece.
+    const callingx = makeCallingx({
+      getAvailableAudioEndpoints: jest.fn().mockResolvedValue(speakerSnapshot),
+    });
+    const { CallManager } = loadCallManager({
+      os: 'android',
+      nativeManager,
+      callingx,
+    });
+    new CallManager().speaker.setForceSpeakerphoneOn(false);
+    await new Promise((r) => setImmediate(r));
+
+    expect(callingx.requestAudioEndpointChange).toHaveBeenCalledWith(
+      'type:id',
+      'bt1',
+    );
+  });
+
+  it('start() enters telecom-managed mode and forwards the default endpoint', () => {
+    const nativeManager = makeNativeManager();
+    const callingx = makeCallingx();
+    const { CallManager } = loadCallManager({
+      os: 'android',
+      nativeManager,
+      callingx,
+    });
+    new CallManager().start({
+      audioRole: 'communicator',
+      deviceEndpointType: 'earpiece',
+    });
+
+    expect(callingx.setDefaultAudioDeviceEndpointType).toHaveBeenCalledWith(
+      'earpiece',
+    );
+    expect(nativeManager.setTelecomManagedMode).toHaveBeenCalledWith(true);
+    expect(nativeManager.setAudioRole).toHaveBeenCalledWith('communicator');
+    expect(nativeManager.start).toHaveBeenCalled();
+  });
+
+  it('start() disables telecom-managed mode for non-telecom (classic) calls', () => {
+    const nativeManager = makeNativeManager();
+    // callingx present but no registered call and ongoing disabled -> classic path.
+    const callingx = makeCallingx({
+      hasRegisteredCall: jest.fn().mockReturnValue(false),
+      isOngoingCallsEnabled: false,
+    });
+    const { CallManager } = loadCallManager({
+      os: 'android',
+      nativeManager,
+      callingx,
+    });
+    new CallManager().start({ audioRole: 'communicator' });
+
+    expect(nativeManager.setTelecomManagedMode).toHaveBeenCalledWith(false);
+    expect(nativeManager.start).toHaveBeenCalled();
+  });
+
+  it('addAudioDeviceChangeListener uses callingx events when telecom-managed', () => {
+    const nativeManager = makeNativeManager();
+    const callingx = makeCallingx();
+    const { CallManager } = loadCallManager({
+      os: 'android',
+      nativeManager,
+      callingx,
+    });
+    const onChange = jest.fn();
+    new CallManager().android.addAudioDeviceChangeListener(onChange);
+
+    expect(callingx.addEventListener).toHaveBeenCalledWith(
+      'didChangeAudioEndpoints',
+      expect.any(Function),
+    );
+    // Simulate a native event and assert adaptation.
+    const cb = callingx.addEventListener.mock.calls[0][1];
+    cb({ callId: 'type:id', ...speakerSnapshot });
+    expect(onChange).toHaveBeenCalledWith({
+      devices: ['Earpiece', 'Speaker', 'Sony WH'],
+      currentEndpointType: 'Speaker',
+      selectedDevice: 'Speaker',
+    });
+  });
+});

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/audio/AudioDeviceManager.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/audio/AudioDeviceManager.kt
@@ -103,6 +103,14 @@ class AudioDeviceManager(
 
     var callAudioRole: CallAudioRole = CallAudioRole.Communicator
 
+    /**
+     * When true, the call is managed by the Android Telecom stack (via callingx).
+     * Telecom owns audio focus, audio mode and device routing, so we must NOT use
+     * AudioManager.setCommunicationDevice / startBluetoothSco / audio-focus APIs here.
+     * We keep owning proximity, keep-screen-on and mic/output mute.
+     */
+    var telecomManagedMode: Boolean = false
+
     val bluetoothManager = BluetoothManager(mReactContext, this)
 
     private val proximityManager by lazy { ProximityManager(mReactContext, this) }
@@ -114,12 +122,14 @@ class AudioDeviceManager(
     }
 
     fun setup() {
-        if (callAudioRole == CallAudioRole.Communicator) {
-            mAudioManager.mode = AudioManager.MODE_IN_COMMUNICATION
-        } else {
-            // Audio routing is handled automatically by the system in normal media mode
-            // and bluetooth microphones may not work on some devices.
-            mAudioManager.mode = AudioManager.MODE_NORMAL
+        if (!telecomManagedMode) {
+            if (callAudioRole == CallAudioRole.Communicator) {
+                mAudioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+            } else {
+                // Audio routing is handled automatically by the system in normal media mode
+                // and bluetooth microphones may not work on some devices.
+                mAudioManager.mode = AudioManager.MODE_NORMAL
+            }
         }
         audioFocusUtil.setup(callAudioRole, mReactContext)
     }
@@ -133,33 +143,44 @@ class AudioDeviceManager(
                 // Audio routing is manually controlled by the SDK in communication media mode
                 // and local microphone can be published
                 activity.volumeControlStream = AudioManager.STREAM_VOICE_CALL
-                bluetoothManager.start()
-                mAudioManager.registerAudioDeviceCallback(this, null)
-                updateAudioDeviceState()
+                if (!telecomManagedMode) {
+                    // Telecom owns routing/focus; only run our own routing when not Telecom-managed.
+                    bluetoothManager.start()
+                    mAudioManager.registerAudioDeviceCallback(this, null)
+                    updateAudioDeviceState()
+                }
                 proximityManager.start()
             } else {
                 activity.volumeControlStream = AudioManager.USE_DEFAULT_STREAM_TYPE
             }
-            audioFocusUtil.requestFocus(callAudioRole, mReactContext)
+            if (!telecomManagedMode) {
+                audioFocusUtil.requestFocus(callAudioRole, mReactContext)
+            }
         }
     }
 
     fun stop(activity: Activity) {
         runInAudioThread {
             if (callAudioRole == CallAudioRole.Communicator) {
-                if (Build.VERSION.SDK_INT >= 31) {
-                    mAudioManager.clearCommunicationDevice()
-                } else {
-                    mAudioManager.setSpeakerphoneOn(false)
+                if (!telecomManagedMode) {
+                    // Only tear down what we set up ourselves; Telecom owns its own teardown.
+                    if (Build.VERSION.SDK_INT >= 31) {
+                        mAudioManager.clearCommunicationDevice()
+                    } else {
+                        mAudioManager.setSpeakerphoneOn(false)
+                    }
+                    bluetoothManager.stop()
                 }
                 callAudioRole = CallAudioRole.Communicator
                 enableStereo = false
                 defaultAudioDevice = AudioDeviceEndpoint.TYPE_SPEAKER
-                bluetoothManager.stop()
                 proximityManager.stop()
             }
             activity.volumeControlStream = AudioManager.USE_DEFAULT_STREAM_TYPE
-            audioFocusUtil.abandonFocus()
+            if (!telecomManagedMode) {
+                audioFocusUtil.abandonFocus()
+            }
+            telecomManagedMode = false
         }
     }
 
@@ -379,6 +400,10 @@ class AudioDeviceManager(
      */
     fun updateAudioDeviceState() {
         runInAudioThread {
+            if (telecomManagedMode) {
+                // Telecom is the single source of truth for routing/endpoints in this mode.
+                return@runInAudioThread
+            }
             val audioDevices = getCurrentDeviceEndpoints()
             val audioDeviceNamesSet = audioDevices.map { it.name }.toSet()
             val devicesChanged = if (cachedAvailableEndpointNamesSet.size != audioDevices.size) {
@@ -551,6 +576,10 @@ class AudioDeviceManager(
     }
 
     private fun sendAudioStatusEvent() {
+        if (telecomManagedMode) {
+            // callingx emits endpoint changes in this mode; avoid duplicate/conflicting events.
+            return
+        }
         try {
             if (mReactContext.hasActiveReactInstance()) {
                 val payload = audioStatusMap()

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/callmanager/StreamInCallManagerModule.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/callmanager/StreamInCallManagerModule.kt
@@ -64,6 +64,18 @@ class StreamInCallManagerModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun setTelecomManagedMode(enabled: Boolean) {
+        AudioDeviceManager.runInAudioThread {
+            if (audioManagerActivated) {
+                Log.e(TAG, "setTelecomManagedMode(): AudioManager is already activated and so telecom-managed mode cannot be changed")
+                return@runInAudioThread
+            }
+            Log.d(TAG, "setTelecomManagedMode(): $enabled")
+            mAudioDeviceManager.telecomManagedMode = enabled
+        }
+    }
+
+    @ReactMethod
     fun setDefaultAudioDeviceEndpointType(endpointDeviceTypeName: String) {
         AudioDeviceManager.runInAudioThread {
             if (audioManagerActivated) {

--- a/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
+++ b/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
@@ -34,9 +34,24 @@ const isAndroidTelecomManaged = (): boolean => {
   );
 };
 
-/** The callId of the (single) call currently registered with Telecom, if any. */
-const getTelecomCallId = (): string | undefined =>
-  CallingxModule?.getRegisteredCallIds()[0];
+/**
+ * When the current call is Telecom-managed, returns the callingx module and the
+ * registered callId. Centralizes the guard so call sites don't repeat the module /
+ * callId checks — `isAndroidTelecomManaged()` already implies the module exists, but
+ * the extra narrowing here is what makes that provable to the type-checker.
+ */
+const getTelecomContext = ():
+  | { cx: NonNullable<typeof CallingxModule>; callId: string }
+  | undefined => {
+  if (!isAndroidTelecomManaged() || !CallingxModule) {
+    return undefined;
+  }
+  const callId = CallingxModule.getRegisteredCallIds()[0];
+  if (!callId) {
+    return undefined;
+  }
+  return { cx: CallingxModule, callId };
+};
 
 /** Map a generic Telecom endpoint type to the SDK's endpoint display name. */
 const endpointTypeToDisplayName = (
@@ -75,13 +90,10 @@ class AndroidCallManager {
    */
   getAudioDeviceStatus = async (): Promise<AudioDeviceStatus> => {
     invariant(Platform.OS === 'android', 'Supported only on Android');
-    if (isAndroidTelecomManaged()) {
-      const callId = getTelecomCallId();
-      if (callId && CallingxModule) {
-        const snapshot =
-          await CallingxModule.getAvailableAudioEndpoints(callId);
-        return snapshotToStatus(snapshot);
-      }
+    const tc = getTelecomContext();
+    if (tc) {
+      const snapshot = await tc.cx.getAvailableAudioEndpoints(tc.callId);
+      return snapshotToStatus(snapshot);
     }
     return NativeManager.getAudioDeviceStatus();
   };
@@ -93,31 +105,29 @@ class AndroidCallManager {
    */
   selectAudioDevice = (endpointName: string): void => {
     invariant(Platform.OS === 'android', 'Supported only on Android');
-    if (isAndroidTelecomManaged()) {
-      const callId = getTelecomCallId();
-      const cx = CallingxModule;
-      if (callId && cx) {
-        // Resolve name -> endpoint id from the current Telecom snapshot, then route via Telecom.
-        cx.getAvailableAudioEndpoints(callId)
-          .then((snapshot) => {
-            const target = snapshot.endpoints.find(
-              (e) => e.name === endpointName,
+    const tc = getTelecomContext();
+    if (tc) {
+      const { cx, callId } = tc;
+      // Resolve name -> endpoint id from the current Telecom snapshot, then route via Telecom.
+      cx.getAvailableAudioEndpoints(callId)
+        .then((snapshot) => {
+          const target = snapshot.endpoints.find(
+            (e) => e.name === endpointName,
+          );
+          if (target) {
+            return cx.requestAudioEndpointChange(callId, target.id);
+          }
+          return undefined;
+        })
+        .catch((error) => {
+          videoLoggerSystem
+            .getLogger('CallManager')
+            .warn(
+              `selectAudioDevice: failed to route to "${endpointName}" for call ${callId} via Telecom`,
+              error,
             );
-            if (target) {
-              return cx.requestAudioEndpointChange(callId, target.id);
-            }
-            return undefined;
-          })
-          .catch((error) => {
-            videoLoggerSystem
-              .getLogger('CallManager')
-              .warn(
-                `selectAudioDevice: failed to route to "${endpointName}" for call ${callId} via Telecom`,
-                error,
-              );
-          });
-        return;
-      }
+        });
+      return;
     }
     NativeManager.chooseAudioDeviceEndpoint(endpointName);
   };
@@ -198,39 +208,37 @@ class SpeakerManager {
    * Forces speakerphone on/off.
    */
   setForceSpeakerphoneOn = (force: boolean): void => {
-    if (isAndroidTelecomManaged()) {
-      const callId = getTelecomCallId();
-      const cx = CallingxModule;
-      if (callId && cx) {
-        // Telecom owns routing: map on -> speaker endpoint, off -> highest-priority
-        // non-speaker endpoint (wired > bluetooth > earpiece), mirroring classic behavior.
-        cx.getAvailableAudioEndpoints(callId)
-          .then((snapshot) => {
-            let target: CallingxAudioEndpoint | undefined;
-            if (force) {
-              target = snapshot.endpoints.find((e) => e.type === 'speaker');
-            } else {
-              // Priority for the "speakerphone off" fallback: prefer wired, then bluetooth, then earpiece.
-              for (const type of ['wired_headset', 'bluetooth', 'earpiece']) {
-                target = snapshot.endpoints.find((e) => e.type === type);
-                if (target) break;
-              }
+    const tc = getTelecomContext();
+    if (tc) {
+      const { cx, callId } = tc;
+      // Telecom owns routing: map on -> speaker endpoint, off -> highest-priority
+      // non-speaker endpoint (wired > bluetooth > earpiece), mirroring classic behavior.
+      cx.getAvailableAudioEndpoints(callId)
+        .then((snapshot) => {
+          let target: CallingxAudioEndpoint | undefined;
+          if (force) {
+            target = snapshot.endpoints.find((e) => e.type === 'speaker');
+          } else {
+            // Priority for the "speakerphone off" fallback: prefer wired, then bluetooth, then earpiece.
+            for (const type of ['wired_headset', 'bluetooth', 'earpiece']) {
+              target = snapshot.endpoints.find((e) => e.type === type);
+              if (target) break;
             }
-            if (target) {
-              return cx.requestAudioEndpointChange(callId, target.id);
-            }
-            return undefined;
-          })
-          .catch((error) => {
-            videoLoggerSystem
-              .getLogger('CallManager')
-              .warn(
-                `setForceSpeakerphoneOn(${force}): failed to route for call ${callId} via Telecom`,
-                error,
-              );
-          });
-        return;
-      }
+          }
+          if (target) {
+            return cx.requestAudioEndpointChange(callId, target.id);
+          }
+          return undefined;
+        })
+        .catch((error) => {
+          videoLoggerSystem
+            .getLogger('CallManager')
+            .warn(
+              `setForceSpeakerphoneOn(${force}): failed to route for call ${callId} via Telecom`,
+              error,
+            );
+        });
+      return;
     }
     NativeManager.setForceSpeakerphoneOn(force);
   };

--- a/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
+++ b/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
@@ -4,6 +4,10 @@ import type {
   IOSAudioInterruptionEvent,
   StreamInCallManagerConfig,
 } from './types';
+import type {
+  AudioEndpoint as CallingxAudioEndpoint,
+  AudioEndpointsSnapshot as CallingxAudioSnapshot,
+} from '@stream-io/react-native-callingx';
 import { getCallingxLibIfAvailable } from '../../utils/push/libs/callingx';
 import { videoLoggerSystem } from '@stream-io/video-client';
 
@@ -52,12 +56,6 @@ const endpointTypeToDisplayName = (
   }
 };
 
-type CallingxAudioEndpoint = { id: string; name: string; type: string };
-type CallingxAudioSnapshot = {
-  endpoints: CallingxAudioEndpoint[];
-  currentEndpoint: CallingxAudioEndpoint | null;
-};
-
 /** Adapt a callingx endpoints snapshot to the SDK's {@link AudioDeviceStatus}. */
 const snapshotToStatus = (
   snapshot: CallingxAudioSnapshot,
@@ -68,11 +66,6 @@ const snapshotToStatus = (
     : 'Unknown',
   selectedDevice: snapshot.currentEndpoint?.name ?? '',
 });
-
-/** Priority for the "speakerphone off" fallback: prefer wired, then bluetooth, then earpiece.
- * only used for Telcom calls for forceSpeakerphoneOn method
- */
-const NON_SPEAKER_PRIORITY = ['wired_headset', 'bluetooth', 'earpiece'];
 
 class AndroidCallManager {
   private eventEmitter?: NativeEventEmitter;
@@ -87,7 +80,7 @@ class AndroidCallManager {
       if (callId && CallingxModule) {
         const snapshot =
           await CallingxModule.getAvailableAudioEndpoints(callId);
-        return snapshotToStatus(snapshot as CallingxAudioSnapshot);
+        return snapshotToStatus(snapshot);
       }
     }
     return NativeManager.getAudioDeviceStatus();
@@ -115,7 +108,14 @@ class AndroidCallManager {
             }
             return undefined;
           })
-          .catch(() => {});
+          .catch((error) => {
+            videoLoggerSystem
+              .getLogger('CallManager')
+              .warn(
+                `selectAudioDevice: failed to route to "${endpointName}" for call ${callId} via Telecom`,
+                error,
+              );
+          });
         return;
       }
     }
@@ -133,7 +133,7 @@ class AndroidCallManager {
     if (isAndroidTelecomManaged() && CallingxModule) {
       const sub = CallingxModule.addEventListener(
         'didChangeAudioEndpoints',
-        (params) => onChange(snapshotToStatus(params as CallingxAudioSnapshot)),
+        (params) => onChange(snapshotToStatus(params)),
       );
       return () => sub.remove();
     }
@@ -200,7 +200,8 @@ class SpeakerManager {
             if (force) {
               target = snapshot.endpoints.find((e) => e.type === 'speaker');
             } else {
-              for (const type of NON_SPEAKER_PRIORITY) {
+              // Priority for the "speakerphone off" fallback: prefer wired, then bluetooth, then earpiece.
+              for (const type of ['wired_headset', 'bluetooth', 'earpiece']) {
                 target = snapshot.endpoints.find((e) => e.type === type);
                 if (target) break;
               }
@@ -210,7 +211,14 @@ class SpeakerManager {
             }
             return undefined;
           })
-          .catch(() => {});
+          .catch((error) => {
+            videoLoggerSystem
+              .getLogger('CallManager')
+              .warn(
+                `setForceSpeakerphoneOn(${force}): failed to route for call ${callId} via Telecom`,
+                error,
+              );
+          });
         return;
       }
     }

--- a/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
+++ b/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
@@ -130,16 +130,26 @@ class AndroidCallManager {
     onChange: (audioDeviceStatus: AudioDeviceStatus) => void,
   ): (() => void) => {
     invariant(Platform.OS === 'android', 'Supported only on Android');
-    if (isAndroidTelecomManaged() && CallingxModule) {
+    const cleanups: Array<() => void> = [];
+
+    // Telecom (callingx) route changes.
+    if (CallingxModule?.isSetup && CallingxModule.isTelecomBacked) {
       const sub = CallingxModule.addEventListener(
         'didChangeAudioEndpoints',
         (params) => onChange(snapshotToStatus(params)),
       );
-      return () => sub.remove();
+      cleanups.push(() => sub.remove());
     }
+
+    // StreamInCallManager route changes (non-Telecom calls). Native
+    // suppresses these while in telecom-managed mode, and callingx emits no
+    // endpoint events for non-Telecom calls, so the two sources never overlap
+    // at runtime — safe to keep both subscribed in parallel.
     this.eventEmitter ??= new NativeEventEmitter(NativeManager);
     const s = this.eventEmitter.addListener('onAudioDeviceChanged', onChange);
-    return () => s.remove();
+    cleanups.push(() => s.remove());
+
+    return () => cleanups.forEach((cleanup) => cleanup());
   };
 }
 

--- a/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
+++ b/packages/react-native-sdk/src/modules/call-manager/CallManager.ts
@@ -15,6 +15,65 @@ const invariant = (condition: boolean, message: string) => {
   if (!condition) throw new Error(message);
 };
 
+/**
+ * On Android, whether the current call is managed by Telecom (via callingx).
+ * In that mode, audio routing/mode is owned by Telecom and StreamInCallManager audio methods should not be used
+ */
+const isAndroidTelecomManaged = (): boolean => {
+  if (Platform.OS !== 'android' || !CallingxModule) {
+    return false;
+  }
+  return (
+    CallingxModule.isSetup &&
+    CallingxModule.isTelecomBacked &&
+    (CallingxModule.hasRegisteredCall() || CallingxModule.isOngoingCallsEnabled)
+  );
+};
+
+/** The callId of the (single) call currently registered with Telecom, if any. */
+const getTelecomCallId = (): string | undefined =>
+  CallingxModule?.getRegisteredCallIds()[0];
+
+/** Map a generic Telecom endpoint type to the SDK's endpoint display name. */
+const endpointTypeToDisplayName = (
+  type: string,
+): AudioDeviceStatus['currentEndpointType'] => {
+  switch (type) {
+    case 'earpiece':
+      return 'Earpiece';
+    case 'speaker':
+      return 'Speaker';
+    case 'wired_headset':
+      return 'Wired Headset';
+    case 'bluetooth':
+      return 'Bluetooth Device';
+    default:
+      return 'Unknown';
+  }
+};
+
+type CallingxAudioEndpoint = { id: string; name: string; type: string };
+type CallingxAudioSnapshot = {
+  endpoints: CallingxAudioEndpoint[];
+  currentEndpoint: CallingxAudioEndpoint | null;
+};
+
+/** Adapt a callingx endpoints snapshot to the SDK's {@link AudioDeviceStatus}. */
+const snapshotToStatus = (
+  snapshot: CallingxAudioSnapshot,
+): AudioDeviceStatus => ({
+  devices: snapshot.endpoints.map((e) => e.name),
+  currentEndpointType: snapshot.currentEndpoint
+    ? endpointTypeToDisplayName(snapshot.currentEndpoint.type)
+    : 'Unknown',
+  selectedDevice: snapshot.currentEndpoint?.name ?? '',
+});
+
+/** Priority for the "speakerphone off" fallback: prefer wired, then bluetooth, then earpiece.
+ * only used for Telcom calls for forceSpeakerphoneOn method
+ */
+const NON_SPEAKER_PRIORITY = ['wired_headset', 'bluetooth', 'earpiece'];
+
 class AndroidCallManager {
   private eventEmitter?: NativeEventEmitter;
 
@@ -23,6 +82,14 @@ class AndroidCallManager {
    */
   getAudioDeviceStatus = async (): Promise<AudioDeviceStatus> => {
     invariant(Platform.OS === 'android', 'Supported only on Android');
+    if (isAndroidTelecomManaged()) {
+      const callId = getTelecomCallId();
+      if (callId && CallingxModule) {
+        const snapshot =
+          await CallingxModule.getAvailableAudioEndpoints(callId);
+        return snapshotToStatus(snapshot as CallingxAudioSnapshot);
+      }
+    }
     return NativeManager.getAudioDeviceStatus();
   };
 
@@ -33,6 +100,25 @@ class AndroidCallManager {
    */
   selectAudioDevice = (endpointName: string): void => {
     invariant(Platform.OS === 'android', 'Supported only on Android');
+    if (isAndroidTelecomManaged()) {
+      const callId = getTelecomCallId();
+      const cx = CallingxModule;
+      if (callId && cx) {
+        // Resolve name -> endpoint id from the current Telecom snapshot, then route via Telecom.
+        cx.getAvailableAudioEndpoints(callId)
+          .then((snapshot) => {
+            const target = snapshot.endpoints.find(
+              (e) => e.name === endpointName,
+            );
+            if (target) {
+              return cx.requestAudioEndpointChange(callId, target.id);
+            }
+            return undefined;
+          })
+          .catch(() => {});
+        return;
+      }
+    }
     NativeManager.chooseAudioDeviceEndpoint(endpointName);
   };
 
@@ -44,6 +130,13 @@ class AndroidCallManager {
     onChange: (audioDeviceStatus: AudioDeviceStatus) => void,
   ): (() => void) => {
     invariant(Platform.OS === 'android', 'Supported only on Android');
+    if (isAndroidTelecomManaged() && CallingxModule) {
+      const sub = CallingxModule.addEventListener(
+        'didChangeAudioEndpoints',
+        (params) => onChange(snapshotToStatus(params as CallingxAudioSnapshot)),
+      );
+      return () => sub.remove();
+    }
     this.eventEmitter ??= new NativeEventEmitter(NativeManager);
     const s = this.eventEmitter.addListener('onAudioDeviceChanged', onChange);
     return () => s.remove();
@@ -95,6 +188,32 @@ class SpeakerManager {
    * Forces speakerphone on/off.
    */
   setForceSpeakerphoneOn = (force: boolean): void => {
+    if (isAndroidTelecomManaged()) {
+      const callId = getTelecomCallId();
+      const cx = CallingxModule;
+      if (callId && cx) {
+        // Telecom owns routing: map on -> speaker endpoint, off -> highest-priority
+        // non-speaker endpoint (wired > bluetooth > earpiece), mirroring classic behavior.
+        cx.getAvailableAudioEndpoints(callId)
+          .then((snapshot) => {
+            let target: CallingxAudioEndpoint | undefined;
+            if (force) {
+              target = snapshot.endpoints.find((e) => e.type === 'speaker');
+            } else {
+              for (const type of NON_SPEAKER_PRIORITY) {
+                target = snapshot.endpoints.find((e) => e.type === type);
+                if (target) break;
+              }
+            }
+            if (target) {
+              return cx.requestAudioEndpointChange(callId, target.id);
+            }
+            return undefined;
+          })
+          .catch(() => {});
+        return;
+      }
+    }
     NativeManager.setForceSpeakerphoneOn(force);
   };
 }
@@ -148,6 +267,22 @@ export class CallManager {
           'start: skipping start as callkit is handling the audio session',
         );
       return;
+    }
+    if (isAndroidTelecomManaged()) {
+      // Telecom owns routing/focus; forward the sticky preference to callingx and run in
+      // telecom-managed mode (StreamInCallManager keeps proximity/keep-screen-on only).
+      if (config?.audioRole !== 'listener' && CallingxModule) {
+        CallingxModule.setDefaultAudioDeviceEndpointType(
+          config?.deviceEndpointType ?? 'speaker',
+        );
+      }
+      NativeManager.setTelecomManagedMode(true);
+      NativeManager.setAudioRole(config?.audioRole ?? 'communicator');
+      NativeManager.start();
+      return;
+    }
+    if (Platform.OS === 'android') {
+      NativeManager.setTelecomManagedMode(false);
     }
     NativeManager.setAudioRole(config?.audioRole ?? 'communicator');
     if (config?.audioRole === 'communicator') {

--- a/packages/react-native-sdk/src/modules/call-manager/native-module.d.ts
+++ b/packages/react-native-sdk/src/modules/call-manager/native-module.d.ts
@@ -25,6 +25,14 @@ export interface CallManager extends NativeModule {
   setDefaultAudioDeviceEndpointType: (type: DeviceEndpointType) => void;
 
   /**
+   * Enables/disables Telecom-managed mode (Android). Must be set before **start()**.
+   * When enabled, audio focus, mode and device routing are owned by the Android
+   * Telecom stack (via callingx); StreamInCallManager only keeps proximity,
+   * keep-screen-on and mic/output mute.
+   */
+  setTelecomManagedMode: (enabled: boolean) => void;
+
+  /**
    * Choose an audio device endpoint.
    * @param endpointName - The name of the audio device endpoint to choose.
    */

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
@@ -133,6 +133,11 @@ export type StreamVideoConfig = {
        * @default false
        */
       skipIncomingPushInForeground?: boolean;
+      /**
+       * Default audio endpoint for Telecom-managed calls on Android.
+       * @default 'speaker'
+       */
+      defaultDeviceEndpointType?: 'speaker' | 'earpiece';
     };
     /**
      * Whether to reject calls when the user is busy.

--- a/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
+++ b/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
@@ -2,7 +2,7 @@
  * Internal utils for callingx library usage from video-client.
  * See @./registerSDKGlobals.ts for more usage details.
  */
-import { Platform } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 import type { EndCallReason } from '@stream-io/react-native-callingx';
 import { getCallingxLibIfAvailable } from '../../push/libs/callingx';
 import { waitForAudioSessionActivation } from './audioSessionPromise';
@@ -14,6 +14,36 @@ import type {
 import { CallingState, videoLoggerSystem } from '@stream-io/video-client';
 
 const CallingxModule = getCallingxLibIfAvailable();
+
+/**
+ * Fallback when Telecom registration fails/times out on Android: no component would own audio
+ * (Telecom never took over), so re-establish StreamInCallManager in its classic (non-telecom)
+ * mode to keep the call audible. No-op on iOS and when Telecom is not the intended owner.
+ */
+function recoverAudioToClassicMode() {
+  if (Platform.OS !== 'android') {
+    return;
+  }
+  if (!CallingxModule?.isSetup || !CallingxModule.isTelecomBacked) {
+    return;
+  }
+  const StreamInCallManagerNativeModule = NativeModules.StreamInCallManager;
+  if (!StreamInCallManagerNativeModule) {
+    return;
+  }
+  const logger = videoLoggerSystem.getLogger('callingx');
+  logger.warn(
+    'Telecom registration failed; falling back to classic StreamInCallManager audio',
+  );
+  try {
+    StreamInCallManagerNativeModule.stop();
+    StreamInCallManagerNativeModule.setTelecomManagedMode(false);
+    StreamInCallManagerNativeModule.setup();
+    StreamInCallManagerNativeModule.start();
+  } catch (error) {
+    logger.error('recoverAudioToClassicMode: failed to recover audio', error);
+  }
+}
 
 /**
  * Gets the call display name. To be used for display in native call screen.
@@ -97,6 +127,7 @@ export async function registerOutgoingCall(call: Call) {
       `registerOutgoingCall: Error registering outgoing call in callingx: ${call.cid}`,
       error,
     );
+    recoverAudioToClassicMode();
   }
 }
 
@@ -146,6 +177,7 @@ export async function joinCallingxCall(call: Call, activeCalls: Call[]) {
         `startCallingxCall: Error starting call in callingx: ${call.cid}`,
         error,
       );
+      recoverAudioToClassicMode();
     }
   } else if (isIncomingCall) {
     logger.debug(`joinCallingxCall: Joining incoming call ${call.cid}`);
@@ -187,6 +219,7 @@ export async function joinCallingxCall(call: Call, activeCalls: Call[]) {
         `Error joining incoming call in callingx: ${call.cid}`,
         error,
       );
+      recoverAudioToClassicMode();
     }
   }
 }

--- a/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
+++ b/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
@@ -18,13 +18,24 @@ const CallingxModule = getCallingxLibIfAvailable();
 /**
  * Fallback when Telecom registration fails/times out on Android: no component would own audio
  * (Telecom never took over), so re-establish StreamInCallManager in its classic (non-telecom)
- * mode to keep the call audible. No-op on iOS and when Telecom is not the intended owner.
+ * mode to keep the call audible.
  */
 function recoverAudioToClassicMode() {
   if (Platform.OS !== 'android') {
     return;
   }
   if (!CallingxModule?.isSetup || !CallingxModule.isTelecomBacked) {
+    return;
+  }
+  // If a call is already registered, Telecom owns audio for it (the registration
+  // partially succeeded). Switching to classic mode here would fight Telecom's
+  // routing/focus — leave ownership intact.
+  if (CallingxModule.hasRegisteredCall()) {
+    videoLoggerSystem
+      .getLogger('callingx')
+      .debug(
+        'recoverAudioToClassicMode: Telecom already owns a registered call; skipping classic fallback',
+      );
     return;
   }
   const StreamInCallManagerNativeModule = NativeModules.StreamInCallManager;

--- a/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
+++ b/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
@@ -49,7 +49,6 @@ function recoverAudioToClassicMode() {
   try {
     StreamInCallManagerNativeModule.stop();
     StreamInCallManagerNativeModule.setTelecomManagedMode(false);
-    StreamInCallManagerNativeModule.setup();
     StreamInCallManagerNativeModule.start();
   } catch (error) {
     logger.error('recoverAudioToClassicMode: failed to recover audio', error);

--- a/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
+++ b/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
@@ -91,7 +91,9 @@ const streamRNVideoSDKGlobals: StreamRNVideoSDKGlobals = {
         StreamInCallManagerNativeModule.setup();
         return;
       }
-      StreamInCallManagerNativeModule.setTelecomManagedMode(false);
+      if (Platform.OS === 'android') {
+        StreamInCallManagerNativeModule.setTelecomManagedMode(false);
+      }
       StreamInCallManagerNativeModule.setDefaultAudioDeviceEndpointType(
         defaultDevice,
       );

--- a/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
+++ b/packages/react-native-sdk/src/utils/internal/registerSDKGlobals.ts
@@ -45,6 +45,31 @@ const shouldBypassForCallKit = ({
   return bypass;
 };
 
+/**
+ * On Android, when the call is registered with the Telecom stack (via CallingX),
+ * routing/focus/mode must be owned by Telecom (per Android guidance we must not use
+ * AudioManager.setCommunicationDevice / startBluetoothSco). Unlike iOS, we do NOT skip
+ * StreamInCallManager entirely — Telecom provides no proximity/keep-screen-on — instead we
+ * run it in "telecom-managed" mode where it only keeps proximity/keep-screen-on/mute.
+ */
+const isAndroidTelecomManaged = ({
+  isRingingTypeCall,
+}: {
+  isRingingTypeCall: boolean;
+}): boolean => {
+  if (Platform.OS !== 'android') {
+    return false;
+  }
+  if (!CallingxModule) {
+    return false;
+  }
+  return (
+    CallingxModule.isSetup &&
+    CallingxModule.isTelecomBacked &&
+    (isRingingTypeCall || CallingxModule.isOngoingCallsEnabled)
+  );
+};
+
 const streamRNVideoSDKGlobals: StreamRNVideoSDKGlobals = {
   callingX: {
     joinCall: joinCallingxCall,
@@ -58,6 +83,15 @@ const streamRNVideoSDKGlobals: StreamRNVideoSDKGlobals = {
         CallingxModule?.setDefaultAudioDeviceEndpointType(defaultDevice);
         return;
       }
+      if (isAndroidTelecomManaged({ isRingingTypeCall })) {
+        // Telecom owns routing; forward the sticky preference to callingx and run the
+        // in-call manager in telecom-managed mode (proximity/keep-screen-on only).
+        CallingxModule?.setDefaultAudioDeviceEndpointType(defaultDevice);
+        StreamInCallManagerNativeModule.setTelecomManagedMode(true);
+        StreamInCallManagerNativeModule.setup();
+        return;
+      }
+      StreamInCallManagerNativeModule.setTelecomManagedMode(false);
       StreamInCallManagerNativeModule.setDefaultAudioDeviceEndpointType(
         defaultDevice,
       );
@@ -67,6 +101,8 @@ const streamRNVideoSDKGlobals: StreamRNVideoSDKGlobals = {
       if (shouldBypassForCallKit({ isRingingTypeCall })) {
         return;
       }
+      // Android telecom-managed calls still start (for proximity/keep-screen-on);
+      // the native side skips routing/focus internally.
       StreamInCallManagerNativeModule.start();
     },
     stop: ({ isRingingTypeCall }) => {

--- a/packages/react-native-sdk/src/utils/push/libs/callingx.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/callingx.ts
@@ -84,6 +84,10 @@ export function extractCallingExpOptions(
       androidOptions.skipIncomingPushInForeground =
         pushConfig.android.skipIncomingPushInForeground;
     }
+    if (pushConfig.android.defaultDeviceEndpointType !== undefined) {
+      androidOptions.defaultDeviceEndpointType =
+        pushConfig.android.defaultDeviceEndpointType;
+    }
   }
 
   if (foregroundServiceConfig.android.channel) {

--- a/sample-apps/react-native/dogfood/src/screens/Call/JoinCallScreen.tsx
+++ b/sample-apps/react-native/dogfood/src/screens/Call/JoinCallScreen.tsx
@@ -50,6 +50,7 @@ const JoinCallScreen = () => {
       const call = videoClient?.call('default', randomId());
       await call?.getOrCreate({
         ring: true,
+        video: true,
         data: {
           // more timeout to cancel the call automatically so that it works when callee's app is in quit state
           settings_override: {

--- a/sample-apps/react-native/expo-video-sample/components/CreateRingingCall.tsx
+++ b/sample-apps/react-native/expo-video-sample/components/CreateRingingCall.tsx
@@ -30,6 +30,7 @@ export default function CreateRingingCall() {
       const call = videoClient?.call('default', randomId());
       await call?.getOrCreate({
         ring: true,
+        video: true,
         data: {
           settings_override: {
             ring: {


### PR DESCRIPTION
### 💡 Overview

**Primarily this PR implements the advice below from Android core-telecom docs**

<img width="944" height="629" alt="image" src="https://github.com/user-attachments/assets/b2b02f92-118f-4577-a5ab-19b651a9f5d0" />

Other changes: 

* Fix: incoming calls were always added as Audio type calls, now properly reads from push data
* Feat: setPushConfig support for defaultAudioDeviceType like iOS for Android

Fixes #2320  

### 📝 Implementation notes

Incallmanager delegates Audio routing to callingx. But still supports reading state through it and calling its methods. 

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android Telecom-managed audio routing with endpoint snapshot updates via `didChangeAudioEndpoints`, including listing available endpoints and switching endpoints.
  * Introduced `defaultDeviceEndpointType` to set the starting/default audio endpoint for Telecom-managed calls; added native APIs to check Telecom mode, get registered call IDs, and manage endpoints.
* **Bug Fixes**
  * Normalized endpoint event payloads for more reliable parsing, and reduced duplicate/conflicting notifications in Telecom-managed mode; cleared stored snapshots when calls end.
  * Removed iOS route-change notifications (no Telecom audio routing on iOS).
* **Tests**
  * Added Jest coverage for Telecom-managed endpoint status and `didChangeAudioEndpoints`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->