### PR TITLE
fix: only render RTCView once stream has a video track

### DIFF
--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/index.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/index.tsx
@@ -90,8 +90,11 @@ export const VideoRenderer = React.memo(
       ? screenShareStream
       : videoStream) as unknown as MediaStream | undefined;
 
+    const hasVideoTrackInStream =
+      !!videoStreamToRender && videoStreamToRender.getVideoTracks().length > 0;
+
     const canShowVideo =
-      !!videoStreamToRender &&
+      hasVideoTrackInStream &&
       isVisible &&
       isPublishingVideoTrack &&
       !hasPausedTrack(participant, trackType) &&


### PR DESCRIPTION
### 💡 Overview

Native RTCView does not observe about late arriving tracks. So a local video which may have empty video track initially would always not render the actual video track after it arrives later. This PR fixes that.

### 📝 Implementation notes

We just render RTCView after video track is present 

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video rendering by ensuring a media stream contains a video track before displaying it.
  * Prevented unnecessary iOS screenshot registration when no video track is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->