### PR TITLE
chore: adjusted condition for enabling/disabling camera/mic

### DIFF
--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -7,7 +7,6 @@ import { VideoSettingsResponse } from '../gen/coordinator';
 import { TrackType } from '../gen/video/sfu/models/models';
 import { isMobile } from '../helpers/compatibility';
 import { isReactNative } from '../helpers/platforms';
-import { CallingState } from '../store';
 import { DevicePersistenceOptions } from './devicePersistence';
 
 export class CameraManager extends DeviceManager<CameraManagerState> {
@@ -126,10 +125,7 @@ export class CameraManager extends DeviceManager<CameraManagerState> {
   }
 
   override enable(): Promise<void> {
-    if (
-      isReactNative() &&
-      this.call.state.callingState !== CallingState.JOINED
-    ) {
+    if (isReactNative() && !this.call.hasMediaEngine) {
       this.state.setPendingStatus('enabled');
       return Promise.resolve();
     }
@@ -142,10 +138,7 @@ export class CameraManager extends DeviceManager<CameraManagerState> {
   override async disable(
     forceStopOrOptions?: boolean | { forceStop?: boolean },
   ): Promise<void> {
-    if (
-      isReactNative() &&
-      this.call.state.callingState !== CallingState.JOINED
-    ) {
+    if (isReactNative() && !this.call.hasMediaEngine) {
       this.state.setPendingStatus('disabled');
       return;
     }
@@ -159,10 +152,7 @@ export class CameraManager extends DeviceManager<CameraManagerState> {
   }
 
   override toggle(): Promise<void> {
-    if (
-      isReactNative() &&
-      this.call.state.callingState !== CallingState.JOINED
-    ) {
+    if (isReactNative() && !this.call.hasMediaEngine) {
       this.state.setPendingStatus(
         this.state.optimisticStatus === 'enabled' ? 'disabled' : 'enabled',
       );

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -191,10 +191,7 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
   }
 
   override enable(): Promise<void> {
-    if (
-      isReactNative() &&
-      this.call.state.callingState !== CallingState.JOINED
-    ) {
+    if (isReactNative() && !this.call.hasMediaEngine) {
       this.state.setPendingStatus('enabled');
       return Promise.resolve();
     }
@@ -207,10 +204,7 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
   override async disable(
     forceStopOrOptions?: boolean | { forceStop?: boolean },
   ): Promise<void> {
-    if (
-      isReactNative() &&
-      this.call.state.callingState !== CallingState.JOINED
-    ) {
+    if (isReactNative() && !this.call.hasMediaEngine) {
       this.state.setPendingStatus('disabled');
       return;
     }
@@ -224,10 +218,7 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
   }
 
   override toggle(): Promise<void> {
-    if (
-      isReactNative() &&
-      this.call.state.callingState !== CallingState.JOINED
-    ) {
+    if (isReactNative() && !this.call.hasMediaEngine) {
       this.state.setPendingStatus(
         this.state.optimisticStatus === 'enabled' ? 'disabled' : 'enabled',
       );

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -97,6 +97,7 @@ export const mockCall = (): Partial<Call> => {
   return {
     cid: 'default:test-call',
     state: callState,
+    hasMediaEngine: true,
     publish: vi.fn(),
     stopPublish: vi.fn(),
     streamClient: fromPartial({


### PR DESCRIPTION
### 💡 Overview

This PR adjusts enable/disable behavior for camera and microphone device managers. Condition for applying real state to device is changed. Instead of checking `call.state` we check `call.hasMediaEngine`. This makes enable/disable work as is for whole join/leave window without checking exact call state (which covers reconnection cases). 

🎫 Ticket: https://linear.app/stream/issue/RN-421/adjust-camera-and-mic-enabledisable-condition


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera and microphone enable, disable, and toggle behavior in React Native calls.
  * Media controls now respond correctly based on media engine availability, including before a call is fully joined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->