### PR TITLE
fix(client): fix stale mid in SetPublisher after PeerConnection rollback

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -467,9 +467,10 @@ export class Publisher extends BasePeerConnection {
         // doesn't match the m-section carrying the track stops the SFU from
         // correlating the two: it then answers with every offered codec instead
         // of the announced one, and we publish the first codec of that list.
-        // See https://www.w3.org/TR/webrtc/#set-description - applying a local
-        // offer sets `transceiver.[[Mid]]` (step 10.1.2), and a rollback resets
-        // it to null for a transceiver that wasn't associated yet (step 11.2.1).
+        // Per https://www.w3.org/TR/webrtc/#set-description, applying a local
+        // offer associates the transceiver with its m-section and sets
+        // `[[Mid]]` to `[[JsepMid]]`; a rollback disassociates a transceiver
+        // that wasn't associated before and resets both slots to null.
         const tracks = this.getAnnouncedTracks(offer.sdp);
         if (!tracks.length)
           throw new Error(`Can't negotiate without any tracks`);

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -459,6 +459,17 @@ export class Publisher extends BasePeerConnection {
       try {
         this.isIceRestarting = options?.iceRestart ?? false;
         await this.pc.setLocalDescription(offer);
+
+        // the announced tracks have to be read after `setLocalDescription`.
+        // `transceiver.mid` is null until the offer is applied, and reading the
+        // tracks earlier makes `extractMid` guess the mid from the offer SDP.
+        // That guess goes stale after a rolled-back negotiation, and a mid that
+        // doesn't match the m-section carrying the track stops the SFU from
+        // correlating the two: it then answers with every offered codec instead
+        // of the announced one, and we publish the first codec of that list.
+        // See https://www.w3.org/TR/webrtc/#set-description - applying a local
+        // offer sets `transceiver.[[Mid]]` (step 10.1.2), and a rollback resets
+        // it to null for a transceiver that wasn't associated yet (step 11.2.1).
         const tracks = this.getAnnouncedTracks(offer.sdp);
         if (!tracks.length)
           throw new Error(`Can't negotiate without any tracks`);

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -456,12 +456,12 @@ export class Publisher extends BasePeerConnection {
   private negotiate = async (options?: RTCOfferOptions): Promise<void> => {
     return withoutConcurrency(`publisher.negotiate.${this.lock}`, async () => {
       const offer = await this.pc.createOffer(options);
-      const tracks = this.getAnnouncedTracks(offer.sdp);
-      if (!tracks.length) throw new Error(`Can't negotiate without any tracks`);
-
       try {
         this.isIceRestarting = options?.iceRestart ?? false;
         await this.pc.setLocalDescription(offer);
+        const tracks = this.getAnnouncedTracks(offer.sdp);
+        if (!tracks.length)
+          throw new Error(`Can't negotiate without any tracks`);
 
         const { sdp: baseSdp = '' } = offer;
         const {

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -1343,7 +1343,6 @@ describe('Publisher', () => {
       const transceiver = new RTCRtpTransceiver();
       // @ts-expect-error test setup
       transceiver.sender.track = track;
-      // a fresh transceiver has no `mid` until an offer is applied
       // @ts-expect-error readonly field
       transceiver.mid = null;
 
@@ -1354,13 +1353,10 @@ describe('Publisher', () => {
         negotiated: false,
       });
 
-      // the first attempt gets the only m-line, mid `0`
       const firstOffer = {
         type: 'offer',
         sdp: sdpWith([{ mid: '0', trackId: track.id, port: 9 }]),
       };
-      // after the rollback, the m-line `0` is left over (rejected, no msid)
-      // and the track is re-offered in a new m-line, mid `1`
       const secondOffer = {
         type: 'offer',
         sdp: sdpWith([
@@ -1376,8 +1372,6 @@ describe('Publisher', () => {
         // @ts-expect-error TS picks up the wrong overload
         .mockResolvedValueOnce(secondOffer);
 
-      // mimic the browser: `mid` is assigned when the offer is applied,
-      // and reverted when the offer is rolled back
       vi.spyOn(pc, 'setLocalDescription').mockImplementation(async (desc) => {
         // @ts-expect-error readonly field
         transceiver.mid =
@@ -1392,7 +1386,6 @@ describe('Publisher', () => {
       });
       vi.spyOn(pc, 'setRemoteDescription').mockResolvedValue();
 
-      // the first negotiation fails -> rollback
       sfuClient.setPublisher = vi
         .fn()
         .mockRejectedValueOnce(new Error('SetPublisherTimeout'));
@@ -1404,7 +1397,6 @@ describe('Publisher', () => {
       });
       expect(transceiver.mid).toBeNull();
 
-      // the second negotiation succeeds
       sfuClient.setPublisher = vi
         .fn()
         .mockResolvedValue({ response: { sdp: 'answer-sdp' } });

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -1318,6 +1318,105 @@ describe('Publisher', () => {
     });
   });
 
+  describe('mid assignment during negotiation', () => {
+    const sdpWith = (
+      sections: Array<{ mid: string; trackId?: string; port: number }>,
+    ) =>
+      [
+        'v=0',
+        'o=- 0 0 IN IP4 127.0.0.1',
+        's=-',
+        't=0 0',
+        ...sections.flatMap((s) => [
+          `m=video ${s.port} UDP/TLS/RTP/SAVPF 96`,
+          'c=IN IP4 0.0.0.0',
+          `a=mid:${s.mid}`,
+          ...(s.trackId
+            ? [`a=msid:stream-id ${s.trackId}`, 'a=sendonly']
+            : ['a=inactive']),
+        ]),
+        '',
+      ].join('\r\n');
+
+    it('announces the mid the browser assigned, not the one guessed from the pending offer', async () => {
+      const track = new MediaStreamTrack();
+      const transceiver = new RTCRtpTransceiver();
+      // @ts-expect-error test setup
+      transceiver.sender.track = track;
+      // a fresh transceiver has no `mid` until an offer is applied
+      // @ts-expect-error readonly field
+      transceiver.mid = null;
+
+      publisher['transceiverCache'].add({
+        publishOption: publisher['publishOptions'][0],
+        transceiver,
+        options: {},
+        negotiated: false,
+      });
+
+      // the first attempt gets the only m-line, mid `0`
+      const firstOffer = {
+        type: 'offer',
+        sdp: sdpWith([{ mid: '0', trackId: track.id, port: 9 }]),
+      };
+      // after the rollback, the m-line `0` is left over (rejected, no msid)
+      // and the track is re-offered in a new m-line, mid `1`
+      const secondOffer = {
+        type: 'offer',
+        sdp: sdpWith([
+          { mid: '0', port: 0 },
+          { mid: '1', trackId: track.id, port: 9 },
+        ]),
+      };
+
+      const pc = publisher['pc'];
+      vi.spyOn(pc, 'createOffer')
+        // @ts-expect-error TS picks up the wrong overload
+        .mockResolvedValueOnce(firstOffer)
+        // @ts-expect-error TS picks up the wrong overload
+        .mockResolvedValueOnce(secondOffer);
+
+      // mimic the browser: `mid` is assigned when the offer is applied,
+      // and reverted when the offer is rolled back
+      vi.spyOn(pc, 'setLocalDescription').mockImplementation(async (desc) => {
+        // @ts-expect-error readonly field
+        transceiver.mid =
+          desc?.sdp === firstOffer.sdp
+            ? '0'
+            : desc?.sdp === secondOffer.sdp
+              ? '1'
+              : null; // rollback reverts the mid of a never-negotiated transceiver
+        // @ts-expect-error readonly field
+        pc.signalingState =
+          desc?.type === 'rollback' ? 'stable' : 'have-local-offer';
+      });
+      vi.spyOn(pc, 'setRemoteDescription').mockResolvedValue();
+
+      // the first negotiation fails -> rollback
+      sfuClient.setPublisher = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('SetPublisherTimeout'));
+      await expect(publisher['negotiate']()).rejects.toThrow(
+        'SetPublisherTimeout',
+      );
+      expect(pc.setLocalDescription).toHaveBeenLastCalledWith({
+        type: 'rollback',
+      });
+      expect(transceiver.mid).toBeNull();
+
+      // the second negotiation succeeds
+      sfuClient.setPublisher = vi
+        .fn()
+        .mockResolvedValue({ response: { sdp: 'answer-sdp' } });
+      await publisher['negotiate']();
+
+      expect(sfuClient.setPublisher).toHaveBeenCalledWith({
+        sdp: secondOffer.sdp,
+        tracks: [expect.objectContaining({ trackId: track.id, mid: '1' })],
+      });
+    });
+  });
+
   describe('Firefox unpublish workaround', () => {
     const mockSenderParams = (
       transceiver: RTCRtpTransceiver,


### PR DESCRIPTION
### 💡 Overview
This PR fixes the publisher sending the SFU a `mid` that doesn't exist in the SDP it was sent with. The announced tracks are read before `setLocalDescription()`. At that point `transceiver.mid` is `null`, so `extractMid` falls back to the offer SDP: it looks for the m-line whose `a=msid` carries the track id, and if there's no match it returns the transceiver's index instead. After a failed negotiation is rolled back neither holds `a=msid` still names the track the sender was created with, not the clone `replaceTrack()` swapped in, and the browser's `mid` counter has moved past the transceiver index.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1048/stale-mid-in-setpublisher-after-peerconnection-rollbacks

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebRTC negotiation error handling and rollback behavior during retries.
  * Ensured media track announcements use the browser-assigned identifier when negotiation is retried.
  * Enhanced recovery when negotiation fails or when no media tracks are detected, preventing stale negotiation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->