### PR TITLE
fix(react-dogfood): do not request video ring on audio_call dialer

### DIFF
--- a/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
+++ b/sample-apps/react/react-dogfood/components/Ringing/DialerPage.tsx
@@ -145,7 +145,10 @@ export const DialerPage = ({
       setRingingCall(call);
       await call.getOrCreate({
         ring: true,
-        video: true,
+        // the backend rejects ring requests with `video: true` on call types
+        // that have video disabled (e.g. `audio_call`):
+        // "Video is not enabled for this call"
+        video: callType !== 'audio_call',
         data: {
           members,
           settings_override: {


### PR DESCRIPTION
### 💡 Overview

The dialer page (`/ring?type=audio_call`) hardcodes `video: true` in its `call.getOrCreate({ ring: true, ... })` request regardless of the call type from the URL. The backend rejects ring requests with `video: true` on call types that have video disabled:

```
GetOrCreateCall failed with error: "Video is not enabled for this call" (code 4)
```

This breaks the audio ring flow on getstream.io/video/demos/ring (demo app `mmhfdzb5evj2`) — and with it every incoming-call E2E test in `stream-video-android`, including its develop nightly (red since ~Jul 2–6).

Reproduction against the API:

```
POST /video/call/audio_call/x  {"ring":true,"video":true}   → 400 code 4 "Video is not enabled for this call"
POST /video/call/audio_call/x  {"ring":true,"video":false}  → 200
```

### 📝 Implementation notes

One line in `DialerPage.tsx`: derive the `video` flag from the call type instead of hardcoding it — `video: callType !== 'audio_call'`. Non-ring `getOrCreate` calls are unaffected (the backend only validates the flag on ring requests).

Evidence trail (buddy browser recording showing the error toast, timeline, API probes): stream-video-android run `28856205639` artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call setup so audio-only calls no longer attempt to enable video, preventing call initiation errors in supported cases.
  * Video is now enabled only for call types that support it, making dialing more reliable overall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->