### PR TITLE
feat(react-dogfood): support query params in the call create API

### DIFF
--- a/sample-apps/react/react-dogfood/pages/api/call/create.ts
+++ b/sample-apps/react/react-dogfood/pages/api/call/create.ts
@@ -4,28 +4,57 @@ import { meetingId } from '../../../lib/idGenerators';
 import { getRandomWords } from '../../../lib/names';
 
 /**
- * A yargs-parsed flag counts as "set" when present, unless explicitly negated
- * (`--no-e2ee` -> false, or `--e2ee=false`). Bare `--e2ee` / `--private` parse
- * to `true`, which URLSearchParams stringifies to `"true"`.
+ * A flag counts as "set" when present, unless explicitly negated (`--no-e2ee`
+ * -> false, or `e2ee=false`). Bare `--e2ee` / `--private` parse to `true`, and
+ * a bare `?e2ee` query param arrives as an empty string; both count as set.
  */
 const isFlagSet = (value: string | null): boolean =>
   value !== null && value !== 'false' && value !== '0';
+
+/**
+ * Flags reach this endpoint two ways: as real query params on a direct request
+ * (`/api/call/create?cid=default:standup&e2ee`), or inside the Slack slash
+ * command text (`/call --cid=default:standup --e2ee`), which yargs parses.
+ * Both are merged into one set, and the body wins on collision.
+ */
+const collectFlags = async (req: NextApiRequest) => {
+  const flags = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(req.query)) {
+    // a repeated param (`?type=a&type=b`) collapses to its first value, which
+    // is what `URLSearchParams.get` resolves to on the join URL anyway
+    const firstValue = Array.isArray(value) ? value[0] : value;
+    if (firstValue === undefined) continue;
+    flags.set(key, firstValue);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { _, $0, ...args } = await yargs().parse(req.body?.text || '');
+  for (const [key, value] of Object.entries(args)) {
+    flags.set(key, String(value));
+  }
+
+  return flags;
+};
 
 const createCallSlackHookAPI = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  console.log(`Received input`, req.body);
-  const initiator = req.body.user_name || 'Stream Pronto Bot';
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { _, $0, ...args } = await yargs().parse(req.body.text || '');
-  const queryParams = new URLSearchParams(args as Record<string, string>);
+  console.log(`Received input`, { query: req.query, body: req.body });
 
   try {
+    const queryParams = await collectFlags(req);
+
+    const initiator =
+      req.body?.user_name ||
+      queryParams.get('user_name') ||
+      'Stream Pronto Bot';
+    queryParams.delete('user_name');
+
     const cid = queryParams.get('cid');
-    if (cid) {
-      queryParams.delete('cid');
-    }
+    queryParams.delete('cid');
+
     let [type, id] = cid?.split(':') || [];
     if (!id && type) {
       id = type;
@@ -40,10 +69,8 @@ const createCallSlackHookAPI = async (
       queryParams.set('type', type);
     }
 
-    const staging = queryParams.get('staging');
-    if (staging) {
-      queryParams.delete('staging');
-    }
+    const staging = isFlagSet(queryParams.get('staging'));
+    queryParams.delete('staging');
 
     const withE2ee =
       isFlagSet(queryParams.get('e2ee')) ||


### PR DESCRIPTION
### 💡 Overview

`/api/call/create` only read its flags from the Slack slash command body (`req.body.text`, parsed by yargs). This makes the same flags work as real query params, so the endpoint can be called directly:

```
GET /api/call/create?cid=audio_room:standup&e2ee
```

Both sources merge into a single flag set, and **the request body wins on collision**. The Slack path is unchanged.

A side effect worth knowing: because the body wins, defaults can now be baked into the Slack slash command URL itself (e.g. `…/api/call/create?type=audio_room`) and a user's `--flags` still override them.

### 📝 Implementation notes

A new `collectFlags(req)` helper seeds a `URLSearchParams` from `req.query`, then overwrites it with the yargs-parsed body args. Repeated query params (`?layout=grid&layout=speaker`) collapse to the first value, which is what `URLSearchParams.get` resolves to on the join URL anyway.

Three fixes that query param support surfaced:

- **`req.body?.text`** — a request with no body used to throw a `TypeError` on `req.body.user_name` *outside* the `try` block, returning a 500 instead of the ephemeral Slack error. The parse and `initiator` moved inside the `try`.
- **`staging`** now goes through `isFlagSet` and is deleted unconditionally. A bare `?staging` arrives as `''`, which is falsy, so it both missed the staging host and leaked `staging=` onto the join URL. Same unconditional delete for `cid`.
- **`user_name`** is read from the query as a fallback (the Slack body field still wins) and stripped from the join URL.

Verified against the real handler with a throwaway vitest harness (deleted before commit, this app has no test setup): Slack body flags unchanged; query-only with a bare `?e2ee`; body overriding a query `cid`; body `--no-e2ee` negating a query `?e2ee`; no-body requests not throwing; bare `?staging` selecting the staging host and being stripped; repeated params collapsing; generated meeting id when no `cid` is given.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for initiating calls using query parameters or Slack command arguments.
  * Added query-based options for initiator and call ID values.
  * Preserved support for staging, end-to-end encrypted, and private call options.

* **Bug Fixes**
  * Improved handling of boolean staging flags.
  * Prevented control parameters from being included in generated join links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->