### PR TITLE
fix(client): refresh live call state on reconnect re-watch

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -39,6 +39,7 @@ import {
   BlockUserResponse,
   CallRingEvent,
   CallSettingsResponse,
+  CallStateResponseFields,
   CollectUserFeedbackRequest,
   CollectUserFeedbackResponse,
   Credentials,
@@ -941,6 +942,18 @@ export class Call {
   };
 
   /**
+   * Applies a backend-provided call state snapshot
+   * (call, members, own capabilities) to this instance.
+   *
+   * @internal an internal method and should not be used outside the SDK.
+   */
+  updateFromCallStateResponse = (response: CallStateResponseFields) => {
+    this.state.updateFromCallResponse(response.call);
+    this.state.setMembers(response.members);
+    this.state.setOwnCapabilities(response.own_capabilities);
+  };
+
+  /**
    * Loads the information about the call.
    *
    * @param params.ring if set to true, a `call.ring` event will be sent to the call members.
@@ -961,9 +974,7 @@ export class Call {
       params,
     );
 
-    this.state.updateFromCallResponse(response.call);
-    this.state.setMembers(response.members);
-    this.state.setOwnCapabilities(response.own_capabilities);
+    this.updateFromCallStateResponse(response);
 
     if (params?.ring) {
       this.ringingSubject.next(true);
@@ -997,9 +1008,7 @@ export class Call {
       GetOrCreateCallRequest
     >(this.streamClientBasePath, data);
 
-    this.state.updateFromCallResponse(response.call);
-    this.state.setMembers(response.members);
-    this.state.setOwnCapabilities(response.own_capabilities);
+    this.updateFromCallStateResponse(response);
 
     if (data?.ring) {
       this.ringingSubject.next(true);

--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -249,6 +249,17 @@ export class StreamVideoClient {
   };
 
   /**
+   * Queries the API for calls matching the given filters.
+   * @param data the query data.
+   */
+  private doQueryCalls = (data: QueryCallsRequest) => {
+    return this.streamClient.post<QueryCallsResponse, QueryCallsRequest>(
+      '/calls',
+      data,
+    );
+  };
+
+  /**
    * Rewatches the given calls with retry logic.
    * @param callsToReWatch array of call IDs to rewatch
    */
@@ -261,10 +272,21 @@ export class StreamVideoClient {
           `Rewatching calls ${callsToReWatch.join(', ')} attempt ${attempt + 1}`,
         );
 
-        await this.queryCalls({
+        const response = await this.doQueryCalls({
           watch: true,
           filter_conditions: { cid: { $in: callsToReWatch } },
         });
+
+        for (const c of response.calls) {
+          const call = this.writeableStateStore.findCall(
+            c.call.type,
+            c.call.id,
+          );
+
+          if (call) {
+            call.updateFromCallStateResponse(c);
+          }
+        }
 
         return;
       } catch (err) {
@@ -454,10 +476,7 @@ export class StreamVideoClient {
    * @param data the query data.
    */
   queryCalls = async (data: QueryCallsRequest = {}) => {
-    const response = await this.streamClient.post<
-      QueryCallsResponse,
-      QueryCallsRequest
-    >('/calls', data);
+    const response = await this.doQueryCalls(data);
     const calls = [];
     for (const c of response.calls) {
       const call = new Call({

--- a/packages/client/src/__tests__/StreamVideoClient.rewatch.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.rewatch.test.ts
@@ -126,47 +126,6 @@ describe('StreamVideoClient re-watching calls on reconnect', () => {
     await vi.waitFor(() => expect(leave).toHaveBeenCalled());
   });
 
-  it('drops a ringing call cancelled by the caller while the socket was down', async () => {
-    const call = await setupRingingCall();
-    const leave = vi.spyOn(call, 'leave').mockResolvedValue(undefined);
-
-    const session = CallRingPayload.call.session!;
-    const callerId = CallRingPayload.call.created_by.id;
-    vi.spyOn(client.streamClient, 'post').mockResolvedValue(
-      queryCallsResponse({
-        ...CallRingPayload.call,
-        session: {
-          ...session,
-          rejected_by: { [callerId]: '2025-08-14T14:49:00Z' },
-        },
-      }),
-    );
-
-    reconnect();
-
-    // the caller cancelled -> this device should stop ringing
-    await vi.waitFor(() => expect(leave).toHaveBeenCalled());
-  });
-
-  it('drops a ringing call that ended while the socket was down', async () => {
-    const call = await setupRingingCall();
-    const leave = vi.spyOn(call, 'leave').mockResolvedValue(undefined);
-
-    const session = CallRingPayload.call.session!;
-    vi.spyOn(client.streamClient, 'post').mockResolvedValue(
-      queryCallsResponse({
-        ...CallRingPayload.call,
-        ended_at: '2025-08-14T14:49:00Z',
-        session: { ...session, ended_at: '2025-08-14T14:49:00Z' },
-      }),
-    );
-
-    reconnect();
-
-    // the call ended -> this device should stop ringing
-    await vi.waitFor(() => expect(leave).toHaveBeenCalled());
-  });
-
   it('queryCalls returns an independent instance for registered calls', async () => {
     // e.g. being on a call while watching a dashboard of calls:
     // leaving the joined instance must not silence the dashboard instance

--- a/packages/client/src/__tests__/StreamVideoClient.rewatch.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.rewatch.test.ts
@@ -1,0 +1,254 @@
+import '../rtc/__tests__/mocks/webrtc.mocks';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StreamVideoClient } from '../StreamVideoClient';
+import { Call } from '../Call';
+import { CallRingPayload } from './data';
+import { settled, withoutConcurrency } from '../helpers/concurrency';
+import { getCallInitConcurrencyTag } from '../helpers/clientUtils';
+import { CallingState } from '../store';
+import type { StreamVideoEvent } from '../coordinator/connection/types';
+import type {
+  CallResponse,
+  ConnectedEvent,
+  GetCallResponse,
+  QueryCallsResponse,
+} from '../gen/coordinator';
+
+const apiKey = 'mock-api-key';
+// the receiver of the CallRingPayload fixture
+const userId = 'marcelo';
+
+const queryCallsResponse = (call: CallResponse): QueryCallsResponse => ({
+  duration: '1ms',
+  calls: [{ call, members: CallRingPayload.members, own_capabilities: [] }],
+});
+
+const countListeners = (client: StreamVideoClient) =>
+  Object.values(client.streamClient.listeners).reduce(
+    (count, listeners) => count + (listeners?.length ?? 0),
+    0,
+  );
+
+describe('StreamVideoClient re-watching calls on reconnect', () => {
+  let client: StreamVideoClient;
+
+  beforeEach(async () => {
+    client = new StreamVideoClient(apiKey, {
+      // tests run in node, so we have to fake being in browser env
+      browser: true,
+    });
+    client.streamClient.connectUser = vi.fn().mockResolvedValue({
+      me: { id: userId },
+    } as ConnectedEvent);
+    await client.connectUser({ id: userId }, 'mock-token');
+  });
+
+  afterEach(() => {
+    for (const call of client.state.calls) {
+      call['cancelAutoDrop']();
+    }
+    vi.restoreAllMocks();
+  });
+
+  const setupRingingCall = async () => {
+    vi.spyOn(client.streamClient, 'get').mockResolvedValue({
+      duration: '1ms',
+      call: CallRingPayload.call,
+      members: CallRingPayload.members,
+      own_capabilities: [],
+    } as GetCallResponse);
+
+    client.streamClient.dispatchEvent(CallRingPayload as StreamVideoEvent);
+    await settled(getCallInitConcurrencyTag(CallRingPayload.call_cid));
+
+    const [call] = client.state.calls;
+    expect(call).toBeDefined();
+    expect(call.watching).toBe(true);
+    expect(call.state.callingState).toBe(CallingState.RINGING);
+    return call;
+  };
+
+  const reconnect = () => {
+    client.streamClient.dispatchEvent({
+      type: 'connection.changed',
+      online: true,
+    });
+  };
+
+  it('reuses the registered instance and refreshes its state', async () => {
+    const call = await setupRingingCall();
+    const listenerCountBeforeReconnect = countListeners(client);
+
+    const post = vi
+      .spyOn(client.streamClient, 'post')
+      .mockResolvedValue(
+        queryCallsResponse({ ...CallRingPayload.call, recording: true }),
+      );
+
+    reconnect();
+
+    await vi.waitFor(() => expect(post).toHaveBeenCalled());
+    expect(post).toHaveBeenCalledWith('/calls', {
+      watch: true,
+      filter_conditions: { cid: { $in: [call.cid] } },
+    });
+
+    // the refreshed state must reach the instance the integrator holds
+    await vi.waitFor(() => expect(call.state.recording).toBe(true));
+    expect(client.state.calls).toHaveLength(1);
+    expect(client.state.calls[0]).toBe(call);
+    expect(call.watching).toBe(true);
+
+    // re-watching must not leak event handlers (one orphaned Call
+    // used to register its handlers on every reconnect)
+    expect(countListeners(client)).toBe(listenerCountBeforeReconnect);
+  });
+
+  it('drops a ringing call accepted elsewhere while the socket was down', async () => {
+    const call = await setupRingingCall();
+    const leave = vi.spyOn(call, 'leave').mockResolvedValue(undefined);
+
+    const session = CallRingPayload.call.session!;
+    vi.spyOn(client.streamClient, 'post').mockResolvedValue(
+      queryCallsResponse({
+        ...CallRingPayload.call,
+        session: {
+          ...session,
+          accepted_by: { [userId]: '2025-08-14T14:49:00Z' },
+        },
+      }),
+    );
+
+    reconnect();
+
+    // accepted on another device -> this device should stop ringing
+    await vi.waitFor(() => expect(leave).toHaveBeenCalled());
+  });
+
+  it('drops a ringing call cancelled by the caller while the socket was down', async () => {
+    const call = await setupRingingCall();
+    const leave = vi.spyOn(call, 'leave').mockResolvedValue(undefined);
+
+    const session = CallRingPayload.call.session!;
+    const callerId = CallRingPayload.call.created_by.id;
+    vi.spyOn(client.streamClient, 'post').mockResolvedValue(
+      queryCallsResponse({
+        ...CallRingPayload.call,
+        session: {
+          ...session,
+          rejected_by: { [callerId]: '2025-08-14T14:49:00Z' },
+        },
+      }),
+    );
+
+    reconnect();
+
+    // the caller cancelled -> this device should stop ringing
+    await vi.waitFor(() => expect(leave).toHaveBeenCalled());
+  });
+
+  it('drops a ringing call that ended while the socket was down', async () => {
+    const call = await setupRingingCall();
+    const leave = vi.spyOn(call, 'leave').mockResolvedValue(undefined);
+
+    const session = CallRingPayload.call.session!;
+    vi.spyOn(client.streamClient, 'post').mockResolvedValue(
+      queryCallsResponse({
+        ...CallRingPayload.call,
+        ended_at: '2025-08-14T14:49:00Z',
+        session: { ...session, ended_at: '2025-08-14T14:49:00Z' },
+      }),
+    );
+
+    reconnect();
+
+    // the call ended -> this device should stop ringing
+    await vi.waitFor(() => expect(leave).toHaveBeenCalled());
+  });
+
+  it('queryCalls returns an independent instance for registered calls', async () => {
+    // e.g. being on a call while watching a dashboard of calls:
+    // leaving the joined instance must not silence the dashboard instance
+    const joinedCall = await setupRingingCall();
+    vi.spyOn(client.streamClient, 'post').mockResolvedValue(
+      queryCallsResponse(CallRingPayload.call),
+    );
+
+    const result = await client.queryCalls({ watch: true });
+    const [dashboardCall] = result.calls;
+    expect(dashboardCall).not.toBe(joinedCall);
+    expect(client.state.calls[0]).toBe(joinedCall);
+
+    await joinedCall.leave({ reject: false });
+
+    client.streamClient.dispatchEvent({
+      type: 'call.updated',
+      call_cid: joinedCall.cid,
+      created_at: '2025-08-14T14:50:00Z',
+      call: { ...CallRingPayload.call, recording: true },
+    } as StreamVideoEvent);
+
+    await vi.waitFor(() => expect(dashboardCall.state.recording).toBe(true));
+  });
+
+  it('creates and registers a new instance for unknown cids', async () => {
+    vi.spyOn(client.streamClient, 'post').mockResolvedValue(
+      queryCallsResponse(CallRingPayload.call),
+    );
+
+    const result = await client.queryCalls({ watch: true });
+
+    expect(result.calls).toHaveLength(1);
+    const [call] = result.calls;
+    expect(call).toBeInstanceOf(Call);
+    expect(call.watching).toBe(true);
+    expect(client.state.calls[0]).toBe(call);
+  });
+
+  it('does not resurrect a call that leaves during a re-watch', async () => {
+    const listenersBeforeRing = countListeners(client);
+    const call = await setupRingingCall();
+    const post = vi
+      .spyOn(client.streamClient, 'post')
+      .mockResolvedValue(queryCallsResponse(CallRingPayload.call));
+
+    // hold the call's join/leave queue so leave() is still in flight
+    // while the re-watch response is being processed
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseGate = resolve));
+    withoutConcurrency(call['joinLeaveConcurrencyTag'], () => gate);
+    const leavePromise = call.leave({ reject: false });
+
+    reconnect();
+    await vi.waitFor(() => expect(post).toHaveBeenCalled());
+    await Promise.resolve();
+
+    releaseGate();
+    await leavePromise;
+
+    // the left call must stay dead: not re-registered, not re-initialized,
+    // and all of its event handlers released
+    expect(client.state.calls).toHaveLength(0);
+    expect(call.state.callingState).toBe(CallingState.LEFT);
+    expect(countListeners(client)).toBe(listenersBeforeRing);
+  });
+
+  it('creates a fresh instance when the previous one has left', async () => {
+    const call = await setupRingingCall();
+    const post = vi
+      .spyOn(client.streamClient, 'post')
+      .mockResolvedValue(queryCallsResponse(CallRingPayload.call));
+
+    // leaving unregisters the call from the client store
+    await call.leave({ reject: false });
+    expect(client.state.calls).toHaveLength(0);
+
+    const result = await client.queryCalls({ watch: true });
+    expect(post).toHaveBeenCalled();
+    expect(result.calls).toHaveLength(1);
+    expect(result.calls[0]).not.toBe(call);
+    expect(client.state.calls[0]).toBe(result.calls[0]);
+    expect(result.calls[0].watching).toBe(true);
+  });
+});

--- a/packages/client/src/__tests__/StreamVideoClient.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.test.ts
@@ -277,7 +277,7 @@ describe('StreamVideoClient.connectUser retries', () => {
 });
 
 describe('StreamVideoClient.watchCalls retries', () => {
-  it('should retry queryCalls up to 3 times after reconnecting', async () => {
+  it('should retry the re-watch request up to 3 times after reconnecting', async () => {
     vi.useFakeTimers();
     const client = new StreamVideoClient(apiKey, {
       browser: true,
@@ -290,8 +290,8 @@ describe('StreamVideoClient.watchCalls retries', () => {
     const call = client.call('default', generateUUIDv4());
     await call.getOrCreate();
 
-    const queryCallsSpy = vi
-      .spyOn(client, 'queryCalls')
+    const doQueryCalls = vi
+      .spyOn(client as any, 'doQueryCalls')
       .mockRejectedValueOnce(new Error('fail 1'))
       .mockRejectedValueOnce(new Error('fail 2'))
       .mockResolvedValue({
@@ -306,7 +306,7 @@ describe('StreamVideoClient.watchCalls retries', () => {
 
     await vi.runAllTimersAsync();
 
-    expect(queryCallsSpy).toHaveBeenCalledTimes(3);
+    expect(doQueryCalls).toHaveBeenCalledTimes(3);
 
     await client.disconnectUser();
 
@@ -327,8 +327,8 @@ describe('StreamVideoClient.watchCalls retries', () => {
     const call = client.call('default', generateUUIDv4());
     await call.getOrCreate();
 
-    const queryCallsSpy = vi
-      .spyOn(client, 'queryCalls')
+    const doQueryCalls = vi
+      .spyOn(client as any, 'doQueryCalls')
       .mockRejectedValueOnce(new Error('fail 1'))
       .mockRejectedValueOnce(new Error('fail 2'))
       .mockRejectedValueOnce(new Error('fail 3'))
@@ -344,7 +344,7 @@ describe('StreamVideoClient.watchCalls retries', () => {
 
     await vi.runAllTimersAsync();
 
-    expect(queryCallsSpy).toHaveBeenCalledTimes(3);
+    expect(doQueryCalls).toHaveBeenCalledTimes(3);
 
     await client.disconnectUser();
     vi.useRealTimers();
@@ -363,10 +363,12 @@ describe('StreamVideoClient.watchCalls retries', () => {
     const call = client.call('default', generateUUIDv4());
     await call.getOrCreate();
 
-    const queryCallsSpy = vi.spyOn(client, 'queryCalls').mockResolvedValue({
-      calls: [],
-      duration: '0ms',
-    });
+    const doQueryCalls = vi
+      .spyOn(client as any, 'doQueryCalls')
+      .mockResolvedValue({
+        calls: [],
+        duration: '0ms',
+      });
 
     client.streamClient.dispatchEvent({
       type: 'connection.changed',
@@ -375,7 +377,7 @@ describe('StreamVideoClient.watchCalls retries', () => {
 
     await vi.runAllTimersAsync();
 
-    expect(queryCallsSpy).toHaveBeenCalledTimes(1);
+    expect(doQueryCalls).toHaveBeenCalledTimes(1);
 
     await client.disconnectUser();
     vi.useRealTimers();


### PR DESCRIPTION
### 💡 Overview

This PR fixes an issue where reconnect re-watch responses refreshed state on a newly-created `Call` instance instead of the already-registered live instance. On coordinator WS reconnect, watched calls are now queried directly and the returned call state snapshot is merged into the existing `Call`. This keeps app-held call references up to date and avoids creating orphan `Call` instances whose event handlers would remain registered. Also adds regression coverage for live state refresh and listener count stability across reconnect re-watch.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1095/reconnect-re-watch-builds-a-duplicate-call-that-is-then-discarded

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call state refresh during reconnection and rewatch flows.
  * Preserved existing call instances while refreshing their state.
  * Prevented ended, cancelled, or accepted ringing calls from reappearing after disconnection.
  * Ensured calls are recreated correctly after being left.
  * Improved call search results and lifecycle handling during concurrent leave and rewatch operations.

* **Tests**
  * Added comprehensive coverage for reconnect, rewatch, call lifecycle, and concurrent operation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->