### PR TITLE
feat(react-sdk): show blocked audio overlay per participant

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -404,6 +404,7 @@ export class Call {
       this.tracer,
     );
     this.blockedAudioTracker = new BlockedAudioTracker(this.tracer);
+    this.leaveCallHooks.add(this.blockedAudioTracker.dispose);
 
     if (typeof document !== 'undefined') {
       this.audioBindingsWatchdog = new AudioBindingsWatchdog(

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -404,7 +404,7 @@ export class Call {
       this.tracer,
     );
     this.blockedAudioTracker = new BlockedAudioTracker(this.tracer);
-    this.leaveCallHooks.add(this.blockedAudioTracker.dispose);
+    this.leaveCallHooks.add(this.blockedAudioTracker.reset);
 
     if (typeof document !== 'undefined') {
       this.audioBindingsWatchdog = new AudioBindingsWatchdog(

--- a/packages/client/src/helpers/BlockedAudioTracker.ts
+++ b/packages/client/src/helpers/BlockedAudioTracker.ts
@@ -1,8 +1,17 @@
 import { BehaviorSubject, distinctUntilChanged, map } from 'rxjs';
 import { videoLoggerSystem } from '../logger';
 import { Tracer } from '../stats';
-import { setCurrentValue, setCurrentValueAsync } from '../store/rxUtils';
+import {
+  isShallowArrayEqual,
+  setCurrentValue,
+  setCurrentValueAsync,
+} from '../store/rxUtils';
 import { timeboxed } from '../coordinator/connection/utils';
+
+type BlockedAudioElement = {
+  element: HTMLAudioElement;
+  sessionId?: string;
+};
 
 /**
  * Tracks audio elements that the browser's autoplay policy has blocked.
@@ -11,8 +20,8 @@ export class BlockedAudioTracker {
   private logger = videoLoggerSystem.getLogger('BlockedAudioTracker');
   private tracer: Tracer;
 
-  private blockedElementsSubject = new BehaviorSubject(
-    new Set<HTMLAudioElement>(),
+  private blockedElementsSubject = new BehaviorSubject<BlockedAudioElement[]>(
+    [],
   );
 
   /**
@@ -21,8 +30,29 @@ export class BlockedAudioTracker {
    * Use {@link resumeAudio} within a user gesture to unblock.
    */
   autoplayBlocked$ = this.blockedElementsSubject.pipe(
-    map((elements) => elements.size > 0),
+    map((elements) => elements.length > 0),
     distinctUntilChanged(),
+  );
+
+  /**
+   * The list of participant `sessionId`s whose audio element is currently
+   * blocked by the browser's autoplay policy. Only some participants may be
+   * blocked (e.g. one joined while a gesture was active and a later one was
+   * not), so use this to render a per-participant affordance rather than a
+   * call-wide one. Call {@link resumeAudio} within a user gesture to unblock
+   * all of them.
+   *
+   * Session ids are registered together with the audio element.
+   */
+  blockedSessionIds$ = this.blockedElementsSubject.pipe(
+    map((elements) => {
+      const ids: string[] = [];
+      elements.forEach(({ sessionId }) => {
+        if (sessionId && !ids.includes(sessionId)) ids.push(sessionId);
+      });
+      return ids;
+    }),
+    distinctUntilChanged(isShallowArrayEqual),
   );
 
   constructor(tracer: Tracer) {
@@ -32,12 +62,33 @@ export class BlockedAudioTracker {
   /**
    * Registers an audio element as blocked by the browser's autoplay policy.
    */
-  markBlocked = (audioElement: HTMLAudioElement, blocked: boolean) => {
+  markBlocked = (
+    audioElement: HTMLAudioElement,
+    blocked: boolean,
+    sessionId?: string,
+  ) => {
     setCurrentValue(this.blockedElementsSubject, (elements) => {
-      if (blocked) elements.add(audioElement);
-      else elements.delete(audioElement);
-      return elements;
+      if (!blocked) {
+        return elements.filter(({ element }) => element !== audioElement);
+      }
+
+      const existing = elements.find(({ element }) => element === audioElement);
+      if (existing) {
+        return elements.map((entry) =>
+          entry.element === audioElement
+            ? { element: audioElement, sessionId: sessionId ?? entry.sessionId }
+            : entry,
+        );
+      }
+
+      return [...elements, { element: audioElement, sessionId }];
     });
+  };
+
+  dispose = () => {
+    if (this.blockedElementsSubject.getValue().length > 0) {
+      this.blockedElementsSubject.next([]);
+    }
   };
 
   /**
@@ -45,7 +96,9 @@ export class BlockedAudioTracker {
    * by the browser's autoplay policy.
    */
   isBlocked = (audioElement: HTMLAudioElement): boolean => {
-    return this.blockedElementsSubject.getValue().has(audioElement);
+    return this.blockedElementsSubject
+      .getValue()
+      .some(({ element }) => element === audioElement);
   };
 
   /**
@@ -57,17 +110,18 @@ export class BlockedAudioTracker {
     await setCurrentValueAsync(
       this.blockedElementsSubject,
       async (elements) => {
+        let next = elements;
         await Promise.all(
-          Array.from(elements, async (element) => {
+          elements.map(async ({ element }) => {
             try {
               if (element.srcObject) await timeboxed([element.play()], 2000);
-              elements.delete(element);
+              next = next.filter((entry) => entry.element !== element);
             } catch (err) {
               this.logger.warn(`Can't resume audio for element`, element, err);
             }
           }),
         );
-        return elements;
+        return next;
       },
     );
   };

--- a/packages/client/src/helpers/BlockedAudioTracker.ts
+++ b/packages/client/src/helpers/BlockedAudioTracker.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, distinctUntilChanged, map } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, map, shareReplay } from 'rxjs';
 import { videoLoggerSystem } from '../logger';
 import { Tracer } from '../stats';
 import {
@@ -53,6 +53,7 @@ export class BlockedAudioTracker {
       return ids;
     }),
     distinctUntilChanged(isShallowArrayEqual),
+    shareReplay({ bufferSize: 1, refCount: true }),
   );
 
   constructor(tracer: Tracer) {
@@ -85,7 +86,10 @@ export class BlockedAudioTracker {
     });
   };
 
-  dispose = () => {
+  /**
+   * Clears all tracked elements. The tracker stays usable afterwards.
+   */
+  reset = () => {
     if (this.blockedElementsSubject.getValue().length > 0) {
       this.blockedElementsSubject.next([]);
     }

--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -328,6 +328,11 @@ export class DynascaleManager {
     let gainNode: GainNode | undefined = undefined;
     let audioWatchdog: MediaPlaybackWatchdog | undefined = undefined;
 
+    const clearBlockedAudio = () => {
+      this.blockedAudioTracker.markBlocked(audioElement, false);
+    };
+    audioElement.addEventListener('playing', clearBlockedAudio);
+
     const isAudioTrack = trackType === 'audioTrack';
     const trackKey = isAudioTrack ? 'audioStream' : 'screenShareAudioStream';
     const updateMediaStreamSubscription = participant$
@@ -369,7 +374,11 @@ export class DynascaleManager {
               this.tracer.trace('audioPlaybackError', e.message);
               if (e.name === 'NotAllowedError') {
                 this.tracer.trace('audioPlaybackBlocked', null);
-                this.blockedAudioTracker.markBlocked(audioElement, true);
+                this.blockedAudioTracker.markBlocked(
+                  audioElement,
+                  true,
+                  sessionId,
+                );
               }
               this.logger.warn(`Failed to play audio stream`, e);
             });
@@ -405,7 +414,8 @@ export class DynascaleManager {
     audioElement.autoplay = true;
 
     return () => {
-      this.blockedAudioTracker.markBlocked(audioElement, false);
+      audioElement.removeEventListener('playing', clearBlockedAudio);
+      clearBlockedAudio();
       sinkIdSubscription?.unsubscribe();
       volumeSubscription.unsubscribe();
       updateMediaStreamSubscription.unsubscribe();

--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -329,6 +329,7 @@ export class DynascaleManager {
     let audioWatchdog: MediaPlaybackWatchdog | undefined = undefined;
 
     const clearBlockedAudio = () => {
+      if (!this.blockedAudioTracker.isBlocked(audioElement)) return;
       this.blockedAudioTracker.markBlocked(audioElement, false);
     };
     audioElement.addEventListener('playing', clearBlockedAudio);
@@ -346,7 +347,7 @@ export class DynascaleManager {
           audioWatchdog?.dispose();
           audioWatchdog = undefined;
           if (!source) {
-            this.blockedAudioTracker.markBlocked(audioElement, false);
+            clearBlockedAudio();
             return;
           }
 

--- a/packages/client/src/helpers/__tests__/BlockedAudioTracker.test.ts
+++ b/packages/client/src/helpers/__tests__/BlockedAudioTracker.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BlockedAudioTracker } from '../BlockedAudioTracker';
 import { getCurrentValue } from '../../store/rxUtils';
 import type { Tracer } from '../../stats';
@@ -28,6 +28,10 @@ describe('BlockedAudioTracker', () => {
   beforeEach(() => {
     tracer = createTracer();
     tracker = new BlockedAudioTracker(tracer);
+  });
+
+  afterEach(() => {
+    tracker.dispose();
   });
 
   it('emits autoplayBlocked$ true after markBlocked(el, true)', () => {
@@ -58,14 +62,58 @@ describe('BlockedAudioTracker', () => {
     expect(getCurrentValue(tracker.autoplayBlocked$)).toBe(false);
   });
 
+  it('emits blocked participant session ids', () => {
+    const el1 = createAudioElement();
+    const el2 = createAudioElement();
+
+    tracker.markBlocked(el1, true, 'session-id-1');
+    tracker.markBlocked(el2, true, 'session-id-2');
+
+    expect(getCurrentValue(tracker.blockedSessionIds$)).toEqual([
+      'session-id-1',
+      'session-id-2',
+    ]);
+
+    tracker.markBlocked(el1, false);
+
+    expect(getCurrentValue(tracker.blockedSessionIds$)).toEqual([
+      'session-id-2',
+    ]);
+  });
+
+  it(`doesn't emit when blocked participant session ids don't change`, () => {
+    const el1 = createAudioElement();
+    const el2 = createAudioElement();
+    tracker.markBlocked(el1, true, 'session-id-1');
+
+    const subscriber = vi.fn();
+    const subscription = tracker.blockedSessionIds$.subscribe(subscriber);
+
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    tracker.markBlocked(el1, true, 'session-id-1');
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    tracker.markBlocked(el2, true, 'session-id-1');
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    tracker.markBlocked(el1, false);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    tracker.markBlocked(el2, false);
+    expect(subscriber).toHaveBeenCalledTimes(2);
+
+    subscription.unsubscribe();
+  });
+
   it('resumeAudio plays each element with srcObject and clears successful ones', async () => {
     const el1 = createAudioElement();
     const el2 = createAudioElement();
     const play1 = vi.spyOn(el1, 'play').mockResolvedValue();
     const play2 = vi.spyOn(el2, 'play').mockResolvedValue();
 
-    tracker.markBlocked(el1, true);
-    tracker.markBlocked(el2, true);
+    tracker.markBlocked(el1, true, 'session-id-1');
+    tracker.markBlocked(el2, true, 'session-id-2');
 
     await tracker.resumeAudio();
 
@@ -82,8 +130,8 @@ describe('BlockedAudioTracker', () => {
       new DOMException('', 'NotAllowedError'),
     );
 
-    tracker.markBlocked(ok, true);
-    tracker.markBlocked(stillBlocked, true);
+    tracker.markBlocked(ok, true, 'session-id-1');
+    tracker.markBlocked(stillBlocked, true, 'session-id-2');
 
     await tracker.resumeAudio();
 
@@ -100,7 +148,7 @@ describe('BlockedAudioTracker', () => {
     const detached = createAudioElement(false);
     const play = vi.spyOn(detached, 'play').mockResolvedValue();
 
-    tracker.markBlocked(detached, true);
+    tracker.markBlocked(detached, true, 'session-id');
     await tracker.resumeAudio();
 
     expect(play).not.toHaveBeenCalled();

--- a/packages/client/src/helpers/__tests__/BlockedAudioTracker.test.ts
+++ b/packages/client/src/helpers/__tests__/BlockedAudioTracker.test.ts
@@ -31,7 +31,7 @@ describe('BlockedAudioTracker', () => {
   });
 
   afterEach(() => {
-    tracker.dispose();
+    tracker.reset();
   });
 
   it('emits autoplayBlocked$ true after markBlocked(el, true)', () => {

--- a/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
+++ b/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
@@ -143,6 +143,47 @@ describe('DynascaleManager', () => {
       cleanup?.();
     });
 
+    it('audio: tracks the blocked session and clears it once the element plays', async () => {
+      vi.useFakeTimers();
+      const audioElement = document.createElement('audio');
+      Object.defineProperty(audioElement, 'srcObject', { writable: true });
+      vi.spyOn(audioElement, 'play').mockRejectedValue(
+        new DOMException('', 'NotAllowedError'),
+      );
+
+      // @ts-expect-error incomplete data
+      call.state.updateOrAddParticipant('session-id', {
+        userId: 'user-id',
+        sessionId: 'session-id',
+        publishedTracks: [],
+      });
+
+      const cleanup = dynascaleManager.bindAudioElement(
+        audioElement,
+        'session-id',
+        'audioTrack',
+      );
+
+      call.state.updateParticipant('session-id', {
+        audioStream: new MediaStream(),
+      });
+      await vi.advanceTimersByTimeAsync(0); // flush the rejected play()
+
+      expect(call.blockedAudioTracker.isBlocked(audioElement)).toBe(true);
+      expect(
+        getCurrentValue(call.blockedAudioTracker.blockedSessionIds$),
+      ).toEqual(['session-id']);
+
+      audioElement.dispatchEvent(new Event('playing'));
+
+      expect(call.blockedAudioTracker.isBlocked(audioElement)).toBe(false);
+      expect(
+        getCurrentValue(call.blockedAudioTracker.blockedSessionIds$),
+      ).toEqual([]);
+
+      cleanup?.();
+    });
+
     it('audio: Safari should use AudioContext for audio playback', () => {
       globalThis._isSafari = true;
       dynascaleManager.setUseWebAudio(true); // enabled by default on Safari

--- a/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
+++ b/packages/client/src/helpers/__tests__/DynascaleManager.test.ts
@@ -145,43 +145,47 @@ describe('DynascaleManager', () => {
 
     it('audio: tracks the blocked session and clears it once the element plays', async () => {
       vi.useFakeTimers();
-      const audioElement = document.createElement('audio');
-      Object.defineProperty(audioElement, 'srcObject', { writable: true });
-      vi.spyOn(audioElement, 'play').mockRejectedValue(
-        new DOMException('', 'NotAllowedError'),
-      );
+      let cleanup: ReturnType<typeof dynascaleManager.bindAudioElement>;
+      try {
+        const audioElement = document.createElement('audio');
+        Object.defineProperty(audioElement, 'srcObject', { writable: true });
+        vi.spyOn(audioElement, 'play').mockRejectedValue(
+          new DOMException('', 'NotAllowedError'),
+        );
 
-      // @ts-expect-error incomplete data
-      call.state.updateOrAddParticipant('session-id', {
-        userId: 'user-id',
-        sessionId: 'session-id',
-        publishedTracks: [],
-      });
+        // @ts-expect-error incomplete data
+        call.state.updateOrAddParticipant('session-id', {
+          userId: 'user-id',
+          sessionId: 'session-id',
+          publishedTracks: [],
+        });
 
-      const cleanup = dynascaleManager.bindAudioElement(
-        audioElement,
-        'session-id',
-        'audioTrack',
-      );
+        cleanup = dynascaleManager.bindAudioElement(
+          audioElement,
+          'session-id',
+          'audioTrack',
+        );
 
-      call.state.updateParticipant('session-id', {
-        audioStream: new MediaStream(),
-      });
-      await vi.advanceTimersByTimeAsync(0); // flush the rejected play()
+        call.state.updateParticipant('session-id', {
+          audioStream: new MediaStream(),
+        });
+        await vi.advanceTimersByTimeAsync(0); // flush the rejected play()
 
-      expect(call.blockedAudioTracker.isBlocked(audioElement)).toBe(true);
-      expect(
-        getCurrentValue(call.blockedAudioTracker.blockedSessionIds$),
-      ).toEqual(['session-id']);
+        expect(call.blockedAudioTracker.isBlocked(audioElement)).toBe(true);
+        expect(
+          getCurrentValue(call.blockedAudioTracker.blockedSessionIds$),
+        ).toEqual(['session-id']);
 
-      audioElement.dispatchEvent(new Event('playing'));
+        audioElement.dispatchEvent(new Event('playing'));
 
-      expect(call.blockedAudioTracker.isBlocked(audioElement)).toBe(false);
-      expect(
-        getCurrentValue(call.blockedAudioTracker.blockedSessionIds$),
-      ).toEqual([]);
-
-      cleanup?.();
+        expect(call.blockedAudioTracker.isBlocked(audioElement)).toBe(false);
+        expect(
+          getCurrentValue(call.blockedAudioTracker.blockedSessionIds$),
+        ).toEqual([]);
+      } finally {
+        cleanup?.();
+        vi.useRealTimers();
+      }
     });
 
     it('audio: Safari should use AudioContext for audio playback', () => {

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -409,21 +409,6 @@ export class CallState {
     this.closedCaptions$ = this.closedCaptionsSubject.asObservable();
 
     /**
-     * Performs shallow comparison of two arrays.
-     * Expects primitive values: [1, 2, 3] is equal to [2, 1, 3].
-     */
-    const isShallowEqual = <T>(a: Array<T>, b: Array<T>): boolean => {
-      if (a.length !== b.length) return false;
-      for (const item of a) {
-        if (!b.includes(item)) return false;
-      }
-      for (const item of b) {
-        if (!a.includes(item)) return false;
-      }
-      return true;
-    };
-
-    /**
      * Creates an Observable from the given subject by piping to the
      * `distinctUntilChanged()` operator.
      */
@@ -436,7 +421,10 @@ export class CallState {
     this.anonymousParticipantCount$ = duc(
       this.anonymousParticipantCountSubject,
     );
-    this.blockedUserIds$ = duc(this.blockedUserIdsSubject, isShallowEqual);
+    this.blockedUserIds$ = duc(
+      this.blockedUserIdsSubject,
+      RxUtils.isShallowArrayEqual,
+    );
     this.backstage$ = duc(this.backstageSubject);
     this.callingState$ = duc(this.callingStateSubject);
     this.ownCapabilities$ = combineLatest([
@@ -471,7 +459,7 @@ export class CallState {
 
         return nextCapabilities;
       }),
-      distinctUntilChanged(isShallowEqual),
+      distinctUntilChanged(RxUtils.isShallowArrayEqual),
       shareReplay({ bufferSize: 1, refCount: true }),
     );
     this.participantCount$ = duc(this.participantCountSubject);

--- a/packages/client/src/store/rxUtils.ts
+++ b/packages/client/src/store/rxUtils.ts
@@ -11,6 +11,21 @@ type AsyncFunctionPatch<T> = (currentValue: T) => Promise<T>;
 export type Patch<T> = T | FunctionPatch<T>;
 
 /**
+ * Performs shallow comparison of two arrays.
+ * Expects primitive values: [1, 2, 3] is equal to [2, 1, 3].
+ */
+export const isShallowArrayEqual = <T>(a: Array<T>, b: Array<T>): boolean => {
+  if (a.length !== b.length) return false;
+  for (const item of a) {
+    if (!b.includes(item)) return false;
+  }
+  for (const item of b) {
+    if (!a.includes(item)) return false;
+  }
+  return true;
+};
+
+/**
  * Checks if the provided update is a function patch.
  *
  * @param update the value to check.

--- a/packages/react-bindings/src/hooks/callStateHooks.ts
+++ b/packages/react-bindings/src/hooks/callStateHooks.ts
@@ -521,6 +521,25 @@ export const useIsAutoplayBlocked = (): boolean => {
 };
 
 /**
+ * Stable empty-array fallback for {@link useAutoplayBlockedSessionIds}, kept at
+ * module scope so the `useObservableValue` dep reference is stable.
+ */
+const BLOCKED_SESSION_IDS$ = of<string[]>([]);
+
+/**
+ * Returns the participant `sessionId`s whose audio is currently blocked
+ * by the browser's autoplay policy. Use it to render a per-participant audio
+ * affordance; only some participants may be blocked. Returns an empty list on
+ * React Native / when there is no call.
+ */
+export const useAutoplayBlockedSessionIds = (): string[] => {
+  const call = useCall();
+  return useObservableValue(
+    call?.blockedAudioTracker.blockedSessionIds$ ?? BLOCKED_SESSION_IDS$,
+  );
+};
+
+/**
  * Returns the current call's closed captions queue.
  */
 export const useCallClosedCaptions = (): CallClosedCaption[] => {

--- a/packages/react-bindings/src/hooks/callStateHooks.ts
+++ b/packages/react-bindings/src/hooks/callStateHooks.ts
@@ -24,6 +24,7 @@ import { useObservableValue } from './useObservableValue';
 const EMPTY_DEVICES_ARRAY = Object.freeze<MediaDeviceInfo[]>(
   [],
 ) as MediaDeviceInfo[];
+const EMPTY_BLOCKED_SESSION_IDS = Object.freeze<string[]>([]) as string[];
 
 export type UseInputMediaDeviceOptions = {
   /**
@@ -524,7 +525,7 @@ export const useIsAutoplayBlocked = (): boolean => {
  * Stable empty-array fallback for {@link useAutoplayBlockedSessionIds}, kept at
  * module scope so the `useObservableValue` dep reference is stable.
  */
-const BLOCKED_SESSION_IDS$ = of<string[]>([]);
+const BLOCKED_SESSION_IDS$ = of(EMPTY_BLOCKED_SESSION_IDS);
 
 /**
  * Returns the participant `sessionId`s whose audio is currently blocked
@@ -536,6 +537,7 @@ export const useAutoplayBlockedSessionIds = (): string[] => {
   const call = useCall();
   return useObservableValue(
     call?.blockedAudioTracker.blockedSessionIds$ ?? BLOCKED_SESSION_IDS$,
+    EMPTY_BLOCKED_SESSION_IDS,
   );
 };
 

--- a/packages/react-sdk/src/core/components/ParticipantView/DefaultParticipantViewUI.tsx
+++ b/packages/react-sdk/src/core/components/ParticipantView/DefaultParticipantViewUI.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stream-io/video-client';
 import {
   useCall,
+  useCallStateHooks,
   useI18n,
   useIsAudioConnecting,
   useIsVideoConnecting,
@@ -44,6 +45,13 @@ export type DefaultParticipantViewUIProps = {
    * Custom component to render the context menu
    */
   ParticipantActionsContextMenu?: ComponentType;
+  /**
+   * Rendered over the tile when this participant's audio is blocked by the
+   * browser's autoplay policy. Selecting it calls {@link Call.resumeAudio} to
+   * unblock audio. Defaults to
+   * {@link DefaultAudioBlockedNotification}; pass `null` to disable.
+   */
+  AudioBlockedNotification?: ComponentType | null;
 };
 
 const ToggleButton = forwardRef<HTMLButtonElement, ToggleMenuButtonProps>(
@@ -79,14 +87,51 @@ export const DefaultScreenShareOverlay = () => {
   );
 };
 
+/**
+ * Rendered over a remote participant's tile when the browser's autoplay policy
+ * has blocked their audio. Selecting it calls `call.resumeAudio()`, unblocking
+ * every blocked element at once.
+ */
+export const DefaultAudioBlockedNotification = () => {
+  const call = useCall();
+  const { t } = useI18n();
+
+  return (
+    <button
+      type="button"
+      className="str-video__audio-blocked-notification"
+      onClick={call?.resumeAudio}
+    >
+      <span className="str-video__audio-blocked-notification__message">
+        <Icon icon="speaker" />
+        <span className="str-video__audio-blocked-notification__text">
+          <span className="str-video__audio-blocked-notification__title">
+            {t('Audio blocked')}
+          </span>
+          <span className="str-video__audio-blocked-notification__subtitle">
+            {t('Click or tap to play audio')}
+          </span>
+        </span>
+      </span>
+    </button>
+  );
+};
+
 export const DefaultParticipantViewUI = ({
   indicatorsVisible = true,
   menuPlacement = 'bottom-start',
   showMenuButton = true,
   ParticipantActionsContextMenu = DefaultParticipantActionsContextMenu,
+  AudioBlockedNotification = DefaultAudioBlockedNotification,
 }: DefaultParticipantViewUIProps) => {
   const { participant, trackType } = useParticipantViewContext();
+  const { useAutoplayBlockedSessionIds } = useCallStateHooks();
+  const blockedSessionIds = useAutoplayBlockedSessionIds();
   const isScreenSharing = hasScreenShare(participant);
+  const shouldShowAudioBlockedNotification =
+    !participant.isLocalParticipant &&
+    trackType !== 'screenShareTrack' &&
+    blockedSessionIds.includes(participant.sessionId);
 
   if (
     participant.isLocalParticipant &&
@@ -114,6 +159,9 @@ export const DefaultParticipantViewUI = ({
       )}
       <Reaction participant={participant} />
       <ParticipantDetails indicatorsVisible={indicatorsVisible} />
+      {AudioBlockedNotification && shouldShowAudioBlockedNotification && (
+        <AudioBlockedNotification />
+      )}
     </>
   );
 };

--- a/packages/react-sdk/src/core/components/ParticipantView/DefaultParticipantViewUI.tsx
+++ b/packages/react-sdk/src/core/components/ParticipantView/DefaultParticipantViewUI.tsx
@@ -106,7 +106,7 @@ export const DefaultAudioBlockedNotification = () => {
         <Icon icon="speaker" />
         <span className="str-video__audio-blocked-notification__text">
           <span className="str-video__audio-blocked-notification__title">
-            {t('Audio blocked')}
+            {t('Audio is blocked by your system')}
           </span>
           <span className="str-video__audio-blocked-notification__subtitle">
             {t('Click or tap to play audio')}

--- a/packages/react-sdk/src/core/components/ParticipantView/DefaultParticipantViewUI.tsx
+++ b/packages/react-sdk/src/core/components/ParticipantView/DefaultParticipantViewUI.tsx
@@ -101,6 +101,7 @@ export const DefaultAudioBlockedNotification = () => {
       type="button"
       className="str-video__audio-blocked-notification"
       onClick={call?.resumeAudio}
+      aria-live="polite"
     >
       <span className="str-video__audio-blocked-notification__message">
         <Icon icon="speaker" />

--- a/packages/react-sdk/src/translations/en.json
+++ b/packages/react-sdk/src/translations/en.json
@@ -54,7 +54,7 @@
   "You are presenting your screen": "You are presenting your screen",
   "Stop Screen Sharing": "Stop Screen Sharing",
 
-  "Audio blocked": "Audio blocked",
+  "Audio is blocked by your system'": "Audio is blocked by your system'",
   "Click or tap to play audio": "Click or tap to play audio",
 
   "Allow": "Allow",

--- a/packages/react-sdk/src/translations/en.json
+++ b/packages/react-sdk/src/translations/en.json
@@ -54,6 +54,9 @@
   "You are presenting your screen": "You are presenting your screen",
   "Stop Screen Sharing": "Stop Screen Sharing",
 
+  "Audio blocked": "Audio blocked",
+  "Click or tap to play audio": "Click or tap to play audio",
+
   "Allow": "Allow",
   "Revoke": "Revoke",
   "Dismiss": "Dismiss",

--- a/packages/react-sdk/src/translations/en.json
+++ b/packages/react-sdk/src/translations/en.json
@@ -54,7 +54,7 @@
   "You are presenting your screen": "You are presenting your screen",
   "Stop Screen Sharing": "Stop Screen Sharing",
 
-  "Audio is blocked by your system'": "Audio is blocked by your system'",
+  "Audio is blocked by your system": "Audio is blocked by your system",
   "Click or tap to play audio": "Click or tap to play audio",
 
   "Allow": "Allow",

--- a/packages/styling/index.scss
+++ b/packages/styling/index.scss
@@ -4,6 +4,7 @@
 @use 'src/global-theme-variables';
 @use 'src/utils';
 
+@use 'src/AudioBlockedNotification';
 @use 'src/Avatar';
 @use 'src/Button';
 @use 'src/BackgroundFilters';

--- a/packages/styling/src/AudioBlockedNotification/AudioBlockedNotification-layout.scss
+++ b/packages/styling/src/AudioBlockedNotification/AudioBlockedNotification-layout.scss
@@ -1,0 +1,51 @@
+.str-video__audio-blocked-notification {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+
+  .str-video__audio-blocked-notification__message {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.625rem;
+    max-width: calc(100% - 1.6rem);
+
+    .str-video__icon {
+      width: 1.5rem;
+      height: 1.5rem;
+      flex-shrink: 0;
+    }
+  }
+
+  .str-video__audio-blocked-notification__text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    min-width: 0;
+    line-height: 1.25;
+  }
+
+  .str-video__audio-blocked-notification__title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .str-video__audio-blocked-notification__subtitle {
+    font-size: 0.75rem;
+    font-weight: 400;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/packages/styling/src/AudioBlockedNotification/AudioBlockedNotification-theme.scss
+++ b/packages/styling/src/AudioBlockedNotification/AudioBlockedNotification-theme.scss
@@ -1,0 +1,24 @@
+.str-video__audio-blocked-notification {
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: inherit;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.45);
+  }
+
+  .str-video__audio-blocked-notification__message {
+    background-color: var(--str-video__background-color1);
+    border-radius: var(--str-video__border-radius-xs);
+    color: var(--str-video__text-color1);
+    z-index: 100;
+
+    .str-video__icon {
+      background-color: var(--str-video__text-color1);
+    }
+  }
+
+  .str-video__audio-blocked-notification__subtitle {
+    color: rgba(255, 255, 255, 0.7);
+  }
+}

--- a/packages/styling/src/AudioBlockedNotification/AudioBlockedNotification-theme.scss
+++ b/packages/styling/src/AudioBlockedNotification/AudioBlockedNotification-theme.scss
@@ -19,6 +19,6 @@
   }
 
   .str-video__audio-blocked-notification__subtitle {
-    color: rgba(255, 255, 255, 0.7);
+    color: var(--str-video__text-color2);
   }
 }

--- a/packages/styling/src/AudioBlockedNotification/AudioBlockedNotification-theme.scss
+++ b/packages/styling/src/AudioBlockedNotification/AudioBlockedNotification-theme.scss
@@ -1,17 +1,16 @@
 .str-video__audio-blocked-notification {
-  background: rgba(0, 0, 0, 0.35);
+  background: var(--str-video__audio-blocked-overlay-color);
   border-radius: inherit;
   transition: background-color 0.15s ease;
 
   &:hover {
-    background: rgba(0, 0, 0, 0.45);
+    background: var(--str-video__audio-blocked-overlay-color-hovered);
   }
 
   .str-video__audio-blocked-notification__message {
     background-color: var(--str-video__background-color1);
     border-radius: var(--str-video__border-radius-xs);
     color: var(--str-video__text-color1);
-    z-index: 100;
 
     .str-video__icon {
       background-color: var(--str-video__text-color1);

--- a/packages/styling/src/AudioBlockedNotification/index.scss
+++ b/packages/styling/src/AudioBlockedNotification/index.scss
@@ -1,0 +1,2 @@
+@use 'AudioBlockedNotification-layout';
+@use 'AudioBlockedNotification-theme';

--- a/packages/styling/src/_global-theme-variables.scss
+++ b/packages/styling/src/_global-theme-variables.scss
@@ -115,6 +115,8 @@
   --str-video__overlay-color: rgba(39, 42, 48, 0.75);
   --str-video__livestream-overlay-color: rgba(39, 42, 48, 0.25);
   --str-video__livestream-overlay-color-hovered: rgba(39, 42, 48, 0.5);
+  --str-video__audio-blocked-overlay-color: rgba(39, 42, 48, 0.35);
+  --str-video__audio-blocked-overlay-color-hovered: rgba(39, 42, 48, 0.45);
 
   // Icons - base64 encoded SVGs
 


### PR DESCRIPTION
### 💡 Overview
This PR adds a blocked-audio overlay to the default React participant UI. When the browser blocks playback for a remote participant’s audio, the affected participant tile shows an overlay that lets the user tap/click to resume call audio.  This mainly addresses WebKit/Safari autoplay behavior. WebKit allows audible playback when there is an active transient user gesture, but that activation is short-lived. In current WebKit source, the default transient activation duration is `5s`. If remote audio arrives, or is reattached after mute/unmute, outside that activation window, `audioElement.play()` can reject with `NotAllowedError`.

### 📝 Implementation notes
The overlay can be customized through `DefaultParticipantViewUI` via the `AudioBlockedNotification` prop, or disabled with `AudioBlockedNotification={null}`.

🎫 Ticket: https://linear.app/stream/issue/REACT-1045/display-blocked-audio-per-participant

📑 Docs: https://github.com/GetStream/docs-content/pull/1449


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary
* **New Features**
  * Added a remote participant “audio blocked” overlay with a click/tap prompt to resume playback.
  * Introduced session-aware blocked-audio tracking and a new hook to drive per-participant UI.
  * Added a configurable notification component override, plus new English status/prompt text and styling.

* **Bug Fixes**
  * Improved blocked-audio state cleanup and resume accuracy, including better handling of autoplay/NotAllowedError cases.
  * Ensured blocked-audio tracker resets as part of standard call-exit handling.

* **Tests**
  * Added/updated coverage for session-ID tracking and autoplay resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->