### PR TITLE
feat: improved providerDidReset handling

### DIFF
--- a/packages/react-native-callingx/ios/CallingxImpl.swift
+++ b/packages/react-native-callingx/ios/CallingxImpl.swift
@@ -67,8 +67,6 @@ import stream_react_native_webrtc
     /// iOS 17+ surfaces as system-initiated mutes — artifacts, not user intent, so we skip them.
     /// Set on `willEnableAudioEngine`, cleared on `willStartAudioEngine`. Guarded by `pendingActionsQueue`.
     private var isAudioEngineStarting = false
-    /// Only touched on the CallKit delegate (main) queue
-    private var isAudioSessionActive = false
 
     /// Mute value of the last app-requested `CXSetMutedCallAction`. iOS 17+ round-trips it back as a
     /// system-initiated action of the same value; we skip that echo (a real UI toggle flips the value).
@@ -828,7 +826,6 @@ import stream_react_native_webrtc
 
         // When CallKit activates the AVAudioSession, inform WebRTC as well.
         RTCAudioSession.sharedInstance().audioSessionDidActivate(audioSession)
-        isAudioSessionActive = true
 
         // Enable wake lock to keep the device awake during the call
         DispatchQueue.main.async {
@@ -844,7 +841,6 @@ import stream_react_native_webrtc
         // When CallKit deactivates the AVAudioSession, inform WebRTC as well.
         RTCAudioSession.sharedInstance().audioSessionDidDeactivate(audioSession)
         getAudioDeviceModule()?.reset()
-        isAudioSessionActive = false
 
         // Invariant: callingx ships with maximumCallsPerCallGroup = maximumCallGroups = 1
         // (see packages/react-native-callingx/src/utils/constants.ts defaultiOSOptions).
@@ -899,19 +895,6 @@ import stream_react_native_webrtc
             pendingAnswerActions.removeAll()
             pendingEndActions.removeAll()
             lastAppRequestedMute = nil
-        }
-
-        // A provider reset tears down the audio session, but provider(_:didDeactivate:) is NOT
-        // guaranteed to fire afterwards. Mirror didDeactivate's teardown here, gated by
-        // `isAudioSessionActive` so it runs exactly once.
-        if isAudioSessionActive {
-            let rtcSession = RTCAudioSession.sharedInstance()
-            rtcSession.audioSessionDidDeactivate(rtcSession.session)
-            getAudioDeviceModule()?.reset()
-            DispatchQueue.main.async {
-                UIApplication.shared.isIdleTimerDisabled = false
-            }
-            isAudioSessionActive = false
         }
 
         // Snapshot the tracked cids before wiping storage: JS leaves exactly the calls CallKit was tracking. 

--- a/packages/react-native-callingx/ios/CallingxImpl.swift
+++ b/packages/react-native-callingx/ios/CallingxImpl.swift
@@ -67,6 +67,8 @@ import stream_react_native_webrtc
     /// iOS 17+ surfaces as system-initiated mutes — artifacts, not user intent, so we skip them.
     /// Set on `willEnableAudioEngine`, cleared on `willStartAudioEngine`. Guarded by `pendingActionsQueue`.
     private var isAudioEngineStarting = false
+    /// Only touched on the CallKit delegate (main) queue
+    private var isAudioSessionActive = false
 
     /// Mute value of the last app-requested `CXSetMutedCallAction`. iOS 17+ round-trips it back as a
     /// system-initiated action of the same value; we skip that echo (a real UI toggle flips the value).
@@ -826,6 +828,7 @@ import stream_react_native_webrtc
 
         // When CallKit activates the AVAudioSession, inform WebRTC as well.
         RTCAudioSession.sharedInstance().audioSessionDidActivate(audioSession)
+        isAudioSessionActive = true
 
         // Enable wake lock to keep the device awake during the call
         DispatchQueue.main.async {
@@ -841,6 +844,7 @@ import stream_react_native_webrtc
         // When CallKit deactivates the AVAudioSession, inform WebRTC as well.
         RTCAudioSession.sharedInstance().audioSessionDidDeactivate(audioSession)
         getAudioDeviceModule()?.reset()
+        isAudioSessionActive = false
 
         // Invariant: callingx ships with maximumCallsPerCallGroup = maximumCallGroups = 1
         // (see packages/react-native-callingx/src/utils/constants.ts defaultiOSOptions).
@@ -897,15 +901,25 @@ import stream_react_native_webrtc
             lastAppRequestedMute = nil
         }
 
-        // A provider reset invalidates all CallKit calls. didDeactivate is not
-        // guaranteed to fire in its usual shape afterwards, so release ownership
-        // here and wipe UUIDStorage to keep the `count() == 0` discriminator in
-        // didDeactivate honest (stale entries would otherwise refuse to release
-        // ownership on the next end-of-call).
-        CallingxImpl.uuidStorage?.removeAllObjects()
-        CallingxSessionOwnership.callingxOwnsSession = false
+        // A provider reset tears down the audio session, but provider(_:didDeactivate:) is NOT
+        // guaranteed to fire afterwards. Mirror didDeactivate's teardown here, gated by
+        // `isAudioSessionActive` so it runs exactly once.
+        if isAudioSessionActive {
+            let rtcSession = RTCAudioSession.sharedInstance()
+            rtcSession.audioSessionDidDeactivate(rtcSession.session)
+            getAudioDeviceModule()?.reset()
+            DispatchQueue.main.async {
+                UIApplication.shared.isIdleTimerDisabled = false
+            }
+            isAudioSessionActive = false
+        }
 
-        sendEvent(CallingxEvents.providerReset, body: nil)
+        // Snapshot the tracked cids before wiping storage: JS leaves exactly the calls CallKit was tracking. 
+        let trackedCids = CallingxImpl.uuidStorage?.allCids() ?? []
+        CallingxSessionOwnership.callingxOwnsSession = false
+        CallingxImpl.uuidStorage?.removeAllObjects()
+
+        sendEvent(CallingxEvents.providerReset, body: ["callCids": trackedCids])
     }
     
     // MARK: - Pending Action Fulfillment

--- a/packages/react-native-callingx/ios/UUIDStorage.swift
+++ b/packages/react-native-callingx/ios/UUIDStorage.swift
@@ -90,6 +90,12 @@ import CallKit
         }
     }
 
+    public func allCids() -> [String] {
+        return queue.sync {
+            return Array(callsByCid.keys)
+        }
+    }
+    
     // MARK: - Legacy API (preserved for backward compatibility)
 
     public func allUUIDs() -> [UUID] {

--- a/packages/react-native-callingx/src/types.ts
+++ b/packages/react-native-callingx/src/types.ts
@@ -360,7 +360,8 @@ export type EventName =
   | 'didReceiveStartCallAction'
   | 'didPerformSetMutedCallAction'
   | 'didActivateAudioSession'
-  | 'didDeactivateAudioSession';
+  | 'didDeactivateAudioSession'
+  | 'providerReset';
 
 export type IOSAudioInterruptionEvent = {
   source: 'callingx';
@@ -399,6 +400,9 @@ export type EventParams = {
   };
   didActivateAudioSession: undefined;
   didDeactivateAudioSession: undefined;
+  providerReset: {
+    callCids: string[];
+  };
 };
 
 export type VoipEventName =

--- a/packages/react-native-sdk/src/utils/internal/callingx/audioSessionPromise.ts
+++ b/packages/react-native-sdk/src/utils/internal/callingx/audioSessionPromise.ts
@@ -43,13 +43,8 @@ export function waitForAudioSessionActivation(): Promise<void> {
 /**
  * Resolves the pending audio session activation promise.
  * Called when the didActivateAudioSession event fires or on timeout.
- *
- * @param onlyIfPending if `true`, only releases a waiter that already exists and otherwise does
- * nothing. If `false` (default) and no waiter exists, it remembers the activation so the next
- * waiter resolves immediately (handles the cold-start race). Pass `true` on teardown (e.g. a
- * provider reset), where there's nothing to "remember" — the session is going away, not activating.
  */
-export function resolvePendingAudioSession(onlyIfPending = false): void {
+export function resolvePendingAudioSession(): void {
   if (pendingTimeout) {
     clearTimeout(pendingTimeout);
     pendingTimeout = null;
@@ -64,7 +59,7 @@ export function resolvePendingAudioSession(onlyIfPending = false): void {
     }
     pendingResolve = null;
     isAudioSessionAlreadyActivated = false;
-  } else if (!onlyIfPending) {
+  } else {
     isAudioSessionAlreadyActivated = true;
   }
 }

--- a/packages/react-native-sdk/src/utils/internal/callingx/audioSessionPromise.ts
+++ b/packages/react-native-sdk/src/utils/internal/callingx/audioSessionPromise.ts
@@ -43,8 +43,13 @@ export function waitForAudioSessionActivation(): Promise<void> {
 /**
  * Resolves the pending audio session activation promise.
  * Called when the didActivateAudioSession event fires or on timeout.
+ *
+ * @param onlyIfPending if `true`, only releases a waiter that already exists and otherwise does
+ * nothing. If `false` (default) and no waiter exists, it remembers the activation so the next
+ * waiter resolves immediately (handles the cold-start race). Pass `true` on teardown (e.g. a
+ * provider reset), where there's nothing to "remember" — the session is going away, not activating.
  */
-export function resolvePendingAudioSession(): void {
+export function resolvePendingAudioSession(onlyIfPending = false): void {
   if (pendingTimeout) {
     clearTimeout(pendingTimeout);
     pendingTimeout = null;
@@ -59,7 +64,7 @@ export function resolvePendingAudioSession(): void {
     }
     pendingResolve = null;
     isAudioSessionAlreadyActivated = false;
-  } else {
+  } else if (!onlyIfPending) {
     isAudioSessionAlreadyActivated = true;
   }
 }

--- a/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
+++ b/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
@@ -93,12 +93,6 @@ const onProviderReset =
   async ({ callCids }: EventParams['providerReset']) => {
     logger.debug(`onProviderReset event callCids: ${callCids?.join(', ')}`);
 
-    // After a reset, didActivate/didDeactivate may never fire, so a join flow awaiting the audio
-    // session would hang forever. Release any in-flight waiter — but pass onlyIfPending so we don't
-    // latch "already activated" and make the next call skip its own wait (the session is torn down,
-    // not activated).
-    resolvePendingAudioSession(true);
-
     if (!callCids?.length) {
       return;
     }

--- a/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
+++ b/packages/react-native-sdk/src/utils/push/setupCallingExpEvents.ts
@@ -1,4 +1,8 @@
-import { videoLoggerSystem } from '@stream-io/video-client';
+import {
+  CallingState,
+  videoLoggerSystem,
+  type StreamVideoClient,
+} from '@stream-io/video-client';
 import type { StreamVideoConfig } from '../StreamVideoRN/types';
 import {
   clearPushWSEventSubscriptions,
@@ -50,6 +54,10 @@ export function setupCallingExpEvents(pushConfig: NonNullable<PushConfig>) {
     onDidDeactivateAudioSession,
   );
 
+  callingx.addEventListener('providerReset', (params) => {
+    onProviderReset(pushConfig)(params);
+  });
+
   //NOTE: until getInitialEvents invocation, events are delayed and won't be sent to event listeners, this is a way to make sure none of required events are missed
   //in most cases there will be no delayed answers or ends, but if so we don't want to miss any of them
   const events = callingx.getInitialEvents();
@@ -65,6 +73,8 @@ export function setupCallingExpEvents(pushConfig: NonNullable<PushConfig>) {
       onDidActivateAudioSession();
     } else if (eventName === 'didDeactivateAudioSession') {
       onDidDeactivateAudioSession();
+    } else if (eventName === 'providerReset') {
+      onProviderReset(pushConfig)(params as EventParams['providerReset']);
     }
   });
 }
@@ -77,6 +87,42 @@ const onDidActivateAudioSession = () => {
 const onDidDeactivateAudioSession = () => {
   logger.debug('callingExpDidDeactivateAudioSession');
 };
+
+const onProviderReset =
+  (pushConfig: PushConfig) =>
+  async ({ callCids }: EventParams['providerReset']) => {
+    logger.debug(`onProviderReset event callCids: ${callCids?.join(', ')}`);
+
+    // After a reset, didActivate/didDeactivate may never fire, so a join flow awaiting the audio
+    // session would hang forever. Release any in-flight waiter — but pass onlyIfPending so we don't
+    // latch "already activated" and make the next call skip its own wait (the session is torn down,
+    // not activated).
+    resolvePendingAudioSession(true);
+
+    if (!callCids?.length) {
+      return;
+    }
+
+    let videoClient: StreamVideoClient | undefined;
+    try {
+      videoClient = await pushConfig.createStreamVideoClient();
+    } catch (e) {
+      logger.error('onProviderReset: failed to resolve video client', e);
+      return;
+    }
+    if (!videoClient) {
+      return;
+    }
+
+    for (const cid of callCids) {
+      const call = videoClient.state.calls.find((c) => c.cid === cid);
+      if (call && call.state.callingState !== CallingState.LEFT) {
+        call?.leave().catch((error: unknown) => {
+          logger.error(`onProviderReset: error leaving call ${cid}`, error);
+        });
+      }
+    }
+  };
 
 const onAcceptCall =
   (pushConfig: PushConfig) =>


### PR DESCRIPTION
### 💡 Overview

Added CallKit providerDidReset handling - leave the call when the event is triggered.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/RN-415/cxprovider-leave-on-reset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider reset event support with the affected call IDs included.
  * Reset events are now handled for both live and previously received notifications.
* **Bug Fixes**
  * Automatically leaves active calls when the calling provider resets.
  * Improved handling of reset scenarios, including logging failures without interrupting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->