### PR TITLE
fix: background video filters should refresh on orientation change

### DIFF
--- a/packages/video-filters-react-native/android/src/main/java/com/streamio/videofiltersreactnative/factories/VirtualBackgroundFactory.kt
+++ b/packages/video-filters-react-native/android/src/main/java/com/streamio/videofiltersreactnative/factories/VirtualBackgroundFactory.kt
@@ -222,35 +222,32 @@ private class VirtualBackgroundVideoFilter(
         scaledForegroundBitmap = null
     }
 
-    private fun scaleVirtualBackgroundBitmap(bitmap: Bitmap, targetHeight: Int): Bitmap {
-        val scale = targetHeight.toFloat() / bitmap.height
-        return ensureAlpha(
-            Bitmap.createScaledBitmap(
-                /* src = */
-                bitmap,
-                /* dstWidth = */
-                (bitmap.width * scale).toInt(),
-                /* dstHeight = */
-                targetHeight,
-                /* filter = */
-                true,
-            ),
+    // Cover-scale (like CSS object-fit: cover): scale the source uniformly so it fills the
+    // entire frame, center it, and crop the overflow. This keeps the background covering the
+    // whole frame in any orientation instead of only matching the frame height, which left
+    // a portrait image covering only part of a landscape frame.
+    // Computed once per frame-size change (cached in maybeInit), not per frame.
+    private fun scaleVirtualBackgroundBitmap(
+        bitmap: Bitmap,
+        targetWidth: Int,
+        targetHeight: Int,
+    ): Bitmap {
+        val scale = maxOf(
+            targetWidth.toFloat() / bitmap.width,
+            targetHeight.toFloat() / bitmap.height,
         )
-    }
-
-    private fun ensureAlpha(original: Bitmap): Bitmap {
-        return if (original.hasAlpha()) {
-            original
-        } else {
-            val bitmapWithAlpha = Bitmap.createBitmap(
-                original.width,
-                original.height,
-                Bitmap.Config.ARGB_8888,
+        // ARGB_8888 always has an alpha channel, required for the DST_OVER background draw.
+        val result = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(result)
+        val matrix = Matrix().apply {
+            setScale(scale, scale)
+            postTranslate(
+                (targetWidth - bitmap.width * scale) / 2f,
+                (targetHeight - bitmap.height * scale) / 2f,
             )
-            val canvas = Canvas(bitmapWithAlpha)
-            canvas.drawBitmap(original, 0f, 0f, null)
-            bitmapWithAlpha
         }
+        canvas.drawBitmap(bitmap, matrix, Paint(Paint.FILTER_BITMAP_FLAG))
+        return result
     }
 
     private fun maybeInit(
@@ -262,6 +259,7 @@ private class VirtualBackgroundVideoFilter(
             scaledForegroundBitmap?.recycle()
             scaledVirtualBackgroundBitmap = scaleVirtualBackgroundBitmap(
                 bitmap = backgroundImageBitmap,
+                targetWidth = videoFrameBitmap.width,
                 targetHeight = videoFrameBitmap.height,
             )
             scaledForegroundBitmap = Bitmap.createBitmap(

--- a/packages/video-filters-react-native/ios/VideoFrameProcessors/Utils/VideoFilters.swift
+++ b/packages/video-filters-react-native/ios/VideoFrameProcessors/Utils/VideoFilters.swift
@@ -2,46 +2,29 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
-#if canImport(UIKit)
+import CoreImage
 import Foundation
-import UIKit
 
-extension UIInterfaceOrientation {
-    /// Values of `CGImagePropertyOrientation` define the position of the pixel coordinate origin
-    /// point (0,0) and the directions of the coordinate axes relative to the intended display orientation of
-    /// the image. While `UIInterfaceOrientation` uses a different point as its (0,0), this extension
-    /// provides a simple way of mapping device orientation to image orientation.
+extension RTCVideoRotation {
+    /// Maps the capture pipeline's frame rotation to the image orientation used when orienting
+    /// the background image. Using the frame's own rotation metadata keeps the background in sync
+    /// with the outgoing video even when the app UI is orientation-locked or mid-rotation, unlike
+    /// reading the UI's interface orientation.
     var cgOrientation: CGImagePropertyOrientation {
         switch self {
-        /// Handle known portrait orientations
-        case .portrait:
+        case ._0:
+            return .up
+        case ._90:
             return .left
-
-        case .portraitUpsideDown:
-            return .right
-
-        /// Handle known landscape orientations
-        case .landscapeLeft:
-            return .up
-
-        case .landscapeRight:
+        case ._180:
             return .down
-
-        /// Unknown case, return `up` for consistency
-        case .unknown:
-            return .up
-
-        /// Default case for unknown orientations or future additions
-        /// Returns `up` for consistency.
+        case ._270:
+            return .right
         @unknown default:
             return .up
         }
     }
 }
-
-#endif // #if canImport(UIKit)
-
-import Foundation
 
 open class VideoFilter: NSObject, VideoFrameProcessorDelegate {
 
@@ -60,8 +43,6 @@ open class VideoFilter: NSObject, VideoFrameProcessorDelegate {
     public var filter: (Input) -> CIImage
     
     private let context: CIContext
-    
-    var sceneOrientation: UIInterfaceOrientation = .unknown
 
     /// Initializes a new VideoFilter instance with the provided parameters.
     public init(
@@ -70,26 +51,8 @@ open class VideoFilter: NSObject, VideoFrameProcessorDelegate {
         self.filter = filter
         self.context = CIContext(options: [CIContextOption.useSoftwareRenderer: false])
         super.init()
-        // listen to when the device's orientation changes
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updateRotation),
-            name: UIDevice.orientationDidChangeNotification,
-            object: nil
-        )
-        updateRotation()
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-    @objc private func updateRotation() {
-        DispatchQueue.main.async {
-            self.sceneOrientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation ?? .unknown
-        }
-    }
-    
     public func capturer(_ capturer: RTCVideoCapturer!, didCapture frame: RTCVideoFrame!) -> RTCVideoFrame! {
         if let rtcCVPixelBuffer = frame.buffer as? RTCCVPixelBuffer {
             let pixelBuffer = rtcCVPixelBuffer.pixelBuffer
@@ -99,7 +62,7 @@ open class VideoFilter: NSObject, VideoFrameProcessorDelegate {
                 Input(
                     originalImage: CIImage(cvPixelBuffer: pixelBuffer),
                     originalPixelBuffer: pixelBuffer,
-                    originalImageOrientation: self.sceneOrientation.cgOrientation
+                    originalImageOrientation: frame.rotation.cgOrientation
                 )
             )
             CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)


### PR DESCRIPTION
### 💡 Overview

Background image video filters now correctly follow the video orientation. 

### 📝 Implementation notes

- Android (`VirtualBackgroundFactory.kt`): replaced scale-to-height with a cover-scale (fill frame, center, crop overflow) so the background covers the full frame in any orientation. Rotation is already baked into the frame bitmap upstream, so no rotation plumbing was needed. Also drops a redundant ensureAlpha allocation for alpha-less (JPEG) backgrounds.

- iOS (`VideoFilters.swift`): orient the background from RTCVideoFrame.rotation per frame (0→up, 90→left, 180→down, 270→right) instead of UIApplication interface orientation; removed the now-dead orientation observer and UIInterfaceOrientation mapping.

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual background scaling so images fill the video frame consistently while remaining centered.
  * Enhanced background compositing compatibility for transparent images.
  * Corrected captured video orientation handling across different device rotations.
  * Reduced orientation-related inconsistencies by deriving image rotation directly from each video frame.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->