### PR TITLE
fix(video-filters-web): export BaseVideoProcessor

### DIFF
--- a/packages/video-filters-web/index.ts
+++ b/packages/video-filters-web/index.ts
@@ -4,5 +4,6 @@ export { SegmentationLevel } from './src/legacy/segmentation';
 export * from './src/legacy/tflite';
 export * from './src/mediapipe';
 export * from './src/types';
+export * from './src/BaseVideoProcessor';
 export * from './src/VirtualBackground';
 export * from './src/FullScreenBlur';


### PR DESCRIPTION
### 💡 Overview

`BaseVideoProcessor` is the documented base class for building custom video processors, but it was only imported internally (by `VirtualBackground` and `FullScreenBlur`) and never re-exported from the package entry point. Consumers following the [video compositing docs](https://getstream.io/video/docs/react/advanced/video-compositing/) cannot `import { BaseVideoProcessor } from '@stream-io/video-filters-web'` today. This exports it.

### 📝 Implementation notes

Adds `export * from './src/BaseVideoProcessor'` to `packages/video-filters-web/index.ts`. No runtime/behavior change — it only widens the public surface to include the already-existing abstract class.

🎫 Ticket: N/A

📑 Docs: https://github.com/GetStream/docs-content/pull/1439


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `BaseVideoProcessor` to the package’s public exports, making it available for broader use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->