### PR TITLE
ci(release): version @stream-io/typescript-config to stop phantom dependency bumps

### DIFF
--- a/packages/typescript-config/project.json
+++ b/packages/typescript-config/project.json
@@ -1,0 +1,17 @@
+{
+  "name": "@stream-io/typescript-config",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "version": {
+      "executor": "@jscutlery/semver:version",
+      "options": {
+        "dryRun": false,
+        "baseBranch": "main",
+        "preset": "conventionalcommits",
+        "skipProjectChangelog": true,
+        "push": true,
+        "skipCommitTypes": ["ci", "docs"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 💡 Overview

Every release bumps a patch version of nearly every package, whether or not it changed. The culprit is `@stream-io/typescript-config`, which shows up in each changelog as:

```
### Dependency Updates
- `@stream-io/typescript-config` updated to version `0.1.0`
```

Always `0.1.0`. Every release, since 2026-06-26. `audio-filters-web` has three releases (0.10.1, 0.10.2, 0.10.3) whose only content is that line.

**Root cause.** The package is a workspace `devDependency` of nine packages, all of which set `trackDeps: true`, so Nx puts it in the project graph and semver walks the edge. But it is `private`, has no `version` target, and so nothing ever creates a `@stream-io/typescript-config-x.y.z` tag. In `try-bump.js` that means:

1. `getLastVersion()` throws "No semver tag found" → falls back to `0.0.0`.
2. With no commits in the package since the dependent's tag, semver recurses into `tryBump` **without a `since`**, and because `_isInitialVersion('0.0.0')` is true the baseline becomes `getFirstCommitRef()` — the first commit of the entire repo.
3. Scanning all of history finds the one commit that ever touched the package, `d9ea158` `feat: upgrade to TypeScript 6.0.3…`, so `semver.inc('0.0.0', 'minor')` → **`0.1.0`**.
4. `semver.gt('0.1.0', '0.0.0')` is true, and `_isNewVersion` only rejects `null`/`0.0.0`, so it counts as a dependency update.
5. `projectVersion.version === null && dependencyUpdates.length` → forced `_manualBump(…, 'patch')`.

Both sides are static: the computed version is recalculated from scratch every time, and the `0.0.0` baseline never advances because nothing tags the package. So it is permanently "just updated". This is [jscutlery/semver#526](https://github.com/jscutlery/semver/issues/526), open since June 2022.

The blast radius matches the dependency list exactly — `styling` and `codemod`, the only two packages that don't depend on `typescript-config`, were never affected, and `client` is immune for the other reason: it's the one package that doesn't set `trackDeps`.

**Fix.** Give the package its own `version` target. It now gets tagged on each real change, the baseline advances, and dependents bump only when the shared tsconfig genuinely changes.

### 📝 Implementation notes

Config choices:

- **No `publish` or `github` post-target** — the package is `private`. Both release scripts already skip private packages (`comment-released-prs.mts` filters on `manifest.private`), so no npm links or PR comments will be emitted for it.
- **`skipProjectChangelog: true`** — matching the private dogfood app. `enrich-dependency-changelogs.mts` returns early when a package has no `CHANGELOG.md`, and it only enriches *runtime* deps, so a devDependency was never enriched anyway.
- **`skipCommitTypes: ["ci", "docs"]`** — the intersection of all nine dependents' skip lists. This guarantees `typescript-config` bumps at least as eagerly as any dependent reacts to it, so a dependent can never bump while citing a stale version of it.

Verification, against this repo using the plugin's own `_getDependencyVersions`:

```
# today
typescript-config lastVersion : <throws: No semver tag found> -> falls back to 0.0.0
commits in packages/typescript-config since @stream-io/audio-filters-web-0.10.2 : 0
resolved dependency versions  : [{"version":"0.1.0","dependencyName":"@stream-io/typescript-config"}]

# with the tag this target creates
typescript-config lastVersion : 0.1.0
commits in packages/typescript-config since @stream-io/audio-filters-web-0.10.2 : 0
resolved dependency versions  : [{"version":null,"dependencyName":"@stream-io/typescript-config"}]
```

**Expect one more round of bumps.** On the first release after this merges, `typescript-config` releases `0.1.0` (`dependsOn: ["^version"]` runs it before its dependents) and its own `chore(…): release version 0.1.0` commit lands in the package path. Dependents that don't skip `chore` will see it and bump once more. From the following release on, it's quiet. This commit is typed `ci` precisely because every dependent skips `ci`, so it contributes nothing extra.

**Unrelated footgun found along the way, worth its own follow-up:** `nx run <package>:version --dryRun` is not safe in this repo. `targetDefaults` sets `version: { dependsOn: ["^version"] }` and Nx does not forward `--dryRun` to dependency tasks, so every `^version` dependency runs for real — writing `package.json`, committing, tagging and pushing. Anyone "testing" a release that way will cut and push real tags. Worth either a note in the release runbook or defaulting `push: false` with CI passing `--push`.

🎫 Ticket: n/a

📑 Docs: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated semantic versioning for the TypeScript configuration package.
  * Releases now follow conventional commit rules, helping ensure consistent version updates.
  * Documentation-only and CI-only changes are excluded from version bumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->