### PR TITLE
fix(react-dogfood): correct closed captions capability checks

### DIFF
--- a/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
+++ b/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
@@ -4,6 +4,7 @@ import {
   CompositeButton,
   Icon,
   OwnCapability,
+  TranscriptionSettingsResponseClosedCaptionModeEnum,
   useCall,
   useCallStateHooks,
   useI18n,
@@ -13,13 +14,19 @@ import {
 export const ToggleClosedCaptionsButton = () => {
   const call = useCall();
   const { t } = useI18n();
-  const { useIsCallCaptioningInProgress, useHasPermissions } =
+  const { useCallSettings, useIsCallCaptioningInProgress, useHasPermissions } =
     useCallStateHooks();
+  const settings = useCallSettings();
   const isCaptioned = useIsCallCaptioningInProgress();
-  const canToggle = useHasPermissions(
-    OwnCapability.START_CLOSED_CAPTIONS_CALL,
-    OwnCapability.STOP_CLOSED_CAPTIONS_CALL,
-  );
+  const canStart = useHasPermissions(OwnCapability.START_CLOSED_CAPTIONS_CALL);
+  const canStop = useHasPermissions(OwnCapability.STOP_CLOSED_CAPTIONS_CALL);
+  const canToggle = isCaptioned ? canStop : canStart;
+  const isClosedCaptionsEnabled =
+    settings?.transcription.closed_caption_mode !==
+    TranscriptionSettingsResponseClosedCaptionModeEnum.DISABLED;
+
+  if (!isClosedCaptionsEnabled || (!canStart && !canStop)) return null;
+
   return (
     <WithTooltip title={t('Toggle closed captions')}>
       <CompositeButton


### PR DESCRIPTION
### 💡 Overview

The closed captions button in the react-dogfood call controls was gated on both `START_CLOSED_CAPTIONS_CALL` and `STOP_CLOSED_CAPTIONS_CALL` at once. `useHasPermissions` uses `.every()`, so a user holding only one of the two grants saw a permanently disabled button. The call's `transcription.closed_caption_mode` was never consulted either, so the button looked actionable even when captions are disabled for the call type — clicking it just failed server-side.

### 📝 Implementation notes

- `canStart` / `canStop` are now checked separately; `canToggle` picks the one matching the current captioning state.
- Added the `closed_caption_mode !== 'disabled'` gate, matching the settings-plus-capability pattern in `NoiseCancellationProvider`.
- The button is hidden when captions are disabled for the call or the user holds neither grant, and stays rendered-but-disabled in the asymmetric case (captions running, user may start but not stop) so it doesn't vanish mid-call.

Verified with `tsc --noEmit` and `eslint`. Not exercised in a browser: the interesting branches need a call type with `closed_caption_mode: disabled` and a role missing one of the two grants, which the default dogfood login doesn't reproduce.

🎫 Ticket: https://linear.app/stream/issue/REACT-1077


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved closed-caption controls to reflect the action currently available.
  * Disabled the control when the required permission is unavailable.
  * Hid the control when closed captions are disabled or inaccessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->