### PR TITLE
fix(client): preserve ICE state in peer connection failure reports

### DIFF
--- a/packages/client/src/reporting/ClientEventReporter.ts
+++ b/packages/client/src/reporting/ClientEventReporter.ts
@@ -38,6 +38,8 @@ export type MediaPermissionState =
   | 'GRANTED'
   | 'NOT_INITIATED';
 
+export type ReportedIceState = 'CONNECTED' | 'FAILED' | 'NOT_CONNECTED';
+
 export type JoinReason =
   | 'first-attempt'
   | 'network-available'
@@ -86,6 +88,7 @@ type PeerConnectionPairState = StagePairState & {
   sfuId: string;
   userSessionId: string;
   wasPreviouslyConnected: boolean;
+  lastIceState?: RTCIceConnectionState;
 };
 
 const pcKey = (cid: string, role: ClientEventPeerConnection): string =>
@@ -356,20 +359,8 @@ export class ClientEventReporter {
       this.failCoordinator(cid);
       this.failWs(cid);
 
-      this.emitPeerConnectionFailure(
-        cid,
-        'publish',
-        code,
-        reason,
-        'NOT_CONNECTED',
-      );
-      this.emitPeerConnectionFailure(
-        cid,
-        'subscribe',
-        code,
-        reason,
-        'NOT_CONNECTED',
-      );
+      this.emitPeerConnectionFailure(cid, 'publish', code, reason);
+      this.emitPeerConnectionFailure(cid, 'subscribe', code, reason);
     } catch (err) {
       this.logger.warn('Failed to report abort', err);
     }
@@ -384,7 +375,6 @@ export class ClientEventReporter {
         role,
         'CLIENT_ABORTED',
         'superseded by a new join attempt',
-        'NOT_CONNECTED',
       );
     }
   };
@@ -573,34 +563,35 @@ export class ClientEventReporter {
     const role: ClientEventPeerConnection =
       event.peerType === PeerType.SUBSCRIBER ? 'subscribe' : 'publish';
 
-    if (event.stateType === 'ice' && event.state === 'failed') {
-      this.emitPeerConnectionFailure(
-        cid,
-        role,
-        'ICE_CONNECTIVITY_FAILED',
-        'ICE connectivity checks failed',
-        'FAILED',
-      );
+    const pair = this.peerConnectionPairs.get(pcKey(cid, role));
+    if (pair) pair.lastIceState = event.iceConnectionState;
+
+    if (event.stateType === 'ice') {
+      if (event.state === 'failed') {
+        this.emitPeerConnectionFailure(
+          cid,
+          role,
+          'ICE_CONNECTIVITY_FAILED',
+          'ICE connectivity checks failed',
+        );
+      }
       return;
     }
 
-    if (event.stateType === 'peerConnection' && event.state === 'failed') {
+    if (event.state === 'failed') {
       this.emitPeerConnectionFailure(
         cid,
         role,
         'DTLS_CONNECTIVITY_FAILED',
         'DTLS connectivity checks failed',
-        'CONNECTED',
       );
       return;
     }
 
-    if (event.stateType !== 'peerConnection') return;
-
     switch (event.state) {
       case 'connecting':
-        if (this.peerConnectionPairs.has(pcKey(cid, role))) return;
-        this.openPeerConnectionPair(cid, role);
+        if (pair) return;
+        this.openPeerConnectionPair(cid, role, event.iceConnectionState);
         break;
       case 'connected':
         this.emitPeerConnectionSuccess(cid, role);
@@ -614,6 +605,7 @@ export class ClientEventReporter {
   private openPeerConnectionPair = (
     cid: string,
     role: ClientEventPeerConnection,
+    iceConnectionState: RTCIceConnectionState,
   ) => {
     const key = pcKey(cid, role);
     const pair: PeerConnectionPairState = {
@@ -624,6 +616,7 @@ export class ClientEventReporter {
       sfuId: this.getSfuId(cid),
       userSessionId: this.getUserSessionId(cid),
       wasPreviouslyConnected: this.pcEverConnected.get(key) === true,
+      lastIceState: iceConnectionState,
     };
     this.peerConnectionPairs.set(key, pair);
 
@@ -670,7 +663,6 @@ export class ClientEventReporter {
     role: ClientEventPeerConnection,
     code: ClientEventStandardCode,
     reason: string,
-    iceState: 'CONNECTED' | 'FAILED' | 'NOT_CONNECTED',
   ) => {
     const key = pcKey(cid, role);
     const pair = this.peerConnectionPairs.get(key);
@@ -689,7 +681,7 @@ export class ClientEventReporter {
       outcome: 'failure',
       retry_count_attempt: 0,
       elapsed_time: Date.now() - pair.startedAt,
-      ice_state: iceState,
+      ice_state: toReportedIceState(pair.lastIceState),
       retry_failure_reason: reason,
       retry_failure_code: code,
     });
@@ -781,6 +773,20 @@ export class ClientEventReporter {
     return false;
   };
 }
+
+const toReportedIceState = (
+  state: RTCIceConnectionState | undefined,
+): ReportedIceState => {
+  switch (state) {
+    case 'connected':
+    case 'completed':
+      return 'CONNECTED';
+    case 'failed':
+      return 'FAILED';
+    default:
+      return 'NOT_CONNECTED';
+  }
+};
 
 const readPermissionStatus = (
   permission: BrowserPermission,

--- a/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
+++ b/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
@@ -7,6 +7,7 @@ import { ErrorFromResponse } from '../../coordinator/connection/types';
 import { SfuTimeoutError } from '../../errors';
 import type { AxiosResponse } from 'axios';
 import { PeerType, TrackType } from '../../gen/video/sfu/models/models';
+import type { PeerConnectionStateChangeEvent } from '../../rtc';
 
 vi.mock('../../devices', () => ({
   getAudioBrowserPermission: () => ({ asStateObservable: () => of('granted') }),
@@ -14,6 +15,27 @@ vi.mock('../../devices', () => ({
 }));
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const peerConnectionEvent = (
+  peerType: PeerType,
+  state: RTCPeerConnectionState,
+  iceConnectionState: RTCIceConnectionState,
+): PeerConnectionStateChangeEvent => ({
+  peerType,
+  stateType: 'peerConnection',
+  state,
+  iceConnectionState,
+});
+
+const iceEvent = (
+  peerType: PeerType,
+  state: RTCIceConnectionState,
+): PeerConnectionStateChangeEvent => ({
+  peerType,
+  stateType: 'ice',
+  state,
+  iceConnectionState: state,
+});
 
 describe('ClientEventReporter', () => {
   const cid = 'default:call-1';
@@ -23,6 +45,21 @@ describe('ClientEventReporter', () => {
 
   const postedEvents = (): Array<Record<string, any>> =>
     doAxiosRequest.mock.calls.map((call) => call[2].events[0]);
+
+  const reportPeerConnectionState = (
+    peerType: PeerType,
+    state: RTCPeerConnectionState,
+    iceConnectionState: RTCIceConnectionState,
+  ) => {
+    reporter.onPeerConnectionStateChange(
+      cid,
+      peerConnectionEvent(peerType, state, iceConnectionState),
+    );
+  };
+
+  const reportIceState = (peerType: PeerType, state: RTCIceConnectionState) => {
+    reporter.onPeerConnectionStateChange(cid, iceEvent(peerType, state));
+  };
 
   beforeEach(() => {
     doAxiosRequest = vi.fn().mockResolvedValue({});
@@ -465,16 +502,16 @@ describe('ClientEventReporter', () => {
 
   it('tracks a publisher peer connection connect', async () => {
     reporter.startCorrelation(cid, 'first-attempt');
-    reporter.onPeerConnectionStateChange(cid, {
-      peerType: PeerType.PUBLISHER_UNSPECIFIED,
-      stateType: 'peerConnection',
-      state: 'connecting',
-    });
-    reporter.onPeerConnectionStateChange(cid, {
-      peerType: PeerType.PUBLISHER_UNSPECIFIED,
-      stateType: 'peerConnection',
-      state: 'connected',
-    });
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'connecting',
+      'checking',
+    );
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'connected',
+      'connected',
+    );
     await flush();
 
     const events = postedEvents().filter(
@@ -497,16 +534,8 @@ describe('ClientEventReporter', () => {
 
   it('reports an ICE failure on the peer connection', async () => {
     reporter.startCorrelation(cid, 'first-attempt');
-    reporter.onPeerConnectionStateChange(cid, {
-      peerType: PeerType.SUBSCRIBER,
-      stateType: 'peerConnection',
-      state: 'connecting',
-    });
-    reporter.onPeerConnectionStateChange(cid, {
-      peerType: PeerType.SUBSCRIBER,
-      stateType: 'ice',
-      state: 'failed',
-    });
+    reportPeerConnectionState(PeerType.SUBSCRIBER, 'connecting', 'checking');
+    reportIceState(PeerType.SUBSCRIBER, 'failed');
     await flush();
 
     const completed = postedEvents().filter(
@@ -522,25 +551,111 @@ describe('ClientEventReporter', () => {
     });
   });
 
+  it('reports a DTLS failure with the real ICE state (connected)', async () => {
+    reporter.startCorrelation(cid, 'first-attempt');
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'connecting',
+      'checking',
+    );
+    reportIceState(PeerType.PUBLISHER_UNSPECIFIED, 'connected');
+    // Aggregate connection fails while ICE stays connected -> genuine DTLS.
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'failed',
+      'connected',
+    );
+    await flush();
+
+    const completed = postedEvents().filter(
+      (e) =>
+        e.stage === 'PeerConnectionConnect' && e.event_type === 'completed',
+    );
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      outcome: 'failure',
+      peer_connection: 'publish',
+      retry_failure_code: 'DTLS_CONNECTIVITY_FAILED',
+      ice_state: 'CONNECTED',
+    });
+  });
+
+  it('reports a DTLS failure with the real ICE state (never connected)', async () => {
+    reporter.startCorrelation(cid, 'first-attempt');
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'connecting',
+      'checking',
+    );
+    // ICE is still `checking` when the aggregate peer-connection state fails:
+    // the reported ice_state must be NOT_CONNECTED, not an assumed CONNECTED.
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'failed',
+      'checking',
+    );
+    await flush();
+
+    const completed = postedEvents().filter(
+      (e) =>
+        e.stage === 'PeerConnectionConnect' && e.event_type === 'completed',
+    );
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      outcome: 'failure',
+      peer_connection: 'publish',
+      retry_failure_code: 'DTLS_CONNECTIVITY_FAILED',
+      ice_state: 'NOT_CONNECTED',
+    });
+  });
+
+  it('reports the ICE state captured when the pair opened, with no ICE event', async () => {
+    reporter.startCorrelation(cid, 'first-attempt');
+    // The pair opens with ICE already connected (carried on the connecting
+    // event); no separate ICE event is ever delivered.
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'connecting',
+      'connected',
+    );
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'failed',
+      'connected',
+    );
+    await flush();
+
+    const completed = postedEvents().filter(
+      (e) =>
+        e.stage === 'PeerConnectionConnect' && e.event_type === 'completed',
+    );
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      outcome: 'failure',
+      retry_failure_code: 'DTLS_CONNECTIVITY_FAILED',
+      ice_state: 'CONNECTED',
+    });
+  });
+
   it('opens a fresh peer connection pair after a new correlation', async () => {
     reporter.startCorrelation(cid, 'first-attempt');
-    reporter.onPeerConnectionStateChange(cid, {
-      peerType: PeerType.PUBLISHER_UNSPECIFIED,
-      stateType: 'peerConnection',
-      state: 'connecting',
-    });
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'connecting',
+      'checking',
+    );
 
     reporter.startCorrelation(cid, 'full-rejoin');
-    reporter.onPeerConnectionStateChange(cid, {
-      peerType: PeerType.PUBLISHER_UNSPECIFIED,
-      stateType: 'peerConnection',
-      state: 'connecting',
-    });
-    reporter.onPeerConnectionStateChange(cid, {
-      peerType: PeerType.PUBLISHER_UNSPECIFIED,
-      stateType: 'peerConnection',
-      state: 'connected',
-    });
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'connecting',
+      'checking',
+    );
+    reportPeerConnectionState(
+      PeerType.PUBLISHER_UNSPECIFIED,
+      'connected',
+      'connected',
+    );
     await flush();
 
     const pc = postedEvents().filter(
@@ -566,16 +681,16 @@ describe('ClientEventReporter', () => {
   it('marks a peer connection as previously connected on reconnect', async () => {
     reporter.startCorrelation(cid, 'first-attempt');
     const connect = () => {
-      reporter.onPeerConnectionStateChange(cid, {
-        peerType: PeerType.PUBLISHER_UNSPECIFIED,
-        stateType: 'peerConnection',
-        state: 'connecting',
-      });
-      reporter.onPeerConnectionStateChange(cid, {
-        peerType: PeerType.PUBLISHER_UNSPECIFIED,
-        stateType: 'peerConnection',
-        state: 'connected',
-      });
+      reportPeerConnectionState(
+        PeerType.PUBLISHER_UNSPECIFIED,
+        'connecting',
+        'checking',
+      );
+      reportPeerConnectionState(
+        PeerType.PUBLISHER_UNSPECIFIED,
+        'connected',
+        'connected',
+      );
     };
     connect();
     connect();

--- a/packages/client/src/rtc/BasePeerConnection.ts
+++ b/packages/client/src/rtc/BasePeerConnection.ts
@@ -362,6 +362,7 @@ export abstract class BasePeerConnection {
     try {
       this.onPeerConnectionStateChange?.({
         peerType: this.peerType,
+        iceConnectionState: this.pc.iceConnectionState,
         ...event,
       });
     } catch (err) {

--- a/packages/client/src/rtc/types.ts
+++ b/packages/client/src/rtc/types.ts
@@ -60,18 +60,20 @@ export type OnIceConnected = (peerType: PeerType) => void;
  * Snapshot of the peer connection's ICE and DTLS state surfaced to telemetry
  * consumers (e.g. `ClientEventReporter`). Fired on every transition of
  * either `iceConnectionState` or `peerConnectionState`.
+ *
+ * `iceConnectionState` is the live `RTCPeerConnection.iceConnectionState` read
+ * at the moment the event fires, regardless of which transition triggered it.
+ * Consumers must use it (rather than assuming a value from `stateType`) because
+ * the browser does not guarantee the relative ordering of the `ice` and
+ * `peerConnection` `failed` transitions.
  */
-export type PeerConnectionStateChangeEvent =
-  | {
-      peerType: PeerType;
-      stateType: 'ice';
-      state: RTCIceConnectionState;
-    }
-  | {
-      peerType: PeerType;
-      stateType: 'peerConnection';
-      state: RTCPeerConnectionState;
-    };
+export type PeerConnectionStateChangeEvent = {
+  peerType: PeerType;
+  iceConnectionState: RTCIceConnectionState;
+} & (
+  | { stateType: 'ice'; state: RTCIceConnectionState }
+  | { stateType: 'peerConnection'; state: RTCPeerConnectionState }
+);
 
 export type OnPeerConnectionStateChange = (
   event: PeerConnectionStateChangeEvent,


### PR DESCRIPTION
### 💡 Overview
This PR fixes peer connection failure reporting by preserving the observed ICE connection state on client event telemetry. Previously, the reporter inferred `ice_state` from the type of failure callback, which could misreport DTLS failures as having connected ICE, or lose the ICE state captured when the peer connection pair opened. The change carries the live `RTCPeerConnection.iceConnectionState `through peer connection state-change events and uses it when completing PeerConnectionConnect failure reports.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer-connection failure reporting by preserving the latest ICE connection state.
  * More accurately distinguishes connected, failed, and not-connected states during connection and reconnection flows.
  * Ensures connection events consistently include the current ICE status for more reliable diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->