### PR TITLE
fix(client): only deselect the speaker device on a real disconnect

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -3371,7 +3371,9 @@ export class Call {
     skipSpeakerApply: boolean,
   ) => {
     if (!skipSpeakerApply) {
-      this.speaker.apply(settings);
+      await this.speaker.apply(settings).catch((err) => {
+        this.logger.warn('Speaker init failed', err);
+      });
     }
     await this.camera.apply(settings.video, publish).catch((err) => {
       this.logger.warn('Camera init failed', err);

--- a/packages/client/src/devices/SpeakerManager.ts
+++ b/packages/client/src/devices/SpeakerManager.ts
@@ -125,7 +125,7 @@ export class SpeakerManager {
       this.subscriptions.push(
         createSubscription(
           combineLatest([
-            deviceIds$.pipe(pairwise()),
+            deviceIds$!.pipe(pairwise()),
             this.state.selectedDevice$,
           ]),
           ([[prevDevices, currentDevices], deviceId]) => {

--- a/packages/client/src/devices/SpeakerManager.ts
+++ b/packages/client/src/devices/SpeakerManager.ts
@@ -1,4 +1,4 @@
-import { combineLatest } from 'rxjs';
+import { combineLatest, pairwise } from 'rxjs';
 import { Call } from '../Call';
 import { isReactNative } from '../helpers/platforms';
 import { SpeakerState } from './SpeakerState';
@@ -102,13 +102,16 @@ export class SpeakerManager {
     if (deviceIds$ && !isReactNative()) {
       this.subscriptions.push(
         createSubscription(
-          combineLatest([deviceIds$, this.state.selectedDevice$]),
-          ([devices, deviceId]) => {
+          combineLatest([
+            deviceIds$.pipe(pairwise()),
+            this.state.selectedDevice$,
+          ]),
+          ([[prevDevices, currentDevices], deviceId]) => {
             if (!deviceId) return;
-            const device = devices.find(
-              (d) => d.deviceId === deviceId && d.kind === 'audiooutput',
-            );
-            if (!device) this.select('');
+            const isDisconnected =
+              this.findDevice(prevDevices, deviceId) &&
+              !this.findDevice(currentDevices, deviceId);
+            if (isDisconnected) this.select('');
           },
         ),
       );
@@ -202,6 +205,9 @@ export class SpeakerManager {
       return { audioVolume: volume };
     });
   }
+
+  private findDevice = (devices: MediaDeviceInfo[], deviceId: string) =>
+    devices.find((d) => d.deviceId === deviceId && d.kind === 'audiooutput');
 
   private persistSpeakerDevicePreference(selectedDevice: string) {
     const { storageKey } = this.devicePersistence;

--- a/packages/client/src/devices/SpeakerManager.ts
+++ b/packages/client/src/devices/SpeakerManager.ts
@@ -1,4 +1,4 @@
-import { combineLatest, pairwise } from 'rxjs';
+import { combineLatest, firstValueFrom, pairwise } from 'rxjs';
 import { Call } from '../Call';
 import { isReactNative } from '../helpers/platforms';
 import { SpeakerState } from './SpeakerState';
@@ -39,11 +39,15 @@ export class SpeakerManager {
     this.setup();
   }
 
-  apply(settings: CallSettingsResponse) {
-    return isReactNative() ? this.applyRN(settings) : this.applyWeb();
+  async apply(settings: CallSettingsResponse): Promise<void> {
+    if (isReactNative()) {
+      this.applyRN(settings);
+      return;
+    }
+    await this.applyWeb();
   }
 
-  private applyWeb() {
+  private async applyWeb() {
     const { enabled, storageKey } = this.devicePersistence;
     if (!enabled) return;
 
@@ -56,8 +60,26 @@ export class SpeakerManager {
       preference.selectedDeviceId === defaultDeviceId
         ? ''
         : preference.selectedDeviceId;
-    if (this.state.selectedDevice !== nextDeviceId) {
-      this.select(nextDeviceId);
+    if (!nextDeviceId) {
+      if (this.state.selectedDevice !== nextDeviceId) {
+        this.select(nextDeviceId);
+      }
+      return;
+    }
+
+    const permissionState = await firstValueFrom(
+      getAudioBrowserPermission(this.call.tracer).asStateObservable(),
+    );
+    if (permissionState !== 'granted') return;
+
+    const devices = await firstValueFrom(this.listDevices());
+    const device =
+      this.findDevice(devices, nextDeviceId) ??
+      (preference.selectedDeviceLabel
+        ? devices.find((d) => d.label === preference.selectedDeviceLabel)
+        : undefined);
+    if (device && this.state.selectedDevice !== device.deviceId) {
+      this.select(device.deviceId);
     }
   }
 

--- a/packages/client/src/devices/__tests__/SpeakerManager.test.ts
+++ b/packages/client/src/devices/__tests__/SpeakerManager.test.ts
@@ -6,8 +6,10 @@ import {
   emitDeviceIds,
   LocalStorageMock,
   mockAudioDevices,
+  mockAudioOutputDevices,
   mockBrowserPermission,
   mockDeviceIds$,
+  mockDevicesWithoutAudioPermission,
 } from './mocks';
 import { of } from 'rxjs';
 import { SpeakerManager } from '../SpeakerManager';
@@ -122,13 +124,34 @@ describe('SpeakerManager.test', () => {
   });
 
   it('should disable device if selected device is disconnected', () => {
-    emitDeviceIds(mockAudioDevices);
-    const deviceId = mockAudioDevices[1].deviceId;
+    const deviceId = mockAudioOutputDevices[0].deviceId;
+    emitDeviceIds([...mockAudioDevices, ...mockAudioOutputDevices]);
     manager.select(deviceId);
 
-    emitDeviceIds(mockAudioDevices.slice(2));
+    emitDeviceIds([...mockAudioDevices, ...mockAudioOutputDevices.slice(1)]);
 
     expect(manager.state.selectedDevice).toBe('');
+  });
+
+  it('should keep the selection when the device list never exposed audio ids', () => {
+    const deviceId = mockAudioOutputDevices[0].deviceId;
+    emitDeviceIds(mockDevicesWithoutAudioPermission);
+
+    manager.select(deviceId);
+    expect(manager.state.selectedDevice).toBe(deviceId);
+
+    emitDeviceIds(mockDevicesWithoutAudioPermission);
+    expect(manager.state.selectedDevice).toBe(deviceId);
+  });
+
+  it('should keep the selection when the device appears in a later enumeration', () => {
+    const deviceId = mockAudioOutputDevices[0].deviceId;
+    emitDeviceIds(mockDevicesWithoutAudioPermission);
+    manager.select(deviceId);
+
+    emitDeviceIds([...mockAudioDevices, ...mockAudioOutputDevices]);
+
+    expect(manager.state.selectedDevice).toBe(deviceId);
   });
 
   it('persists speaker selection when permission is granted', async () => {
@@ -159,16 +182,9 @@ describe('SpeakerManager.test', () => {
   });
 
   describe('apply (web)', () => {
-    it('does nothing when persistence is disabled', () => {
-      const selectSpy = vi.spyOn(manager, 'select');
-      // @ts-expect-error - partial data
-      manager.apply({});
-      expect(selectSpy).not.toHaveBeenCalled();
-    });
-
-    it('selects the persisted speaker device', () => {
+    const createPersistedManager = () => {
       const streamClient = new StreamClient('abc123');
-      const persistedManager = new SpeakerManager(
+      return new SpeakerManager(
         new Call({
           id: '',
           type: '',
@@ -178,18 +194,27 @@ describe('SpeakerManager.test', () => {
         }),
         { enabled: true, storageKey },
       );
+    };
 
+    const persist = (selectedDeviceId: string, selectedDeviceLabel: string) => {
       localStorageMock.setItem(
         storageKey,
         JSON.stringify({
-          speaker: [
-            {
-              selectedDeviceId: 'speaker-1',
-              selectedDeviceLabel: 'Speaker 1',
-            },
-          ],
+          speaker: [{ selectedDeviceId, selectedDeviceLabel }],
         }),
       );
+    };
+
+    it('does nothing when persistence is disabled', () => {
+      const selectSpy = vi.spyOn(manager, 'select');
+      // @ts-expect-error - partial data
+      manager.apply({});
+      expect(selectSpy).not.toHaveBeenCalled();
+    });
+
+    it('selects the persisted speaker device', () => {
+      const persistedManager = createPersistedManager();
+      persist('speaker-1', 'Speaker 1');
 
       const selectSpy = vi.spyOn(persistedManager, 'select');
       // @ts-expect-error - partial data
@@ -200,30 +225,9 @@ describe('SpeakerManager.test', () => {
     });
 
     it('selects system default when persisted device is default', () => {
-      const streamClient = new StreamClient('abc123');
-      const persistedManager = new SpeakerManager(
-        new Call({
-          id: '',
-          type: '',
-          streamClient,
-          clientEventReporter: new ClientEventReporter({ streamClient }),
-          clientStore: new StreamVideoWriteableStateStore(),
-        }),
-        { enabled: true, storageKey },
-      );
+      const persistedManager = createPersistedManager();
       persistedManager.select('previous-device');
-
-      localStorageMock.setItem(
-        storageKey,
-        JSON.stringify({
-          speaker: [
-            {
-              selectedDeviceId: defaultDeviceId,
-              selectedDeviceLabel: '',
-            },
-          ],
-        }),
-      );
+      persist(defaultDeviceId, '');
 
       const selectSpy = vi.spyOn(persistedManager, 'select');
       // @ts-expect-error - partial data

--- a/packages/client/src/devices/__tests__/SpeakerManager.test.ts
+++ b/packages/client/src/devices/__tests__/SpeakerManager.test.ts
@@ -205,33 +205,125 @@ describe('SpeakerManager.test', () => {
       );
     };
 
-    it('does nothing when persistence is disabled', () => {
+    it('does nothing when persistence is disabled', async () => {
       const selectSpy = vi.spyOn(manager, 'select');
       // @ts-expect-error - partial data
-      manager.apply({});
+      await manager.apply({});
       expect(selectSpy).not.toHaveBeenCalled();
     });
 
-    it('selects the persisted speaker device', () => {
+    it('selects the persisted speaker device', async () => {
       const persistedManager = createPersistedManager();
+      vi.spyOn(persistedManager, 'listDevices').mockReturnValue(
+        of([
+          {
+            deviceId: 'speaker-1',
+            kind: 'audiooutput',
+            label: 'Speaker 1',
+            groupId: 'speaker-group',
+          } as MediaDeviceInfo,
+        ]),
+      );
       persist('speaker-1', 'Speaker 1');
 
       const selectSpy = vi.spyOn(persistedManager, 'select');
       // @ts-expect-error - partial data
-      persistedManager.apply({});
+      await persistedManager.apply({});
 
       expect(selectSpy).toHaveBeenCalledWith('speaker-1');
       expect(persistedManager.state.selectedDevice).toBe('speaker-1');
     });
 
-    it('selects system default when persisted device is default', () => {
+    it('does not select a missing persisted speaker device', async () => {
+      const persistedManager = createPersistedManager();
+      vi.spyOn(persistedManager, 'listDevices').mockReturnValue(
+        of(mockAudioOutputDevices),
+      );
+      persist('speaker-1', 'Speaker 1');
+
+      const selectSpy = vi.spyOn(persistedManager, 'select');
+      // @ts-expect-error - partial data
+      await persistedManager.apply({});
+
+      expect(selectSpy).not.toHaveBeenCalled();
+      expect(persistedManager.state.selectedDevice).toBe('');
+    });
+
+    it('does not restore a speaker preference when audio permission is not granted', async () => {
+      const persistedManager = createPersistedManager();
+      vi.spyOn(mockBrowserPermission, 'asStateObservable').mockReturnValue(
+        of('prompt'),
+      );
+      const listDevicesSpy = vi.spyOn(persistedManager, 'listDevices');
+      persist('speaker-1', 'Speaker 1');
+
+      const selectSpy = vi.spyOn(persistedManager, 'select');
+      // @ts-expect-error - partial data
+      await persistedManager.apply({});
+
+      expect(listDevicesSpy).not.toHaveBeenCalled();
+      expect(selectSpy).not.toHaveBeenCalled();
+      expect(persistedManager.state.selectedDevice).toBe('');
+    });
+
+    it('does not restore a speaker preference from a non-output device with the same label', async () => {
+      const persistedManager = createPersistedManager();
+      const videoDevice = {
+        deviceId: 'video-device-id',
+        kind: 'videoinput',
+        label: 'RODECaster Video (19f7:006b)',
+        groupId: 'video-group',
+      } as MediaDeviceInfo;
+      const outputDevice = {
+        deviceId: 'speaker-device-id',
+        kind: 'audiooutput',
+        label: 'RODECaster Video (19f7:006b)',
+        groupId: 'speaker-group',
+      } as MediaDeviceInfo;
+      vi.spyOn(persistedManager, 'listDevices').mockReturnValue(
+        of([outputDevice]),
+      );
+      persist('missing-speaker-device-id', outputDevice.label);
+
+      const selectSpy = vi.spyOn(persistedManager, 'select');
+      // @ts-expect-error - partial data
+      await persistedManager.apply({});
+
+      expect(selectSpy).toHaveBeenCalledWith(outputDevice.deviceId);
+      expect(selectSpy).not.toHaveBeenCalledWith(videoDevice.deviceId);
+      expect(persistedManager.state.selectedDevice).toBe(outputDevice.deviceId);
+    });
+
+    it('does not restore a speaker preference from an empty label placeholder', async () => {
+      const persistedManager = createPersistedManager();
+      vi.spyOn(persistedManager, 'listDevices').mockReturnValue(
+        of([
+          {
+            deviceId: '',
+            kind: 'audiooutput',
+            label: '',
+            groupId: '',
+          } as MediaDeviceInfo,
+        ]),
+      );
+      persist('missing-speaker-device-id', '');
+
+      const selectSpy = vi.spyOn(persistedManager, 'select');
+      // @ts-expect-error - partial data
+      await persistedManager.apply({});
+
+      expect(selectSpy).not.toHaveBeenCalled();
+      expect(persistedManager.state.selectedDevice).toBe('');
+    });
+
+    it('selects system default when persisted device is default', async () => {
       const persistedManager = createPersistedManager();
       persistedManager.select('previous-device');
       persist(defaultDeviceId, '');
 
       const selectSpy = vi.spyOn(persistedManager, 'select');
       // @ts-expect-error - partial data
-      persistedManager.apply({});
+      await persistedManager.apply({});
 
       expect(selectSpy).toHaveBeenCalledWith('');
       expect(persistedManager.state.selectedDevice).toBe('');

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -71,6 +71,35 @@ export const mockAudioDevices = [
   },
 ] as MediaDeviceInfo[];
 
+export const mockAudioOutputDevices = [
+  {
+    deviceId:
+      'f1602a62d9d363c0711de07182751b646b87cfc0edd9e89d2849289e49304158',
+    kind: 'audiooutput',
+    label: 'RODECaster Video (19f7:006b)',
+    groupId: '27f43ef815ab224429532d6e8ebbeb00d7a895e0cbb0c2e4fcbe5b370f234259',
+  },
+  {
+    deviceId:
+      'd542885e6a47d7a38837aee0323bd2c50e825971690f47295cb338e1f1061283',
+    kind: 'audiooutput',
+    label: 'MacBook Pro Speakers (Built-in)',
+    groupId: 'a8708545cb3969c0b7e3712d2ffdbc381992aeb5577b06cd71ba7a94ee20cf3e',
+  },
+] as MediaDeviceInfo[];
+
+export const mockDevicesWithoutAudioPermission = [
+  { deviceId: '', kind: 'audioinput', label: '', groupId: '' },
+  {
+    deviceId:
+      'f10561a0bbd3effbd25645e7f06fc2e261255afeb05f6bc4fdaba3ed7bd9c2b7',
+    kind: 'videoinput',
+    label: 'RODECaster Video (19f7:006b)',
+    groupId: '27f43ef815ab224429532d6e8ebbeb00d7a895e0cbb0c2e4fcbe5b370f234259',
+  },
+  { deviceId: '', kind: 'audiooutput', label: '', groupId: '' },
+] as MediaDeviceInfo[];
+
 export const mockCall = (): Partial<Call> => {
   const callState = new CallState();
   callState.setCallingState(CallingState.JOINED);

--- a/packages/client/src/devices/__tests__/mocks.ts
+++ b/packages/client/src/devices/__tests__/mocks.ts
@@ -6,7 +6,7 @@ import {
   OwnCapability,
 } from '../../gen/coordinator';
 import { Call } from '../../Call';
-import { of, Subject } from 'rxjs';
+import { of, ReplaySubject } from 'rxjs';
 import { BrowserPermission } from '../BrowserPermission';
 import { Tracer } from '../../stats';
 
@@ -284,9 +284,9 @@ export const createLocalStorageMock = (): LocalStorageMock => {
   };
 };
 
-let deviceIds: Subject<MediaDeviceInfo[]>;
+let deviceIds: ReplaySubject<MediaDeviceInfo[]>;
 export const mockDeviceIds$ = () => {
-  deviceIds = new Subject();
+  deviceIds = new ReplaySubject(1);
   return deviceIds;
 };
 


### PR DESCRIPTION
### 💡 Overview

This PR fixes an issue where the selected speaker was silently reset to the system default, so remote participants' audio played through the wrong output. `SpeakerManager` deselects the speaker when it disappears from the device list, but the check treated "not in the list" as "disconnected". Browsers withhold `audiooutput` device ids until **microphone** permission is granted, and `deviceIds$` caches its first enumeration, refreshing only on a hardware `devicechange` and  never on a permission change. If mic permission hasn't been granted yet when that first enumeration runs the cached snapshot holds no usable output ids for the rest of the session, so a valid selection matches nothing and gets wiped: synchronously, inside the very `select()` call that made it.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1082/speaker-selection-reset

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speaker selection reliability when audio device information is temporarily unavailable.
  * Preserved selected speakers while devices may reappear during later scans.
  * Cleared selections only when a previously available device is confirmed removed.
  * Improved handling of browser permissions, default speakers, and speaker setup errors.

* **Tests**
  * Expanded coverage for permission-limited devices, delayed detection, persistence, and default speaker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->