### PR TITLE
fix(client): granular E2EE key removal

### DIFF
--- a/packages/client/src/rtc/e2ee/EncryptionManager.ts
+++ b/packages/client/src/rtc/e2ee/EncryptionManager.ts
@@ -186,12 +186,26 @@ export class EncryptionManager
   };
 
   /**
-   * Drop a user's keys, revoking their ability to decrypt later frames.
-   * Call it when a participant leaves.
+   * Retire one of a user's key epochs, leaving their other epochs usable.
+   *
+   * @param userId - The key owner.
+   * @param keyIndex - The exact epoch to remove. Absent epochs are a no-op.
    */
-  removeKeys = (userId: string): void => {
+  removeKey = (userId: string, keyIndex: number): void => {
     this.assertUsable();
-    this.worker.postMessage({ type: 'cmd.remove_keys', userId });
+    this.validateKeyIndex(keyIndex);
+    this.worker.postMessage({ type: 'cmd.remove_key', userId, keyIndex });
+  };
+
+  /**
+   * Drop every key a user holds, revoking their ability to decrypt later
+   * frames. Call it when a participant leaves.
+   *
+   * To retire one rotated epoch instead, use {@link removeKey}.
+   */
+  removeAllKeys = (userId: string): void => {
+    this.assertUsable();
+    this.worker.postMessage({ type: 'cmd.remove_all_keys', userId });
   };
 
   /**

--- a/packages/client/src/rtc/e2ee/SPEC.md
+++ b/packages/client/src/rtc/e2ee/SPEC.md
@@ -37,8 +37,10 @@ EncryptionManager.create(userId, {
 
 // key distribution (host-owned: the SDK never derives or exchanges keys)
 setKey(userId: string, keyIndex: number, rawKey: bytes): void
+removeKey(userId: string, keyIndex: number): void
+removeAllKeys(userId: string): void
+
 setSharedKey(keyIndex: number, rawKey: bytes): void
-removeKeys(userId: string): void
 removeSharedKey(keyIndex: number): void
 
 // diagnostics
@@ -74,8 +76,8 @@ await call.join();
 - **`keyIndex` is 0-255** (one trailer byte). Reject anything else at the API boundary. The index identifies a key slot, not a monotonic sequence, so a long-running rotation may wrap 255 → 0 and re-use low indices. Reusing an occupied index replaces that slot immediately, so the host must not reuse it until frames from the old epoch can no longer be in flight.
 - **`rawKey` is exactly 16 bytes** (AES-128) or **32 bytes** (AES-256). Reject other lengths.
 - **The key buffer is copied, not consumed.** Callers may re-import the same bytes.
-- A successful **`setSharedKey(keyIndex, rawKey)`** stores or replaces that shared receive epoch and makes it the active shared epoch for encryption. A failed import changes neither the key ring nor the active epoch.
-- **`removeSharedKey(keyIndex)`** removes exactly that shared receive epoch. Removing the active epoch disables shared-key encryption until another `setSharedKey` succeeds; an older retained epoch is never reactivated implicitly.
+- **Removal comes in per-epoch and per-user forms, and the names must stay distinct.** `removeKey(userId, keyIndex)` retires one epoch; `removeAllKeys(userId)` revokes the participant entirely. Do not render these as overloads of one name: dropping the index argument would then silently mean "revoke everything", which is the opposite of the caller's intent and impossible to catch in review.
+- **Every key operation's outcome is tabulated in Appendix B.** Implement the edge cases (removing the latest or active epoch, a failed import, an absent index) from that table rather than from prose.
 - **Join request carries `e2ee: true`** so the backend knows the call is encrypted.
 - The internal attach points (`encrypt(sender, codec, trackType)` / `decrypt(receiver, userId, trackType)`) are called by the RTC layer, not by apps. Keeping them behind a small interface lets an integrator plug in a different scheme (e.g. SFrame).
 
@@ -90,25 +92,33 @@ A per-user key is identified by **`(userId, keyIndex)`**. A shared key is identi
 - **Shared keys** (`setSharedKey`): an indexed fallback receive-key ring used for any user without a per-user key at the requested index. The most recently imported shared epoch is explicitly active for encryption; older epochs remain receive-only so delayed frames survive a rotation.
 - **Resolution on decode:** per-user entry at that `keyIndex` first; else the shared-key entry at that index; else no key (frame dropped, `missing_key` fired).
 - **Resolution on encode:** the most recently imported per-user key for the local user; else the active shared key. Retained inactive shared epochs must never be selected for encryption.
-- **`removeKeys(userId)`** drops that user's key material but **must not reset the frame counter** (see §9).
-- **`removeSharedKey(keyIndex)`** drops only that shared epoch. If it was active, shared-key encode fallback becomes unavailable; retained older epochs remain usable for decryption but inactive for encryption.
+- **No key operation resets the frame counter** (§9).
 
-### Shared-key rotation
+The state after any individual key call is tabulated in **Appendix B**.
 
-The host owns the grace period and retires old epochs explicitly:
+### 3.1 Rotation
+
+The host owns the grace period and retires old epochs explicitly. Both key kinds follow the same shape - import the new epoch, let frames on the old one drain, then retire it:
 
 ```ts
+await api.distributeToAll(nextKey);
 manager.setSharedKey(7, nextKey); // epoch 7 becomes active; older epochs remain
-// distribute epoch 7 and allow delayed frames from the prior epoch to drain
+// allow delayed frames on epoch 6 to drain
 manager.removeSharedKey(6); // epoch 6 can no longer decrypt
+
+await api.distributeToAll(nextAliceKey);
+manager.setKey(alice, 7, nextAliceKey); // epoch 7 becomes alice's latest
+manager.removeKey(alice, 6); // alice's epoch 6 can no longer decrypt
 ```
+
+Retiring one epoch is what `removeKey` is for; `removeAllKeys` is for a participant leaving. Reaching for `removeAllKeys` mid-rotation would drop the epoch that is currently working along with the one being retired.
 
 All participants must use the same `keyIndex` for the same shared key. Do not reuse an
 index while frames encrypted with its previous material may still arrive: the new import
 replaces that slot, so those delayed frames would resolve the replacement key and fail
 authentication.
 
-### Per-import state
+### 3.2 Per-import state
 
 Every key import generates:
 
@@ -354,7 +364,7 @@ The counter is a 32-bit IV field and **must never wrap**: a wrap folds into a pr
 >
 > 1. **One counter per manager**, shared across every track and codec. Hold it as a single value, never a map keyed by user id - a wrong or changed id would hand out a fresh counter starting at 1 under the same key and prefix.
 > 2. **Check before incrementing**, and never store a value past the ceiling.
-> 3. **Never reset it on a key operation.** `setKey`, `setSharedKey`, `removeKeys` and `removeSharedKey` all leave it untouched; only a new manager starts at 0.
+> 3. **Never reset it on a key operation.** Every method in §3 leaves it untouched; only a new manager starts at 0.
 > 4. **Throw at the ceiling.** The frame is dropped and `encryption_failed` is emitted. This is the only counter threshold; nothing fires below it.
 > 5. **Fresh 8-byte `ivPrefix` from a cryptographic RNG on every key import.** Never derived from a user id, session id, timestamp or counter; never reused across imports; never shortened.
 
@@ -367,11 +377,11 @@ counter = c
 
 Rules 1 and 5 are two independent guards, covering two different scopes (§4). Resetting the counter on import, as rule 3 forbids, collapses them into one.
 
-| Action                           | Frame counter           | `ivPrefix`                |
-| -------------------------------- | ----------------------- | ------------------------- |
-| `setKey` / `setSharedKey`        | unchanged, keeps rising | fresh random for the slot |
-| `removeKeys` / `removeSharedKey` | unchanged, keeps rising | dropped with the slot     |
-| new manager                      | reset to 0              | -                         |
+| Action                    | Frame counter           | `ivPrefix`                |
+| ------------------------- | ----------------------- | ------------------------- |
+| `setKey` / `setSharedKey` | unchanged, keeps rising | fresh random for the slot |
+| any `remove*`             | unchanged, keeps rising | dropped with the slot     |
+| new manager               | reset to 0              | -                         |
 
 Key state per action is §3; this table covers only the counter and the prefix.
 
@@ -537,3 +547,40 @@ Worked example, a typical camera call: Opus at 20 ms ptime contributes 50 fps, a
 | Camera + mic, single stream (SVC, 1 rid) | ~80 fps   | ~20 months        |
 
 That is continuous publishing within a single session, and the counter resets with each new manager, so no real call approaches it. The ceiling is a correctness guard, not an operational event.
+
+---
+
+## Appendix B: key operation outcomes
+
+Normative, unlike Appendix A. One row per key call from §3. "Encode key" is the result of the encode resolution in §3, and only matters for the local user.
+
+**Per-user keys.** Every epoch stays available to decrypt until removed.
+
+| Action             | When                    | Slots after           | Encode key after         |
+| ------------------ | ----------------------- | --------------------- | ------------------------ |
+| `setKey(u, i)`     | import succeeds         | `i` added or replaced | `i`                      |
+| `setKey(u, i)`     | bad index or key length | unchanged             | unchanged                |
+| `setKey(u, i)`     | import fails            | unchanged             | unchanged                |
+| `removeKey(u, i)`  | `i` held, not latest    | `i` gone              | unchanged                |
+| `removeKey(u, i)`  | `i` held, is latest     | `i` gone              | active shared, else none |
+| `removeKey(u, i)`  | `i` not held            | unchanged             | unchanged                |
+| `removeAllKeys(u)` | always                  | all of `u` gone       | active shared, else none |
+
+**Shared-key epochs.** One epoch is active for encryption; the rest are receive-only.
+
+| Action               | When                    | Ring after            | Active epoch after |
+| -------------------- | ----------------------- | --------------------- | ------------------ |
+| `setSharedKey(i)`    | import succeeds         | `i` added or replaced | `i`                |
+| `setSharedKey(i)`    | bad index or key length | unchanged             | unchanged          |
+| `setSharedKey(i)`    | import fails            | unchanged             | unchanged          |
+| `removeSharedKey(i)` | `i` held, not active    | `i` gone              | unchanged          |
+| `removeSharedKey(i)` | `i` held, is active     | `i` gone              | none               |
+| `removeSharedKey(i)` | `i` not held            | unchanged             | unchanged          |
+
+Behind the rows:
+
+- **Nothing is promoted implicitly.** Removing the epoch that was encrypting falls to the next step of the resolution order, never to an older epoch of the same kind.
+- **A failed import changes nothing.** A bad index or key length throws before the store is reached; a failed import is logged internally. Either way the previous epoch survives, including when it was the active one.
+- **Removals are silent.** No key call emits an event. The effect shows on the next frame, or via `key_state` (§10). A frame naming a removed epoch raises `missing_key`.
+- **Calls apply in order.** A serialized queue owns the store, so `setSharedKey(7)` then `removeSharedKey(7)` lands in that order.
+- Each import gets a fresh `ivPrefix` (§3.2), no removal touches the frame counter (§9), and every call throws after `dispose()`.

--- a/packages/client/src/rtc/e2ee/__tests__/EncryptionManager.test.ts
+++ b/packages/client/src/rtc/e2ee/__tests__/EncryptionManager.test.ts
@@ -98,9 +98,14 @@ describe('EncryptionManager', () => {
         { type: 'cmd.remove_shared_key', keyIndex: 0 },
       ],
       [
-        'removeKeys',
-        () => manager.removeKeys('remote-user'),
-        { type: 'cmd.remove_keys', userId: 'remote-user' },
+        'removeKey',
+        () => manager.removeKey('remote-user', 3),
+        { type: 'cmd.remove_key', userId: 'remote-user', keyIndex: 3 },
+      ],
+      [
+        'removeAllKeys',
+        () => manager.removeAllKeys('remote-user'),
+        { type: 'cmd.remove_all_keys', userId: 'remote-user' },
       ],
       [
         'requestKeyState',
@@ -150,6 +155,19 @@ describe('EncryptionManager', () => {
       // receiver would silently look up the wrong key.
       for (const bad of [256, -1, 1.5, NaN]) {
         expect(call(m, bad, 16)).toThrow(/keyIndex/);
+      }
+    });
+
+    // The per-epoch removals carry no key material, so they sit outside the
+    // table above while sharing its index rule.
+    it.each([
+      ['removeKey', (i: number) => () => manager.removeKey('user', i)],
+      ['removeSharedKey', (i: number) => () => manager.removeSharedKey(i)],
+    ])('%s applies the same keyIndex rule', (_name, at) => {
+      expect(at(0)).not.toThrow();
+      expect(at(255)).not.toThrow();
+      for (const bad of [256, -1, 1.5, NaN]) {
+        expect(at(bad)).toThrow(/keyIndex/);
       }
     });
 
@@ -446,7 +464,8 @@ describe('EncryptionManager', () => {
         /is disposed/,
       );
       expect(() => manager.removeSharedKey(0)).toThrow(/is disposed/);
-      expect(() => manager.removeKeys('user')).toThrow(/is disposed/);
+      expect(() => manager.removeKey('user', 0)).toThrow(/is disposed/);
+      expect(() => manager.removeAllKeys('user')).toThrow(/is disposed/);
       expect(() => manager.requestKeyState()).toThrow(/is disposed/);
       expect(() => manager.enablePerformanceReporting(true)).toThrow(
         /is disposed/,

--- a/packages/client/src/rtc/e2ee/__tests__/frameCounter.test.ts
+++ b/packages/client/src/rtc/e2ee/__tests__/frameCounter.test.ts
@@ -36,12 +36,12 @@ describe('nextFrameCounter', () => {
     expect(nextFrameCounter()).toBe(3);
   });
 
-  it('survives removeKeys — counter is never rolled back', async () => {
+  it('survives removeAllKeys — counter is never rolled back', async () => {
     await keyStore.importKey('alice', 1, rawKey());
     expect(nextFrameCounter()).toBe(1);
     expect(nextFrameCounter()).toBe(2);
 
-    keyStore.removeKeys('alice');
+    keyStore.removeAllKeys('alice');
 
     // Re-import the same raw key. Counter must NOT restart — otherwise
     // we'd reuse IVs on the new import's first frames.
@@ -69,7 +69,7 @@ describe('nextFrameCounter', () => {
     expect(() => nextFrameCounter()).toThrow(/counter exhausted/);
 
     // Same after dropping the user's keys entirely.
-    keyStore.removeKeys('alice');
+    keyStore.removeAllKeys('alice');
     await keyStore.importKey('alice', 8, rawKey());
     expect(() => nextFrameCounter()).toThrow(/counter exhausted/);
   });

--- a/packages/client/src/rtc/e2ee/__tests__/keyStore.test.ts
+++ b/packages/client/src/rtc/e2ee/__tests__/keyStore.test.ts
@@ -160,12 +160,59 @@ describe('shared-key rotation', () => {
   });
 });
 
-describe('removeKeys', () => {
+describe('removeKey', () => {
+  it('retires one epoch and leaves the rest decryptable', async () => {
+    await keyStore.importKey('alice', 1, rawKey(0x01));
+    await keyStore.importKey('alice', 2, rawKey(0x02));
+
+    keyStore.removeKey('alice', 1);
+
+    expect(keyStore.getKey('alice', 1)).toBeUndefined();
+    expect(keyStore.getKey('alice', 2)).toBeDefined();
+    // Epoch 2 is still the latest, so encoding is untouched.
+    expect(keyStore.getLatestKey('alice')).toMatchObject({ keyIndex: 2 });
+  });
+
+  it('clears the latest pointer when it removes the latest epoch', async () => {
+    await keyStore.importKey('alice', 1, rawKey(0x01));
+    await keyStore.importKey('alice', 2, rawKey(0x02));
+    await keyStore.importSharedKey(9, rawKey(0x09));
+
+    keyStore.removeKey('alice', 2);
+
+    // Leaving the pointer on the removed index would resolve nothing here and
+    // silently fall through to the shared epoch below, widening the key scope
+    // of every outgoing frame. Epoch 1 must not be promoted either.
+    expect(keyStore.getKey('alice', 1)).toBeDefined();
+    expect(keyStore.getLatestKey('alice')).toMatchObject({ keyIndex: 9 });
+  });
+
+  it('leaves no per-user key at all when the last epoch goes', async () => {
+    await keyStore.importKey('alice', 1, rawKey(0x01));
+
+    keyStore.removeKey('alice', 1);
+
+    expect(keyStore.getLatestKey('alice')).toBeNull();
+    expect(keyStore.keyState().perUserKeys).toEqual([]);
+  });
+
+  it('is a no-op for an epoch or user it does not hold', async () => {
+    await keyStore.importKey('alice', 1, rawKey(0x01));
+
+    keyStore.removeKey('alice', 7);
+    keyStore.removeKey('nobody', 1);
+
+    expect(keyStore.getKey('alice', 1)).toBeDefined();
+    expect(keyStore.getLatestKey('alice')).toMatchObject({ keyIndex: 1 });
+  });
+});
+
+describe('removeAllKeys', () => {
   it('deletes that user key state and leaves the others', async () => {
     await keyStore.importKey('alice', 1, rawKey(0x01));
     await keyStore.importKey('bob', 1, rawKey(0x02));
 
-    keyStore.removeKeys('alice');
+    keyStore.removeAllKeys('alice');
 
     expect(keyStore.getKey('alice', 1)).toBeUndefined();
     expect(keyStore.getLatestKey('alice')).toBeNull();

--- a/packages/client/src/rtc/e2ee/__tests__/transform-pipeline.test.ts
+++ b/packages/client/src/rtc/e2ee/__tests__/transform-pipeline.test.ts
@@ -74,8 +74,8 @@ const removeSharedKey = async (keyIndex: number) => {
   message({ type: 'cmd.remove_shared_key', keyIndex });
   await flush();
 };
-const removeKeys = async (userId: string) => {
-  message({ type: 'cmd.remove_keys', userId });
+const removeAllKeys = async (userId: string) => {
+  message({ type: 'cmd.remove_all_keys', userId });
   await flush();
 };
 
@@ -366,7 +366,7 @@ describe('decode pipeline edge behaviors', () => {
     const [encrypted] = await drive('encode', user, 'vp8', [
       frame([1, 2, 3, 4, 5, 6, 7, 8], 'delta'),
     ]);
-    await removeKeys(user);
+    await removeAllKeys(user);
     posted.length = 0;
     const out = await drive('decode', user, undefined, [encrypted], 'AUDIO');
     expect(out).toHaveLength(0);

--- a/packages/client/src/rtc/e2ee/e2ee-worker/e2ee-worker-impl.ts
+++ b/packages/client/src/rtc/e2ee/e2ee-worker/e2ee-worker-impl.ts
@@ -108,8 +108,13 @@ addEventListener('message', ({ data }) => {
       case 'cmd.remove_shared_key':
         keyStore.removeSharedKey(data.keyIndex);
         break;
-      case 'cmd.remove_keys':
-        keyStore.removeKeys(data.userId);
+      case 'cmd.remove_key':
+        // Deliberately keeps this user's decode stats: they are still
+        // publishing, one epoch was retired.
+        keyStore.removeKey(data.userId, data.keyIndex);
+        break;
+      case 'cmd.remove_all_keys':
+        keyStore.removeAllKeys(data.userId);
         decodeStats.removeUser(data.userId);
         break;
       case 'cmd.enable_performance_reporting':

--- a/packages/client/src/rtc/e2ee/e2ee-worker/frameCounter.ts
+++ b/packages/client/src/rtc/e2ee/e2ee-worker/frameCounter.ts
@@ -5,7 +5,7 @@ import { COUNTER_HARD_LIMIT } from './constants';
  * publishes: the IV is `ivPrefix ∥ counter`, so two tracks drawing from
  * separate counters would encrypt different frames under the same IV.
  *
- * Survives `removeKeys` on purpose - if the same raw key is imported again the
+ * Survives `removeAllKeys` on purpose - if the same raw key is imported again the
  * counter keeps climbing, so no (ivPrefix, counter) pair repeats. Second guard
  * against IV reuse, after the per-import random prefix.
  */

--- a/packages/client/src/rtc/e2ee/e2ee-worker/keyStore.ts
+++ b/packages/client/src/rtc/e2ee/e2ee-worker/keyStore.ts
@@ -137,11 +137,29 @@ export class KeyStore {
   };
 
   /**
+   * Retire exactly one of a user's epochs, leaving the rest usable.
+   *
+   * Clearing `latestKeyIndex` along with the slot is load-bearing. Left on a
+   * removed index, {@link getLatestKey} resolves nothing there and falls
+   * through to the active shared epoch, so the local user's frames would
+   * quietly move from a key only they hold to one every participant holds. No
+   * older epoch is promoted either, matching {@link removeSharedKey}.
+   */
+  removeKey = (userId: string, keyIndex: number) => {
+    const perKeyIndex = this.perUserKeys.get(userId);
+    if (!perKeyIndex?.delete(keyIndex)) return;
+    if (perKeyIndex.size === 0) this.perUserKeys.delete(userId);
+    if (this.latestKeyIndex.get(userId) === keyIndex) {
+      this.latestKeyIndex.delete(userId);
+    }
+  };
+
+  /**
    * Leaves the frame counters intact on purpose: a reset counter would reuse
    * IVs if the same raw key is imported again later. They live in
    * `frameCounter.ts`, so this cannot reach them even by accident.
    */
-  removeKeys = (userId: string) => {
+  removeAllKeys = (userId: string) => {
     this.perUserKeys.delete(userId);
     this.latestKeyIndex.delete(userId);
   };

--- a/sample-apps/react/e2ee-demo/src/harness/E2EEHarness.ts
+++ b/sample-apps/react/e2ee-demo/src/harness/E2EEHarness.ts
@@ -611,9 +611,9 @@ export class E2EEHarness {
     // Revoke per-user keys so the shared key is the baseline.
     for (const p of targets) {
       for (const other of targets) {
-        if (other.userId !== p.userId) p.manager?.removeKeys(other.userId);
+        if (other.userId !== p.userId) p.manager?.removeAllKeys(other.userId);
       }
-      p.manager?.removeKeys(p.userId);
+      p.manager?.removeAllKeys(p.userId);
       p.currentKey = key;
       p.keyIndex = keyIndex;
       this.clearEncoderWarnings(p);
@@ -642,7 +642,7 @@ export class E2EEHarness {
     this.publishDebugHandles();
     for (const other of this.participants) {
       if (other.role === 'spy') continue;
-      other.manager?.removeKeys(targetUserId);
+      other.manager?.removeAllKeys(targetUserId);
       other.failingFrom.delete(targetUserId);
       other.stalledFrom.delete(targetUserId);
       this.addLog(
@@ -679,7 +679,7 @@ export class E2EEHarness {
       // A participant joined as plain has no manager and so never held the key.
       // Skip it rather than logging a revocation that did not happen.
       if (!h.manager) continue;
-      h.manager.removeKeys(targetUserId);
+      h.manager.removeAllKeys(targetUserId);
       this.addLog(
         h.userId,
         `Revoked ${this.nameFor(targetUserId)}'s key`,


### PR DESCRIPTION
### 💡 Overview

Follow-up to #2366. Per-user keys had no way to retire a single epoch: `removeSharedKey(keyIndex)` drops one shared epoch, but the per-user side only had `removeKeys(userId)`, which drops everything that user holds.

- **Added `removeKey(userId, keyIndex)`** — retires one epoch, leaving the user's others usable. Rotation and single-epoch revocation previously required dropping every epoch and re-importing the current one, which opens a decrypt gap.
- **Renamed `removeKeys` → `removeAllKeys`**, so the two cannot be confused. `removeKey` vs `removeKeys` differs by one character, and on the platforms this spec targets they would likely be overloads of one name, where omitting the index silently means "revoke everything".
- **SPEC: added Appendix B**, tabulating the outcome of every key call, now that both key kinds retain and remove epochs one at a time.

### 📝 Implementation notes

- Removing a user's latest epoch clears the latest-key pointer along with the slot. Left behind, it resolves nothing and falls through to the active shared epoch, quietly moving outgoing frames from a key only the local user holds to one every participant holds. No older epoch is promoted in its place, matching `removeSharedKey`. Three of the four new `keyStore` tests cover this.
- Granular removal deliberately keeps the user's decode perf stats; only `removeAllKeys` discards them, since the peer is still publishing after one epoch is retired.
- `removeKey` validates `keyIndex` at the API boundary like the other index-taking methods.

Full client suite (1064 tests), lint, typecheck and build pass.

🎫 Ticket:

📑 Docs:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retiring an individual encryption key epoch while preserving other keys.
  - Added separate controls for removing one key or all keys associated with a participant.
  - Preserved frame-counter state when keys are removed.

- **Bug Fixes**
  - Improved key and decode-statistics handling after individual or complete key removal.

- **Tests**
  - Added validation for supported key indexes and removal behavior across active, inactive, and final epochs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->