### PR TITLE
fix(client): cancel in-flight joins when the user leaves

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1182,6 +1182,12 @@ export class Call {
               delete joinData.migrating_from_list;
               return;
             } catch (err) {
+              // the user left mid-attempt: the failure is a consequence of that,
+              // so resolve quietly instead of rejecting `join()`
+              if (supersededByLeave()) {
+                this.logger.debug('Join superseded by leave; discarding error');
+                return;
+              }
               this.logger.warn(`Failed to join call (${attempt})`, this.cid);
               if (
                 (err instanceof ErrorFromResponse && err.unrecoverable) ||
@@ -1278,6 +1284,12 @@ export class Call {
           'CoordinatorJoin',
           () => this.doJoinRequest(data, supersededByLeave),
         );
+        if (supersededByLeave()) {
+          this.logger.debug(
+            'Join superseded by leave; discarding join response',
+          );
+          return 'superseded';
+        }
         this.credentials = joinResponse.credentials;
         statsOptions = joinResponse.stats_options;
         this.lastStatsOptions = statsOptions;
@@ -1294,11 +1306,6 @@ export class Call {
         }
         throw error;
       }
-    }
-
-    if (supersededByLeave()) {
-      this.logger.debug('Join superseded by leave; not creating an SFU client');
-      return 'superseded';
     }
 
     const previousSfuClient = this.sfuClient;
@@ -1360,6 +1367,12 @@ export class Call {
 
       const unifiedSessionId = this.unifiedSessionId;
       const capabilities = Array.from(this.clientCapabilities);
+      if (supersededByLeave()) {
+        this.logger.debug(
+          'Join superseded by leave; skipping the join request',
+        );
+        return 'superseded';
+      }
       try {
         const { callState, fastReconnectDeadlineSeconds, publishOptions } =
           await this.clientEventReporter.track(this.cid, 'WSJoin', () =>

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -129,7 +129,7 @@ import {
   TrackMuteType,
   VideoTrackType,
 } from './types';
-import { BehaviorSubject, Subject, takeWhile } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { ReconnectDetails } from './gen/video/sfu/event/events';
 import {
   ClientCapability,
@@ -716,17 +716,6 @@ export class Call {
       }
 
       this.leaveGeneration += 1;
-
-      if (callingState === CallingState.JOINING) {
-        const waitUntilCallJoined = () => {
-          return new Promise<void>((resolve) => {
-            this.state.callingState$
-              .pipe(takeWhile((state) => state !== CallingState.JOINED, true))
-              .subscribe(() => resolve());
-          });
-        };
-        await waitUntilCallJoined();
-      }
 
       if (callingState === CallingState.RINGING && reject !== false) {
         if (reject) {
@@ -1333,6 +1322,16 @@ export class Call {
     this.unifiedSessionId ??= sfuClient.sessionId;
     this.trackSubscriptionManager.setSfuClient(sfuClient);
 
+    const abandonJoin = () => {
+      if (previousSfuClient !== sfuClient) {
+        previousSfuClient?.close(
+          StreamSfuClient.DISPOSE_OLD_SOCKET,
+          'Join superseded by leave',
+        );
+      }
+      return 'superseded' as const;
+    };
+
     const clientDetails = await getClientDetails();
     // we don't need to send JoinRequest if we are re-using an existing healthy SFU client
     if (previousSfuClient !== sfuClient) {
@@ -1344,7 +1343,7 @@ export class Call {
       // skip if a leave superseded this join so codec detection doesn't resolve to a default factory.
       if (supersededByLeave()) {
         this.logger.debug('Join superseded by leave; skipping codec detection');
-        return 'superseded';
+        return abandonJoin();
       }
       const [subscriberSdp, publisherSdp] = await Promise.all([
         getGenericSdp('recvonly', dangerouslyForceCodec, subscriberFmtpLine),
@@ -1371,7 +1370,7 @@ export class Call {
         this.logger.debug(
           'Join superseded by leave; skipping the join request',
         );
-        return 'superseded';
+        return abandonJoin();
       }
       try {
         const { callState, fastReconnectDeadlineSeconds, publishOptions } =
@@ -1406,7 +1405,7 @@ export class Call {
           'Join request failed, connection considered unhealthy',
         );
         // restore the previous call state if the join-flow fails, unless a
-        // `leave()` won the race in the meantime (LEFT must stick)
+        // `leave()` happened in the meantime
         if (!supersededByLeave()) {
           this.state.setCallingState(callingState);
         }
@@ -1418,7 +1417,7 @@ export class Call {
     // peer-connection setup below (both run synchronously after this, so one check covers them).
     if (supersededByLeave()) {
       this.logger.debug('Join superseded by leave; aborting join flow');
-      return 'superseded';
+      return abandonJoin();
     }
 
     if (!performingMigration) {

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -2194,9 +2194,22 @@ export class Call {
       delete this.joinCallData?.migrating_from_list;
     }
 
+    const releasePreMigrationResources = async () => {
+      await currentSubscriber?.dispose();
+      await currentPublisher?.dispose();
+
+      // and close the previous SFU client, without specifying close code
+      currentSfuClient.close(StreamSfuClient.NORMAL_CLOSURE, 'Migrating away');
+    };
+
     // a `leave()` happened while joining: skip the restores and, crucially, the
-    // unconditional `JOINED` transition below
-    if (outcome === 'superseded') return;
+    // unconditional `JOINED` transition below. Release the pre-migration
+    // resources here -- `leave()` only tears down what the `Call` holds now, and
+    // the join may already have swapped in new instances.
+    if (outcome === 'superseded') {
+      await releasePreMigrationResources();
+      return;
+    }
 
     await this.restorePublishedTracks();
     this.restoreSubscribedTracks();
@@ -2212,11 +2225,7 @@ export class Call {
       // the `migrationTask`
       this.state.setCallingState(CallingState.JOINED);
     } finally {
-      await currentSubscriber?.dispose();
-      await currentPublisher?.dispose();
-
-      // and close the previous SFU client, without specifying close code
-      currentSfuClient.close(StreamSfuClient.NORMAL_CLOSURE, 'Migrating away');
+      await releasePreMigrationResources();
     }
     this.sfuStatsReporter?.sendReconnectionTime(
       WebsocketReconnectStrategy.MIGRATE,

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -1121,6 +1121,10 @@ export class Call {
       throw new Error(`Illegal State: call.join() shall be called only once`);
     }
 
+    const joinLeaveGeneration = this.leaveGeneration;
+    const supersededByLeave = () =>
+      this.leaveGeneration !== joinLeaveGeneration;
+
     // we need this to be set before the callingx.joinCall() is
     // called to avoid registering the test call in the CallKit/Telecom
     this.allowOwnTracksLoopback = allowOwnTracksLoopback;
@@ -1133,6 +1137,12 @@ export class Call {
     if (callingX) {
       // for Android/iOS, we need to start the call in the callingx library as soon as possible
       await callingX.joinCall(this, this.clientStore.calls);
+    }
+
+    // guard in case CallKit/Telecom)registration took more time than leave() to complete
+    if (supersededByLeave()) {
+      this.logger.debug('Join superseded by leave; skipping join');
+      return;
     }
 
     await this.setup();
@@ -1159,6 +1169,12 @@ export class Call {
         'first-attempt',
         async () => {
           for (let attempt = 0; attempt < maxJoinRetries; attempt++) {
+            // when superseded by leave, an error while doJoin() (an SFU WS timeout, say)
+            // would request a next attempt, we prevent that here
+            if (supersededByLeave()) {
+              this.logger.debug('Join superseded by leave; stopping retries');
+              return;
+            }
             try {
               this.logger.trace(`Joining call (${attempt})`, this.cid);
               await this.doJoin(data);
@@ -1216,7 +1232,9 @@ export class Call {
    *
    * @returns a promise which resolves once the call join-flow has finished.
    */
-  private doJoin = async (data?: JoinCallData): Promise<void> => {
+  private doJoin = async (
+    data?: JoinCallData,
+  ): Promise<'joined' | 'superseded'> => {
     const connectStartTime = Date.now();
     const callingState = this.state.callingState;
     const joinLeaveGeneration = this.leaveGeneration;
@@ -1258,15 +1276,17 @@ export class Call {
         const joinResponse = await this.clientEventReporter.track(
           this.cid,
           'CoordinatorJoin',
-          () => this.doJoinRequest(data),
+          () => this.doJoinRequest(data, supersededByLeave),
         );
         this.credentials = joinResponse.credentials;
         statsOptions = joinResponse.stats_options;
         this.lastStatsOptions = statsOptions;
       } catch (error) {
-        // prevent triggering reconnect flow if the state is OFFLINE
+        // prevent triggering reconnect flow if the state is OFFLINE, and never
+        // restore over a `leave()` that happened while this join was in flight
         const avoidRestoreState =
-          this.state.callingState === CallingState.OFFLINE;
+          this.state.callingState === CallingState.OFFLINE ||
+          supersededByLeave();
 
         if (!avoidRestoreState) {
           // restore the previous call state if the join-flow fails
@@ -1274,6 +1294,11 @@ export class Call {
         }
         throw error;
       }
+    }
+
+    if (supersededByLeave()) {
+      this.logger.debug('Join superseded by leave; not creating an SFU client');
+      return 'superseded';
     }
 
     const previousSfuClient = this.sfuClient;
@@ -1312,7 +1337,7 @@ export class Call {
       // skip if a leave superseded this join so codec detection doesn't resolve to a default factory.
       if (supersededByLeave()) {
         this.logger.debug('Join superseded by leave; skipping codec detection');
-        return;
+        return 'superseded';
       }
       const [subscriberSdp, publisherSdp] = await Promise.all([
         getGenericSdp('recvonly', dangerouslyForceCodec, subscriberFmtpLine),
@@ -1367,8 +1392,11 @@ export class Call {
           StreamSfuClient.JOIN_FAILED,
           'Join request failed, connection considered unhealthy',
         );
-        // restore the previous call state if the join-flow fails
-        this.state.setCallingState(callingState);
+        // restore the previous call state if the join-flow fails, unless a
+        // `leave()` won the race in the meantime (LEFT must stick)
+        if (!supersededByLeave()) {
+          this.state.setCallingState(callingState);
+        }
         throw error;
       }
     }
@@ -1377,7 +1405,7 @@ export class Call {
     // peer-connection setup below (both run synchronously after this, so one check covers them).
     if (supersededByLeave()) {
       this.logger.debug('Join superseded by leave; aborting join flow');
-      return;
+      return 'superseded';
     }
 
     if (!performingMigration) {
@@ -1402,6 +1430,7 @@ export class Call {
         publishOptions: this.currentPublishOptions || [],
         closePreviousInstances: !performingMigration,
         unifiedSessionId: this.unifiedSessionId,
+        isStale: supersededByLeave,
       });
     }
 
@@ -1462,7 +1491,16 @@ export class Call {
     // rolling window decays naturally as old timestamps age out.
     this.consecutiveNegotiationFailures = 0;
 
+    // Closing the previous SFU socket and applying the device settings above are
+    // further awaits, each a window for a `leave()`. Report the cancellation
+    // rather than a join, so callers skip their post-join work.
+    if (supersededByLeave()) {
+      this.logger.debug('Join superseded by leave; not reporting a join');
+      return 'superseded';
+    }
+
     this.logger.info(`Joined call ${this.cid}`);
+    return 'joined';
   };
 
   /**
@@ -1585,6 +1623,7 @@ export class Call {
     publishOptions: PublishOption[];
     closePreviousInstances: boolean;
     unifiedSessionId: string;
+    isStale?: () => boolean;
   }) => {
     const {
       sfuClient,
@@ -1594,6 +1633,7 @@ export class Call {
       publishOptions,
       closePreviousInstances,
       unifiedSessionId,
+      isStale,
     } = opts;
     const {
       enable_rtc_stats: enableTracing,
@@ -1608,6 +1648,13 @@ export class Call {
       await this.subscriber.dispose();
       this.state.removeAllOrphanedTracks();
     }
+    // While stats was flushed a `leave()` can complete in between.
+    // Skip pc setup if so
+    if (isStale?.()) {
+      this.logger.debug('Left during peer connection setup; not creating one');
+      return;
+    }
+
     const basePeerConnectionOptions: BasePeerConnectionOpts = {
       sfuClient,
       dispatcher: this.dispatcher,
@@ -1653,6 +1700,10 @@ export class Call {
       if (closePreviousInstances && this.publisher) {
         await this.publisher.dispose();
       }
+      if (isStale?.()) {
+        this.logger.debug('Left during peer connection setup; stopping');
+        return;
+      }
       this.publisher = new Publisher(
         basePeerConnectionOptions,
         publishOptions,
@@ -1696,7 +1747,10 @@ export class Call {
    * @internal
    * @param data the join call data.
    */
-  doJoinRequest = async (data?: JoinCallData): Promise<JoinCallResponse> => {
+  doJoinRequest = async (
+    data?: JoinCallData,
+    isStale?: () => boolean,
+  ): Promise<JoinCallResponse> => {
     const location = await this.streamClient.getLocationHint();
     const e2ee = !!this.e2eeManager;
     const request: JoinCallRequest = { ...data, location, e2ee };
@@ -1704,6 +1758,15 @@ export class Call {
       JoinCallResponse,
       JoinCallRequest
     >(`${this.streamClientBasePath}/join`, request);
+
+    if (isStale?.()) {
+      // leave() happened while the join request was in flight
+      // skipping any update from response
+      this.logger.debug(
+        'Join request completed after leave; dropping response',
+      );
+      return joinResponse;
+    }
 
     this.state.updateFromCallResponse(joinResponse.call);
     this.state.setMembers(joinResponse.members);
@@ -1823,7 +1886,8 @@ export class Call {
       callingState === CallingState.JOINING ||
       callingState === CallingState.RECONNECTING ||
       callingState === CallingState.MIGRATING ||
-      callingState === CallingState.RECONNECTING_FAILED
+      callingState === CallingState.RECONNECTING_FAILED ||
+      callingState === CallingState.LEFT
     )
       return;
 
@@ -2054,7 +2118,7 @@ export class Call {
     const reconnectStartTime = Date.now();
     this.reconnectStrategy = WebsocketReconnectStrategy.FAST;
     this.state.setCallingState(CallingState.RECONNECTING);
-    await this.doJoin(this.joinCallData);
+    if ((await this.doJoin(this.joinCallData)) === 'superseded') return;
     await this.get(); // fetch the latest call state, as it might have changed
     this.sfuStatsReporter?.sendReconnectionTime(
       WebsocketReconnectStrategy.FAST,
@@ -2074,9 +2138,13 @@ export class Call {
       this.reconnectReason === ReconnectReason.NETWORK_BACK_ONLINE
         ? 'network-available'
         : 'full-rejoin';
-    await this.clientEventReporter.withJoinLifecycle(this.cid, joinReason, () =>
-      this.doJoin(this.joinCallData),
+    const outcome = await this.clientEventReporter.withJoinLifecycle(
+      this.cid,
+      joinReason,
+      () => this.doJoin(this.joinCallData),
     );
+    // don't restore tracks onto a call the user left mid-join
+    if (outcome === 'superseded') return;
     await this.restorePublishedTracks();
     this.restoreSubscribedTracks();
     this.sfuStatsReporter?.sendReconnectionTime(
@@ -2106,9 +2174,10 @@ export class Call {
 
     const migrationTask = makeSafePromise(currentSfuClient.enterMigration());
 
+    let outcome: 'joined' | 'superseded';
     try {
       const currentSfu = currentSfuClient.edgeName;
-      await this.clientEventReporter.withJoinLifecycle(
+      outcome = await this.clientEventReporter.withJoinLifecycle(
         this.cid,
         'migration',
         () =>
@@ -2124,6 +2193,10 @@ export class Call {
       delete this.joinCallData?.migrating_from;
       delete this.joinCallData?.migrating_from_list;
     }
+
+    // a `leave()` happened while joining: skip the restores and, crucially, the
+    // unconditional `JOINED` transition below
+    if (outcome === 'superseded') return;
 
     await this.restorePublishedTracks();
     this.restoreSubscribedTracks();

--- a/packages/client/src/__tests__/Call.lifecycle.test.ts
+++ b/packages/client/src/__tests__/Call.lifecycle.test.ts
@@ -12,9 +12,9 @@ import { generateUUIDv4 } from '../coordinator/connection/utils';
 import { CallingState, StreamVideoWriteableStateStore } from '../store';
 import { WebsocketReconnectStrategy } from '../gen/video/sfu/models/models';
 
-const deferred = () => {
-  let resolve = () => {};
-  const promise = new Promise<void>((r) => {
+const deferred = <T = void>() => {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((r) => {
     resolve = r;
   });
   return { promise, resolve };
@@ -203,7 +203,7 @@ describe('Call lifecycle wiring', () => {
     vi.spyOn(streamClient, 'getLocationHint').mockResolvedValue('hint');
     const accept = vi.spyOn(call, 'accept').mockResolvedValue({} as never);
     const registerOrUpdateCall = vi.spyOn(clientStore, 'registerOrUpdateCall');
-    const coordinatorJoin = deferred();
+    const coordinatorJoin = deferred<unknown>();
     const post = vi
       .spyOn(streamClient, 'post')
       .mockReturnValue(coordinatorJoin.promise as Promise<never>);
@@ -226,7 +226,7 @@ describe('Call lifecycle wiring', () => {
         },
       },
       stats_options: { reporting_interval_ms: 0, enable_rtc_stats: false },
-    } as never);
+    });
     await joining;
 
     expect(call.state.callingState).toBe(CallingState.LEFT);

--- a/packages/client/src/__tests__/Call.lifecycle.test.ts
+++ b/packages/client/src/__tests__/Call.lifecycle.test.ts
@@ -218,68 +218,77 @@ describe('Call lifecycle wiring', () => {
   // to IDLE and re-registers the call), and MIGRATE sets JOINED unconditionally
   // once the migration task settles.
   describe.each([
-    { strategy: 'reconnectFast' as const, expectRevivedTo: 'idle' },
-    { strategy: 'reconnectMigrate' as const, expectRevivedTo: 'joined' },
-  ])('$strategy after a cancelled join', ({ strategy }) => {
-    it('performs no post-join work', async () => {
-      vi.spyOn(streamClient, '_hasConnectionID').mockReturnValue(true);
-      vi.spyOn(streamClient, 'get').mockResolvedValue({
-        call: { settings: {} },
-        members: [],
-        own_capabilities: [],
-      } as never);
-      vi.spyOn(call.state, 'updateFromCallResponse').mockImplementation(
-        () => {},
-      );
-      vi.spyOn(call.state, 'setMembers').mockImplementation(() => {});
-      vi.spyOn(call.state, 'setOwnCapabilities').mockImplementation(() => {});
-      // @ts-expect-error stubbing a private member for the test
-      vi.spyOn(call, 'applyDeviceConfig').mockResolvedValue(undefined);
-      // @ts-expect-error stubbing a private member for the test
-      vi.spyOn(call, 'restorePublishedTracks').mockResolvedValue(undefined);
-      // @ts-expect-error stubbing a private member for the test
-      vi.spyOn(call, 'restoreSubscribedTracks').mockImplementation(() => {});
-      // @ts-expect-error a minimal SFU client, only the migration path uses it
-      call.sfuClient = {
-        edgeName: 'sfu-a',
-        sessionId: 'session-a',
-        isHealthy: false,
-        enterMigration: () => Promise.resolve(),
-        leaveAndClose: async () => {},
-        close: () => {},
-      };
+    // only MIGRATE keeps pre-migration instances that its own cleanup owns
+    { strategy: 'reconnectFast' as const, releasesPreMigration: false },
+    { strategy: 'reconnectMigrate' as const, releasesPreMigration: true },
+  ])(
+    '$strategy after a cancelled join',
+    ({ strategy, releasesPreMigration }) => {
+      it('performs no post-join work', async () => {
+        vi.spyOn(streamClient, '_hasConnectionID').mockReturnValue(true);
+        vi.spyOn(streamClient, 'get').mockResolvedValue({
+          call: { settings: {} },
+          members: [],
+          own_capabilities: [],
+        } as never);
+        vi.spyOn(call.state, 'updateFromCallResponse').mockImplementation(
+          () => {},
+        );
+        vi.spyOn(call.state, 'setMembers').mockImplementation(() => {});
+        vi.spyOn(call.state, 'setOwnCapabilities').mockImplementation(() => {});
+        // @ts-expect-error stubbing a private member for the test
+        vi.spyOn(call, 'applyDeviceConfig').mockResolvedValue(undefined);
+        // @ts-expect-error stubbing a private member for the test
+        vi.spyOn(call, 'restorePublishedTracks').mockResolvedValue(undefined);
+        // @ts-expect-error stubbing a private member for the test
+        vi.spyOn(call, 'restoreSubscribedTracks').mockImplementation(() => {});
+        const close = vi.fn();
+        // @ts-expect-error a minimal SFU client, only the migration path uses it
+        call.sfuClient = {
+          edgeName: 'sfu-a',
+          sessionId: 'session-a',
+          isHealthy: false,
+          enterMigration: () => Promise.resolve(),
+          leaveAndClose: async () => {},
+          close,
+        };
 
-      let joinStarted = () => {};
-      const joinInFlight = new Promise<void>((resolve) => {
-        joinStarted = resolve;
+        let joinStarted = () => {};
+        const joinInFlight = new Promise<void>((resolve) => {
+          joinStarted = resolve;
+        });
+        let finishJoin = () => {};
+        const joinBlocked = new Promise<void>((resolve) => {
+          finishJoin = resolve;
+        });
+        // what `doJoin` reports once a `leave()` has superseded it
+        // @ts-expect-error stubbing a private member for the test
+        call.doJoin = vi.fn(async () => {
+          joinStarted();
+          await joinBlocked;
+          return 'superseded' as const;
+        });
+
+        // @ts-expect-error invoking a private member for the test
+        const reconnect = call[strategy]();
+        await joinInFlight;
+
+        // the user hangs up mid-reconnect
+        await call.leave();
+        expect(call.state.callingState).toBe(CallingState.LEFT);
+
+        finishJoin();
+        await reconnect;
+
+        expect(call.state.callingState).toBe(CallingState.LEFT);
+        expect(clientStore.calls).not.toContain(call);
+        // the pre-migration SFU client is only ever released by the migration
+        // itself: `leave()` tears down what the `Call` holds, which by then is the
+        // client the cancelled join swapped in
+        expect(close).toHaveBeenCalledTimes(releasesPreMigration ? 1 : 0);
       });
-      let finishJoin = () => {};
-      const joinBlocked = new Promise<void>((resolve) => {
-        finishJoin = resolve;
-      });
-      // what `doJoin` reports once a `leave()` has superseded it
-      // @ts-expect-error stubbing a private member for the test
-      call.doJoin = vi.fn(async () => {
-        joinStarted();
-        await joinBlocked;
-        return 'superseded' as const;
-      });
-
-      // @ts-expect-error invoking a private member for the test
-      const reconnect = call[strategy]();
-      await joinInFlight;
-
-      // the user hangs up mid-reconnect
-      await call.leave();
-      expect(call.state.callingState).toBe(CallingState.LEFT);
-
-      finishJoin();
-      await reconnect;
-
-      expect(call.state.callingState).toBe(CallingState.LEFT);
-      expect(clientStore.calls).not.toContain(call);
-    });
-  });
+    },
+  );
 
   // `initPublisherAndSubscriber` awaits twice before it is done creating the new
   // instances: the previous reporter's final sample and the old peer connections'

--- a/packages/client/src/__tests__/Call.lifecycle.test.ts
+++ b/packages/client/src/__tests__/Call.lifecycle.test.ts
@@ -12,6 +12,38 @@ import { generateUUIDv4 } from '../coordinator/connection/utils';
 import { CallingState, StreamVideoWriteableStateStore } from '../store';
 import { WebsocketReconnectStrategy } from '../gen/video/sfu/models/models';
 
+const deferred = () => {
+  let resolve = () => {};
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+};
+
+/** Blocks the first call until `gate` resolves; later calls pass through, so a
+ *  concurrent `leave()` making the same call can still complete. */
+const blockFirstCall = (gate: Promise<void>, onReached: () => void) => {
+  let calls = 0;
+  return async () => {
+    if (++calls === 1) {
+      onReached();
+      await gate;
+    }
+  };
+};
+
+const fakeSfuClient = (overrides: Record<string, unknown> = {}) => ({
+  tag: '1',
+  edgeName: 'sfu-a',
+  sessionId: 'session-a',
+  isHealthy: false,
+  enterMigration: () => Promise.resolve(),
+  leaveAndClose: async () => {},
+  close: () => {},
+  getTrace: () => undefined,
+  ...overrides,
+});
+
 describe('Call lifecycle wiring', () => {
   let call: Call;
   let streamClient: StreamClient;
@@ -30,7 +62,21 @@ describe('Call lifecycle wiring', () => {
       clientEventReporter,
       clientStore,
     });
+    // pass-through: the join lifecycle reporting is not under test here
+    vi.spyOn(clientEventReporter, 'withJoinLifecycle').mockImplementation(
+      (_cid, _reason, op) => op(),
+    );
   });
+
+  /** Stubs everything a coordinator response would otherwise apply. */
+  const stubResponseHandling = () => {
+    vi.spyOn(streamClient, '_hasConnectionID').mockReturnValue(true);
+    vi.spyOn(call.state, 'setMembers').mockImplementation(() => {});
+    vi.spyOn(call.state, 'setOwnCapabilities').mockImplementation(() => {});
+    return vi
+      .spyOn(call.state, 'updateFromCallResponse')
+      .mockImplementation(() => {});
+  };
 
   // Regression guard for the Call-owned helper teardown chain. Each of
   // these helpers holds a resource (timer, listener, AudioContext) that
@@ -75,110 +121,99 @@ describe('Call lifecycle wiring', () => {
     expect(audioBindingsOrder).toBeLessThan(dynascaleOrder);
   });
 
-  // Regression guard for the leave-during-join race. With a blocked SFU each
-  // join attempt burns the WS-open timeout, so the retry loop can still be
-  // running when the user hits hang up. A retry started after `leave()` puts
-  // the calling state back to JOINING/JOINED and the call screen reappears,
-  // which is what makes hang up look like it did nothing.
-  it('stops join retries when the user leaves mid-join', async () => {
-    vi.spyOn(clientEventReporter, 'withJoinLifecycle').mockImplementation(
-      (_cid, _reason, fn) => fn(),
-    );
-    const doJoin = vi.fn(async () => {
-      // the user hangs up while this attempt is in flight
-      await call.leave();
-      throw new Error('SFU WS connection failed to open after 5000ms');
+  // With a blocked SFU every attempt burns the WS-open timeout, so the retry
+  // loop is still running when the user hits hang up. A later attempt would put
+  // the calling state back to JOINING/JOINED and the call screen would reappear,
+  // which is what makes hang up look like it did nothing. On the final attempt
+  // the failure is rethrown, which used to reject `join()` (and end the call by
+  // cid with an `error` reason) for what the user asked for.
+  describe.each([3, 1])('with maxJoinRetries: %i', (maxJoinRetries) => {
+    it('resolves without reviving the call when a leave lands mid-attempt', async () => {
+      const doJoin = vi.fn(async () => {
+        await call.leave();
+        throw new Error('SFU WS connection failed to open after 5000ms');
+      });
+      // @ts-expect-error stubbing a private member for the test
+      call.doJoin = doJoin;
+
+      await expect(call.join({ maxJoinRetries })).resolves.toBeUndefined();
+
+      expect(doJoin).toHaveBeenCalledTimes(1);
+      expect(call.state.callingState).toBe(CallingState.LEFT);
     });
-    // @ts-expect-error overriding a private member for the test
+  });
+
+  // The same, for a hangup during the backoff between two attempts: the next
+  // attempt snapshots the already-bumped leave generation as its own baseline,
+  // so only the loop can stop it.
+  it('starts no further attempt when a leave lands during the retry backoff', async () => {
+    const doJoin = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('SFU WS connection failed'))
+      .mockResolvedValue('joined');
+    // @ts-expect-error stubbing a private member for the test
     call.doJoin = doJoin;
 
-    await call.join({ maxJoinRetries: 3 });
+    const joining = call.join({ maxJoinRetries: 3 });
+    // the first attempt fails, then the user hangs up while the loop sleeps
+    await vi.waitFor(() => expect(doJoin).toHaveBeenCalled());
+    await call.leave();
+    await joining;
 
     expect(doJoin).toHaveBeenCalledTimes(1);
     expect(call.state.callingState).toBe(CallingState.LEFT);
   });
 
-  // Same race, but through the React Native native-registration preflight:
-  // `join()` awaits CallKit/Telecom registration before anything else, which is
-  // long enough for a native `endCall` to complete a full `leave()`. The join
-  // must not carry on (and `setup()` must not revive LEFT back to IDLE).
+  // On React Native `join()` awaits CallKit/Telecom registration before anything
+  // else, which is long enough for a native `endCall` to complete a full
+  // `leave()`. The join must not carry on, and `setup()` must not revive LEFT.
   it('abandons the join when the user leaves during native registration', async () => {
-    let releaseNativeRegistration = () => {};
-    const nativeRegistration = new Promise<void>((resolve) => {
-      releaseNativeRegistration = resolve;
-    });
-    const streamRNVideoSDK = {
+    const nativeRegistration = deferred();
+    // @ts-expect-error partial RN SDK bridge, only the join/leave path is used
+    globalThis.streamRNVideoSDK = {
       callingX: {
-        joinCall: vi.fn(() => nativeRegistration),
+        joinCall: vi.fn(() => nativeRegistration.promise),
         endCall: vi.fn(),
         unwireAudioEngineSubscription: vi.fn(),
       },
       callManager: { stop: vi.fn() },
     };
-    // @ts-expect-error partial RN SDK bridge, only the join/leave path is used
-    globalThis.streamRNVideoSDK = streamRNVideoSDK;
-
     const doJoin = vi.fn();
-    // @ts-expect-error overriding a private member for the test
+    // @ts-expect-error stubbing a private member for the test
     call.doJoin = doJoin;
 
-    const joinPromise = call.join();
-    // the user hangs up (e.g. the CallKit `endCall` event) while the native
-    // registration is still pending
+    const joining = call.join();
     await call.leave();
     expect(call.state.callingState).toBe(CallingState.LEFT);
 
-    releaseNativeRegistration();
-    await joinPromise;
+    nativeRegistration.resolve();
+    await joining;
 
     expect(doJoin).not.toHaveBeenCalled();
     expect(call.state.callingState).toBe(CallingState.LEFT);
   });
 
-  // A `leave()` can also complete while the coordinator join request is still
-  // in flight. Its response must be discarded: `doJoinRequest` re-registers the
-  // call in the client store (which `leave()` just undid), and the SFU client
-  // created afterwards is invisible to the teardown that already ran, so its
-  // socket and listeners would never be closed.
+  // A `leave()` can also complete while the coordinator join request is in
+  // flight. Applying the response would repopulate a left call, re-register it
+  // in the client store, and tell the caller we accepted a call the user just
+  // hung up. Caching its credentials would make the next `join()` skip the
+  // coordinator block -- and with it the store registration.
   it('discards the coordinator join response when the user already left', async () => {
-    vi.spyOn(clientEventReporter, 'withJoinLifecycle').mockImplementation(
-      (_cid, _reason, fn) => fn(),
-    );
-    vi.spyOn(streamClient, '_hasConnectionID').mockReturnValue(true);
+    const updateFromCallResponse = stubResponseHandling();
     vi.spyOn(streamClient, 'getLocationHint').mockResolvedValue('hint');
-    // mocked so the assertions below can't be satisfied by a throwing state
-    // update -- each one must be provably never reached
-    const updateFromCallResponse = vi
-      .spyOn(call.state, 'updateFromCallResponse')
-      .mockImplementation(() => {});
-    const setMembers = vi
-      .spyOn(call.state, 'setMembers')
-      .mockImplementation(() => {});
-    const setOwnCapabilities = vi
-      .spyOn(call.state, 'setOwnCapabilities')
-      .mockImplementation(() => {});
     const accept = vi.spyOn(call, 'accept').mockResolvedValue({} as never);
     const registerOrUpdateCall = vi.spyOn(clientStore, 'registerOrUpdateCall');
-    const unregisterCall = vi.spyOn(clientStore, 'unregisterCall');
-
-    let respondToCoordinator: (response: unknown) => void = () => {};
-    const coordinatorJoin = new Promise((resolve) => {
-      respondToCoordinator = resolve;
-    });
+    const coordinatorJoin = deferred();
     const post = vi
       .spyOn(streamClient, 'post')
-      .mockReturnValue(coordinatorJoin as Promise<never>);
+      .mockReturnValue(coordinatorJoin.promise as Promise<never>);
 
-    const joinPromise = call.join();
+    const joining = call.join();
     await vi.waitFor(() => expect(post).toHaveBeenCalled());
-
-    // the user hangs up before the coordinator responds
     await call.leave();
     expect(call.state.callingState).toBe(CallingState.LEFT);
-    // `leave()` unregisters the call itself; only later calls are of interest
-    const unregisterCallsAfterLeave = unregisterCall.mock.calls.length;
 
-    respondToCoordinator({
+    coordinatorJoin.resolve({
       call: {},
       members: [],
       own_capabilities: [],
@@ -191,194 +226,139 @@ describe('Call lifecycle wiring', () => {
         },
       },
       stats_options: { reporting_interval_ms: 0, enable_rtc_stats: false },
-    });
-    await joinPromise;
+    } as never);
+    await joining;
 
     expect(call.state.callingState).toBe(CallingState.LEFT);
     expect(clientStore.calls).not.toContain(call);
-    // @ts-expect-error reading a private member for the test
-    expect(call.sfuClient).toBeUndefined();
-    // none of the response's side effects may be applied -- they are not
-    // undoable, and `accept()` would tell the caller we picked up a call the
-    // user just hung up
+    expect(call.watching).toBe(false);
     expect(updateFromCallResponse).not.toHaveBeenCalled();
-    expect(setMembers).not.toHaveBeenCalled();
-    expect(setOwnCapabilities).not.toHaveBeenCalled();
     expect(accept).not.toHaveBeenCalled();
     expect(registerOrUpdateCall).not.toHaveBeenCalled();
-    expect(call.watching).toBe(false);
-    // compensating for a registration that never happened is not attempt-scoped:
-    // with a reused `Call` instance it would evict a newer, live join
-    expect(unregisterCall.mock.calls.length).toBe(unregisterCallsAfterLeave);
+    // @ts-expect-error reading a private member for the test
+    expect(call.sfuClient).toBeUndefined();
+    // @ts-expect-error reading a private member for the test
+    expect(call.credentials).toBeUndefined();
+    // @ts-expect-error reading a private member for the test
+    expect(call.lastStatsOptions).toBeUndefined();
   });
 
   // Reconnection runs on its own concurrency tag, so a hangup can land in the
   // middle of it. `doJoin` cancels itself, but its callers used to carry on with
   // post-join work regardless: FAST calls `get()` (whose `setup()` revives LEFT
   // to IDLE and re-registers the call), and MIGRATE sets JOINED unconditionally
-  // once the migration task settles.
+  // once the migration task settles. MIGRATE also owns the release of the
+  // pre-migration instances, which `leave()` no longer holds by then.
   describe.each([
-    // only MIGRATE keeps pre-migration instances that its own cleanup owns
     { strategy: 'reconnectFast' as const, releasesPreMigration: false },
     { strategy: 'reconnectMigrate' as const, releasesPreMigration: true },
   ])(
     '$strategy after a cancelled join',
     ({ strategy, releasesPreMigration }) => {
       it('performs no post-join work', async () => {
-        vi.spyOn(streamClient, '_hasConnectionID').mockReturnValue(true);
+        stubResponseHandling();
         vi.spyOn(streamClient, 'get').mockResolvedValue({
           call: { settings: {} },
           members: [],
           own_capabilities: [],
         } as never);
-        vi.spyOn(call.state, 'updateFromCallResponse').mockImplementation(
-          () => {},
-        );
-        vi.spyOn(call.state, 'setMembers').mockImplementation(() => {});
-        vi.spyOn(call.state, 'setOwnCapabilities').mockImplementation(() => {});
-        // @ts-expect-error stubbing a private member for the test
+        // @ts-expect-error stubbing private members for the test
         vi.spyOn(call, 'applyDeviceConfig').mockResolvedValue(undefined);
-        // @ts-expect-error stubbing a private member for the test
+        // @ts-expect-error stubbing private members for the test
         vi.spyOn(call, 'restorePublishedTracks').mockResolvedValue(undefined);
-        // @ts-expect-error stubbing a private member for the test
+        // @ts-expect-error stubbing private members for the test
         vi.spyOn(call, 'restoreSubscribedTracks').mockImplementation(() => {});
         const close = vi.fn();
-        // @ts-expect-error a minimal SFU client, only the migration path uses it
-        call.sfuClient = {
-          edgeName: 'sfu-a',
-          sessionId: 'session-a',
-          isHealthy: false,
-          enterMigration: () => Promise.resolve(),
-          leaveAndClose: async () => {},
-          close,
-        };
+        // @ts-expect-error a minimal SFU client for the reconnect paths
+        call.sfuClient = fakeSfuClient({ close });
 
-        let joinStarted = () => {};
-        const joinInFlight = new Promise<void>((resolve) => {
-          joinStarted = resolve;
-        });
-        let finishJoin = () => {};
-        const joinBlocked = new Promise<void>((resolve) => {
-          finishJoin = resolve;
-        });
-        // what `doJoin` reports once a `leave()` has superseded it
+        const join = deferred();
+        const joinInFlight = deferred();
         // @ts-expect-error stubbing a private member for the test
         call.doJoin = vi.fn(async () => {
-          joinStarted();
-          await joinBlocked;
+          joinInFlight.resolve();
+          await join.promise;
+          // what `doJoin` reports once a `leave()` has superseded it
           return 'superseded' as const;
         });
 
         // @ts-expect-error invoking a private member for the test
         const reconnect = call[strategy]();
-        await joinInFlight;
-
-        // the user hangs up mid-reconnect
+        await joinInFlight.promise;
         await call.leave();
         expect(call.state.callingState).toBe(CallingState.LEFT);
 
-        finishJoin();
+        join.resolve();
         await reconnect;
 
         expect(call.state.callingState).toBe(CallingState.LEFT);
         expect(clientStore.calls).not.toContain(call);
-        // the pre-migration SFU client is only ever released by the migration
-        // itself: `leave()` tears down what the `Call` holds, which by then is the
-        // client the cancelled join swapped in
         expect(close).toHaveBeenCalledTimes(releasesPreMigration ? 1 : 0);
       });
     },
   );
 
   // `initPublisherAndSubscriber` awaits twice before it is done creating the new
-  // instances: the previous reporter's final sample and the old peer connections'
-  // disposal. A `leave()` can complete in either window, and anything created
-  // afterwards is invisible to the teardown that already ran: leaked peer
-  // connections keep reporting stats and can trigger a reconnect through
-  // `onReconnectionNeeded`.
-  describe.each(['the final stats sample', 'the publisher disposal'])(
-    'a leave during %s',
-    (window) => {
-      it('leaves no peer connections behind', async () => {
-        let release = () => {};
-        const blocked = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        let reachedWindow = () => {};
-        const inWindow = new Promise<void>((resolve) => {
-          reachedWindow = resolve;
-        });
-        // block only the call made by the setup below; `leave()` makes the same
-        // calls and has to be able to complete
-        let blockedCalls = 0;
-        const blockOnce = async () => {
-          blockedCalls++;
-          if (blockedCalls === 1) {
-            reachedWindow();
-            await blocked;
-          }
-        };
-        const blockingFinalSample = window === 'the final stats sample';
+  // instances: the previous reporter's final sample, and the old publisher's
+  // disposal. A `leave()` completing in either window would leave peer
+  // connections and reporters behind that its teardown never sees -- they keep
+  // reporting stats and can trigger a reconnect via `onReconnectionNeeded`.
+  describe.each([
+    { window: 'the final stats sample', blockFlush: true },
+    { window: 'the publisher disposal', blockFlush: false },
+  ])('a leave during $window', ({ blockFlush }) => {
+    it('leaves no peer connections behind', async () => {
+      const gate = deferred();
+      const inWindow = deferred();
+      const block = blockFirstCall(gate.promise, inWindow.resolve);
+      // @ts-expect-error stubbing a private member for the test
+      call.sfuStatsReporter = {
+        flush: blockFlush ? block : async () => {},
+        stop: () => {},
+      };
+      if (!blockFlush) {
+        // the previous publisher, disposed after the first staleness check and
+        // before the new publisher and the reporters are created
         // @ts-expect-error stubbing a private member for the test
-        call.sfuStatsReporter = {
-          flush: blockingFinalSample ? blockOnce : async () => {},
-          stop: () => {},
-        };
-        if (!blockingFinalSample) {
-          // the previous publisher, disposed after the first staleness check
-          // and before the new publisher and reporters are created
-          // @ts-expect-error stubbing a private member for the test
-          call.publisher = { dispose: blockOnce };
-        }
-        const sfuClient = {
-          tag: '1',
-          edgeName: 'sfu-a',
-          sessionId: 'session-a',
-          isHealthy: true,
-          leaveAndClose: async () => {},
-          close: () => {},
-          getTrace: () => undefined,
-        };
-        // @ts-expect-error a minimal SFU client for the peer-connection setup
-        call.sfuClient = sfuClient;
-        // @ts-expect-error reading a private member for the test
-        const generation = call.leaveGeneration;
+        call.publisher = { dispose: block };
+      }
+      const sfuClient = fakeSfuClient({ isHealthy: true });
+      // @ts-expect-error a minimal SFU client for the peer-connection setup
+      call.sfuClient = sfuClient;
+      // @ts-expect-error reading a private member for the test
+      const generation = call.leaveGeneration;
 
-        // @ts-expect-error invoking a private member for the test
-        const setupPeerConnections = call.initPublisherAndSubscriber({
-          sfuClient,
-          connectionConfig: {},
-          clientDetails: {},
-          statsOptions: {
-            enable_rtc_stats: false,
-            reporting_interval_ms: 2000,
-          },
-          publishOptions: [],
-          closePreviousInstances: true,
-          unifiedSessionId: 'unified-1',
-          // the predicate `doJoin` passes: the same leave-generation comparison
-          // @ts-expect-error reading a private member for the test
-          isStale: () => call.leaveGeneration !== generation,
-        });
-        await inWindow;
-
-        await call.leave();
-        expect(call.state.callingState).toBe(CallingState.LEFT);
-
-        release();
-        await setupPeerConnections;
-
+      // @ts-expect-error invoking a private member for the test
+      const setupPeerConnections = call.initPublisherAndSubscriber({
+        sfuClient,
+        connectionConfig: {},
+        clientDetails: {},
+        statsOptions: { enable_rtc_stats: false, reporting_interval_ms: 2000 },
+        publishOptions: [],
+        closePreviousInstances: true,
+        unifiedSessionId: 'unified-1',
+        // the predicate `doJoin` passes: the same leave-generation comparison
         // @ts-expect-error reading a private member for the test
-        expect(call.subscriber).toBeUndefined();
-        // @ts-expect-error reading a private member for the test
-        expect(call.publisher).toBeUndefined();
-        // @ts-expect-error reading a private member for the test
-        expect(call.statsReporter).toBeUndefined();
-        // @ts-expect-error reading a private member for the test
-        expect(call.sfuStatsReporter).toBeUndefined();
+        isStale: () => call.leaveGeneration !== generation,
       });
-    },
-  );
+      await inWindow.promise;
+
+      await call.leave();
+      expect(call.state.callingState).toBe(CallingState.LEFT);
+
+      gate.resolve();
+      await setupPeerConnections;
+
+      // @ts-expect-error reading private members for the test
+      expect(call.subscriber).toBeUndefined();
+      // @ts-expect-error reading private members for the test
+      expect(call.publisher).toBeUndefined();
+      // @ts-expect-error reading private members for the test
+      expect(call.statsReporter).toBeUndefined();
+      // @ts-expect-error reading private members for the test
+      expect(call.sfuStatsReporter).toBeUndefined();
+    });
+  });
 
   // Defense in depth for the same class of escape: whatever manages to call
   // `reconnect()` after teardown (a peer connection that outlived it, a late SFU

--- a/packages/client/src/__tests__/Call.lifecycle.test.ts
+++ b/packages/client/src/__tests__/Call.lifecycle.test.ts
@@ -9,19 +9,26 @@ import { Call } from '../Call';
 import { StreamClient } from '../coordinator/connection/client';
 import { ClientEventReporter } from '../reporting';
 import { generateUUIDv4 } from '../coordinator/connection/utils';
-import { StreamVideoWriteableStateStore } from '../store';
+import { CallingState, StreamVideoWriteableStateStore } from '../store';
+import { WebsocketReconnectStrategy } from '../gen/video/sfu/models/models';
 
 describe('Call lifecycle wiring', () => {
   let call: Call;
+  let streamClient: StreamClient;
+  let clientEventReporter: ClientEventReporter;
+  let clientStore: StreamVideoWriteableStateStore;
 
   beforeEach(() => {
-    const streamClient = new StreamClient('abc');
+    delete globalThis.streamRNVideoSDK;
+    streamClient = new StreamClient('abc');
+    clientEventReporter = new ClientEventReporter({ streamClient });
+    clientStore = new StreamVideoWriteableStateStore();
     call = new Call({
       type: 'test',
       id: generateUUIDv4(),
       streamClient,
-      clientEventReporter: new ClientEventReporter({ streamClient }),
-      clientStore: new StreamVideoWriteableStateStore(),
+      clientEventReporter,
+      clientStore,
     });
   });
 
@@ -66,5 +73,317 @@ describe('Call lifecycle wiring', () => {
 
     expect(trackSubOrder).toBeLessThan(audioBindingsOrder);
     expect(audioBindingsOrder).toBeLessThan(dynascaleOrder);
+  });
+
+  // Regression guard for the leave-during-join race. With a blocked SFU each
+  // join attempt burns the WS-open timeout, so the retry loop can still be
+  // running when the user hits hang up. A retry started after `leave()` puts
+  // the calling state back to JOINING/JOINED and the call screen reappears,
+  // which is what makes hang up look like it did nothing.
+  it('stops join retries when the user leaves mid-join', async () => {
+    vi.spyOn(clientEventReporter, 'withJoinLifecycle').mockImplementation(
+      (_cid, _reason, fn) => fn(),
+    );
+    const doJoin = vi.fn(async () => {
+      // the user hangs up while this attempt is in flight
+      await call.leave();
+      throw new Error('SFU WS connection failed to open after 5000ms');
+    });
+    // @ts-expect-error overriding a private member for the test
+    call.doJoin = doJoin;
+
+    await call.join({ maxJoinRetries: 3 });
+
+    expect(doJoin).toHaveBeenCalledTimes(1);
+    expect(call.state.callingState).toBe(CallingState.LEFT);
+  });
+
+  // Same race, but through the React Native native-registration preflight:
+  // `join()` awaits CallKit/Telecom registration before anything else, which is
+  // long enough for a native `endCall` to complete a full `leave()`. The join
+  // must not carry on (and `setup()` must not revive LEFT back to IDLE).
+  it('abandons the join when the user leaves during native registration', async () => {
+    let releaseNativeRegistration = () => {};
+    const nativeRegistration = new Promise<void>((resolve) => {
+      releaseNativeRegistration = resolve;
+    });
+    const streamRNVideoSDK = {
+      callingX: {
+        joinCall: vi.fn(() => nativeRegistration),
+        endCall: vi.fn(),
+        unwireAudioEngineSubscription: vi.fn(),
+      },
+      callManager: { stop: vi.fn() },
+    };
+    // @ts-expect-error partial RN SDK bridge, only the join/leave path is used
+    globalThis.streamRNVideoSDK = streamRNVideoSDK;
+
+    const doJoin = vi.fn();
+    // @ts-expect-error overriding a private member for the test
+    call.doJoin = doJoin;
+
+    const joinPromise = call.join();
+    // the user hangs up (e.g. the CallKit `endCall` event) while the native
+    // registration is still pending
+    await call.leave();
+    expect(call.state.callingState).toBe(CallingState.LEFT);
+
+    releaseNativeRegistration();
+    await joinPromise;
+
+    expect(doJoin).not.toHaveBeenCalled();
+    expect(call.state.callingState).toBe(CallingState.LEFT);
+  });
+
+  // A `leave()` can also complete while the coordinator join request is still
+  // in flight. Its response must be discarded: `doJoinRequest` re-registers the
+  // call in the client store (which `leave()` just undid), and the SFU client
+  // created afterwards is invisible to the teardown that already ran, so its
+  // socket and listeners would never be closed.
+  it('discards the coordinator join response when the user already left', async () => {
+    vi.spyOn(clientEventReporter, 'withJoinLifecycle').mockImplementation(
+      (_cid, _reason, fn) => fn(),
+    );
+    vi.spyOn(streamClient, '_hasConnectionID').mockReturnValue(true);
+    vi.spyOn(streamClient, 'getLocationHint').mockResolvedValue('hint');
+    // mocked so the assertions below can't be satisfied by a throwing state
+    // update -- each one must be provably never reached
+    const updateFromCallResponse = vi
+      .spyOn(call.state, 'updateFromCallResponse')
+      .mockImplementation(() => {});
+    const setMembers = vi
+      .spyOn(call.state, 'setMembers')
+      .mockImplementation(() => {});
+    const setOwnCapabilities = vi
+      .spyOn(call.state, 'setOwnCapabilities')
+      .mockImplementation(() => {});
+    const accept = vi.spyOn(call, 'accept').mockResolvedValue({} as never);
+    const registerOrUpdateCall = vi.spyOn(clientStore, 'registerOrUpdateCall');
+    const unregisterCall = vi.spyOn(clientStore, 'unregisterCall');
+
+    let respondToCoordinator: (response: unknown) => void = () => {};
+    const coordinatorJoin = new Promise((resolve) => {
+      respondToCoordinator = resolve;
+    });
+    const post = vi
+      .spyOn(streamClient, 'post')
+      .mockReturnValue(coordinatorJoin as Promise<never>);
+
+    const joinPromise = call.join();
+    await vi.waitFor(() => expect(post).toHaveBeenCalled());
+
+    // the user hangs up before the coordinator responds
+    await call.leave();
+    expect(call.state.callingState).toBe(CallingState.LEFT);
+    // `leave()` unregisters the call itself; only later calls are of interest
+    const unregisterCallsAfterLeave = unregisterCall.mock.calls.length;
+
+    respondToCoordinator({
+      call: {},
+      members: [],
+      own_capabilities: [],
+      credentials: {
+        token: 'token',
+        server: {
+          url: 'https://sfu.example.com/twirp',
+          ws_endpoint: 'wss://sfu.example.com/ws',
+          edge_name: 'test-sfu',
+        },
+      },
+      stats_options: { reporting_interval_ms: 0, enable_rtc_stats: false },
+    });
+    await joinPromise;
+
+    expect(call.state.callingState).toBe(CallingState.LEFT);
+    expect(clientStore.calls).not.toContain(call);
+    // @ts-expect-error reading a private member for the test
+    expect(call.sfuClient).toBeUndefined();
+    // none of the response's side effects may be applied -- they are not
+    // undoable, and `accept()` would tell the caller we picked up a call the
+    // user just hung up
+    expect(updateFromCallResponse).not.toHaveBeenCalled();
+    expect(setMembers).not.toHaveBeenCalled();
+    expect(setOwnCapabilities).not.toHaveBeenCalled();
+    expect(accept).not.toHaveBeenCalled();
+    expect(registerOrUpdateCall).not.toHaveBeenCalled();
+    expect(call.watching).toBe(false);
+    // compensating for a registration that never happened is not attempt-scoped:
+    // with a reused `Call` instance it would evict a newer, live join
+    expect(unregisterCall.mock.calls.length).toBe(unregisterCallsAfterLeave);
+  });
+
+  // Reconnection runs on its own concurrency tag, so a hangup can land in the
+  // middle of it. `doJoin` cancels itself, but its callers used to carry on with
+  // post-join work regardless: FAST calls `get()` (whose `setup()` revives LEFT
+  // to IDLE and re-registers the call), and MIGRATE sets JOINED unconditionally
+  // once the migration task settles.
+  describe.each([
+    { strategy: 'reconnectFast' as const, expectRevivedTo: 'idle' },
+    { strategy: 'reconnectMigrate' as const, expectRevivedTo: 'joined' },
+  ])('$strategy after a cancelled join', ({ strategy }) => {
+    it('performs no post-join work', async () => {
+      vi.spyOn(streamClient, '_hasConnectionID').mockReturnValue(true);
+      vi.spyOn(streamClient, 'get').mockResolvedValue({
+        call: { settings: {} },
+        members: [],
+        own_capabilities: [],
+      } as never);
+      vi.spyOn(call.state, 'updateFromCallResponse').mockImplementation(
+        () => {},
+      );
+      vi.spyOn(call.state, 'setMembers').mockImplementation(() => {});
+      vi.spyOn(call.state, 'setOwnCapabilities').mockImplementation(() => {});
+      // @ts-expect-error stubbing a private member for the test
+      vi.spyOn(call, 'applyDeviceConfig').mockResolvedValue(undefined);
+      // @ts-expect-error stubbing a private member for the test
+      vi.spyOn(call, 'restorePublishedTracks').mockResolvedValue(undefined);
+      // @ts-expect-error stubbing a private member for the test
+      vi.spyOn(call, 'restoreSubscribedTracks').mockImplementation(() => {});
+      // @ts-expect-error a minimal SFU client, only the migration path uses it
+      call.sfuClient = {
+        edgeName: 'sfu-a',
+        sessionId: 'session-a',
+        isHealthy: false,
+        enterMigration: () => Promise.resolve(),
+        leaveAndClose: async () => {},
+        close: () => {},
+      };
+
+      let joinStarted = () => {};
+      const joinInFlight = new Promise<void>((resolve) => {
+        joinStarted = resolve;
+      });
+      let finishJoin = () => {};
+      const joinBlocked = new Promise<void>((resolve) => {
+        finishJoin = resolve;
+      });
+      // what `doJoin` reports once a `leave()` has superseded it
+      // @ts-expect-error stubbing a private member for the test
+      call.doJoin = vi.fn(async () => {
+        joinStarted();
+        await joinBlocked;
+        return 'superseded' as const;
+      });
+
+      // @ts-expect-error invoking a private member for the test
+      const reconnect = call[strategy]();
+      await joinInFlight;
+
+      // the user hangs up mid-reconnect
+      await call.leave();
+      expect(call.state.callingState).toBe(CallingState.LEFT);
+
+      finishJoin();
+      await reconnect;
+
+      expect(call.state.callingState).toBe(CallingState.LEFT);
+      expect(clientStore.calls).not.toContain(call);
+    });
+  });
+
+  // `initPublisherAndSubscriber` awaits twice before it is done creating the new
+  // instances: the previous reporter's final sample and the old peer connections'
+  // disposal. A `leave()` can complete in either window, and anything created
+  // afterwards is invisible to the teardown that already ran: leaked peer
+  // connections keep reporting stats and can trigger a reconnect through
+  // `onReconnectionNeeded`.
+  describe.each(['the final stats sample', 'the publisher disposal'])(
+    'a leave during %s',
+    (window) => {
+      it('leaves no peer connections behind', async () => {
+        let release = () => {};
+        const blocked = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        let reachedWindow = () => {};
+        const inWindow = new Promise<void>((resolve) => {
+          reachedWindow = resolve;
+        });
+        // block only the call made by the setup below; `leave()` makes the same
+        // calls and has to be able to complete
+        let blockedCalls = 0;
+        const blockOnce = async () => {
+          blockedCalls++;
+          if (blockedCalls === 1) {
+            reachedWindow();
+            await blocked;
+          }
+        };
+        const blockingFinalSample = window === 'the final stats sample';
+        // @ts-expect-error stubbing a private member for the test
+        call.sfuStatsReporter = {
+          flush: blockingFinalSample ? blockOnce : async () => {},
+          stop: () => {},
+        };
+        if (!blockingFinalSample) {
+          // the previous publisher, disposed after the first staleness check
+          // and before the new publisher and reporters are created
+          // @ts-expect-error stubbing a private member for the test
+          call.publisher = { dispose: blockOnce };
+        }
+        const sfuClient = {
+          tag: '1',
+          edgeName: 'sfu-a',
+          sessionId: 'session-a',
+          isHealthy: true,
+          leaveAndClose: async () => {},
+          close: () => {},
+          getTrace: () => undefined,
+        };
+        // @ts-expect-error a minimal SFU client for the peer-connection setup
+        call.sfuClient = sfuClient;
+        // @ts-expect-error reading a private member for the test
+        const generation = call.leaveGeneration;
+
+        // @ts-expect-error invoking a private member for the test
+        const setupPeerConnections = call.initPublisherAndSubscriber({
+          sfuClient,
+          connectionConfig: {},
+          clientDetails: {},
+          statsOptions: {
+            enable_rtc_stats: false,
+            reporting_interval_ms: 2000,
+          },
+          publishOptions: [],
+          closePreviousInstances: true,
+          unifiedSessionId: 'unified-1',
+          // the predicate `doJoin` passes: the same leave-generation comparison
+          // @ts-expect-error reading a private member for the test
+          isStale: () => call.leaveGeneration !== generation,
+        });
+        await inWindow;
+
+        await call.leave();
+        expect(call.state.callingState).toBe(CallingState.LEFT);
+
+        release();
+        await setupPeerConnections;
+
+        // @ts-expect-error reading a private member for the test
+        expect(call.subscriber).toBeUndefined();
+        // @ts-expect-error reading a private member for the test
+        expect(call.publisher).toBeUndefined();
+        // @ts-expect-error reading a private member for the test
+        expect(call.statsReporter).toBeUndefined();
+        // @ts-expect-error reading a private member for the test
+        expect(call.sfuStatsReporter).toBeUndefined();
+      });
+    },
+  );
+
+  // Defense in depth for the same class of escape: whatever manages to call
+  // `reconnect()` after teardown (a peer connection that outlived it, a late SFU
+  // socket close) must not re-join the call behind the user's back.
+  it('does not reconnect a call that has been left', async () => {
+    const doJoin = vi.fn();
+    // @ts-expect-error stubbing a private member for the test
+    call.doJoin = doJoin;
+
+    await call.leave();
+    // @ts-expect-error invoking a private member for the test
+    await call.reconnect(WebsocketReconnectStrategy.REJOIN, 'test');
+
+    expect(doJoin).not.toHaveBeenCalled();
+    expect(call.state.callingState).toBe(CallingState.LEFT);
   });
 });


### PR DESCRIPTION
### 💡 Overview

`leave()` now cancels a join completely: no further retries, no coordinator response applied, no peer connections or reporters created, and reconnect callers skip post-join work on a left call.

### 📝 Implementation notes

Reuses the existing supersededByLeave pattern.

Now also checked in the retry loop and at each await in doJoin, and surfaced as a 'joined' | 'superseded' result for reconnect callers.

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved call lifecycle handling when leaving during an ongoing join or reconnection.
  - Prevented stale connection attempts from restoring call state or creating unnecessary media connections.
  - Ensured resources are released after cancelled joins, migrations, and reconnections.
  - Improved cancellation during retries and peer-connection setup.
  - Ensured calls remain correctly marked as left after a join is superseded.
  - Improved lifecycle reporting by removing outdated session identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->