### PR TITLE
fix(client): never announce two tracks for the same publish option

### DIFF
--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -109,8 +109,6 @@ export class Publisher extends BasePeerConnection {
     options: TrackPublishOptions = {},
   ) => {
     return withoutConcurrency(this.transceiverLockKey, async () => {
-      // the options are read after the lock is acquired, as they may have
-      // changed while this publish was waiting for its turn
       const publishOptions = this.publishOptions.filter(
         (o) => o.trackType === trackType,
       );

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -40,6 +40,7 @@ export class Publisher extends BasePeerConnection {
   private readonly clonedTracks = new Set<MediaStreamTrack>();
   private publishOptions: PublishOption[];
   private readonly selfSubEnabled: boolean;
+  private readonly transceiverLockKey = `publisher.tx.${this.lock}`;
 
   /**
    * Constructs a new `Publisher` instance.
@@ -107,28 +108,33 @@ export class Publisher extends BasePeerConnection {
     trackType: TrackType,
     options: TrackPublishOptions = {},
   ) => {
-    if (!this.publishOptions.some((o) => o.trackType === trackType)) {
-      throw new Error(`No publish options found for ${TrackType[trackType]}`);
-    }
+    return withoutConcurrency(this.transceiverLockKey, async () => {
+      // the options are read after the lock is acquired, as they may have
+      // changed while this publish was waiting for its turn
+      const publishOptions = this.publishOptions.filter(
+        (o) => o.trackType === trackType,
+      );
+      if (!publishOptions.length) {
+        throw new Error(`No publish options found for ${TrackType[trackType]}`);
+      }
 
-    for (const publishOption of this.publishOptions) {
-      if (publishOption.trackType !== trackType) continue;
+      for (const publishOption of publishOptions) {
+        // create a clone of the track as otherwise the same trackId will
+        // appear in the SDP in multiple transceivers
+        const trackToPublish = this.cloneTrack(track);
 
-      // create a clone of the track as otherwise the same trackId will
-      // appear in the SDP in multiple transceivers
-      const trackToPublish = this.cloneTrack(track);
-
-      const bundle = this.transceiverCache.get(publishOption);
-      if (!bundle) {
-        await this.addTransceiver(trackToPublish, publishOption, options);
-      } else {
-        const previousTrack = bundle.transceiver.sender.track;
-        await this.updateTransceiver(bundle, trackToPublish, options);
-        if (!isReactNative()) {
-          this.stopTrack(previousTrack);
+        const bundle = this.transceiverCache.get(publishOption);
+        if (!bundle) {
+          await this.addTransceiver(trackToPublish, publishOption, options);
+        } else {
+          const previousTrack = bundle.transceiver.sender.track;
+          await this.updateTransceiver(bundle, trackToPublish, options);
+          if (!isReactNative()) {
+            this.stopTrack(previousTrack);
+          }
         }
       }
-    }
+    });
   };
 
   /**
@@ -139,6 +145,7 @@ export class Publisher extends BasePeerConnection {
     publishOption: PublishOption,
     options: TrackPublishOptions,
   ) => {
+    const trackType = publishOption.trackType;
     const encodings = isAudioTrackType(publishOption.trackType)
       ? computeAudioLayers(publishOption, options)
       : computeVideoLayers(track, publishOption);
@@ -149,17 +156,18 @@ export class Publisher extends BasePeerConnection {
       direction: 'sendonly',
       sendEncodings,
     });
+    // claim the cache entry in the same task that created the transceiver:
+    // an await in between would let a concurrent caller add a second one
+    // for the same publish option
+    this.transceiverCache.add({ publishOption, transceiver, options });
+    this.trackIdToTrackType.set(track.id, trackType);
+    this.logger.debug(`Added ${TrackType[trackType]} transceiver`);
 
     const params = transceiver.sender.getParameters();
     params.degradationPreference =
       toRTCDegradationPreference(publishOption.degradationPreference) ??
       'maintain-framerate';
     await transceiver.sender.setParameters(params);
-
-    const trackType = publishOption.trackType;
-    this.logger.debug(`Added ${TrackType[trackType]} transceiver`);
-    this.transceiverCache.add({ publishOption, transceiver, options });
-    this.trackIdToTrackType.set(track.id, trackType);
 
     await this.negotiate();
   };
@@ -225,38 +233,40 @@ export class Publisher extends BasePeerConnection {
    * Synchronizes the current Publisher state with the provided publish options.
    */
   private syncPublishOptions = async () => {
-    // enable publishing with new options -> [av1, vp9]
-    for (const publishOption of this.publishOptions) {
-      const { trackType } = publishOption;
-      if (!this.isPublishing(trackType)) continue;
-      if (this.transceiverCache.has(publishOption)) continue;
+    return withoutConcurrency(this.transceiverLockKey, async () => {
+      // enable publishing with new options -> [av1, vp9]
+      for (const publishOption of this.publishOptions) {
+        const { trackType } = publishOption;
+        if (!this.isPublishing(trackType)) continue;
+        if (this.transceiverCache.has(publishOption)) continue;
 
-      const item = this.transceiverCache.find(
-        (i) =>
-          !!i.transceiver.sender.track &&
-          i.publishOption.trackType === trackType,
-      );
-      if (!item) continue;
+        const item = this.transceiverCache.find(
+          (i) =>
+            !!i.transceiver.sender.track &&
+            i.publishOption.trackType === trackType,
+        );
+        if (!item) continue;
 
-      // take the track from the existing transceiver for the same track type,
-      // clone it and publish it with the new publish options
-      const track = this.cloneTrack(item.transceiver.sender.track!);
-      await this.addTransceiver(track, publishOption, item.options);
-    }
+        // take the track from the existing transceiver for the same track type,
+        // clone it and publish it with the new publish options
+        const track = this.cloneTrack(item.transceiver.sender.track!);
+        await this.addTransceiver(track, publishOption, item.options);
+      }
 
-    // stop publishing with options not required anymore -> [vp9]
-    for (const item of this.transceiverCache.items()) {
-      const { publishOption, transceiver } = item;
-      const hasPublishOption = this.publishOptions.some(
-        (option) =>
-          option.id === publishOption.id &&
-          option.trackType === publishOption.trackType,
-      );
-      if (hasPublishOption) continue;
-      // it is safe to stop the track here, it is a clone
-      this.stopTrack(transceiver.sender.track);
-      await this.updateTransceiver(item, null);
-    }
+      // stop publishing with options not required anymore -> [vp9]
+      for (const item of this.transceiverCache.items()) {
+        const { publishOption, transceiver } = item;
+        const hasPublishOption = this.publishOptions.some(
+          (option) =>
+            option.id === publishOption.id &&
+            option.trackType === publishOption.trackType,
+        );
+        if (hasPublishOption) continue;
+        // it is safe to stop the track here, it is a clone
+        this.stopTrack(transceiver.sender.track);
+        await this.updateTransceiver(item, null);
+      }
+    });
   };
 
   /**

--- a/packages/client/src/rtc/Publisher.ts
+++ b/packages/client/src/rtc/Publisher.ts
@@ -40,7 +40,7 @@ export class Publisher extends BasePeerConnection {
   private readonly clonedTracks = new Set<MediaStreamTrack>();
   private publishOptions: PublishOption[];
   private readonly selfSubEnabled: boolean;
-  private readonly transceiverLockKey = `publisher.tx.${this.lock}`;
+  private readonly transceiverLockKey = `pub.tx.${this.lock}`;
 
   /**
    * Constructs a new `Publisher` instance.

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -24,6 +24,7 @@ import { IceTrickleBuffer } from '../IceTrickleBuffer';
 import { StreamClient } from '../../coordinator/connection/client';
 import { TransceiverCache } from '../TransceiverCache';
 import { promiseWithResolvers } from '../../helpers/promise';
+import { settled } from '../../helpers/concurrency';
 import { isFirefox } from '../../helpers/browsers';
 
 vi.mock('../../StreamSfuClient', () => {
@@ -1934,6 +1935,206 @@ describe('Publisher', () => {
       expect(setParametersSpy).not.toHaveBeenCalled();
       // track.stop() still runs so local resources are released
       expect(trackStopSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('concurrent transceiver management', () => {
+    const videoOption = (id: number, codecName: string): PublishOption =>
+      fromPartial({
+        id,
+        trackType: TrackType.VIDEO,
+        bitrate: 1000,
+        codec: { name: codecName },
+        fps: 30,
+        maxTemporalLayers: 3,
+        maxSpatialLayers: 3,
+        degradationPreference: DegradationPreference.UNSPECIFIED,
+      });
+
+    const makeTrack = (): MediaStreamTrack => {
+      const track = new MediaStreamTrack();
+      // @ts-expect-error readonly field
+      track.id = crypto.randomUUID();
+      vi.spyOn(track, 'clone').mockImplementation(() => makeTrack());
+      return track;
+    };
+
+    const makeTransceiver = (track: MediaStreamTrack) => {
+      const transceiver = new RTCRtpTransceiver();
+      // @ts-expect-error test setup
+      transceiver.sender.track = track;
+      transceiver.sender.replaceTrack = vi.fn(async (next) => {
+        // @ts-expect-error test setup
+        transceiver.sender.track = next;
+      });
+      return transceiver;
+    };
+
+    /**
+     * The shared mock returns the same transceiver for every call, which would
+     * hide duplicates. Give every `addTransceiver` call its own transceiver,
+     * with the track bound to the sender like the browser does.
+     */
+    const withDistinctTransceivers = (
+      decorate: (transceiver: RTCRtpTransceiver) => void = () => {},
+    ) => {
+      vi.spyOn(publisher['pc'], 'addTransceiver').mockImplementation(
+        // @ts-expect-error the mock only implements what the Publisher uses
+        (track: MediaStreamTrack) => {
+          const transceiver = makeTransceiver(track);
+          decorate(transceiver);
+          return transceiver;
+        },
+      );
+    };
+
+    const announcedKeys = () =>
+      publisher
+        .getAnnouncedTracks(undefined)
+        .map((track) => `${track.trackType}:${track.publishOptionId}`);
+
+    beforeEach(() => {
+      withDistinctTransceivers();
+      // @ts-expect-error private method
+      vi.spyOn(publisher, 'negotiate').mockResolvedValue();
+    });
+
+    it('announces one track per publish option when publish() runs concurrently', async () => {
+      await Promise.all([
+        publisher.publish(makeTrack(), TrackType.VIDEO),
+        publisher.publish(makeTrack(), TrackType.VIDEO),
+      ]);
+
+      expect(publisher['transceiverCache'].items()).toHaveLength(1);
+      expect(announcedKeys()).toEqual([`${TrackType.VIDEO}:1`]);
+    });
+
+    it('announces one track per publish option when publish() runs during a codec switch', async () => {
+      const track = makeTrack();
+      await publisher.publish(track, TrackType.VIDEO);
+
+      // stall the first await inside addTransceiver, so the codec switch is
+      // still in-flight when the next publish() looks up the cache
+      let releaseCodecSwitch!: () => void;
+      const codecSwitch = new Promise<void>((resolve) => {
+        releaseCodecSwitch = resolve;
+      });
+      withDistinctTransceivers((transceiver) => {
+        transceiver.sender.setParameters = vi.fn(() => codecSwitch);
+      });
+
+      dispatcher.dispatch(
+        SfuEvent.create({
+          eventPayload: {
+            oneofKind: 'changePublishOptions',
+            changePublishOptions: {
+              publishOptions: [videoOption(1, 'vp9'), videoOption(2, 'av1')],
+              reason: 'test',
+            },
+          },
+        }) as DispatchableMessage<'changePublishOptions'>,
+        'test',
+      );
+      await vi.waitFor(() =>
+        expect(publisher['pc'].addTransceiver).toHaveBeenCalled(),
+      );
+
+      const publishTask = publisher.publish(track, TrackType.VIDEO);
+      // let publish() reach the cache lookup for the new publish option
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      releaseCodecSwitch();
+      await publishTask;
+      await settled(publisher['eventLockKey']('changePublishOptions'));
+
+      expect(announcedKeys()).toEqual([
+        `${TrackType.VIDEO}:1`,
+        `${TrackType.VIDEO}:2`,
+      ]);
+    });
+
+    it('rejects a queued publish whose publish options were retired', async () => {
+      // stall the first negotiation, so the next publish() has to queue
+      const firstNegotiation = promiseWithResolvers<void>();
+      let negotiations = 0;
+      // @ts-expect-error private method
+      vi.spyOn(publisher, 'negotiate').mockImplementation(() =>
+        ++negotiations === 1 ? firstNegotiation.promise : Promise.resolve(),
+      );
+
+      const firstPublish = publisher.publish(makeTrack(), TrackType.VIDEO);
+      await vi.waitFor(() => expect(negotiations).toBe(1));
+
+      const queuedPublish = publisher.publish(makeTrack(), TrackType.VIDEO);
+      // video is retired while the second publish waits for the lock
+      publisher['publishOptions'] = [];
+
+      firstNegotiation.resolve();
+      await firstPublish;
+
+      // it must not report success without having published anything
+      await expect(queuedPublish).rejects.toThrow(
+        'No publish options found for VIDEO',
+      );
+      expect(publisher['pc'].addTransceiver).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not keep publishing with an option retired mid-publish', async () => {
+      publisher['publishOptions'] = [
+        videoOption(1, 'vp9'),
+        videoOption(2, 'av1'),
+      ];
+
+      // stall the first negotiation, so publish() is suspended in its loop
+      // after option 1 was added but before option 2 is reached
+      const firstNegotiation = promiseWithResolvers<void>();
+      let negotiations = 0;
+      // @ts-expect-error private method
+      vi.spyOn(publisher, 'negotiate').mockImplementation(() =>
+        ++negotiations === 1 ? firstNegotiation.promise : Promise.resolve(),
+      );
+
+      const publishTask = publisher.publish(makeTrack(), TrackType.VIDEO);
+      await vi.waitFor(() => expect(negotiations).toBe(1));
+
+      dispatcher.dispatch(
+        SfuEvent.create({
+          eventPayload: {
+            oneofKind: 'changePublishOptions',
+            changePublishOptions: {
+              publishOptions: [videoOption(1, 'vp9')],
+              reason: 'test',
+            },
+          },
+        }) as DispatchableMessage<'changePublishOptions'>,
+        'test',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      firstNegotiation.resolve();
+      await publishTask;
+      await settled(publisher['eventLockKey']('changePublishOptions'));
+
+      expect(announcedKeys()).toEqual([`${TrackType.VIDEO}:1`]);
+    });
+
+    it('reuses the transceiver on republish after setParameters failed', async () => {
+      withDistinctTransceivers((transceiver) => {
+        transceiver.sender.setParameters = vi
+          .fn()
+          .mockRejectedValueOnce(new Error('InvalidModificationError'));
+      });
+
+      await expect(
+        publisher.publish(makeTrack(), TrackType.VIDEO),
+      ).rejects.toThrow('InvalidModificationError');
+
+      // the transceiver the browser created is tracked, so the republish
+      // reuses it instead of adding a second one for the same publish option
+      await publisher.publish(makeTrack(), TrackType.VIDEO);
+
+      expect(publisher['pc'].addTransceiver).toHaveBeenCalledTimes(1);
+      expect(publisher['transceiverCache'].items()).toHaveLength(1);
+      expect(announcedKeys()).toEqual([`${TrackType.VIDEO}:1`]);
     });
   });
 });

--- a/packages/client/src/rtc/__tests__/Publisher.test.ts
+++ b/packages/client/src/rtc/__tests__/Publisher.test.ts
@@ -2040,8 +2040,11 @@ describe('Publisher', () => {
       );
 
       const publishTask = publisher.publish(track, TrackType.VIDEO);
-      // let publish() reach the cache lookup for the new publish option
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // a macrotask boundary drains the pending microtasks, which is as far
+      // as an unserialized publish() can get: up to the cache lookup for the
+      // new publish option. It cannot resolve earlier under load, so this
+      // does not depend on wall-clock timing.
+      await new Promise((resolve) => setTimeout(resolve, 0));
       releaseCodecSwitch();
       await publishTask;
       await settled(publisher['eventLockKey']('changePublishOptions'));
@@ -2108,7 +2111,9 @@ describe('Publisher', () => {
         }) as DispatchableMessage<'changePublishOptions'>,
         'test',
       );
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // the handler runs synchronously, so the retired options are in place
+      // and syncPublishOptions is already queued behind this publish
+      expect(publisher['publishOptions']).toHaveLength(1);
 
       firstNegotiation.resolve();
       await publishTask;


### PR DESCRIPTION
### 💡 Overview

When a `SetPublisher` announces two tracks with the same `track_type` **and** the same `publish_option_id`, the SFU accepts the request, negotiates the publisher PC, then fails in `AddUpTrack` with `layer already exists` and force-rejoins the participant. The client re-offers the same shape on rejoin, so the participant can loop and never publish - the failure is session-fatal, not track-fatal.

The client could produce that payload. `Publisher.addTransceiver` had a check-then-add split by an `await`: the transceiver was created by `pc.addTransceiver()`, but the `TransceiverCache` entry was only claimed after `sender.setParameters()` resolved. A second caller entering that window saw no entry for the publish option and created a second transceiver for it, and `getAnnouncedTracks` then emitted two `TrackInfo`s with the same `trackType` + `publishOptionId`.

Two paths reached it: two concurrent `publish()` calls for one track type (app code not awaiting, or `restorePublishedTracks()` during a rejoin overlapping a `camera.enable()` - `doJoin` flips the state to `JOINED` before restore runs, so the device manager's `JOINED` check no longer holds it back), and a `changePublishOptions` codec switch interleaving with a publish.

### 📝 Implementation notes

Three changes in `Publisher`, each covered by a test that was verified red against the mechanism it guards:

- **The cache entry is claimed in the same task that creates the transceiver.** Everything from `transceiverCache.get()` down to `pc.addTransceiver()` is synchronous, so moving the `add` above the first `await` collapses check and act into one uninterrupted job - the window ceases to exist rather than being guarded, for every caller. It also means a rejected `setParameters()` no longer leaks an untracked transceiver: the republish reuses the existing one through `updateTransceiver` instead of adding a second (previously the first was orphaned in the SDP, announced to nobody).
- **`publish` and `syncPublishOptions` share a `publisher.tx.<lock>` tag.** This fixes a second, distinct bug: `publish` iterates the array reference it captured, so while it is parked mid-loop a `changePublishOptions` can retire an option whose teardown finds nothing in the cache yet, and the resumed loop then creates a transceiver for it - a live track announced with a `publishOptionId` the SFU no longer offers, which nothing cleans up. Verified: `['2:1','2:2']` without the lock, `['2:1']` with it.
- **`publish` validates its publish options after acquiring the lock.** A queued publish could otherwise pass a stale check and loop zero times while resolving successfully, at which point `Call.publish` pushes the track type into `publishedTracks` and reports it unmuted to the SFU - a track that remotes see as published but that never sends media.

🎫 Ticket: https://linear.app/stream/issue/VID-1376/sfu-force-rejoins-publisher-when-a-client-announces-two-tracks-of-the

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when publishing multiple tracks or updating publish options concurrently.
  * Prevented duplicate track announcements during concurrent publishes and codec/parameter changes.
  * Ensured queued publishing actions halt correctly when publish options are removed mid-operation.
  * Enhanced recovery behavior, including reusing existing transceivers after parameter update failures.
* **Tests**
  * Added concurrency-focused coverage to validate correct transceiver management and deterministic behavior under contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->