### PR TITLE
fix(client): require stable playback before resetting watchdog retries

### DIFF
--- a/packages/client/src/helpers/MediaPlaybackWatchdog.ts
+++ b/packages/client/src/helpers/MediaPlaybackWatchdog.ts
@@ -23,8 +23,10 @@ export class MediaPlaybackWatchdog {
   private tracer: Tracer;
   private controller = new AbortController();
   private pendingTimer: ReturnType<typeof setTimeout> | undefined;
+  private settleTimer: ReturnType<typeof setTimeout> | undefined;
   private attempt = 0;
   private disposed = false;
+  private stopped = false;
 
   constructor(opts: MediaPlaybackWatchdogOptions) {
     this.element = opts.element;
@@ -46,38 +48,62 @@ export class MediaPlaybackWatchdog {
     if (this.disposed) return;
     this.disposed = true;
     this.controller.abort();
+    this.clearTimers();
+  };
+
+  private clearTimers = () => {
     if (this.pendingTimer) clearTimeout(this.pendingTimer);
     this.pendingTimer = undefined;
+    if (this.settleTimer) clearTimeout(this.settleTimer);
+    this.settleTimer = undefined;
   };
 
   private onPlaying = () => {
-    if (this.attempt > 0) {
-      this.tracer.trace('mediaPlayback.recover.success', {
-        kind: this.kind,
-        attempts: this.attempt,
-      });
-    }
-    this.attempt = 0;
     if (this.pendingTimer) clearTimeout(this.pendingTimer);
     this.pendingTimer = undefined;
+    if (this.attempt === 0 || this.settleTimer) return;
+    this.settleTimer ??= setTimeout(this.onSettled, 1000);
+  };
+
+  private onSettled = () => {
+    this.settleTimer = undefined;
+    if (this.element.paused) return;
+    this.tracer.trace('mediaPlayback.recover.success', {
+      kind: this.kind,
+      attempts: this.attempt,
+    });
+    this.attempt = 0;
+    this.stopped = false;
   };
 
   private onPauseOrSuspend = (event: Event) => {
-    if (this.disposed) return;
+    if (this.disposed || this.stopped) return;
     this.tracer.trace('mediaPlayback.paused', {
       kind: this.kind,
       reason: event.type,
     });
+    if (this.settleTimer) clearTimeout(this.settleTimer);
+    this.settleTimer = undefined;
     this.scheduleRecovery();
   };
 
   private scheduleRecovery = () => {
-    if (this.disposed || this.pendingTimer) return;
+    if (this.disposed || this.stopped || this.pendingTimer) return;
     const skipReason = this.computeSkipReason();
     if (skipReason) {
       this.tracer.trace('mediaPlayback.recover.skipped', {
         kind: this.kind,
         reason: skipReason,
+      });
+      return;
+    }
+
+    if (this.attempt >= 10) {
+      this.stopped = true;
+      this.clearTimers();
+      this.tracer.trace('mediaPlayback.recover.giveUp', {
+        kind: this.kind,
+        attempts: this.attempt,
       });
       return;
     }
@@ -109,13 +135,6 @@ export class MediaPlaybackWatchdog {
     } catch (err) {
       if (this.disposed) return;
       this.logger.warn(`Failed to recover ${this.kind} playback`, err);
-      if (this.attempt >= 10) {
-        this.tracer.trace('mediaPlayback.recover.giveUp', {
-          kind: this.kind,
-          attempts: this.attempt,
-        });
-        return;
-      }
       this.scheduleRecovery();
     }
   };

--- a/packages/client/src/helpers/__tests__/MediaPlaybackWatchdog.test.ts
+++ b/packages/client/src/helpers/__tests__/MediaPlaybackWatchdog.test.ts
@@ -28,18 +28,31 @@ const createMediaElement = (
   state: FakeMediaState = {},
 ) => {
   const el = document.createElement(kind) as HTMLMediaElement;
-  Object.defineProperty(el, 'srcObject', { writable: true });
+  Object.defineProperty(el, 'srcObject', {
+    value: 'srcObject' in state ? state.srcObject : new MediaStream(),
+    writable: true,
+  });
   Object.defineProperty(el, 'paused', { writable: true, configurable: true });
   Object.defineProperty(el, 'readyState', {
+    value: state.readyState ?? 4,
     writable: true,
     configurable: true,
   });
-  Object.defineProperty(el, 'ended', { writable: true, configurable: true });
-  el.srcObject = 'srcObject' in state ? state.srcObject : new MediaStream();
-  el.paused = state.paused ?? true;
-  el.readyState = state.readyState ?? 4;
-  el.ended = state.ended ?? false;
+  Object.defineProperty(el, 'ended', {
+    value: state.ended ?? false,
+    writable: true,
+    configurable: true,
+  });
+  setPaused(el, state.paused ?? true);
   return el;
+};
+
+const setPaused = (el: HTMLMediaElement, paused: boolean) => {
+  Object.defineProperty(el, 'paused', {
+    value: paused,
+    writable: true,
+    configurable: true,
+  });
 };
 
 type SetupOpts = {
@@ -111,13 +124,129 @@ describe('MediaPlaybackWatchdog', () => {
     await vi.advanceTimersByTimeAsync(6000);
     expect(play).toHaveBeenCalledTimes(2);
 
-    // Simulate the element actually starting to play.
+    // Simulate the element actually starting to play, and staying up long
+    // enough for the recovery to count as settled.
+    setPaused(el, false);
     el.dispatchEvent(new Event('playing'));
+    await vi.advanceTimersByTimeAsync(1000);
 
-    // A subsequent pause should still trigger a fresh recovery attempt.
+    // A subsequent pause should trigger a fresh, immediate recovery attempt.
+    setPaused(el, true);
     el.dispatchEvent(new Event('pause'));
     await vi.advanceTimersByTimeAsync(0);
     expect(play).toHaveBeenCalledTimes(3);
+  });
+
+  it('backs off instead of retrying immediately when playback has not settled', async () => {
+    el.dispatchEvent(new Event('pause'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(play).toHaveBeenCalledTimes(1);
+
+    // resumed, but re-paused before the settle delay elapsed
+    setPaused(el, false);
+    el.dispatchEvent(new Event('playing'));
+    expect(tracer.trace).not.toHaveBeenCalledWith(
+      'mediaPlayback.recover.success',
+      {
+        kind: 'audio',
+        attempts: 1,
+      },
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    setPaused(el, true);
+    el.dispatchEvent(new Event('pause'));
+
+    // the next attempt is subject to backoff, not scheduled on the next tick
+    await vi.advanceTimersByTimeAsync(0);
+    expect(play).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(play).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops fighting an element that re-pauses after every successful play', async () => {
+    setup({ kind: 'video' });
+    // Safari re-pauses the element right after play() resolves. This used to
+    // reset the attempt counter, so the loop spun with a zero delay forever.
+    play.mockImplementation(async () => {
+      setPaused(el, false);
+      el.dispatchEvent(new Event('playing'));
+      setPaused(el, true);
+      el.dispatchEvent(new Event('pause'));
+    });
+
+    el.dispatchEvent(new Event('pause'));
+    for (let i = 0; i < 20; i++) {
+      await vi.advanceTimersByTimeAsync(6000);
+    }
+
+    expect(play).toHaveBeenCalledTimes(10);
+    expect(tracer.trace).toHaveBeenCalledWith('mediaPlayback.recover.giveUp', {
+      kind: 'video',
+      attempts: 10,
+    });
+
+    // External playback can still emit `playing` after the watchdog gave up
+    // (for example from a user gesture or another playback helper). If it
+    // re-pauses before settling, it must not revive the watchdog or trace a
+    // false recovery success.
+    setPaused(el, false);
+    el.dispatchEvent(new Event('playing'));
+    setPaused(el, true);
+    el.dispatchEvent(new Event('pause'));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(tracer.trace).not.toHaveBeenCalledWith(
+      'mediaPlayback.recover.success',
+      {
+        kind: 'video',
+        attempts: 10,
+      },
+    );
+
+    // and it stays stopped, without tracing the pause storm
+    const traceMock = tracer.trace as unknown as MockInstance;
+    const tracesBefore = traceMock.mock.calls.length;
+    for (let i = 0; i < 100; i++) {
+      el.dispatchEvent(new Event('pause'));
+    }
+    await vi.advanceTimersByTimeAsync(6000);
+
+    expect(play).toHaveBeenCalledTimes(10);
+    expect(traceMock.mock.calls.length).toBe(tracesBefore);
+  });
+
+  it('revives once playback genuinely holds for the settle window', async () => {
+    setup({ kind: 'video' });
+    play.mockImplementation(async () => {
+      setPaused(el, false);
+      el.dispatchEvent(new Event('playing'));
+      setPaused(el, true);
+      el.dispatchEvent(new Event('pause'));
+    });
+
+    el.dispatchEvent(new Event('pause'));
+    for (let i = 0; i < 20; i++) {
+      await vi.advanceTimersByTimeAsync(6000);
+    }
+    expect(play).toHaveBeenCalledTimes(10); // gave up
+
+    play.mockResolvedValue(undefined);
+    setPaused(el, false);
+    el.dispatchEvent(new Event('playing'));
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(tracer.trace).toHaveBeenCalledWith('mediaPlayback.recover.success', {
+      kind: 'video',
+      attempts: 10,
+    });
+
+    // recovery is live again: the attempt counter was reset, so a fresh pause
+    // gets an immediate attempt rather than being ignored
+    setPaused(el, true);
+    el.dispatchEvent(new Event('pause'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(play).toHaveBeenCalledTimes(11);
   });
 
   it('does not attempt recovery when srcObject is null', async () => {


### PR DESCRIPTION
### 💡 Overview
This PR fixes an unbounded retry loop in MediaPlaybackWatchdog. When an element pauses, the watchdog calls `play() `to recover it but it treated a resolved play() promise as a successful recovery and reset its attempt counter. On Safari, where the element was re-paused immediately after every successful play(), that meant every retry looked like the first: the backoff never engaged, and the attempt >= 10 ceiling was unreachable because it only ran when play() rejected.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1058/audio-recovery-triggers-an-endless-retry-loop-on-safari

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media playback recovery when playback pauses unexpectedly.
  * Recovery now confirms stable playback before resetting retry attempts.
  * Added safeguards to stop retries after repeated failures and prevent unnecessary recovery attempts.
  * Improved handling when playback resumes after a previous recovery limit was reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->