### PR TITLE
chore: deprecate isExpo prop in push config

### DIFF
--- a/packages/react-native-sdk/CLAUDE.md
+++ b/packages/react-native-sdk/CLAUDE.md
@@ -484,7 +484,6 @@ The SDK only handles **ringing call** push notifications. Non-ringing notificati
 
 ```tsx
 // Safely check if library is installed
-const firebase = getFirebaseMessagingLibNoThrow();
 const callingx = getCallingxLib();
 ```
 

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
@@ -26,6 +26,9 @@ export type StreamVideoConfig = {
    * @default undefined
    */
   push?: {
+    /**
+     * @deprecated Expo is auto-detected; this value is ignored and the property will be removed in a future major version.
+     */
     isExpo?: boolean;
     /**
      * The publish options to be used when joining a call from a push notification.

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -5,11 +5,7 @@ import {
 } from '@stream-io/video-client';
 import { AppState, Platform } from 'react-native';
 import type { StreamVideoConfig } from '../StreamVideoRN/types';
-import {
-  type FirebaseMessagingTypes,
-  getFirebaseMessagingLib,
-  getFirebaseMessagingLibNoThrow,
-} from './libs';
+import { type FirebaseMessagingTypes, getFirebaseMessagingLib } from './libs';
 import { pushUnsubscriptionCallbacks } from './internal/constants';
 import { canListenToWS, shouldCallBeClosed } from './internal/utils';
 import { setPushLogoutCallback } from '../internal/pushLogoutCallback';
@@ -60,18 +56,14 @@ export async function initAndroidPushToken(
     await client.addDevice(token, 'firebase', push_provider_name);
   };
 
-  const messaging = pushConfig.isExpo
-    ? getFirebaseMessagingLibNoThrow(true)
-    : getFirebaseMessagingLib();
-  if (messaging) {
-    logger.debug(`setting firebase token listeners`);
-    const unsubscribe = messaging().onTokenRefresh((refreshedToken) =>
-      setDeviceToken(refreshedToken),
-    );
-    setUnsubscribeListener(unsubscribe);
-    const token = await messaging().getToken();
-    await setDeviceToken(token);
-  }
+  const messaging = getFirebaseMessagingLib();
+  logger.debug(`setting firebase token listeners`);
+  const unsubscribe = messaging().onTokenRefresh((refreshedToken) =>
+    setDeviceToken(refreshedToken),
+  );
+  setUnsubscribeListener(unsubscribe);
+  const token = await messaging().getToken();
+  await setDeviceToken(token);
 }
 
 /**

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
@@ -1,5 +1,4 @@
 import { lib, type Type } from './lib';
-import { videoLoggerSystem } from '@stream-io/video-client';
 
 export type { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 export type FirebaseMessagingType = Type;
@@ -12,24 +11,6 @@ export function getFirebaseMessagingLib(): FirebaseMessagingType {
     throw Error(
       '@react-native-firebase/messaging is not installed. ' +
         INSTALLATION_INSTRUCTION,
-    );
-  }
-  return lib;
-}
-
-export function getFirebaseMessagingLibNoThrow(
-  isExpo: boolean,
-): FirebaseMessagingType | undefined {
-  if (!lib) {
-    const logger = videoLoggerSystem.getLogger(
-      'getFirebaseMessagingLibNoThrow',
-    );
-    logger.debug(
-      `${
-        isExpo
-          ? 'In Expo, @react-native-firebase/messaging library is required to receive ringing notifications in app killed state for Android.'
-          : ''
-      }${INSTALLATION_INSTRUCTION}`,
     );
   }
   return lib;

--- a/sample-apps/react-native/expo-video-sample/utils/setPushConfig.ts
+++ b/sample-apps/react-native/expo-video-sample/utils/setPushConfig.ts
@@ -10,7 +10,6 @@ import { registerNonRingingNotificationHandler } from './registerNonRingingNotif
 
 export function setPushConfig() {
   StreamVideoRN.setPushConfig({
-    isExpo: true,
     ios: {
       pushProviderName: 'rn-expo-apn-video-p8',
     },

--- a/sample-apps/react-native/ringing-tutorial/utils/setPushConfig.ts
+++ b/sample-apps/react-native/ringing-tutorial/utils/setPushConfig.ts
@@ -8,7 +8,6 @@ import { Users } from '../constants/Users';
 const API_KEY = 'par8f5s3gn2j';
 export function setPushConfig() {
   StreamVideoRN.setPushConfig({
-    isExpo: true,
     ios: {
       pushProviderName: 'expo-apn-video-ringingtutorial',
     },


### PR DESCRIPTION
### 💡 Overview

isExpo is not used by SDK anymore as we require RN-firebase lib for ringing

### 📝 Implementation notes

Deprecated the prop

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Push notifications now automatically detect the Expo environment.
  * Removed the need to configure the Expo flag in push settings.
  * Android push token setup now initializes messaging consistently.

* **Deprecations**
  * The `isExpo` push configuration option is deprecated and will be removed in a future major release. Its value is now ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->