### PR TITLE
fix(client): use generated call reporting types and remove unused fields

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1142,7 +1142,6 @@ export class Call {
       callId: this.id,
       getCallSessionId: () => this.state.session?.id ?? '',
       getSfuId: () => this.credentials?.server.edge_name ?? '',
-      getUserSessionId: () => this.sfuClient?.sessionId ?? '',
     });
 
     this.joinResponseTimeout = joinResponseTimeout;

--- a/packages/client/src/gen/coordinator/index.ts
+++ b/packages/client/src/gen/coordinator/index.ts
@@ -8469,6 +8469,32 @@ export interface ReportByHistogramBucket {
   upper_bound?: Bound;
 }
 /**
+ * Reports a batch of client-side telemetry events. Each event is validated and processed independently; one invalid event does not block the rest of the batch.
+ * @export
+ * @interface ReportClientEventRequest
+ */
+export interface ReportClientEventRequest {
+  /**
+   * Client-side events to report (1-100 per request)
+   * @type {Array<ClientEvent>}
+   * @memberof ReportClientEventRequest
+   */
+  events: Array<ClientEvent>;
+}
+/**
+ * Response for reporting client-side telemetry events
+ * @export
+ * @interface ReportClientEventResponse
+ */
+export interface ReportClientEventResponse {
+  /**
+   * Duration of the request in milliseconds
+   * @type {string}
+   * @memberof ReportClientEventResponse
+   */
+  duration: string;
+}
+/**
  *
  * @export
  * @interface ReportResponse

--- a/packages/client/src/reporting/ClientEventReporter.ts
+++ b/packages/client/src/reporting/ClientEventReporter.ts
@@ -19,6 +19,11 @@ import type {
   BrowserPermissionState,
 } from '../devices/BrowserPermission';
 import { getCurrentValue } from '../store/rxUtils';
+import type {
+  ClientEvent,
+  ReportClientEventRequest,
+  ReportClientEventResponse,
+} from '../gen/coordinator';
 
 export type ClientEventPeerConnection = 'publish' | 'subscribe';
 
@@ -55,7 +60,6 @@ export type CallReportContext = {
   callId: string;
   getSfuId: () => string;
   getCallSessionId: () => string;
-  getUserSessionId: () => string;
 };
 
 export type ClientEventReporterOptions = {
@@ -80,7 +84,6 @@ type StagePairState = {
 
 type PeerConnectionPairState = StagePairState & {
   sfuId: string;
-  userSessionId: string;
   wasPreviouslyConnected: boolean;
   lastIceState?: RTCIceConnectionState;
 };
@@ -192,9 +195,7 @@ export class ClientEventReporter {
     this.coordinatorWsPair = undefined;
   };
 
-  private buildCoordinatorWsCommon = (
-    pair: StagePairState,
-  ): Record<string, unknown> => ({
+  private buildCoordinatorWsCommon = (pair: StagePairState): ClientEvent => ({
     user_id: pair.userIdSnapshot ?? this.streamClient.userID,
     stage: 'CoordinatorWS',
     stage_id: pair.sid,
@@ -383,7 +384,6 @@ export class ClientEventReporter {
       user_id: this.streamClient.userID || this.coordinatorConnectUserId,
       type: ctx?.callType,
       id: ctx?.callId,
-      call_cid: cid,
       stage: 'JoinInitiated',
       join_attempt_id: joinAttemptId,
       ...(coordinatorConnectId && {
@@ -608,7 +608,6 @@ export class ClientEventReporter {
       startedAt: Date.now(),
       joinAttemptIdSnapshot: this.joinAttemptIds.get(cid),
       sfuId: this.getSfuId(cid),
-      userSessionId: this.getUserSessionId(cid),
       wasPreviouslyConnected: this.pcEverConnected.get(key) === true,
       lastIceState: iceConnectionState,
     };
@@ -620,9 +619,6 @@ export class ClientEventReporter {
       peer_connection: role,
       was_previously_connected: pair.wasPreviouslyConnected,
       ...(pair.sfuId && { sfu_id: pair.sfuId }),
-      ...(pair.userSessionId && {
-        user_session_id: pair.userSessionId,
-      }),
       event_type: 'initiated',
     });
   };
@@ -641,9 +637,6 @@ export class ClientEventReporter {
       peer_connection: role,
       was_previously_connected: pair.wasPreviouslyConnected,
       ...(pair.sfuId && { sfu_id: pair.sfuId }),
-      ...(pair.userSessionId && {
-        user_session_id: pair.userSessionId,
-      }),
       event_type: 'completed',
       outcome: 'success',
       retry_count_attempt: 0,
@@ -667,9 +660,6 @@ export class ClientEventReporter {
       ...this.sessionIdField(cid),
       peer_connection: role,
       was_previously_connected: pair.wasPreviouslyConnected,
-      ...(pair.userSessionId && {
-        user_session_id: pair.userSessionId,
-      }),
       ...(pair.sfuId && { sfu_id: pair.sfuId }),
       event_type: 'completed',
       outcome: 'failure',
@@ -685,10 +675,7 @@ export class ClientEventReporter {
   private getSfuId = (cid: string): string =>
     this.callContexts.get(cid)?.getSfuId() ?? '';
 
-  private getUserSessionId = (cid: string): string =>
-    this.callContexts.get(cid)?.getUserSessionId() ?? '';
-
-  private sessionIdField = (cid: string): Record<string, unknown> => {
+  private sessionIdField = (cid: string): { call_session_id?: string } => {
     const callSessionId = this.callContexts.get(cid)?.getCallSessionId() ?? '';
     return callSessionId ? { call_session_id: callSessionId } : {};
   };
@@ -697,14 +684,13 @@ export class ClientEventReporter {
     cid: string,
     stage: ClientEventStage,
     pair: StagePairState,
-  ): Record<string, unknown> => {
+  ): ClientEvent => {
     const ctx = this.callContexts.get(cid);
     const coordinatorConnectId = this.coordinatorConnectId;
     return {
       user_id: this.streamClient.userID || this.coordinatorConnectUserId,
       type: ctx?.callType ?? '',
       id: ctx?.callId ?? '',
-      call_cid: cid,
       stage,
       stage_id: pair.sid,
       ...(pair.joinAttemptIdSnapshot && {
@@ -719,22 +705,23 @@ export class ClientEventReporter {
     };
   };
 
-  private send = (body: Record<string, unknown>) => {
+  private send = (body: ClientEvent) => {
     if (!this.enabled) return;
     void this.sendWithRetry(body);
   };
 
-  private sendForCall = (cid: string, body: Record<string, unknown>) => {
+  private sendForCall = (cid: string, body: ClientEvent) => {
     if (!this.callContexts.has(cid)) return;
     this.send(body);
   };
 
-  private sendWithRetry = async (
-    body: Record<string, unknown>,
-  ): Promise<boolean> => {
+  private sendWithRetry = async (body: ClientEvent): Promise<boolean> => {
     for (let attempt = 0; attempt < 5; attempt++) {
       try {
-        await this.streamClient.doAxiosRequest(
+        await this.streamClient.doAxiosRequest<
+          ReportClientEventResponse,
+          ReportClientEventRequest
+        >(
           'post',
           '/call_client_event',
           { events: [body] },

--- a/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
+++ b/packages/client/src/reporting/__tests__/ClientEventReporter.test.ts
@@ -77,7 +77,6 @@ describe('ClientEventReporter', () => {
       callId: 'call-1',
       getCallSessionId: () => 'session-1',
       getSfuId: () => 'sfu-1',
-      getUserSessionId: () => 'user-session-1',
     };
     reporter.registerCall(cid, ctx);
   });
@@ -91,7 +90,7 @@ describe('ClientEventReporter', () => {
     expect(events).toHaveLength(2);
     expect(events[0]).toMatchObject({
       event_type: 'initiated',
-      call_cid: cid,
+      id: 'call-1',
       user_id: 'user-1',
       coordinator_connect_id: connectId,
       join_reason: 'first-attempt',
@@ -523,7 +522,6 @@ describe('ClientEventReporter', () => {
       peer_connection: 'publish',
       was_previously_connected: false,
       sfu_id: 'sfu-1',
-      user_session_id: 'user-session-1',
     });
     expect(events[1]).toMatchObject({
       event_type: 'completed',
@@ -712,7 +710,6 @@ describe('ClientEventReporter', () => {
       callId: 'call-2',
       getCallSessionId: () => 'session-2',
       getSfuId: () => 'sfu-2',
-      getUserSessionId: () => 'user-session-2',
     });
 
     reporter.startCorrelation(cid, 'first-attempt');
@@ -722,10 +719,10 @@ describe('ClientEventReporter', () => {
     await flush();
 
     const ws1 = postedEvents().filter(
-      (e) => e.stage === 'WSJoin' && e.call_cid === cid,
+      (e) => e.stage === 'WSJoin' && e.id === 'call-1',
     );
     const ws2 = postedEvents().filter(
-      (e) => e.stage === 'WSJoin' && e.call_cid === cid2,
+      (e) => e.stage === 'WSJoin' && e.id === 'call-2',
     );
     expect(ws1).toHaveLength(2);
     expect(ws2).toHaveLength(2);
@@ -806,7 +803,6 @@ describe('ClientEventReporter (disabled)', () => {
       callId: 'call-1',
       getCallSessionId: () => 'session-1',
       getSfuId: () => 'sfu-1',
-      getUserSessionId: () => 'user-session-1',
     });
   });
 


### PR DESCRIPTION
### 💡 Overview

This PR improves call event reporting type coverage by using the generated coordinator request/response types for `call_client_event`. It also removes fields we no longer send from client reporting payloads, including `user_session_id` and `call_cid`, and cleans up the now-unused reporting context wiring.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call event reporting consistency by using call session identifiers.
  * Updated event association handling for more reliable call tracking.
  * Removed obsolete session information from reported client events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->