### PR TITLE
fix(rn): subscribe spotlight video after a dropped layout event

### DIFF
--- a/packages/react-native-sdk/__tests__/components/CallParticipantsSpotlight.test.tsx
+++ b/packages/react-native-sdk/__tests__/components/CallParticipantsSpotlight.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { mockClientWithUser } from '../mocks/client';
-import { SfuModels } from '@stream-io/video-client';
+import { CallingState, SfuModels } from '@stream-io/video-client';
 import mockParticipant from '../mocks/participant';
 import { ComponentTestIds } from '../../src/constants/TestIds';
 import { mockCall } from '../mocks/call';
-import { render, screen } from '../utils/RNTLTools';
+import { act, fireEvent, render, screen } from '../utils/RNTLTools';
 import { CallParticipantsSpotlight } from '../../src/components/Call/CallLayout/CallParticipantsSpotlight';
 import { CallParticipantsList } from '../../src/components/Call/CallParticipantsList/CallParticipantsList';
 import { ParticipantView } from '../../src/components/Participant/ParticipantView/ParticipantView';
@@ -118,5 +118,59 @@ describe('CallParticipantsSpotlight', () => {
     expect(
       await screen.findByTestId(ComponentTestIds.CALL_PARTICIPANTS_LIST),
     ).toBeVisible();
+  });
+
+  it('keeps the spotlight video subscription when a remote participant moves there from the list', async () => {
+    const call = mockCall(mockClientWithUser(), [
+      mockParticipant({ isLocalParticipant: true, sessionId: P_IDS.LOCAL_1 }),
+      mockParticipant({ sessionId: P_IDS.REMOTE_1 }),
+      mockParticipant({ sessionId: P_IDS.REMOTE_2 }),
+    ]);
+    call.state.setCallingState(CallingState.JOINED);
+
+    render(
+      <CallParticipantsSpotlight
+        CallParticipantsList={CallParticipantsList}
+        ParticipantView={ParticipantView}
+        VideoRenderer={VideoRenderer}
+      />,
+      { call },
+    );
+
+    // `dominantSpeaker` sorts first under the spotlight's preset, so this moves
+    // `sessionId` into the spotlight and the other remote into the list. The
+    // advance covers the layout's 300ms participant debounce, the list's 500ms
+    // viewability re-render and the 600ms subscription debounce, so any delayed
+    // write from the old list cell has landed.
+    const spotlight = (sessionId: P_IDS) =>
+      act(async () => {
+        call.state.updateParticipants({
+          [P_IDS.REMOTE_1]: { isDominantSpeaker: sessionId === P_IDS.REMOTE_1 },
+          [P_IDS.REMOTE_2]: { isDominantSpeaker: sessionId === P_IDS.REMOTE_2 },
+        });
+        jest.advanceTimersByTime(2000);
+      });
+
+    await spotlight(P_IDS.REMOTE_1);
+    // only the spotlight tile renders an RTCView: the list cells are never
+    // reported viewable in this environment, so they render their fallback
+    fireEvent(
+      screen.getByTestId(ComponentTestIds.PARTICIPANT_MEDIA_STREAM),
+      'layout',
+      { nativeEvent: { layout: { width: 800, height: 600, x: 0, y: 0 } } },
+    );
+
+    // REMOTE_2 takes the spotlight and REMOTE_1 drops into the list, with no new
+    // layout event: the tile's geometry is unchanged, so RN would not fire one.
+    // The 800x600 dimension can only come from the layout reported above.
+    await spotlight(P_IDS.REMOTE_2);
+
+    expect(call.trackSubscriptionManager.subscriptions).toContainEqual(
+      expect.objectContaining({
+        sessionId: P_IDS.REMOTE_2,
+        trackType: SfuModels.TrackType.VIDEO,
+        dimension: { width: 800, height: 600 },
+      }),
+    );
   });
 });

--- a/packages/react-native-sdk/__tests__/components/TrackSubscriber.test.tsx
+++ b/packages/react-native-sdk/__tests__/components/TrackSubscriber.test.tsx
@@ -1,20 +1,13 @@
-import React, { createRef } from 'react';
-import { LayoutChangeEvent } from 'react-native';
+import React from 'react';
 import { act, render } from '@testing-library/react-native';
 import { CallingState, SfuModels } from '@stream-io/video-client';
-import TrackSubscriber, {
-  TrackSubscriberHandle,
-} from '../../src/components/Participant/ParticipantView/VideoRenderer/TrackSubscriber';
+import { BehaviorSubject } from 'rxjs';
+import TrackSubscriber from '../../src/components/Participant/ParticipantView/VideoRenderer/TrackSubscriber';
 import mockParticipant from '../mocks/participant';
 import { mockCall } from '../mocks/call';
 import { mockClientWithUser } from '../mocks/client';
 
 jest.useFakeTimers();
-
-const layoutEvent = (width: number, height: number) =>
-  ({
-    nativeEvent: { layout: { width, height, x: 0, y: 0 } },
-  }) as unknown as LayoutChangeEvent;
 
 describe('TrackSubscriber', () => {
   it('requests the video track when the participant appears in state after the subscriber mounted', () => {
@@ -25,15 +18,17 @@ describe('TrackSubscriber', () => {
     call.state.setCallingState(CallingState.JOINED);
 
     const sessionId = 'remote-session-1';
-    const ref = createRef<TrackSubscriberHandle>();
+    const dimensions$ = new BehaviorSubject<
+      SfuModels.VideoDimension | undefined
+    >(undefined);
 
     render(
       <TrackSubscriber
-        ref={ref}
         call={call}
         participantSessionId={sessionId}
         trackType="videoTrack"
         isVisible={true}
+        dimensions$={dimensions$}
       />,
     );
 
@@ -52,7 +47,7 @@ describe('TrackSubscriber', () => {
 
     // The view lays out and reports its dimensions.
     act(() => {
-      ref.current?.onLayoutUpdate(layoutEvent(200, 200));
+      dimensions$.next({ width: 200, height: 200 });
     });
 
     // The client must now request the participant's video track. Before the fix

--- a/packages/react-native-sdk/__tests__/components/VideoRenderer.test.tsx
+++ b/packages/react-native-sdk/__tests__/components/VideoRenderer.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { CallingState, SfuModels } from '@stream-io/video-client';
+import { act, fireEvent, render, screen } from '../utils/RNTLTools';
+import { VideoRenderer } from '../../src/components/Participant/ParticipantView/VideoRenderer';
+import { ComponentTestIds } from '../../src/constants/TestIds';
+import mockParticipant from '../mocks/participant';
+import { mockCall } from '../mocks/call';
+import { mockClientWithUser } from '../mocks/client';
+
+jest.useFakeTimers();
+
+describe('VideoRenderer', () => {
+  it('requests the video track of every remote participant occupying a tile whose layout event was dropped', async () => {
+    const local = mockParticipant({
+      sessionId: 'local',
+      isLocalParticipant: true,
+    });
+    const remotes = [
+      mockParticipant({ sessionId: 'remote-1' }),
+      mockParticipant({ sessionId: 'remote-2' }),
+    ];
+    const call = mockCall(mockClientWithUser(), [local, ...remotes]);
+    call.state.setCallingState(CallingState.JOINED);
+
+    // A spotlight tile keeps the same VideoRenderer across participant changes,
+    // so `onLayout` fires only while the local participant occupies it - at
+    // which point no TrackSubscriber is mounted to receive it.
+    const { rerender } = render(
+      <VideoRenderer participant={local} trackType="videoTrack" />,
+      { call },
+    );
+    await act(async () => {}); // let the providers finish their async setup
+    fireEvent(
+      screen.getByTestId(ComponentTestIds.PARTICIPANT_MEDIA_STREAM),
+      'layout',
+      { nativeEvent: { layout: { width: 400, height: 300, x: 0, y: 0 } } },
+    );
+
+    expect(call.trackSubscriptionManager.subscriptions).toHaveLength(0);
+
+    // Each remote in turn takes over the tile. The geometry never changes, so
+    // React Native does not fire `onLayout` again - so the dropped event must
+    // not be the tile's only source of truth, for the first occupant or any
+    // later one.
+    for (const remote of remotes) {
+      rerender(<VideoRenderer participant={remote} trackType="videoTrack" />);
+      expect(call.trackSubscriptionManager.subscriptions).toContainEqual(
+        expect.objectContaining({
+          sessionId: remote.sessionId,
+          trackType: SfuModels.TrackType.VIDEO,
+          dimension: { width: 400, height: 300 },
+        }),
+      );
+    }
+  });
+});

--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/TrackSubscriber.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/TrackSubscriber.tsx
@@ -1,5 +1,4 @@
-import { forwardRef, useImperativeHandle, useEffect, useMemo } from 'react';
-import { LayoutChangeEvent } from 'react-native';
+import { useEffect } from 'react';
 import {
   Call,
   CallingState,
@@ -18,15 +17,17 @@ import {
   filter,
   map,
 } from 'rxjs';
-export type TrackSubscriberHandle = {
-  onLayoutUpdate: (event: LayoutChangeEvent) => void;
-};
 
 type TrackSubscriberProps = {
   participantSessionId: string;
   call: Call;
   trackType: VideoTrackType;
   isVisible: boolean;
+  /**
+   * The dimensions of the view rendering the track, owned by the parent so that
+   * the last reported layout survives a remount of this component.
+   */
+  dimensions$: BehaviorSubject<SfuModels.VideoDimension | undefined>;
 };
 
 /**
@@ -40,81 +41,61 @@ type TrackSubscriberProps = {
  * 1. When the participant stops publishing the video track
  * 2. When the participant becomes invisible
 */
-const TrackSubscriber = forwardRef<TrackSubscriberHandle, TrackSubscriberProps>(
-  (props, ref) => {
-    const { call, participantSessionId, trackType, isVisible } = props;
-    const dimensions$ = useMemo(() => {
-      return new BehaviorSubject<SfuModels.VideoDimension | undefined>(
-        undefined,
-      );
-    }, []);
+const TrackSubscriber = (props: TrackSubscriberProps) => {
+  const { call, participantSessionId, trackType, isVisible, dimensions$ } =
+    props;
 
-    useEffect(() => {
-      const requestTrackWithDimensions = (
-        debounceType: DebounceType,
-        dimension: SfuModels.VideoDimension | undefined,
-      ) => {
-        if (dimension && (dimension.width === 0 || dimension.height === 0)) {
-          // ignore 0x0 dimensions. this can happen when the video element
-          // is not visible (e.g., has display: none).
-          // we treat this as "unsubscription" as we don't want to keep
-          // consuming bandwidth for a video that is not visible on the screen.
-          dimension = undefined;
-        }
-        call.state.updateParticipantTracks(trackType, {
-          [participantSessionId]: { dimension },
-        });
-        call.trackSubscriptionManager.apply(debounceType);
-      };
-      const isPublishingTrack$ = call.state.participants$.pipe(
-        map((ps) => ps.find((p) => p.sessionId === participantSessionId)),
-        filter((p): p is StreamVideoParticipant => !!p),
-        distinctUntilKeyChanged('publishedTracks'),
-        map((p) =>
-          trackType === 'videoTrack' ? hasVideo(p) : hasScreenShare(p),
-        ),
-        distinctUntilChanged(),
-      );
-      const isJoinedState$ = call.state.callingState$.pipe(
-        map((callingState) => callingState === CallingState.JOINED),
-      );
-
-      const subscription = combineLatest([
-        dimensions$,
-        isPublishingTrack$,
-        isJoinedState$,
-      ]).subscribe(([dimension, isPublishing, isJoined]) => {
-        if (isJoined) {
-          if (!isVisible || !isPublishing) {
-            requestTrackWithDimensions(DebounceType.MEDIUM, undefined);
-          } else if (dimension) {
-            requestTrackWithDimensions(DebounceType.IMMEDIATE, dimension);
-          }
-        }
+  useEffect(() => {
+    const requestTrackWithDimensions = (
+      debounceType: DebounceType,
+      dimension: SfuModels.VideoDimension | undefined,
+    ) => {
+      if (dimension && (dimension.width === 0 || dimension.height === 0)) {
+        // ignore 0x0 dimensions. this can happen when the video element
+        // is not visible (e.g., has display: none).
+        // we treat this as "unsubscription" as we don't want to keep
+        // consuming bandwidth for a video that is not visible on the screen.
+        dimension = undefined;
+      }
+      call.state.updateParticipantTracks(trackType, {
+        [participantSessionId]: { dimension },
       });
-
-      return () => {
-        subscription.unsubscribe();
-      };
-    }, [call, participantSessionId, trackType, isVisible, dimensions$]);
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        onLayoutUpdate: (event) => {
-          const dimension = {
-            width: Math.trunc(event.nativeEvent.layout.width),
-            height: Math.trunc(event.nativeEvent.layout.height),
-          };
-          dimensions$.next(dimension);
-        },
-      }),
-      [dimensions$],
+      call.trackSubscriptionManager.apply(debounceType);
+    };
+    const isPublishingTrack$ = call.state.participants$.pipe(
+      map((ps) => ps.find((p) => p.sessionId === participantSessionId)),
+      filter((p): p is StreamVideoParticipant => !!p),
+      distinctUntilKeyChanged('publishedTracks'),
+      map((p) =>
+        trackType === 'videoTrack' ? hasVideo(p) : hasScreenShare(p),
+      ),
+      distinctUntilChanged(),
+    );
+    const isJoinedState$ = call.state.callingState$.pipe(
+      map((callingState) => callingState === CallingState.JOINED),
     );
 
-    return null;
-  },
-);
+    const subscription = combineLatest([
+      dimensions$,
+      isPublishingTrack$,
+      isJoinedState$,
+    ]).subscribe(([dimension, isPublishing, isJoined]) => {
+      if (isJoined) {
+        if (!isVisible || !isPublishing) {
+          requestTrackWithDimensions(DebounceType.MEDIUM, undefined);
+        } else if (dimension) {
+          requestTrackWithDimensions(DebounceType.IMMEDIATE, dimension);
+        }
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [call, participantSessionId, trackType, isVisible, dimensions$]);
+
+  return null;
+};
 
 TrackSubscriber.displayName = 'TrackSubscriber';
 

--- a/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/index.tsx
+++ b/packages/react-native-sdk/src/components/Participant/ParticipantView/VideoRenderer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import type { MediaStream } from '@stream-io/react-native-webrtc';
 import { RTCView } from '@stream-io/react-native-webrtc';
@@ -7,15 +7,17 @@ import {
   hasPausedTrack,
   hasScreenShare,
   hasVideo,
+  SfuModels,
   type VideoTrackType,
   VisibilityState,
 } from '@stream-io/video-client';
 import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
+import { BehaviorSubject } from 'rxjs';
 import { ParticipantVideoFallback as DefaultParticipantVideoFallback } from '../ParticipantVideoFallback';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import { useTrackDimensions } from '../../../../hooks/useTrackDimensions';
 import { useScreenshotIosContext } from '../../../../contexts/internal/ScreenshotIosContext';
-import TrackSubscriber, { TrackSubscriberHandle } from './TrackSubscriber';
+import TrackSubscriber from './TrackSubscriber';
 
 const DEFAULT_VIEWPORT_VISIBILITY_STATE: Record<
   VideoTrackType,
@@ -59,7 +61,13 @@ export const VideoRenderer = React.memo(
     } = useTheme();
     const call = useCall();
     const { useCameraState, useIncomingVideoSettings } = useCallStateHooks();
-    const trackSubscriberRef = useRef<TrackSubscriberHandle>(null);
+    // a sticky note of the dimensions of the RTCView from onLayout
+    // to reuse for a new participant even if dimensions dont change
+    const dimensions$ = useMemo(
+      () =>
+        new BehaviorSubject<SfuModels.VideoDimension | undefined>(undefined),
+      [],
+    );
     const { isParticipantVideoEnabled } = useIncomingVideoSettings();
     const { direction } = useCameraState();
     const viewRef = useRef(null);
@@ -201,7 +209,10 @@ export const VideoRenderer = React.memo(
     const onLayout: React.ComponentProps<typeof RTCView>['onLayout'] = (
       event,
     ) => {
-      trackSubscriberRef.current?.onLayoutUpdate(event);
+      dimensions$.next({
+        width: Math.trunc(event.nativeEvent.layout.width),
+        height: Math.trunc(event.nativeEvent.layout.height),
+      });
     };
 
     return (
@@ -211,11 +222,11 @@ export const VideoRenderer = React.memo(
       >
         {call && !isLocalParticipant && (
           <TrackSubscriber
-            ref={trackSubscriberRef}
             call={call}
             participantSessionId={sessionId}
             trackType={trackType}
             isVisible={isVisible}
+            dimensions$={dimensions$}
           />
         )}
         {canShowVideo &&


### PR DESCRIPTION
### 💡 Overview

*Bug description:* 

We use spotlight view. Say there are 5 participants in a call. Participant A local and B,C,D,E are remote. Say if local participant is dominant first and shown in spotlight and B,C are visible in bottom list list. D,E are invisible (outside of the list rendering window) and track not subscribed. Since A is dominant first we show A in spotlight and others in list.

If after A, D or E become dominant speaker.  We would see a blank video in spotlight for D and E. 

**Why?:** A is replaced by D or E in spotlight view. Now since A was local participant initially `TrackSubscriber` was not rendered and dimension was not reported. When D replaced the spotlight. `TrackSubscriber` got rendered, but there would be no onLayout update.  Since there was no onLayout update, the track dimensions for D would never be reported and D's track would never be subscribed. 

### 📝 Implementation notes

The fix is very simple: move `dimensions$` ownership from `TrackSubscriber` up to `VideoRenderer`, which
owns the `onLayout` view and is never remounted, and pass it down as a prop. A remounted subscriber now reads the retained dimension synchronously on subscribe.

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video subscription stability when the spotlight or dominant remote participant changes.
  * Preserved existing video tile dimensions even when participant changes do not trigger additional layout events.
  * Improved handling of zero-sized video views to prevent unnecessary subscriptions.

* **Tests**
  * Added regression coverage for participant spotlight changes and retained video dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->