### PR TITLE
perf: emit per-module ESM builds for the React packages

### DIFF
--- a/packages/react-bindings/package.json
+++ b/packages/react-bindings/package.json
@@ -2,13 +2,13 @@
   "name": "@stream-io/video-react-bindings",
   "version": "1.20.0",
   "main": "./dist/index.cjs.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "license": "See license in LICENSE",
   "scripts": {
     "clean": "rimraf dist",
     "start": "rollup -c -w",
-    "build": "NODE_ENV=production rollup -c"
+    "build": "yarn clean && NODE_ENV=production rollup -c"
   },
   "sideEffects": false,
   "repository": {

--- a/packages/react-bindings/rollup.config.mjs
+++ b/packages/react-bindings/rollup.config.mjs
@@ -2,37 +2,54 @@ import typescript from '@rollup/plugin-typescript';
 
 import pkg from './package.json' with { type: 'json' };
 
+const external = [
+  ...Object.keys(pkg.dependencies || {}),
+  ...Object.keys(pkg.peerDependencies || {}),
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime',
+];
+
+const tsconfig =
+  process.env.NODE_ENV === 'production'
+    ? './tsconfig.production.json'
+    : './tsconfig.json';
+
 /**
+ * Per-module ESM output. Emitting one file per source module is what lets the
+ * consumer's bundler drop the modules it doesn't reach - a single fat bundle
+ * cannot be pruned below module granularity. Declarations come from the
+ * CommonJS pass, so this one only emits JavaScript.
+ *
  * @type {import('rollup').RollupOptions}
  */
-const config = {
+const esmConfig = {
   input: 'index.ts',
-  output: [
-    {
-      file: 'dist/index.es.js',
-      format: 'es',
-      sourcemap: true,
-    },
-    {
-      file: 'dist/index.cjs.js',
-      format: 'cjs',
-      sourcemap: true,
-    },
-  ],
-  external: [
-    ...Object.keys(pkg.dependencies || {}),
-    ...Object.keys(pkg.peerDependencies || {}),
-    'react/jsx-runtime',
-    'react/jsx-dev-runtime',
-  ],
-  plugins: [
-    typescript({
-      tsconfig:
-        process.env.NODE_ENV === 'production'
-          ? './tsconfig.production.json'
-          : './tsconfig.json',
-    }),
-  ],
+  output: {
+    dir: 'dist/esm',
+    format: 'es',
+    sourcemap: true,
+    preserveModules: true,
+    preserveModulesRoot: '.',
+    entryFileNames: '[name].js',
+  },
+  external,
+  plugins: [typescript({ tsconfig, outDir: 'dist/esm', declaration: false })],
 };
 
-export default [config];
+/**
+ * Bundlers do not tree-shake CommonJS, so this stays a single bundle.
+ *
+ * @type {import('rollup').RollupOptions}
+ */
+const cjsConfig = {
+  input: 'index.ts',
+  output: {
+    file: 'dist/index.cjs.js',
+    format: 'cjs',
+    sourcemap: true,
+  },
+  external,
+  plugins: [typescript({ tsconfig })],
+};
+
+export default [esmConfig, cjsConfig];

--- a/packages/react-sdk/CLAUDE.md
+++ b/packages/react-sdk/CLAUDE.md
@@ -539,13 +539,22 @@ Audio is simpler than video (no visibility concerns):
 ## Build System
 
 - **Rollup** for bundling (see `rollup.config.mjs`)
-- Produces 2 bundles:
-  - `dist/index.es.js` - ESM build
-  - `dist/index.cjs.js` - CommonJS build
+- Produces 3 builds:
+  - `dist/esm/` - ESM, one file per source module (`preserveModules`), covering
+    both the `index` and `embedded` entrypoints in a single pass so they share
+    their common modules
+  - `dist/index.cjs.js` - CommonJS, a single bundle
+  - `dist/embedded.cjs.js` - CommonJS, embedded entrypoint
+- ESM keeps per-module output so a consumer's bundler can tree-shake at module
+  granularity; CommonJS is never tree-shaken, so it stays a single bundle
+- `package.json#sideEffects` lists the CSS plus the entry files (they carry the
+  top-level `setSdkInfo` call) - every other module must stay side-effect free,
+  or tree-shaking silently stops working
 - CSS copied from `@stream-io/video-styling` during build
 - TypeScript compilation for type definitions
 - Source maps included
-- Special handling for lazy-loaded chunks (e.g., `CallStatsLatencyChart`)
+- Special handling for lazy-loaded chunks (e.g., `CallStatsLatencyChart`) applies
+  to the CommonJS builds; the ESM build has no chunks, every module is its own file
 
 ## Dependencies
 

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -2,17 +2,17 @@
   "name": "@stream-io/video-react-sdk",
   "version": "1.41.0",
   "main": "./dist/index.cjs.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/index.cjs.js"
     },
     "./embedded": {
       "types": "./dist/embedded.d.ts",
-      "import": "./dist/embedded.es.js",
+      "import": "./dist/esm/embedded.js",
       "require": "./dist/embedded.cjs.js"
     },
     "./dist/css/*": "./dist/css/*"
@@ -41,7 +41,11 @@
     "CHANGELOG.md"
   ],
   "sideEffects": [
-    "*.css"
+    "*.css",
+    "./dist/esm/index.js",
+    "./dist/esm/embedded.js",
+    "./dist/index.cjs.js",
+    "./dist/embedded.cjs.js"
   ],
   "dependencies": {
     "@floating-ui/react": "^0.27.20",

--- a/packages/react-sdk/rollup.config.mjs
+++ b/packages/react-sdk/rollup.config.mjs
@@ -26,83 +26,88 @@ const commonPlugins = [
   }),
 ];
 
+const external = [
+  ...Object.keys(pkg.dependencies || {}),
+  ...Object.keys(pkg.peerDependencies || {}),
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime',
+];
+
+const createTypescriptPlugin = (options) =>
+  typescript({
+    tsconfig:
+      process.env.NODE_ENV === 'production'
+        ? './tsconfig.production.json'
+        : './tsconfig.json',
+    ...options,
+  });
+
 /**
- * Main entrypoint configuration
+ * Per-module ESM output for both entrypoints.
+ *
+ * Emitting one file per source module is what lets the consumer's bundler drop
+ * the modules it doesn't reach - a single fat bundle cannot be pruned below
+ * module granularity. Both entrypoints share one config so the modules they
+ * have in common are emitted once instead of written twice into `dist/esm`.
+ *
+ * @type {import('rollup').RollupOptions}
  */
-const mainConfig = {
+const esmConfig = {
+  input: {
+    index: 'index.ts',
+    embedded: 'embedded.ts',
+  },
+  output: {
+    dir: 'dist/esm',
+    format: 'es',
+    sourcemap: true,
+    preserveModules: true,
+    preserveModulesRoot: '.',
+    entryFileNames: '[name].js',
+  },
+  external: [...external, '@stream-io/audio-filters-web'],
+  plugins: [
+    ...commonPlugins,
+    createTypescriptPlugin({ outDir: 'dist/esm', declaration: false }),
+  ],
+};
+
+/**
+ * Main entrypoint, CommonJS. Bundlers do not tree-shake CommonJS, so this stays
+ * a single bundle (plus the lazily loaded chunks).
+ *
+ * @type {import('rollup').RollupOptions}
+ */
+const mainCjsConfig = {
   input: 'index.ts',
-  output: [
-    {
-      dir: 'dist',
-      entryFileNames: 'index.es.js',
-      format: 'es',
-      sourcemap: true,
-      chunkFileNames,
-    },
-    {
-      dir: 'dist',
-      entryFileNames: 'index.cjs.js',
-      format: 'cjs',
-      sourcemap: true,
-      chunkFileNames,
-    },
-  ],
-  external: [
-    ...Object.keys(pkg.dependencies || {}),
-    ...Object.keys(pkg.peerDependencies || {}),
-    'react/jsx-runtime',
-    'react/jsx-dev-runtime',
-  ],
-  plugins: [
-    ...commonPlugins,
-    typescript({
-      tsconfig:
-        process.env.NODE_ENV === 'production'
-          ? './tsconfig.production.json'
-          : './tsconfig.json',
-    }),
-  ],
+  output: {
+    dir: 'dist',
+    entryFileNames: 'index.cjs.js',
+    format: 'cjs',
+    sourcemap: true,
+    chunkFileNames,
+  },
+  external,
+  plugins: [...commonPlugins, createTypescriptPlugin()],
 };
 
 /**
- * Embedded entrypoint configuration
+ * Embedded entrypoint, CommonJS.
+ *
+ * @type {import('rollup').RollupOptions}
  */
-const embeddedConfig = {
+const embeddedCjsConfig = {
   input: 'embedded.ts',
-  output: [
-    {
-      dir: 'dist',
-      entryFileNames: 'embedded.es.js',
-      format: 'es',
-      sourcemap: true,
-      chunkFileNames: (chunkInfo) =>
-        `embedded-${chunkInfo.name}-[hash].[format].js`,
-    },
-    {
-      dir: 'dist',
-      entryFileNames: 'embedded.cjs.js',
-      format: 'cjs',
-      sourcemap: true,
-      chunkFileNames: (chunkInfo) =>
-        `embedded-${chunkInfo.name}-[hash].[format].js`,
-    },
-  ],
-  external: [
-    ...Object.keys(pkg.dependencies || {}),
-    ...Object.keys(pkg.peerDependencies || {}),
-    '@stream-io/audio-filters-web',
-    'react/jsx-runtime',
-    'react/jsx-dev-runtime',
-  ],
-  plugins: [
-    ...commonPlugins,
-    typescript({
-      tsconfig:
-        process.env.NODE_ENV === 'production'
-          ? './tsconfig.production.json'
-          : './tsconfig.json',
-    }),
-  ],
+  output: {
+    dir: 'dist',
+    entryFileNames: 'embedded.cjs.js',
+    format: 'cjs',
+    sourcemap: true,
+    chunkFileNames: (chunkInfo) =>
+      `embedded-${chunkInfo.name}-[hash].[format].js`,
+  },
+  external: [...external, '@stream-io/audio-filters-web'],
+  plugins: [...commonPlugins, createTypescriptPlugin()],
 };
 
-export default [mainConfig, embeddedConfig];
+export default [esmConfig, mainCjsConfig, embeddedCjsConfig];

--- a/packages/video-filters-web/package.json
+++ b/packages/video-filters-web/package.json
@@ -2,13 +2,13 @@
   "name": "@stream-io/video-filters-web",
   "version": "0.8.6",
   "main": "./dist/index.cjs.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "license": "See license in LICENSE",
   "scripts": {
     "clean": "rimraf dist",
     "start": "rollup -c -w",
-    "build": "NODE_ENV=production rollup -c"
+    "build": "yarn clean && NODE_ENV=production rollup -c"
   },
   "repository": {
     "type": "git",

--- a/packages/video-filters-web/rollup.config.mjs
+++ b/packages/video-filters-web/rollup.config.mjs
@@ -3,35 +3,57 @@ import replace from '@rollup/plugin-replace';
 
 import pkg from './package.json' with { type: 'json' };
 
+const external = [
+  ...Object.keys(pkg.dependencies || {}),
+  ...Object.keys(pkg.peerDependencies || {}),
+];
+
+const createReplacePlugin = () =>
+  replace({
+    preventAssignment: true,
+    'process.env.PKG_NAME': JSON.stringify(pkg.name),
+    'process.env.PKG_VERSION': JSON.stringify(pkg.version),
+  });
+
 /**
+ * Per-module ESM output. Emitting one file per source module is what lets the
+ * consumer's bundler drop the modules it doesn't reach - a single fat bundle
+ * cannot be pruned below module granularity. Declarations come from the
+ * CommonJS pass, so this one only emits JavaScript.
+ *
  * @type {import('rollup').RollupOptions}
  */
-const config = {
+const esmConfig = {
   input: 'index.ts',
-  output: [
-    {
-      file: 'dist/index.es.js',
-      format: 'es',
-      sourcemap: true,
-    },
-    {
-      file: 'dist/index.cjs.js',
-      format: 'cjs',
-      sourcemap: true,
-    },
-  ],
-  external: [
-    ...Object.keys(pkg.dependencies || {}),
-    ...Object.keys(pkg.peerDependencies || {}),
-  ],
+  output: {
+    dir: 'dist/esm',
+    format: 'es',
+    sourcemap: true,
+    preserveModules: true,
+    preserveModulesRoot: '.',
+    entryFileNames: '[name].js',
+  },
+  external,
   plugins: [
-    replace({
-      preventAssignment: true,
-      'process.env.PKG_NAME': JSON.stringify(pkg.name),
-      'process.env.PKG_VERSION': JSON.stringify(pkg.version),
-    }),
-    typescript(),
+    createReplacePlugin(),
+    typescript({ outDir: 'dist/esm', declaration: false }),
   ],
 };
 
-export default [config];
+/**
+ * Bundlers do not tree-shake CommonJS, so this stays a single bundle.
+ *
+ * @type {import('rollup').RollupOptions}
+ */
+const cjsConfig = {
+  input: 'index.ts',
+  output: {
+    file: 'dist/index.cjs.js',
+    format: 'cjs',
+    sourcemap: true,
+  },
+  external,
+  plugins: [createReplacePlugin(), typescript()],
+};
+
+export default [esmConfig, cjsConfig];

--- a/scripts/bundle-size/measure.mts
+++ b/scripts/bundle-size/measure.mts
@@ -300,25 +300,26 @@ const CONFIG: PackageConfig[] = [
     entries: [
       {
         files: {
-          esm: [file('dist/index.es.js')],
+          esm: [tree('dist/esm')],
           cjs: [file('dist/index.cjs.js')],
         },
       },
     ],
   },
   {
+    // Both entrypoints share one `dist/esm` tree, so the whole tree is reported
+    // once under the main entry rather than split per entrypoint.
     package: '@stream-io/video-react-sdk',
     entries: [
       {
         files: {
-          esm: [file('dist/index.es.js')],
+          esm: [tree('dist/esm')],
           cjs: [file('dist/index.cjs.js')],
         },
       },
       {
         entry: 'embedded',
         files: {
-          esm: [file('dist/embedded.es.js')],
           cjs: [file('dist/embedded.cjs.js')],
         },
       },
@@ -329,7 +330,7 @@ const CONFIG: PackageConfig[] = [
     entries: [
       {
         files: {
-          esm: [file('dist/index.es.js')],
+          esm: [tree('dist/esm')],
           cjs: [file('dist/index.cjs.js')],
         },
       },


### PR DESCRIPTION
### 💡 Overview

ESM output for `@stream-io/video-react-sdk`, `@stream-io/video-react-bindings` and `@stream-io/video-filters-web` switches to rollup's `preserveModules`, so a consumer's bundler can drop the modules it never reaches. CommonJS is never tree-shaken by any bundler, so it stays a single bundle.

The benefit scales with how narrowly an app uses the component library. Measured across the sample apps (minified bytes, `NODE_ENV=production yarn build:all` on both sides):

| Sample app | Eager before | Eager after | Δ eager | Total before | Total after | Δ total |
|---|--:|--:|--:|--:|--:|--:|
| audio-rooms | 867.5 KB | 810.1 KB | **−6.6%** | 1198.9 KB | 810.1 KB | −32.4% |
| egress-composite | 1061.7 KB | 1049.8 KB | −1.1% | 1393.3 KB | 1049.8 KB | −24.7% |
| react-tutorial | 808.4 KB | 802.0 KB | −0.8% | 1139.9 KB | 802.0 KB | −29.6% |
| e2ee-demo | 831.9 KB | 826.7 KB | −0.6% | 1175.2 KB | 838.5 KB | −28.6% |
| livestream-app | 1541.7 KB | 1536.5 KB | −0.3% | 1873.1 KB | 1536.5 KB | −18.0% |
| zoom-clone | 2491.4 KB | 2487.3 KB | −0.2% | 2925.6 KB | 2590.0 KB | −11.5% |
| messenger-clone | 2643.8 KB | 2638.9 KB | −0.2% | 3078.0 KB | 2741.7 KB | −10.9% |
| react-dogfood (Next.js) | — | — | — | 11274.0 KB | 11345.1 KB | **+0.6%** |

"Eager" is the entry chunk every visitor downloads; "total" is everything deployed. Most of the total reduction is the `background-filters` and `latency-chart` chunks disappearing from apps that never render those components — real, but they were lazy, so it saves deploy bytes rather than load time.

Shipped package output gets smaller too, because react-sdk's `index` and `embedded` entrypoints now build in one pass instead of duplicating their shared modules:

| Package | Before | After | Δ | Files |
|---|--:|--:|--:|--:|
| video-react-sdk | 881,453 B | 822,276 B | −6.7% | 12 → 147 |
| video-react-bindings | 63,970 B | 66,032 B | +3.2% | 2 → 14 |
| video-filters-web | 241,254 B | 245,162 B | +1.6% | 2 → 24 |
| **Total** | **1,186,677 B** | **1,133,470 B** | **−4.5%** | 16 → 185 |

### 📝 Implementation notes

**`sideEffects` now lists the entry files.** `react-sdk/index.ts` calls `setSdkInfo()` at module top level. With a fat bundle that was safe by accident — the entry *was* the whole package. Under `preserveModules` the entry is a thin barrel, so a bundler rewrites imports straight to the inner module, finds the barrel unreferenced and side-effect-free, and deletes it along with that call. Verified both ways: the react-sdk version string appears once in a built consumer bundle with the entries listed, and zero times without them.

**`@stream-io/video-client` is deliberately excluded.** It was built both ways and measured. Splitting it hands a React app ~1.3 KB, while adding 70,768 B to the React Native Metro bundle (Metro does not tree-shake, so per-module output there is pure cost), doubling the Next.js regression, and taking the published file count from 185 to 403. The one case it would help — importing client utilities without ever constructing a `StreamVideoClient` — drops from 235.0 KB to 61.0 KB, but no sample app or reported consumer does that. Sourcemap attribution shows `video-client` contributing a flat ~259 KB to every app regardless of usage; shrinking it needs `Call.ts` (117 KB) and `CallState.ts` (49 KB) broken up, not module splitting.

**Rollup layout.** Each package gets a dedicated ESM config writing to `dist/esm` with `preserveModules`, `preserveModulesRoot: '.'` and `entryFileNames: '[name].js'`; the CommonJS config keeps `output.file` / `inlineDynamicImports`, both of which are incompatible with `preserveModules`. `@rollup/plugin-typescript` requires its `outDir` to sit inside rollup's `dir`, so the ESM configs pass `outDir: 'dist/esm', declaration: false` and declarations continue to come from the CommonJS pass into `dist/index.d.ts` + `dist/src/`. react-sdk's `chunkFileNames` helper is retained for the CommonJS builds, which still rely on it for the lazy `BackgroundFilters` / `CallStatsLatencyChart` splits; the ESM build produces no chunks.

**`module` / `exports` repointed** to `./dist/esm/index.js` (and `./dist/esm/embedded.js`). `main`, `types` and `./dist/css/*` are unchanged, so CommonJS consumers and CSS imports are unaffected. Type resolution verified under `bundler`, `node16` and `nodenext` for all three packages including the `./embedded` subpath. `types` moved to the first condition of `exports["."]` to match `exports["./embedded"]`.

**Build scripts.** `react-bindings` and `video-filters-web` gain `yarn clean &&`, which they lacked — without it the removed `dist/index.es.js` lingers in a local `dist`.

**Not a breaking change in practice.** react-sdk's `exports` map already restricted subpaths to `.`, `./embedded` and `./dist/css/*`, so `dist/index.es.js` was not reachable by modern resolvers. The other two packages have no `exports` map, so an undocumented deep import of `dist/index.es.js` would break.

### ⚠️ Note for reviewers

`scripts/bundle-size/measure.mts` now walks `dist/esm` as a tree. The `video-react-sdk (embedded)` row changes flavour from `esm` to `cjs` — both entrypoints share one ESM tree, which is reported once under the main entry — so the sticky bundle-size comment will show that row as removed/new once. Package *shipped* size is what that comment measures, which is not what this change optimises; it happens to move the right way here for an unrelated reason.

Known pre-existing issue, untouched: sourcemap `sources` paths in these packages do not resolve to the real source tree (they were wrong before this change too). `inlineSources` is enabled, so devtools still show the source. Happy to fix separately.

🎫 Ticket: n/a

📑 Docs: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimized, tree-shakable ESM builds for React bindings, React SDK, and video filters.
  * Preserved CommonJS builds for compatibility.
  * Updated package entry points to use the new ESM module structure.
* **Bug Fixes**
  * Build processes now clean previous output before generating production bundles.
* **Documentation**
  * Updated build documentation to describe ESM modules, CommonJS bundles, shared modules, and lazy-loaded chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->