### PR TITLE
fix(react-native-sdk): make DeepPartial<Theme> accept theme overrides

### DIFF
--- a/packages/react-native-sdk/__tests__/contexts/ThemeContext.test.ts
+++ b/packages/react-native-sdk/__tests__/contexts/ThemeContext.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the theme override type and the deep merge behind `StreamTheme`.
+ *
+ * The type-level assertions below are the regression guard for the case where
+ * `DeepPartial` recursed unconditionally: `Theme` carries a
+ * `[component: string]: any` index signature, the mapped type inherited it as
+ * `DeepPartial<any>`, and every override with a primitive leaf stopped
+ * typechecking. These declarations only compile while that stays fixed, so they
+ * are checked by `yarn test:types` rather than at runtime.
+ */
+
+import { type DeepPartial, mergeThemes } from '../../src/contexts/ThemeContext';
+import { defaultTheme, type Theme } from '../../src/theme/theme';
+
+const colorOverride: DeepPartial<Theme> = {
+  colors: { textPrimary: '#000000' },
+};
+
+const componentStyleOverride: DeepPartial<Theme> = {
+  callControls: { container: { backgroundColor: 'red' } },
+};
+
+const variantOverride: DeepPartial<Theme> = {
+  variants: { roundButtonSizes: { md: 40 } },
+};
+
+const sliceOverride: DeepPartial<Theme['colors']> = {
+  textPrimary: '#000000',
+};
+
+const customComponentOverride: DeepPartial<Theme> = {
+  myCustomComponent: { anything: true },
+};
+
+describe('DeepPartial<Theme>', () => {
+  it('accepts inline overrides at every depth', () => {
+    expect(colorOverride.colors?.textPrimary).toBe('#000000');
+    expect(
+      componentStyleOverride.callControls?.container?.backgroundColor,
+    ).toBe('red');
+    expect(variantOverride.variants?.roundButtonSizes?.md).toBe(40);
+    expect(sliceOverride.textPrimary).toBe('#000000');
+    expect(customComponentOverride.myCustomComponent?.anything).toBe(true);
+  });
+});
+
+describe('mergeThemes', () => {
+  it('returns the default theme when no override is given', () => {
+    expect(mergeThemes({})).toEqual(defaultTheme);
+  });
+
+  it('merges an override into the defaults without dropping siblings', () => {
+    const merged = mergeThemes({ style: colorOverride });
+
+    expect(merged.colors.textPrimary).toBe('#000000');
+    expect(merged.colors.textSecondary).toBe(defaultTheme.colors.textSecondary);
+    expect(merged.variants).toEqual(defaultTheme.variants);
+  });
+
+  it('merges deeply nested component styles', () => {
+    const merged = mergeThemes({ style: componentStyleOverride });
+
+    expect(merged.callControls.container.backgroundColor).toBe('red');
+  });
+
+  it('does not mutate the default theme', () => {
+    const before = defaultTheme.colors.textPrimary;
+    mergeThemes({ style: colorOverride });
+
+    expect(defaultTheme.colors.textPrimary).toBe(before);
+  });
+
+  it('ignores undefined values in the override', () => {
+    const merged = mergeThemes({
+      style: { colors: { textPrimary: undefined } },
+    });
+
+    expect(merged.colors.textPrimary).toBe(defaultTheme.colors.textPrimary);
+  });
+});

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -16,7 +16,7 @@
     "build:expo-plugin": "rimraf expo-config-plugin/dist && tsc --project expo-config-plugin/tsconfig.json",
     "build": "yarn copy-version && bob build && yarn build:expo-plugin",
     "test:expo-plugin": "jest --config=expo-config-plugin/jest.config.js --coverage",
-    "test": "yarn copy-version && jest --coverage && yarn test:expo-plugin",
+    "test": "yarn copy-version && jest --coverage && yarn test:types && yarn test:expo-plugin",
     "test:types": "yarn copy-version && tsc -p tsconfig.spec.json",
     "copy-version": "echo \"export const version = '$npm_package_version';\" > ./src/version.ts"
   },

--- a/packages/react-native-sdk/src/contexts/ThemeContext.tsx
+++ b/packages/react-native-sdk/src/contexts/ThemeContext.tsx
@@ -7,8 +7,17 @@ import React, {
 
 import { defaultTheme, type Theme } from '../theme/theme';
 
+/**
+ * Recursively marks every property of `T` as optional.
+ *
+ * The `extends object` guard is required, not cosmetic: `Theme` carries a
+ * `[component: string]: any` index signature, which the mapped type inherits.
+ * Without the guard that index signature becomes `DeepPartial<any>`, an
+ * all-object type that no primitive leaf can satisfy, and every theme override
+ * fails to typecheck. Guarding short-circuits `any` back to `any`.
+ */
 export type DeepPartial<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>;
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
 export type StreamThemeInputValue = {

--- a/sample-apps/react-native/dogfood/src/theme.ts
+++ b/sample-apps/react-native/dogfood/src/theme.ts
@@ -38,40 +38,31 @@ export const appTheme = {
 export const useCustomTheme = (mode: ThemeMode): DeepPartial<Theme> => {
   const { top, right, bottom, left } = useSafeAreaInsets();
 
-  const variants: DeepPartial<Theme['variants']> = {
-    insets: {
-      top,
-      right,
-      bottom,
-      left,
-    },
-  };
-
-  const lightThemeColors: DeepPartial<Theme['colors']> = {
-    buttonPrimary: '#3399ff',
-    buttonSecondary: '#eff0f1',
-    buttonDisabled: '#ccdfff',
-    buttonWarning: '#dc433b',
-    iconPrimary: '#19232d',
-    iconSecondary: '#3399ff',
-    iconSuccess: '#00e2a1',
-    iconWarning: '#dc433b',
-    sheetPrimary: '#ffffff',
-    sheetSecondary: '#eff0f1',
-    sheetTertiary: '#e3e4e5',
-    sheetOverlay: '#eff0f1a6',
-    textPrimary: '#000000',
-    textSecondary: '#19232d',
-  };
-
   const baseTheme: DeepPartial<Theme> = {
-    variants,
+    variants: {
+      insets: { top, right, bottom, left },
+    },
   };
 
   if (mode === 'light') {
     return {
       ...baseTheme,
-      colors: lightThemeColors,
+      colors: {
+        buttonPrimary: '#3399ff',
+        buttonSecondary: '#eff0f1',
+        buttonDisabled: '#ccdfff',
+        buttonWarning: '#dc433b',
+        iconPrimary: '#19232d',
+        iconSecondary: '#3399ff',
+        iconSuccess: '#00e2a1',
+        iconWarning: '#dc433b',
+        sheetPrimary: '#ffffff',
+        sheetSecondary: '#eff0f1',
+        sheetTertiary: '#e3e4e5',
+        sheetOverlay: '#eff0f1a6',
+        textPrimary: '#000000',
+        textSecondary: '#19232d',
+      },
     };
   }
 

--- a/sample-apps/react-native/expo-video-sample/components/VideoWrapper.tsx
+++ b/sample-apps/react-native/expo-video-sample/components/VideoWrapper.tsx
@@ -82,16 +82,9 @@ export const VideoWrapper = ({ children }: PropsWithChildren<{}>) => {
 const useCustomTheme = (): DeepPartial<Theme> => {
   const { top, right, bottom, left } = useSafeAreaInsets();
 
-  const variants: DeepPartial<Theme['variants']> = {
-    insets: {
-      top,
-      right,
-      bottom,
-      left,
-    },
-  };
-
   return {
-    variants,
+    variants: {
+      insets: { top, right, bottom, left },
+    },
   };
 };

--- a/sample-apps/react-native/ringing-tutorial/contexts/authentication-provider.tsx
+++ b/sample-apps/react-native/ringing-tutorial/contexts/authentication-provider.tsx
@@ -105,16 +105,9 @@ export function AuthenticationProvider({ children }: PropsWithChildren) {
 const useCustomTheme = (): DeepPartial<Theme> => {
   const { top, right, bottom, left } = useSafeAreaInsets();
 
-  const variants: DeepPartial<Theme['variants']> = {
-    insets: {
-      top,
-      right,
-      bottom,
-      left,
-    },
-  };
-
   return {
-    variants,
+    variants: {
+      insets: { top, right, bottom, left },
+    },
   };
 };


### PR DESCRIPTION
### 💡 Overview

`DeepPartial<Theme>` rejected **every** theme override, so the documented way to customise the React Native SDK's theme did not typecheck.

`Theme` ends with a catch-all index signature (`[component: string]: any`). The `DeepPartial` mapped type inherited it as `DeepPartial<any>` — an all-object type that no primitive leaf can satisfy — so any override bottoming out at a string colour or a numeric size failed:

```ts
const t: DeepPartial<Theme> = { colors: { primary: '#005FFF' } };
// error TS2322: Property 'colors' is incompatible with index signature.
//   Type '{ primary: string; }' is not assignable to type 'DeepPartial<any>'.
//     Property 'primary' is incompatible with index signature.
//       Type 'string' is not assignable to type 'DeepPartial<any>'.
```

That is the snippet in `packages/react-native-sdk/CLAUDE.md`, and it never compiled. The reason nobody noticed is that all three RN sample apps had independently worked around it by pulling each override into a pre-annotated variable, which escapes the check a fresh object literal triggers.

### 📝 Implementation notes

**The fix** is one line in `src/contexts/ThemeContext.tsx` — guard the recursion:

```ts
export type DeepPartial<T> = {
  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
};
```

`any extends object ? A : B` distributes to `A | B`, which collapses back to `any`, so the index signature stays permissive and arbitrary component keys keep working. Named properties are unaffected — TypeScript already collapsed `DeepPartial<primitive>` back to the primitive — so this is a **pure widening and cannot break code that compiled before**.

The identical guard was already on the private `DeepPartial` in `src/utils/StreamVideoRN/index.ts`. The two definitions had diverged and only the theme one was broken.

**Sample apps.** With the type fixed, the workarounds are dead weight, so the extracted `variants` variables inline (they were each used once, immediately below their declaration). In dogfood, `lightThemeColors` inlines into its single use site too; `baseTheme` stays a variable since it is referenced twice.

`sample-apps/react-native/dogfood/src/hooks/useTheme.ts` looks similar but imports `DeepPartial`/`Theme` from `stream-chat-react-native`, a different package with its own theme types, so it is untouched.

**Tests / CI.** Adds `__tests__/contexts/ThemeContext.test.ts` with type-level assertions for the four override shapes that used to fail, plus runtime coverage of `mergeThemes`, which had none.

The type half only means something if something typechecks it, and `test:types` was not wired into CI — the RN SDK's `test` script ran `jest`, which strips types via babel, and the package has no `test-ci` script so `test:ci:all` skipped it too. `test:types` is now part of `test`. The workflow already runs `build:all` before `Test RN SDK`, so the built client is in place when it runs.

**Verification**

- Reverting the guard makes the new test file fail with **4 type errors**, all in the assertion block; 0 with it. The regression test is load-bearing, not decorative.
- `test:types` is clean with the client built from this branch (mirroring the CI step order).
- `jest`: 8 suites / 27 tests pass.
- Each sample app was typechecked twice — against the fixed SDK (clean) and against the unfixed one, where the newly inlined code fails with exactly the index-signature error. That confirms the workarounds were load-bearing rather than stylistic.
- `eslint` and `prettier` clean.

**Follow-up, deliberately not in this PR:** nothing in `src/` does dynamic `theme[key]` access, so `[component: string]: any` may not be earning its keep at all — it is what defeats key-name checking on theme overrides in the first place. Removing it would be a breaking change for anyone stashing custom component keys in the theme, so it deserves its own discussion.

🎫 Ticket: N/A

📑 Docs: N/A (the `CLAUDE.md` theming snippet now compiles as written; no public docs change needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme customization typing so nested theme values can be safely provided as partial overrides while preserving primitive values.

* **Tests**
  * Added coverage for theme merging, including nested values, fallback behavior, immutability, and undefined overrides.
  * Added type checks to the standard test workflow.

* **Refactor**
  * Simplified custom theme definitions across sample applications without changing their resulting theme values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->