### PR TITLE
feat(dogfood): improve PiP grid responsiveness

### DIFF
--- a/sample-apps/react/react-dogfood/components/AdaptivePipGrid.tsx
+++ b/sample-apps/react/react-dogfood/components/AdaptivePipGrid.tsx
@@ -1,0 +1,435 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  Call,
+  CallTypes,
+  DefaultParticipantViewUI,
+  defaultSortPreset,
+  hasScreenShare,
+  Icon,
+  IconButton,
+  paginatedLayoutSortPreset,
+  ParticipantView,
+  type ParticipantFilter,
+  type ParticipantPredicate,
+  type ParticipantViewProps,
+  type StreamVideoParticipant,
+  useCall,
+  useFilteredParticipants,
+  useI18n,
+} from '@stream-io/video-react-sdk';
+
+/** Gap between tiles, in px. Keep in sync with the SCSS gap. */
+const GAP = 4;
+/**
+ * The aspect ratio tiles settle on when the window has room for it, matching
+ * the main-layout grids (`ParticipantView`'s own `aspect-ratio: 4/3`).
+ */
+const TARGET_ASPECT = 4 / 3;
+/**
+ * How far the aspect ratio may drift from `TARGET_ASPECT` when space is tight.
+ * Filling a cramped PIP window matters more than faithful framing, so tiles
+ * are allowed to stretch and crop. The bounds come from Google Meet's
+ * document-PIP, measured off its own rendering: 4 participants land on ~0.74
+ * (portrait) in a very wide window, ~1.02 (square) in a medium one and ~1.85
+ * in a narrow one.
+ */
+const CRAMPED_MIN_ASPECT = 3 / 4;
+const CRAMPED_MAX_ASPECT = 16 / 9;
+/**
+ * The container's smaller dimension, in px, at which drift is at its fullest
+ * and at which it stops entirely. Between the two it interpolates, so growing
+ * the window tightens the tiles towards `TARGET_ASPECT` smoothly rather than
+ * snapping at a threshold.
+ */
+const CRAMPED_SIZE = 320;
+const SPACIOUS_SIZE = 640;
+/**
+ * Two arrangements within this much of the best tile area count as a tie, and
+ * the one that fills more of the container height wins. Tile area alone can
+ * pick a grid that is a fraction of a percent bigger but leaves a quarter of
+ * the window empty.
+ */
+const TIE_THRESHOLD = 0.9;
+/**
+ * Below these sizes a tile stops being useful, so we page instead of cramming.
+ * Both axes are checked: with a variable aspect ratio neither dimension
+ * implies the other, and since tiles may be portrait the height floor is the
+ * higher of the two. Raise these to bring the pagination arrows in sooner.
+ */
+const MIN_TILE_WIDTH = 100;
+const MIN_TILE_HEIGHT = 104;
+/** Hard cap on tiles per page, regardless of how large the window gets. */
+const MAX_TILES_PER_PAGE = 16;
+
+/** Avatar placeholder sizing, relative to the smaller tile dimension. */
+const AVATAR_TILE_RATIO = 0.45;
+const MIN_AVATAR_SIZE = 24;
+const MAX_AVATAR_SIZE = 96;
+/** Initials font size, relative to the avatar. */
+const AVATAR_FONT_RATIO = 0.4;
+
+type Tiling = {
+  columns: number;
+  tileWidth: number;
+  tileHeight: number;
+  /** Placeholder avatar size, scaled to the tile. */
+  avatarSize: number;
+};
+
+export type AdaptivePipGridProps = {
+  /**
+   * Whether to exclude the local participant from the grid.
+   * @default false
+   */
+  excludeLocalParticipant?: boolean;
+
+  /**
+   * Predicate to filter call participants or a filter object.
+   */
+  filterParticipants?: ParticipantPredicate | ParticipantFilter;
+
+  /**
+   * When set to `false` disables mirroring of the local participant's video.
+   * @default true
+   */
+  mirrorLocalParticipantVideo?: boolean;
+
+  /**
+   * Whether to show pagination arrows when the participants don't fit the
+   * current window size.
+   * @default true
+   */
+  pageArrowsVisible?: boolean;
+} & Pick<ParticipantViewProps, 'ParticipantViewUI' | 'VideoPlaceholder'>;
+
+/**
+ * A drop-in replacement for `PipLayout.Grid` that derives its column count,
+ * row count and page size from the actual size of the PIP window rather than
+ * from the participant count alone.
+ *
+ * Lives in the dogfood app (not the SDK) so we can iterate on it without
+ * touching the public layout components.
+ */
+export const AdaptivePipGrid = (props: AdaptivePipGridProps) => {
+  const {
+    excludeLocalParticipant = false,
+    filterParticipants,
+    mirrorLocalParticipantVideo = true,
+    pageArrowsVisible = true,
+    VideoPlaceholder,
+    ParticipantViewUI = DefaultParticipantViewUI,
+  } = props;
+
+  const call = useCall();
+  const { t } = useI18n();
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(MAX_TILES_PER_PAGE);
+  const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const [containerElement, setContainerElement] =
+    useState<HTMLDivElement | null>(null);
+  const tilesRef = useRef<HTMLDivElement | null>(null);
+  const pageSizeRef = useRef(pageSize);
+
+  const participants = useFilteredParticipants({
+    excludeLocalParticipant,
+    filterParticipants,
+  });
+  const screenSharingParticipant = participants.find((p) => hasScreenShare(p));
+
+  usePaginatedSortPreset(call);
+
+  useEffect(() => {
+    if (!wrapperElement || !call) return;
+    return call.setViewport(wrapperElement);
+  }, [wrapperElement, call]);
+
+  const pages = useMemo(
+    () => chunk(participants, pageSize),
+    [participants, pageSize],
+  );
+  const pageCount = pages.length;
+
+  const lastPage = Math.max(0, pageCount - 1);
+  if (page > lastPage) {
+    setPage(lastPage);
+  }
+
+  const selectedGroup = pages[page];
+  const mirror = mirrorLocalParticipantVideo ? undefined : false;
+
+  /**
+   * Writes the tile geometry straight to the DOM as custom properties on the
+   * grid element. Deliberately not React state: a `ResizeObserver` callback
+   * runs before paint, so the tiles resize in the same frame as the container.
+   * Routing it through state instead leaves the tiles one frame behind for
+   * every frame of a window drag, which reads as flicker.
+   */
+  const applyGeometry = useCallback(() => {
+    const tiles = tilesRef.current;
+    if (!containerElement || !tiles) return;
+
+    const rect = containerElement.getBoundingClientRect();
+    const width = Math.floor(rect.width);
+    const height = Math.floor(rect.height);
+    if (width <= 0 || height <= 0) return;
+
+    const nextPageSize = getPageSize(width, height);
+    if (nextPageSize !== pageSizeRef.current) {
+      pageSizeRef.current = nextPageSize;
+      setPageSize(nextPageSize);
+    }
+
+    const count = tiles.childElementCount;
+    if (count === 0) return;
+
+    const { columns, tileWidth, tileHeight, avatarSize } = getTiling(
+      count,
+      width,
+      height,
+    );
+    tiles.style.maxWidth = `${columns * tileWidth + (columns - 1) * GAP}px`;
+    tiles.style.setProperty('--rd-pip-tile-width', `${tileWidth}px`);
+    tiles.style.setProperty('--rd-pip-tile-height', `${tileHeight}px`);
+    tiles.style.setProperty('--rd-pip-avatar-size', `${avatarSize}px`);
+    tiles.style.setProperty(
+      '--rd-pip-avatar-font-size',
+      `${Math.round(avatarSize * AVATAR_FONT_RATIO)}px`,
+    );
+  }, [containerElement]);
+
+  useLayoutEffect(applyGeometry);
+
+  useEffect(() => {
+    if (!containerElement) return;
+
+    const view = containerElement.ownerDocument.defaultView ?? window;
+    if (!view.ResizeObserver) {
+      view.addEventListener('resize', applyGeometry);
+      return () => view.removeEventListener('resize', applyGeometry);
+    }
+
+    const observer = new view.ResizeObserver(applyGeometry);
+    observer.observe(containerElement);
+    return () => observer.disconnect();
+  }, [containerElement, applyGeometry]);
+
+  if (!call) return null;
+
+  return (
+    <div className="rd__pip-grid" ref={setWrapperElement}>
+      {screenSharingParticipant &&
+        (screenSharingParticipant.isLocalParticipant ? (
+          <div className="str-video__pip-screen-share-local">
+            <Icon icon="screen-share-off" />
+            <span className="str-video__pip-screen-share-local__title">
+              {t('You are presenting your screen')}
+            </span>
+          </div>
+        ) : (
+          <div className="rd__pip-grid__screen-share">
+            <ParticipantView
+              participant={screenSharingParticipant}
+              trackType="screenShareTrack"
+              muteAudio
+              mirror={false}
+              VideoPlaceholder={VideoPlaceholder}
+              ParticipantViewUI={ParticipantViewUI}
+            />
+          </div>
+        ))}
+      <div className="rd__pip-grid__container" ref={setContainerElement}>
+        {pageArrowsVisible && page > 0 && (
+          <IconButton
+            icon="caret-left"
+            onClick={() =>
+              setPage((currentPage) => Math.max(0, currentPage - 1))
+            }
+            className="str-video__pip-layout__pagination-button str-video__pip-layout__pagination-button--left"
+          />
+        )}
+        <div className="rd__pip-grid__tiles" ref={tilesRef}>
+          {selectedGroup?.map((participant) => (
+            <div key={participant.sessionId} className="rd__pip-grid__tile">
+              <ParticipantView
+                participant={participant}
+                muteAudio
+                mirror={mirror}
+                VideoPlaceholder={VideoPlaceholder}
+                ParticipantViewUI={ParticipantViewUI}
+              />
+            </div>
+          ))}
+        </div>
+        {pageArrowsVisible && page < pageCount - 1 && (
+          <IconButton
+            icon="caret-right"
+            onClick={() =>
+              setPage((currentPage) => Math.min(pageCount - 1, currentPage + 1))
+            }
+            className="str-video__pip-layout__pagination-button str-video__pip-layout__pagination-button--right"
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+AdaptivePipGrid.displayName = 'AdaptivePipGrid';
+
+/**
+ * Chooses the column count that makes each tile as large as possible for the
+ * given participant count and container size. This is the part the SDK's
+ * `PipLayout.Grid` gets wrong in a PIP window: it derives columns from the
+ * participant count alone, which is tuned for a wide 16:9 stage and leaves a
+ * tall, narrow window mostly empty.
+ */
+const getTiling = (count: number, width: number, height: number): Tiling => {
+  const bounds = getAspectBounds(width, height);
+  const candidates: { columns: number; area: number; usedHeight: number }[] =
+    [];
+
+  for (let columns = 1; columns <= count; columns++) {
+    const rows = Math.ceil(count / columns);
+    const { tileWidth, tileHeight } = fitTile(
+      count,
+      columns,
+      width,
+      height,
+      bounds,
+    );
+    if (tileWidth <= 0 || tileHeight <= 0) continue;
+    candidates.push({
+      columns,
+      area: tileWidth * tileHeight,
+      usedHeight: rows * tileHeight + GAP * (rows - 1),
+    });
+  }
+
+  const maxArea = Math.max(0, ...candidates.map((c) => c.area));
+  const best = candidates
+    .filter((c) => c.area >= maxArea * TIE_THRESHOLD)
+    .sort((a, b) => b.usedHeight - a.usedHeight || b.area - a.area)[0];
+
+  const { tileWidth, tileHeight } = best
+    ? fitTile(count, best.columns, width, height, bounds)
+    : { tileWidth: 0, tileHeight: 0 };
+
+  return {
+    columns: best?.columns ?? 1,
+    tileWidth,
+    tileHeight,
+    avatarSize: Math.round(
+      Math.min(
+        MAX_AVATAR_SIZE,
+        Math.max(
+          MIN_AVATAR_SIZE,
+          Math.min(tileWidth, tileHeight) * AVATAR_TILE_RATIO,
+        ),
+      ),
+    ),
+  };
+};
+
+/**
+ * How far the tile aspect ratio may stray from `TARGET_ASPECT`, as a function
+ * of how much room the container has. A cramped window gets the full Meet-like
+ * band so the grid can fill it; a spacious one is pinned to `TARGET_ASPECT` so
+ * tiles look like the main-layout grid instead of cropped portrait strips.
+ */
+const getAspectBounds = (width: number, height: number) => {
+  const smaller = Math.min(width, height);
+  const drift = Math.min(
+    1,
+    Math.max(0, (SPACIOUS_SIZE - smaller) / (SPACIOUS_SIZE - CRAMPED_SIZE)),
+  );
+  return {
+    min: TARGET_ASPECT + (CRAMPED_MIN_ASPECT - TARGET_ASPECT) * drift,
+    max: TARGET_ASPECT + (CRAMPED_MAX_ASPECT - TARGET_ASPECT) * drift,
+  };
+};
+
+/**
+ * Largest tile that fits one cell of a `columns`-wide grid. The tile takes the
+ * cell's aspect ratio where the band allows, so the grid fills the container;
+ * outside the band it falls back to fitting inside the cell.
+ */
+const fitTile = (
+  count: number,
+  columns: number,
+  width: number,
+  height: number,
+  bounds: { min: number; max: number },
+) => {
+  const rows = Math.ceil(count / columns);
+  const cellWidth = (width - GAP * (columns - 1)) / columns;
+  const cellHeight = (height - GAP * (rows - 1)) / rows;
+  if (cellWidth <= 0 || cellHeight <= 0) {
+    return { tileWidth: 0, tileHeight: 0 };
+  }
+
+  const cellAspect = cellWidth / cellHeight;
+  const aspect = Math.min(bounds.max, Math.max(bounds.min, cellAspect));
+
+  return cellAspect > aspect
+    ? {
+        tileWidth: Math.floor(cellHeight * aspect),
+        tileHeight: Math.floor(cellHeight),
+      }
+    : {
+        tileWidth: Math.floor(cellWidth),
+        tileHeight: Math.floor(cellWidth / aspect),
+      };
+};
+
+/**
+ * The largest number of tiles that still renders at a usable size in the given
+ * container. Everything beyond that goes to the next page.
+ *
+ * Scans every candidate rather than stopping at the first one that fails: tile
+ * size is not monotonic in the tile count, because adding a tile can flip the
+ * grid to another column count and make every tile *larger* (in a 288x440
+ * container, 11 tiles are 93x107 while 9 are 142x84).
+ */
+const getPageSize = (width: number, height: number) => {
+  if (width <= 0 || height <= 0) return MAX_TILES_PER_PAGE;
+
+  let pageSize = 1;
+  for (let count = 1; count <= MAX_TILES_PER_PAGE; count++) {
+    const { tileWidth, tileHeight } = getTiling(count, width, height);
+    if (tileWidth >= MIN_TILE_WIDTH && tileHeight >= MIN_TILE_HEIGHT) {
+      pageSize = count;
+    }
+  }
+  return pageSize;
+};
+
+const usePaginatedSortPreset = (call: Call | undefined) => {
+  useEffect(() => {
+    if (!call) return;
+    call.setSortParticipantsBy(paginatedLayoutSortPreset);
+    return () => {
+      const callConfig = CallTypes.get(call.type);
+      call.setSortParticipantsBy(
+        callConfig.options.sortParticipantsBy || defaultSortPreset,
+      );
+    };
+  }, [call]);
+};
+
+const chunk = (participants: StreamVideoParticipant[], size: number) => {
+  if (participants.length === 0) return [];
+  const chunks: StreamVideoParticipant[][] = [];
+  for (let i = 0; i < participants.length; i += size) {
+    chunks.push(participants.slice(i, i + size));
+  }
+  return chunks;
+};

--- a/sample-apps/react/react-dogfood/components/AdaptivePipGrid.tsx
+++ b/sample-apps/react/react-dogfood/components/AdaptivePipGrid.tsx
@@ -28,8 +28,8 @@ import {
 /** Gap between tiles, in px. Keep in sync with the SCSS gap. */
 const GAP = 4;
 /**
- * The aspect ratio tiles settle on when the window has room for it, matching
- * the main-layout grids (`ParticipantView`'s own `aspect-ratio: 4/3`).
+ * The aspect ratio tiles use whenever it fits at a useful size, matching the
+ * main-layout grids (`ParticipantView`'s own `aspect-ratio: 4/3`).
  */
 const TARGET_ASPECT = 4 / 3;
 /**
@@ -164,6 +164,7 @@ export const AdaptivePipGrid = (props: AdaptivePipGridProps) => {
   }
 
   const selectedGroup = pages[page];
+  const selectedGroupSize = selectedGroup?.length ?? 0;
   const mirror = mirrorLocalParticipantVideo ? undefined : false;
 
   /**
@@ -206,7 +207,9 @@ export const AdaptivePipGrid = (props: AdaptivePipGridProps) => {
     );
   }, [containerElement]);
 
-  useLayoutEffect(applyGeometry);
+  useLayoutEffect(() => {
+    applyGeometry();
+  }, [applyGeometry, selectedGroupSize]);
 
   useEffect(() => {
     if (!containerElement) return;
@@ -342,8 +345,8 @@ const getTiling = (count: number, width: number, height: number): Tiling => {
 /**
  * How far the tile aspect ratio may stray from `TARGET_ASPECT`, as a function
  * of how much room the container has. A cramped window gets the full Meet-like
- * band so the grid can fill it; a spacious one is pinned to `TARGET_ASPECT` so
- * tiles look like the main-layout grid instead of cropped portrait strips.
+ * band so the grid can fill it, but `fitTile` still prefers `TARGET_ASPECT`
+ * whenever it fits above the minimum useful tile size.
  */
 const getAspectBounds = (width: number, height: number) => {
   const smaller = Math.min(width, height);
@@ -376,9 +379,25 @@ const fitTile = (
     return { tileWidth: 0, tileHeight: 0 };
   }
 
+  const targetTile = fitTileWithAspect(cellWidth, cellHeight, TARGET_ASPECT);
+  if (
+    targetTile.tileWidth >= MIN_TILE_WIDTH &&
+    targetTile.tileHeight >= MIN_TILE_HEIGHT
+  ) {
+    return targetTile;
+  }
+
   const cellAspect = cellWidth / cellHeight;
   const aspect = Math.min(bounds.max, Math.max(bounds.min, cellAspect));
+  return fitTileWithAspect(cellWidth, cellHeight, aspect);
+};
 
+const fitTileWithAspect = (
+  cellWidth: number,
+  cellHeight: number,
+  aspect: number,
+) => {
+  const cellAspect = cellWidth / cellHeight;
   return cellAspect > aspect
     ? {
         tileWidth: Math.floor(cellHeight * aspect),

--- a/sample-apps/react/react-dogfood/components/StagePip.tsx
+++ b/sample-apps/react/react-dogfood/components/StagePip.tsx
@@ -1,17 +1,17 @@
 import {
   DefaultParticipantViewUI,
   DefaultParticipantViewUIProps,
-  PipLayout,
   StreamTheme,
   ToggleAudioPublishingButton,
   ToggleVideoPublishingButton,
 } from '@stream-io/video-react-sdk';
+import { AdaptivePipGrid } from './AdaptivePipGrid';
 
 export function StagePip() {
   return (
     <StreamTheme>
       <div className="rd__stage-pip">
-        <PipLayout.Grid ParticipantViewUI={PipParticipantViewUI} />
+        <AdaptivePipGrid ParticipantViewUI={PipParticipantViewUI} />
       </div>
       <div className="str-video__call-controls">
         <div className="str-video__call-controls--group str-video__call-controls--media">

--- a/sample-apps/react/react-dogfood/style/AdaptivePipGrid.scss
+++ b/sample-apps/react/react-dogfood/style/AdaptivePipGrid.scss
@@ -1,0 +1,90 @@
+.rd__pip-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--str-video__spacing-xs);
+  padding-inline: var(--str-video__spacing-xs);
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+
+  .rd__pip-grid__screen-share {
+    flex: 0 0 auto;
+    min-height: 0;
+    max-height: 55%;
+    display: flex;
+    justify-content: center;
+
+    .str-video__participant-view {
+      width: auto;
+      max-width: 100%;
+      max-height: 100%;
+      aspect-ratio: 16 / 9;
+    }
+  }
+
+  .rd__pip-grid__container {
+    position: relative;
+    flex: 1 1 0;
+    min-height: 0;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+  }
+
+  .rd__pip-grid__tiles {
+    display: flex;
+    flex-wrap: wrap;
+    align-content: center;
+    justify-content: center;
+    margin-inline: auto;
+    gap: 4px;
+  }
+
+  .rd__pip-grid__tile {
+    flex: 0 0 auto;
+    width: var(--rd-pip-tile-width);
+    height: var(--rd-pip-tile-height);
+    min-width: 0;
+    min-height: 0;
+
+    .str-video__participant-view {
+      width: 100%;
+      height: 100%;
+      max-width: none;
+      max-height: none;
+      aspect-ratio: auto;
+      overflow: hidden;
+
+      &--speaking {
+        outline: none;
+
+        &::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+          border: 2px solid var(--str-video__primary-color);
+          border-radius: var(--str-video__border-radius-sm);
+          pointer-events: none;
+          z-index: 1;
+        }
+      }
+    }
+
+    .str-video__video-placeholder {
+      aspect-ratio: auto;
+    }
+
+    .str-video__video-placeholder__avatar,
+    .str-video__video-placeholder__initials-fallback {
+      width: var(--rd-pip-avatar-size);
+      height: var(--rd-pip-avatar-size);
+      font-size: var(--rd-pip-avatar-font-size);
+    }
+
+    .str-video__notification {
+      display: none;
+    }
+  }
+}

--- a/sample-apps/react/react-dogfood/style/app.scss
+++ b/sample-apps/react/react-dogfood/style/app.scss
@@ -94,7 +94,7 @@ body {
 }
 
 .rd__stage-pip {
-  padding-block: 1rem;
+  padding-block: 0.5rem;
   min-height: 0;
   flex-grow: 1;
 }

--- a/sample-apps/react/react-dogfood/style/index.scss
+++ b/sample-apps/react/react-dogfood/style/index.scss
@@ -26,6 +26,7 @@
 @use 'CallParticipantsView';
 @use 'CallParticipantsScreenView';
 @use 'CallLayout';
+@use 'AdaptivePipGrid';
 
 @use 'SettingsTabModal';
 @use 'ToggleMoreOptionsListButton';


### PR DESCRIPTION
### 💡 Overview

This PR introduces an adaptive PiP grid for the React dogfood app. The grid sizes tiles based on the actual PiP window dimensions, prefers the main grid’s 4:3 tile ratio when there is enough room, and paginates participants when tiles would become too small.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1080/adaptive-pip-grid

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive picture-in-picture participant grid that adapts tile sizing and pagination to available space.
  * Added support for participant filtering, screen sharing, mirrored local video, speaking indicators, and customizable participant views.
  * Added pagination controls for navigating larger participant groups.

* **Style**
  * Improved picture-in-picture layout, avatars, tile sizing, and screen-share presentation.
  * Reduced vertical spacing around the stage picture-in-picture area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->