### PR TITLE
fix(react-native-sdk): replace deprecated ImageBackground in IncomingCall

### DIFF
--- a/packages/react-native-sdk/src/components/Call/RingingCallContent/IncomingCall.tsx
+++ b/packages/react-native-sdk/src/components/Call/RingingCallContent/IncomingCall.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  ImageBackground,
-  StyleSheet,
-  Text,
-  View,
-  type ViewStyle,
-} from 'react-native';
+import { Image, StyleSheet, Text, View, type ViewStyle } from 'react-native';
 import {
   useCallStateHooks,
   useConnectedUser,
@@ -120,18 +114,22 @@ const Background: React.FunctionComponent<{
 
   if (avatarsToShow.length) {
     return (
-      <ImageBackground
-        source={{
-          uri: avatarsToShow[0],
-        }}
+      <View
         style={[
           styles.background,
           { backgroundColor: colors.sheetTertiary },
           incomingCall.background,
         ]}
       >
+        <Image
+          source={{
+            uri: avatarsToShow[0],
+          }}
+          resizeMode="cover"
+          style={StyleSheet.absoluteFill}
+        />
         {children}
-      </ImageBackground>
+      </View>
     );
   }
   return (


### PR DESCRIPTION
### 💡 Overview

Replaces the deprecated `ImageBackground` component in the RN SDK's `IncomingCall` with a `View` + absolutely-positioned `Image`, per the migration guidance in the upcoming React Native `v0.87.0-rc.0` changelog (`ImageBackground` is deprecated there in favor of `View` + `Image`).

### 📝 Implementation notes

- `IncomingCall`'s internal `Background` component now renders a `View` (background color / theme override) with an `Image` absolutely filled inside it, instead of `ImageBackground`.
- No visual or behavioral change - `resizeMode="cover"` matches `ImageBackground`'s default.

🎫 Ticket: N/A

📑 Docs: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the incoming call screen background rendering so avatar images display more reliably behind the call content.
  * Kept the existing overlay layout intact while updating how the background image is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->