### PR TITLE
fix(client): keep devices disabled when querying calls

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -936,11 +936,7 @@ export class Call {
     // const calls = useCalls().filter((c) => c.ringing);
     const calls = this.clientStore.calls.filter((c) => c.cid !== this.cid);
     this.clientStore.setCalls([this, ...calls]);
-    const skipSpeakerApply = isReactNative();
-    await this.applyDeviceConfig(settings, {
-      publish: false,
-      skipSpeakerApply,
-    });
+    await this.applyDeviceConfig(settings, { publish: false });
   };
 
   /**
@@ -976,12 +972,7 @@ export class Call {
       this.watching = true;
       this.clientStore.registerOrUpdateCall(this);
     }
-    // Skip speaker setup on RN if ringing was requested or the call is already ringing
-    const skipSpeakerApply = isReactNative();
-    await this.applyDeviceConfig(response.call.settings, {
-      publish: false,
-      skipSpeakerApply,
-    });
+    await this.applyDeviceConfig(response.call.settings, { publish: false });
 
     return response;
   };
@@ -1012,12 +1003,7 @@ export class Call {
       this.clientStore.registerOrUpdateCall(this);
     }
 
-    // Skip speaker setup on RN if ringing was requested or the call is already ringing
-    const skipSpeakerApply = isReactNative();
-    await this.applyDeviceConfig(response.call.settings, {
-      publish: false,
-      skipSpeakerApply,
-    });
+    await this.applyDeviceConfig(response.call.settings, { publish: false });
 
     return response;
   };
@@ -3378,11 +3364,16 @@ export class Call {
     settings: CallSettingsResponse,
     opts: {
       publish: boolean;
-      skipSpeakerApply: boolean;
+      skipSpeakerApply?: boolean;
       withDisabledDevices?: boolean;
     },
   ) => {
-    const { publish, skipSpeakerApply, withDisabledDevices } = opts;
+    const {
+      publish,
+      // Skip speaker setup on RN if ringing was requested or the call is already ringing
+      skipSpeakerApply = isReactNative(),
+      withDisabledDevices,
+    } = opts;
     if (!skipSpeakerApply) {
       await this.speaker.apply(settings).catch((err) => {
         this.logger.warn('Speaker init failed', err);

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -3375,9 +3375,9 @@ export class Call {
       withDisabledDevices,
     } = opts;
     if (!skipSpeakerApply) {
-      await this.speaker.apply(settings).catch((err) => {
-        this.logger.warn('Speaker init failed', err);
-      });
+      await this.speaker
+        .apply(settings)
+        .catch((err) => this.logger.warn('Speaker init failed', err));
     }
     await this.camera
       .apply(settings.video, publish, withDisabledDevices)

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -3370,7 +3370,7 @@ export class Call {
   ) => {
     const {
       publish,
-      // Skip speaker setup on RN if ringing was requested or the call is already ringing
+ // Skip speaker setup on RN until joining (explicitly passed as false during join())
       skipSpeakerApply = isReactNative(),
       withDisabledDevices,
     } = opts;

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -3370,7 +3370,7 @@ export class Call {
   ) => {
     const {
       publish,
- // Skip speaker setup on RN until joining (explicitly passed as false during join())
+      // Skip speaker setup on RN until joining (explicitly passed as false during join())
       skipSpeakerApply = isReactNative(),
       withDisabledDevices,
     } = opts;

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -937,7 +937,10 @@ export class Call {
     const calls = this.clientStore.calls.filter((c) => c.cid !== this.cid);
     this.clientStore.setCalls([this, ...calls]);
     const skipSpeakerApply = isReactNative();
-    await this.applyDeviceConfig(settings, false, skipSpeakerApply);
+    await this.applyDeviceConfig(settings, {
+      publish: false,
+      skipSpeakerApply,
+    });
   };
 
   /**
@@ -975,11 +978,10 @@ export class Call {
     }
     // Skip speaker setup on RN if ringing was requested or the call is already ringing
     const skipSpeakerApply = isReactNative();
-    await this.applyDeviceConfig(
-      response.call.settings,
-      false,
+    await this.applyDeviceConfig(response.call.settings, {
+      publish: false,
       skipSpeakerApply,
-    );
+    });
 
     return response;
   };
@@ -1012,11 +1014,10 @@ export class Call {
 
     // Skip speaker setup on RN if ringing was requested or the call is already ringing
     const skipSpeakerApply = isReactNative();
-    await this.applyDeviceConfig(
-      response.call.settings,
-      false,
+    await this.applyDeviceConfig(response.call.settings, {
+      publish: false,
       skipSpeakerApply,
-    );
+    });
 
     return response;
   };
@@ -1430,7 +1431,10 @@ export class Call {
       this.state.settings &&
       !supersededByLeave()
     ) {
-      await this.applyDeviceConfig(this.state.settings, true, false);
+      await this.applyDeviceConfig(this.state.settings, {
+        publish: true,
+        skipSpeakerApply: false,
+      });
       this.deviceSettingsAppliedOnce = true;
     }
 
@@ -3372,20 +3376,24 @@ export class Call {
    */
   applyDeviceConfig = async (
     settings: CallSettingsResponse,
-    publish: boolean,
-    skipSpeakerApply: boolean,
+    opts: {
+      publish: boolean;
+      skipSpeakerApply: boolean;
+      withDisabledDevices?: boolean;
+    },
   ) => {
+    const { publish, skipSpeakerApply, withDisabledDevices } = opts;
     if (!skipSpeakerApply) {
       await this.speaker.apply(settings).catch((err) => {
         this.logger.warn('Speaker init failed', err);
       });
     }
-    await this.camera.apply(settings.video, publish).catch((err) => {
-      this.logger.warn('Camera init failed', err);
-    });
-    await this.microphone.apply(settings.audio, publish).catch((err) => {
-      this.logger.warn('Mic init failed', err);
-    });
+    await this.camera
+      .apply(settings.video, publish, withDisabledDevices)
+      .catch((err) => this.logger.warn('Camera init failed', err));
+    await this.microphone
+      .apply(settings.audio, publish, withDisabledDevices)
+      .catch((err) => this.logger.warn('Mic init failed', err));
   };
 
   /**

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -452,8 +452,14 @@ export class StreamVideoClient {
    * Will query the API for calls matching the given filters.
    *
    * @param data the query data.
+   * @param opts additional options, for tweaking the API behavior.
    */
-  queryCalls = async (data: QueryCallsRequest = {}) => {
+  queryCalls = async (
+    data: QueryCallsRequest = {},
+    opts: { withDisabledDevices?: boolean } = {},
+  ) => {
+    const { withDisabledDevices = true } = opts;
+    const skipSpeakerApply = isReactNative();
     const response = await this.streamClient.post<
       QueryCallsResponse,
       QueryCallsRequest
@@ -471,7 +477,11 @@ export class StreamVideoClient {
         clientStore: this.writeableStateStore,
       });
       call.state.updateFromCallResponse(c.call);
-      await call.applyDeviceConfig(c.call.settings, false, isReactNative());
+      await call.applyDeviceConfig(c.call.settings, {
+        publish: false,
+        skipSpeakerApply,
+        withDisabledDevices,
+      });
       if (data.watch) {
         await call.setup();
         this.writeableStateStore.registerCall(call);

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -39,7 +39,6 @@ import {
   getInstanceKey,
 } from './helpers/clientUtils';
 import { logToConsole, ScopedLogger, videoLoggerSystem } from './logger';
-import { isReactNative } from './helpers/platforms';
 import { withoutConcurrency } from './helpers/concurrency';
 import { enableTimerWorker } from './timers';
 import { ClientEventReporter } from './reporting';
@@ -459,7 +458,6 @@ export class StreamVideoClient {
     opts: { withDisabledDevices?: boolean } = {},
   ) => {
     const { withDisabledDevices = true } = opts;
-    const skipSpeakerApply = isReactNative();
     const response = await this.streamClient.post<
       QueryCallsResponse,
       QueryCallsRequest
@@ -479,7 +477,6 @@ export class StreamVideoClient {
       call.state.updateFromCallResponse(c.call);
       await call.applyDeviceConfig(c.call.settings, {
         publish: false,
-        skipSpeakerApply,
         withDisabledDevices,
       });
       if (data.watch) {

--- a/packages/client/src/__tests__/StreamVideoClient.api.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.api.test.ts
@@ -9,6 +9,8 @@ import {
 } from 'vitest';
 import { StreamVideoClient } from '../StreamVideoClient';
 import { Call } from '../Call';
+import { CameraManager } from '../devices/CameraManager';
+import { MicrophoneManager } from '../devices/MicrophoneManager';
 import { CallCreatedPayload } from './data';
 import { generateUUIDv4 } from '../coordinator/connection/utils';
 import type { StreamClient } from '../coordinator/connection/client';
@@ -71,6 +73,37 @@ describe('StreamVideoClient - coordinator API', () => {
     const [call] = result.calls;
     expect(call).toBeInstanceOf(Call);
     expect(call.cid).toBe(CallCreatedPayload.call.cid);
+  });
+
+  it('query calls keeps devices disabled by default', async () => {
+    const response: QueryCallsResponse = {
+      duration: '1ms',
+      calls: [
+        {
+          call: CallCreatedPayload.call,
+          members: CallCreatedPayload.members,
+          own_capabilities: [],
+        },
+      ],
+    };
+    post.mockResolvedValue(response);
+    const applyCamera = vi
+      .spyOn(CameraManager.prototype, 'apply')
+      .mockResolvedValue();
+    const applyMicrophone = vi
+      .spyOn(MicrophoneManager.prototype, 'apply')
+      .mockResolvedValue();
+
+    await client.queryCalls();
+    await client.queryCalls({}, {});
+    await client.queryCalls({}, { withDisabledDevices: false });
+
+    expect(
+      applyCamera.mock.calls.map(([, , forceDisabled]) => forceDisabled),
+    ).toEqual([true, true, false]);
+    expect(
+      applyMicrophone.mock.calls.map(([, , forceDisabled]) => forceDisabled),
+    ).toEqual([true, true, false]);
   });
 
   it('query calls - ongoing', async () => {

--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -187,13 +187,14 @@ export class CameraManager extends DeviceManager<CameraManagerState> {
       this.state.browserPermissionState$,
     );
     if (
-      !forceDisabled &&
       shouldApplyDefaults &&
       this.devicePersistence.enabled &&
       permissionState === 'granted'
     ) {
-      persistedPreferencesApplied =
-        await this.applyPersistedPreferences(enabledInCallType);
+      persistedPreferencesApplied = await this.applyPersistedPreferences(
+        enabledInCallType,
+        forceDisabled,
+      );
     }
 
     // apply a direction and enable the camera only if in "pristine" state,

--- a/packages/client/src/devices/CameraManager.ts
+++ b/packages/client/src/devices/CameraManager.ts
@@ -167,8 +167,13 @@ export class CameraManager extends DeviceManager<CameraManagerState> {
    *
    * @param settings the video settings to apply.
    * @param publish whether to publish the stream after applying the settings.
+   * @param forceDisabled whether to keep the camera disabled, regardless of server-side or local preferences.
    */
-  async apply(settings: VideoSettingsResponse, publish: boolean) {
+  async apply(
+    settings: VideoSettingsResponse,
+    publish: boolean,
+    forceDisabled: boolean = false,
+  ): Promise<void> {
     // Wait for any in progress camera operation
     await this.statusChangeSettled();
     await this.selectTargetResolution(settings.target_resolution);
@@ -182,6 +187,7 @@ export class CameraManager extends DeviceManager<CameraManagerState> {
       this.state.browserPermissionState$,
     );
     if (
+      !forceDisabled &&
       shouldApplyDefaults &&
       this.devicePersistence.enabled &&
       permissionState === 'granted'
@@ -199,7 +205,12 @@ export class CameraManager extends DeviceManager<CameraManagerState> {
         await this.selectDirection(direction, { enableCamera: false });
       }
 
-      if (canPublish && settings.camera_default_on && enabledInCallType) {
+      if (
+        !forceDisabled &&
+        canPublish &&
+        settings.camera_default_on &&
+        enabledInCallType
+      ) {
         await this.enable();
       }
     }

--- a/packages/client/src/devices/DeviceManager.ts
+++ b/packages/client/src/devices/DeviceManager.ts
@@ -842,7 +842,10 @@ export abstract class DeviceManager<
     writePreferences(currentDevice, deviceKey, muted, storageKey);
   }
 
-  protected async applyPersistedPreferences(enabledInCallType: boolean) {
+  protected async applyPersistedPreferences(
+    enabledInCallType: boolean,
+    forceDisabled = false,
+  ) {
     const deviceKey: DevicePreferenceKey =
       this.trackType === TrackType.AUDIO ? 'microphone' : 'camera';
     const preferences = readPreferences(this.devicePersistence.storageKey);
@@ -875,15 +878,15 @@ export abstract class DeviceManager<
 
     const canPublish = this.call.permissionsContext.canPublish(this.trackType);
     if (typeof muted === 'boolean' && enabledInCallType && canPublish) {
-      await this.applyMutedState(muted);
+      await this.applyMutedState(muted, forceDisabled);
       appliedMute = true;
     }
 
     return appliedDevice || appliedMute;
   }
 
-  private async applyMutedState(muted: boolean) {
-    if (this.state.status !== undefined) return;
+  private async applyMutedState(muted: boolean, forceDisabled: boolean) {
+    if (forceDisabled || this.state.status !== undefined) return;
     if (muted) {
       await this.disable();
     } else {

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -388,8 +388,13 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
    * Applies the audio settings to the microphone.
    * @param settings the audio settings to apply.
    * @param publish whether to publish the stream after applying the settings.
+   * @param forceDisabled whether to keep the mic disabled, regardless of server-side or local preferences.
    */
-  async apply(settings: AudioSettingsResponse, publish: boolean) {
+  async apply(
+    settings: AudioSettingsResponse,
+    publish: boolean,
+    forceDisabled: boolean = false,
+  ) {
     // Wait for any in progress mic operation
     await this.statusChangeSettled();
 
@@ -403,6 +408,7 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
       this.state.browserPermissionState$,
     );
     if (
+      !forceDisabled &&
       shouldApplyDefaults &&
       this.devicePersistence.enabled &&
       permissionState === 'granted'
@@ -412,7 +418,7 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
 
     const canPublish = this.call.permissionsContext.canPublish(this.trackType);
     if (shouldApplyDefaults && !persistedPreferencesApplied) {
-      if (canPublish && settings.mic_default_on) {
+      if (!forceDisabled && canPublish && settings.mic_default_on) {
         await this.enable();
       }
     }

--- a/packages/client/src/devices/MicrophoneManager.ts
+++ b/packages/client/src/devices/MicrophoneManager.ts
@@ -408,12 +408,14 @@ export class MicrophoneManager extends AudioDeviceManager<MicrophoneManagerState
       this.state.browserPermissionState$,
     );
     if (
-      !forceDisabled &&
       shouldApplyDefaults &&
       this.devicePersistence.enabled &&
       permissionState === 'granted'
     ) {
-      persistedPreferencesApplied = await this.applyPersistedPreferences(true);
+      persistedPreferencesApplied = await this.applyPersistedPreferences(
+        true,
+        forceDisabled,
+      );
     }
 
     const canPublish = this.call.permissionsContext.canPublish(this.trackType);

--- a/packages/client/src/devices/__tests__/CameraManager.test.ts
+++ b/packages/client/src/devices/__tests__/CameraManager.test.ts
@@ -357,21 +357,20 @@ describe('CameraManager', () => {
         true,
       );
 
-      expect(applySpy).toHaveBeenCalledWith(true);
+      expect(applySpy).toHaveBeenCalledWith(true, false);
       expect(selectDirectionSpy).not.toHaveBeenCalled();
       expect(enableSpy).not.toHaveBeenCalled();
     });
 
-    it('should skip persisted preferences when forced disabled', async () => {
+    it('should apply persisted device preferences without enabling when forced disabled', async () => {
       vi.spyOn(mockBrowserPermission, 'asStateObservable').mockReturnValue(
         of('granted'),
       );
       const devicePersistence = { enabled: true, storageKey: '' };
       const persistedManager = new CameraManager(call, devicePersistence);
-      const applySpy = vi.spyOn(
-        persistedManager as never,
-        'applyPersistedPreferences',
-      );
+      const applySpy = vi
+        .spyOn(persistedManager as never, 'applyPersistedPreferences')
+        .mockResolvedValue(true);
       const enableSpy = vi.spyOn(persistedManager, 'enable');
 
       await persistedManager.apply(
@@ -385,7 +384,7 @@ describe('CameraManager', () => {
         true,
       );
 
-      expect(applySpy).not.toHaveBeenCalled();
+      expect(applySpy).toHaveBeenCalledWith(true, true);
       expect(enableSpy).not.toHaveBeenCalled();
     });
 

--- a/packages/client/src/devices/__tests__/CameraManager.test.ts
+++ b/packages/client/src/devices/__tests__/CameraManager.test.ts
@@ -362,6 +362,33 @@ describe('CameraManager', () => {
       expect(enableSpy).not.toHaveBeenCalled();
     });
 
+    it('should skip persisted preferences when forced disabled', async () => {
+      vi.spyOn(mockBrowserPermission, 'asStateObservable').mockReturnValue(
+        of('granted'),
+      );
+      const devicePersistence = { enabled: true, storageKey: '' };
+      const persistedManager = new CameraManager(call, devicePersistence);
+      const applySpy = vi.spyOn(
+        persistedManager as never,
+        'applyPersistedPreferences',
+      );
+      const enableSpy = vi.spyOn(persistedManager, 'enable');
+
+      await persistedManager.apply(
+        fromPartial({
+          enabled: true,
+          target_resolution: { width: 640, height: 480 },
+          camera_facing: 'front',
+          camera_default_on: true,
+        }),
+        false,
+        true,
+      );
+
+      expect(applySpy).not.toHaveBeenCalled();
+      expect(enableSpy).not.toHaveBeenCalled();
+    });
+
     it('should skip persisted preferences when permission is not granted', async () => {
       vi.spyOn(mockBrowserPermission, 'asStateObservable').mockReturnValue(
         of('prompt'),

--- a/packages/client/src/devices/__tests__/DeviceManager.test.ts
+++ b/packages/client/src/devices/__tests__/DeviceManager.test.ts
@@ -1010,6 +1010,31 @@ describe('Device Manager', () => {
       expect(selectSpy).toHaveBeenCalledWith(mockVideoDevices[1].deviceId);
     });
 
+    it('selects the device without unmuting when forced disabled', async () => {
+      localStorageMock.setItem(
+        storageKey,
+        JSON.stringify({
+          camera: [
+            {
+              selectedDeviceId: mockVideoDevices[0].deviceId,
+              selectedDeviceLabel: mockVideoDevices[0].label,
+              muted: false,
+            },
+          ],
+        }),
+      );
+
+      const selectSpy = vi.spyOn(manager, 'select');
+      const enableSpy = vi.spyOn(manager, 'enable');
+
+      // @ts-expect-error - private API
+      const result = await manager.applyPersistedPreferences(true, true);
+
+      expect(result).toBe(true);
+      expect(selectSpy).toHaveBeenCalledWith(mockVideoDevices[0].deviceId);
+      expect(enableSpy).not.toHaveBeenCalled();
+    });
+
     it('applies muted state without selecting when default device is stored', async () => {
       localStorageMock.setItem(
         storageKey,

--- a/packages/client/src/devices/__tests__/DeviceManager.test.ts
+++ b/packages/client/src/devices/__tests__/DeviceManager.test.ts
@@ -21,7 +21,7 @@ import { DeviceManagerState } from '../DeviceManagerState';
 import { firstValueFrom, of } from 'rxjs';
 import { TrackType } from '../../gen/video/sfu/models/models';
 import { PermissionsContext } from '../../permissions';
-import { readPreferences } from '../devicePersistence';
+import { defaultDeviceId, readPreferences } from '../devicePersistence';
 
 vi.mock('../../reporting/ClientEventReporter', () => ({
   ClientEventReporter: vi.fn(function () {
@@ -1032,6 +1032,29 @@ describe('Device Manager', () => {
 
       expect(result).toBe(true);
       expect(selectSpy).toHaveBeenCalledWith(mockVideoDevices[0].deviceId);
+      expect(enableSpy).not.toHaveBeenCalled();
+    });
+
+    it('retains a default-device mute preference when forced disabled', async () => {
+      localStorageMock.setItem(
+        storageKey,
+        JSON.stringify({
+          camera: [
+            {
+              selectedDeviceId: defaultDeviceId,
+              selectedDeviceLabel: '',
+              muted: false,
+            },
+          ],
+        }),
+      );
+
+      const enableSpy = vi.spyOn(manager, 'enable');
+
+      // @ts-expect-error - private API
+      const result = await manager.applyPersistedPreferences(true, true);
+
+      expect(result).toBe(true);
       expect(enableSpy).not.toHaveBeenCalled();
     });
 

--- a/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
@@ -490,6 +490,29 @@ describe('MicrophoneManager', () => {
       expect(enableSpy).not.toHaveBeenCalled();
     });
 
+    it('should skip persisted preferences when forced disabled', async () => {
+      vi.spyOn(mockBrowserPermission, 'asStateObservable').mockReturnValue(
+        of('granted'),
+      );
+      const devicePersistence = { enabled: true, storageKey: '' };
+      const persistedManager = new MicrophoneManager(
+        call,
+        devicePersistence,
+        'disable-tracks',
+      );
+      const applySpy = vi.spyOn(
+        persistedManager as never,
+        'applyPersistedPreferences',
+      );
+      const enableSpy = vi.spyOn(persistedManager, 'enable');
+
+      // @ts-expect-error - partial data
+      await persistedManager.apply({ mic_default_on: true }, false, true);
+
+      expect(applySpy).not.toHaveBeenCalled();
+      expect(enableSpy).not.toHaveBeenCalled();
+    });
+
     it('should skip persisted preferences when permission is not granted', async () => {
       vi.spyOn(mockBrowserPermission, 'asStateObservable').mockReturnValue(
         of('prompt'),

--- a/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
+++ b/packages/client/src/devices/__tests__/MicrophoneManager.test.ts
@@ -486,11 +486,11 @@ describe('MicrophoneManager', () => {
       // @ts-expect-error - partial data
       await persistedManager.apply({ mic_default_on: true }, true);
 
-      expect(applySpy).toHaveBeenCalledWith(true);
+      expect(applySpy).toHaveBeenCalledWith(true, false);
       expect(enableSpy).not.toHaveBeenCalled();
     });
 
-    it('should skip persisted preferences when forced disabled', async () => {
+    it('should apply persisted device preferences without enabling when forced disabled', async () => {
       vi.spyOn(mockBrowserPermission, 'asStateObservable').mockReturnValue(
         of('granted'),
       );
@@ -500,16 +500,15 @@ describe('MicrophoneManager', () => {
         devicePersistence,
         'disable-tracks',
       );
-      const applySpy = vi.spyOn(
-        persistedManager as never,
-        'applyPersistedPreferences',
-      );
+      const applySpy = vi
+        .spyOn(persistedManager as never, 'applyPersistedPreferences')
+        .mockResolvedValue(true);
       const enableSpy = vi.spyOn(persistedManager, 'enable');
 
       // @ts-expect-error - partial data
       await persistedManager.apply({ mic_default_on: true }, false, true);
 
-      expect(applySpy).not.toHaveBeenCalled();
+      expect(applySpy).toHaveBeenCalledWith(true, true);
       expect(enableSpy).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
### 💡 Overview

Prevent `queryCalls()` from activating a camera or microphone while hydrating calls for read-only listings.

### 📝 Implementation notes

- default queried calls to disabled camera and microphone devices, including when an empty options object is provided
- prevent persisted enabled device preferences from overriding that default
- add regression coverage for query options and persisted preferences

🎫 Ticket: https://github.com/GetStream/stream-video-js/issues/2144

📑 Docs: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional control over whether camera and microphone devices are disabled when calls are queried or configured.
  * Device selection preferences are preserved without automatically re-enabling disabled devices.
  * Speaker handling now uses platform-appropriate defaults when no override is provided.

* **Bug Fixes**
  * Improved consistency when applying device settings across call setup and persisted preferences.

* **Tests**
  * Added coverage for disabled-device behavior and preference preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->