### PR TITLE
chore(sample-apps): remove unused navigationRef and fix memo shadowing

### DIFF
--- a/sample-apps/react-native/dogfood/src/navigators/Call.tsx
+++ b/sample-apps/react-native/dogfood/src/navigators/Call.tsx
@@ -10,16 +10,13 @@ import {
 } from '@stream-io/video-react-native-sdk';
 import { StyleSheet, View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { CallStackParamList, RootStackParamList } from '../../types';
+import { CallStackParamList } from '../../types';
 import { NavigationHeader } from '../components/NavigationHeader';
 import { useOrientation } from '../hooks/useOrientation';
 import { ActiveCall } from '../components/ActiveCall';
 import { LayoutProvider } from '../contexts/LayoutContext';
-import { createNavigationContainerRef } from '@react-navigation/native';
 
 const CallStack = createNativeStackNavigator<CallStackParamList>();
-
-const navigationRef = createNavigationContainerRef<RootStackParamList>();
 
 const Calls = () => {
   const calls = useCalls().filter((c) => c.ringing);

--- a/sample-apps/react/e2ee-demo/src/components/ParticipantPanel.tsx
+++ b/sample-apps/react/e2ee-demo/src/components/ParticipantPanel.tsx
@@ -37,7 +37,7 @@ interface Props {
   events: EventLogEntry[];
 }
 
-export const ParticipantPanel = memo(function ParticipantPanel({
+export const ParticipantPanel = memo(function ParticipantPanelRender({
   participant,
   nameByUserId,
   events,

--- a/sample-apps/react/react-dogfood/pages/join/[callId].tsx
+++ b/sample-apps/react/react-dogfood/pages/join/[callId].tsx
@@ -45,8 +45,7 @@ const CallRoom = (props: ServerSideCredentialsProps) => {
   // end-to-end encrypted - otherwise the backend rejects the (e2ee: true) join.
   // See lib/queryConfigParams.
   const initialEncryptionKey = router.query['encryption_key'] as
-    | string
-    | undefined;
+    string | undefined;
   const e2eeEnabled = isE2EEEnvironment(environment) && !!initialEncryptionKey;
 
   const [client, setClient] = useState<StreamVideoClient>();


### PR DESCRIPTION
### 💡 Overview
This PR fixes the ESLint and Prettier violations that were making `yarn lint:sample-apps` fail.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal code across the React and React Native sample applications.
  * Removed unused navigation declarations and streamlined type annotations.
  * Renamed an internal rendering function without changing component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->