### PR TITLE
fix: fixed ringing calls mute issue

### DIFF
--- a/packages/react-native-sdk/src/hooks/push/useCallingExpWithCallingStateEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useCallingExpWithCallingStateEffect.ts
@@ -242,7 +242,7 @@ export const useCallingExpWithCallingStateEffect = () => {
 
     const traceRecordingState = (trigger: string) => {
       if (activeCall.state.callingState !== CallingState.JOINED) return;
-      if (activeCall.microphone.state.optimisticStatus !== 'enabled') return;
+      if (activeCall.microphone.state.status !== 'enabled') return;
 
       let state;
       try {

--- a/packages/react-native-sdk/src/hooks/push/useCallingExpWithCallingStateEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useCallingExpWithCallingStateEffect.ts
@@ -17,7 +17,7 @@ export const useCallingExpWithCallingStateEffect = () => {
     useCallStateHooks();
 
   const activeCall = useCall();
-  const { isMute, microphone } = useMicrophoneState();
+  const { optimisticStatus, microphone } = useMicrophoneState();
   const callMembers = useCallMembers();
   const participants = useParticipants();
 
@@ -135,8 +135,14 @@ export const useCallingExpWithCallingStateEffect = () => {
       return;
     }
 
-    callingx.setMutedCall(activeCallCid, isMute);
-  }, [activeCallCid, isMute]);
+    if (optimisticStatus === undefined) {
+      logger.debug(
+        `useCallingExpWithCallingStateEffect: mic status is not resolved yet, skipping mute sync for: ${activeCallCid}`,
+      );
+      return;
+    }
+    callingx.setMutedCall(activeCallCid, optimisticStatus === 'disabled');
+  }, [activeCallCid, optimisticStatus]);
 
   // Sync mute state from CallKit → app (only for system-initiated mute actions)
   useEffect(() => {
@@ -165,7 +171,8 @@ export const useCallingExpWithCallingStateEffect = () => {
           return;
         }
 
-        const isCurrentlyMuted = microphone.state.status === 'disabled';
+        const isCurrentlyMuted =
+          microphone.state.optimisticStatus === 'disabled';
         if (isCurrentlyMuted === muted) {
           logger.debug(
             `useCallingExpWithCallingStateEffect: Mic toggle is already in the desired state: ${muted} for call: ${activeCallCid}`,
@@ -235,7 +242,7 @@ export const useCallingExpWithCallingStateEffect = () => {
 
     const traceRecordingState = (trigger: string) => {
       if (activeCall.state.callingState !== CallingState.JOINED) return;
-      if (activeCall.microphone.state.status !== 'enabled') return;
+      if (activeCall.microphone.state.optimisticStatus !== 'enabled') return;
 
       let state;
       try {


### PR DESCRIPTION
### 💡 Overview

This PR contains a fix to muted mic issue for incoming calls:
1. Telecom muting state sync is changed to rely on `optimisticStatus` value, as before join, `status` is not changed.
2. There is a race of call instantiation for incoming calls. When call instance is created within `call.ring` event `ownCapabilities` own capabilities are not set and there is a window, when `canPublish` is false which leads to `optimisticStatus` being `undefined`. Telecom mute sync will ignore the sync in case `optimisticStatus` is `undefined`.

🎫 Ticket: https://linear.app/stream/issue/RN-423/ringing-calls-muted-mic-issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone mute synchronization between the app and CallKit.
  * Prevented conflicting mute updates while microphone status is being confirmed.
  * Enhanced iOS recording-state tracking for more reliable microphone behavior.
  * Reduced unexpected microphone state changes during calls, providing a more consistent mute experience across supported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->