### PR TITLE
fix(client): Prevent concurrent joins 

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -179,7 +179,11 @@ import {
   SpeakerManager,
 } from './devices';
 import { normalize } from './devices/devicePersistence';
-import { hasPending, withoutConcurrency } from './helpers/concurrency';
+import {
+  hasPending,
+  withSingleFlight,
+  withoutConcurrency,
+} from './helpers/concurrency';
 import { ensureExhausted } from './helpers/ensureExhausted';
 import { pushToIfMissing } from './helpers/array';
 import {
@@ -337,11 +341,11 @@ export class Call {
   private deviceSettingsAppliedOnce = false;
   private callManagerStarted = false;
   private leaveGeneration = 0;
-  private joinPromise?: Promise<void>;
   private credentials?: Credentials;
 
   private initialized = false;
   private readonly acceptRejectConcurrencyTag = Symbol('acceptRejectTag');
+  private readonly joinConcurrencyTag = Symbol('joinConcurrencyTag');
   private readonly joinLeaveConcurrencyTag = Symbol('joinLeaveConcurrencyTag');
 
   /**
@@ -1112,21 +1116,15 @@ export class Call {
     rpcRequestTimeout?: number;
     allowOwnTracksLoopback?: boolean;
   } = {}): Promise<void> => {
-    if (this.joinPromise) return this.joinPromise;
-
-    const joinPromise = this.executeJoin({
-      maxJoinRetries,
-      joinResponseTimeout,
-      rpcRequestTimeout,
-      allowOwnTracksLoopback,
-      ...data,
-    }).finally(() => {
-      if (this.joinPromise === joinPromise) {
-        this.joinPromise = undefined;
-      }
-    });
-    this.joinPromise = joinPromise;
-    return joinPromise;
+    return withSingleFlight(this.joinConcurrencyTag, () =>
+      this.executeJoin({
+        maxJoinRetries,
+        joinResponseTimeout,
+        rpcRequestTimeout,
+        allowOwnTracksLoopback,
+        ...data,
+      }),
+    );
   };
 
   private executeJoin = async ({

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -181,7 +181,7 @@ import {
 import { normalize } from './devices/devicePersistence';
 import {
   hasPending,
-  withSingleFlight,
+  singleFlight,
   withoutConcurrency,
 } from './helpers/concurrency';
 import { ensureExhausted } from './helpers/ensureExhausted';
@@ -345,7 +345,6 @@ export class Call {
 
   private initialized = false;
   private readonly acceptRejectConcurrencyTag = Symbol('acceptRejectTag');
-  private readonly joinConcurrencyTag = Symbol('joinConcurrencyTag');
   private readonly joinLeaveConcurrencyTag = Symbol('joinLeaveConcurrencyTag');
 
   /**
@@ -1104,134 +1103,113 @@ export class Call {
    *
    * @returns a promise which resolves once the call join-flow has finished.
    */
-  join = async ({
-    maxJoinRetries = 3,
-    joinResponseTimeout,
-    rpcRequestTimeout,
-    allowOwnTracksLoopback = false,
-    ...data
-  }: JoinCallData & {
-    maxJoinRetries?: number;
-    joinResponseTimeout?: number;
-    rpcRequestTimeout?: number;
-    allowOwnTracksLoopback?: boolean;
-  } = {}): Promise<void> => {
-    return withSingleFlight(this.joinConcurrencyTag, () =>
-      this.executeJoin({
-        maxJoinRetries,
-        joinResponseTimeout,
-        rpcRequestTimeout,
-        allowOwnTracksLoopback,
-        ...data,
-      }),
-    );
-  };
+  join = singleFlight(
+    async ({
+      maxJoinRetries = 3,
+      joinResponseTimeout,
+      rpcRequestTimeout,
+      allowOwnTracksLoopback = false,
+      ...data
+    }: JoinCallData & {
+      maxJoinRetries?: number;
+      joinResponseTimeout?: number;
+      rpcRequestTimeout?: number;
+      allowOwnTracksLoopback?: boolean;
+    } = {}): Promise<void> => {
+      const callingState = this.state.callingState;
 
-  private executeJoin = async ({
-    maxJoinRetries = 3,
-    joinResponseTimeout,
-    rpcRequestTimeout,
-    allowOwnTracksLoopback = false,
-    ...data
-  }: JoinCallData & {
-    maxJoinRetries?: number;
-    joinResponseTimeout?: number;
-    rpcRequestTimeout?: number;
-    allowOwnTracksLoopback?: boolean;
-  } = {}): Promise<void> => {
-    const callingState = this.state.callingState;
+      if ([CallingState.JOINED, CallingState.JOINING].includes(callingState)) {
+        throw new Error(`Illegal State: call.join() shall be called only once`);
+      }
 
-    if ([CallingState.JOINED, CallingState.JOINING].includes(callingState)) {
-      throw new Error(`Illegal State: call.join() shall be called only once`);
-    }
+      // we need this to be set before the callingx.joinCall() is
+      // called to avoid registering the test call in the CallKit/Telecom
+      this.allowOwnTracksLoopback = allowOwnTracksLoopback;
 
-    // we need this to be set before the callingx.joinCall() is
-    // called to avoid registering the test call in the CallKit/Telecom
-    this.allowOwnTracksLoopback = allowOwnTracksLoopback;
+      if (data?.ring) {
+        this.ringingSubject.next(true);
+      }
 
-    if (data?.ring) {
-      this.ringingSubject.next(true);
-    }
+      const callingX = globalThis.streamRNVideoSDK?.callingX;
+      if (callingX) {
+        // for Android/iOS, we need to start the call in the callingx library as soon as possible
+        await callingX.joinCall(this, this.clientStore.calls);
+      }
 
-    const callingX = globalThis.streamRNVideoSDK?.callingX;
-    if (callingX) {
-      // for Android/iOS, we need to start the call in the callingx library as soon as possible
-      await callingX.joinCall(this, this.clientStore.calls);
-    }
+      await this.setup();
 
-    await this.setup();
+      this.clientEventReporter.registerCall(this.cid, {
+        callType: this.type,
+        callId: this.id,
+        getCallSessionId: () => this.state.session?.id ?? '',
+        getSfuId: () => this.credentials?.server.edge_name ?? '',
+      });
 
-    this.clientEventReporter.registerCall(this.cid, {
-      callType: this.type,
-      callId: this.id,
-      getCallSessionId: () => this.state.session?.id ?? '',
-      getSfuId: () => this.credentials?.server.edge_name ?? '',
-    });
+      this.joinResponseTimeout = joinResponseTimeout;
+      this.rpcRequestTimeout = rpcRequestTimeout;
+      // we will count the number of join failures per SFU.
+      // once the number of failures reaches 2, we will piggyback on the `migrating_from`
+      // field to force the coordinator to provide us another SFU
+      const sfuJoinFailures = new Map<string, number>();
+      const joinData: JoinCallData = data;
+      maxJoinRetries = Math.max(maxJoinRetries, 1);
+      try {
+        await this.clientEventReporter.withJoinLifecycle(
+          this.cid,
+          'first-attempt',
+          async () => {
+            for (let attempt = 0; attempt < maxJoinRetries; attempt++) {
+              try {
+                this.logger.trace(`Joining call (${attempt})`, this.cid);
+                await this.doJoin(data);
+                delete joinData.migrating_from;
+                delete joinData.migrating_from_list;
+                return;
+              } catch (err) {
+                this.logger.warn(`Failed to join call (${attempt})`, this.cid);
+                if (
+                  (err instanceof ErrorFromResponse && err.unrecoverable) ||
+                  (err instanceof SfuJoinError && err.unrecoverable)
+                ) {
+                  throw err;
+                }
 
-    this.joinResponseTimeout = joinResponseTimeout;
-    this.rpcRequestTimeout = rpcRequestTimeout;
-    // we will count the number of join failures per SFU.
-    // once the number of failures reaches 2, we will piggyback on the `migrating_from`
-    // field to force the coordinator to provide us another SFU
-    const sfuJoinFailures = new Map<string, number>();
-    const joinData: JoinCallData = data;
-    maxJoinRetries = Math.max(maxJoinRetries, 1);
-    try {
-      await this.clientEventReporter.withJoinLifecycle(
-        this.cid,
-        'first-attempt',
-        async () => {
-          for (let attempt = 0; attempt < maxJoinRetries; attempt++) {
-            try {
-              this.logger.trace(`Joining call (${attempt})`, this.cid);
-              await this.doJoin(data);
-              delete joinData.migrating_from;
-              delete joinData.migrating_from_list;
-              return;
-            } catch (err) {
-              this.logger.warn(`Failed to join call (${attempt})`, this.cid);
-              if (
-                (err instanceof ErrorFromResponse && err.unrecoverable) ||
-                (err instanceof SfuJoinError && err.unrecoverable)
-              ) {
-                throw err;
-              }
+                const switchSfu =
+                  err instanceof SfuJoinError &&
+                  SfuJoinError.isJoinErrorCode(err.errorEvent);
 
-              const switchSfu =
-                err instanceof SfuJoinError &&
-                SfuJoinError.isJoinErrorCode(err.errorEvent);
-
-              const sfuId = this.credentials?.server.edge_name;
-              if (sfuId) {
-                const failures = (sfuJoinFailures.get(sfuId) || 0) + 1;
-                sfuJoinFailures.set(sfuId, failures);
-                if (switchSfu || failures >= 2) {
-                  joinData.migrating_from = sfuId;
-                  joinData.migrating_from_list = Array.from(
-                    sfuJoinFailures.keys(),
-                  );
-                  if (attempt < maxJoinRetries - 1) {
-                    this.clientEventReporter.startCorrelation(
-                      this.cid,
-                      'first-attempt',
+                const sfuId = this.credentials?.server.edge_name;
+                if (sfuId) {
+                  const failures = (sfuJoinFailures.get(sfuId) || 0) + 1;
+                  sfuJoinFailures.set(sfuId, failures);
+                  if (switchSfu || failures >= 2) {
+                    joinData.migrating_from = sfuId;
+                    joinData.migrating_from_list = Array.from(
+                      sfuJoinFailures.keys(),
                     );
+                    if (attempt < maxJoinRetries - 1) {
+                      this.clientEventReporter.startCorrelation(
+                        this.cid,
+                        'first-attempt',
+                      );
+                    }
                   }
                 }
-              }
 
-              if (attempt === maxJoinRetries - 1) {
-                throw err;
+                if (attempt === maxJoinRetries - 1) {
+                  throw err;
+                }
               }
+              await sleep(retryInterval(attempt));
             }
-            await sleep(retryInterval(attempt));
-          }
-        },
-      );
-    } catch (error) {
-      callingX?.endCall(this, 'error');
-      throw error;
-    }
-  };
+          },
+        );
+      } catch (error) {
+        callingX?.endCall(this, 'error');
+        throw error;
+      }
+    },
+  );
 
   /**
    * Will make a single attempt to watch for call related WebSocket events

--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -337,6 +337,7 @@ export class Call {
   private deviceSettingsAppliedOnce = false;
   private callManagerStarted = false;
   private leaveGeneration = 0;
+  private joinPromise?: Promise<void>;
   private credentials?: Credentials;
 
   private initialized = false;
@@ -1100,6 +1101,35 @@ export class Call {
    * @returns a promise which resolves once the call join-flow has finished.
    */
   join = async ({
+    maxJoinRetries = 3,
+    joinResponseTimeout,
+    rpcRequestTimeout,
+    allowOwnTracksLoopback = false,
+    ...data
+  }: JoinCallData & {
+    maxJoinRetries?: number;
+    joinResponseTimeout?: number;
+    rpcRequestTimeout?: number;
+    allowOwnTracksLoopback?: boolean;
+  } = {}): Promise<void> => {
+    if (this.joinPromise) return this.joinPromise;
+
+    const joinPromise = this.executeJoin({
+      maxJoinRetries,
+      joinResponseTimeout,
+      rpcRequestTimeout,
+      allowOwnTracksLoopback,
+      ...data,
+    }).finally(() => {
+      if (this.joinPromise === joinPromise) {
+        this.joinPromise = undefined;
+      }
+    });
+    this.joinPromise = joinPromise;
+    return joinPromise;
+  };
+
+  private executeJoin = async ({
     maxJoinRetries = 3,
     joinResponseTimeout,
     rpcRequestTimeout,

--- a/packages/client/src/__tests__/Call.lifecycle.test.ts
+++ b/packages/client/src/__tests__/Call.lifecycle.test.ts
@@ -4,25 +4,36 @@
 
 import '../rtc/__tests__/mocks/webrtc.mocks';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Call } from '../Call';
 import { StreamClient } from '../coordinator/connection/client';
 import { ClientEventReporter } from '../reporting';
 import { generateUUIDv4 } from '../coordinator/connection/utils';
 import { StreamVideoWriteableStateStore } from '../store';
+import { promiseWithResolvers } from '../helpers/promise';
 
 describe('Call lifecycle wiring', () => {
   let call: Call;
 
   beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      headers: { get: () => 'AMS1-P2' },
+    } as Response);
     const streamClient = new StreamClient('abc');
     call = new Call({
       type: 'test',
       id: generateUUIDv4(),
       streamClient,
-      clientEventReporter: new ClientEventReporter({ streamClient }),
+      clientEventReporter: new ClientEventReporter({
+        streamClient,
+        enabled: false,
+      }),
       clientStore: new StreamVideoWriteableStateStore(),
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   // Regression guard for the Call-owned helper teardown chain. Each of
@@ -66,5 +77,25 @@ describe('Call lifecycle wiring', () => {
 
     expect(trackSubOrder).toBeLessThan(audioBindingsOrder);
     expect(audioBindingsOrder).toBeLessThan(dynascaleOrder);
+  });
+
+  it('call.join() shares an in-flight join flow', async () => {
+    const joinTask = promiseWithResolvers<void>();
+    vi.spyOn(call, 'setup').mockResolvedValue(undefined);
+    const doJoin = vi
+      .spyOn(call as unknown as { doJoin: Call['join'] }, 'doJoin')
+      .mockReturnValue(joinTask.promise);
+
+    const firstJoin = call.join();
+    const secondJoin = call.join();
+
+    await Promise.resolve();
+    expect(doJoin).toHaveBeenCalledTimes(1);
+
+    joinTask.resolve();
+    await expect(Promise.all([firstJoin, secondJoin])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
   });
 });

--- a/packages/client/src/helpers/__tests__/concurrency.test.ts
+++ b/packages/client/src/helpers/__tests__/concurrency.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   hasPending,
+  singleFlight,
   withCancellation,
-  withSingleFlight,
   withoutConcurrency,
 } from '../concurrency';
 
@@ -170,13 +170,12 @@ it('keeps track of pending promises', async () => {
 });
 
 describe('single flight', () => {
-  it('shares an in-flight promise for the same tag', async () => {
-    const tag = Symbol();
+  it('shares an in-flight promise for the wrapped function', async () => {
     const [run1, resolve1] = mockAsyncFn('promise1');
-    const [run2] = mockAsyncFn('promise2');
+    const run = singleFlight(run1);
 
-    const ready1 = withSingleFlight(tag, run1);
-    const ready2 = withSingleFlight(tag, run2);
+    const ready1 = run();
+    const ready2 = run();
 
     expect(ready2).toBe(ready1);
     expect(log).toMatchObject(['promise1 start']);
@@ -190,33 +189,34 @@ describe('single flight', () => {
   });
 
   it('allows a new execution after the in-flight promise settles', async () => {
-    const tag = Symbol();
     const [run1, resolve1] = mockAsyncFn('promise1');
-    const [run2, resolve2] = mockAsyncFn('promise2');
+    const run = singleFlight(run1);
 
-    const ready1 = withSingleFlight(tag, run1);
+    const ready1 = run();
     resolve1();
     await ready1;
 
-    const ready2 = withSingleFlight(tag, run2);
+    const ready2 = run();
     expect(ready2).not.toBe(ready1);
 
-    resolve2();
+    resolve1();
     await ready2;
     expect(log).toMatchObject([
       'promise1 start',
       'promise1 end',
-      'promise2 start',
-      'promise2 end',
+      'promise1 start',
+      'promise1 end',
     ]);
   });
 
-  it('does not share promises across different tags', async () => {
+  it('does not share promises across different wrapped functions', async () => {
     const [runTom, resolveTom] = mockAsyncFn('tom');
     const [runJerry, resolveJerry] = mockAsyncFn('jerry');
+    const tom = singleFlight(runTom);
+    const jerry = singleFlight(runJerry);
 
-    const readyTom = withSingleFlight(Symbol('tom'), runTom);
-    const readyJerry = withSingleFlight(Symbol('jerry'), runJerry);
+    const readyTom = tom();
+    const readyJerry = jerry();
 
     expect(readyJerry).not.toBe(readyTom);
     expect(log).toMatchObject(['tom start', 'jerry start']);
@@ -224,6 +224,21 @@ describe('single flight', () => {
     resolveTom();
     resolveJerry();
     await Promise.all([readyTom, readyJerry]);
+  });
+
+  it('shares the first call arguments while a call is in flight', async () => {
+    const run = singleFlight(async (value: string) => {
+      log.push(`${value} start`);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      log.push(`${value} end`);
+      return value;
+    });
+
+    await expect(Promise.all([run('first'), run('second')])).resolves.toEqual([
+      'first',
+      'first',
+    ]);
+    expect(log).toMatchObject(['first start', 'first end']);
   });
 });
 

--- a/packages/client/src/helpers/__tests__/concurrency.test.ts
+++ b/packages/client/src/helpers/__tests__/concurrency.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   hasPending,
   withCancellation,
+  withSingleFlight,
   withoutConcurrency,
 } from '../concurrency';
 
@@ -166,6 +167,64 @@ it('keeps track of pending promises', async () => {
   resolve2();
   await ready2;
   expect(hasPending(tag)).toBeFalsy();
+});
+
+describe('single flight', () => {
+  it('shares an in-flight promise for the same tag', async () => {
+    const tag = Symbol();
+    const [run1, resolve1] = mockAsyncFn('promise1');
+    const [run2] = mockAsyncFn('promise2');
+
+    const ready1 = withSingleFlight(tag, run1);
+    const ready2 = withSingleFlight(tag, run2);
+
+    expect(ready2).toBe(ready1);
+    expect(log).toMatchObject(['promise1 start']);
+
+    resolve1();
+    await expect(Promise.all([ready1, ready2])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(log).toMatchObject(['promise1 start', 'promise1 end']);
+  });
+
+  it('allows a new execution after the in-flight promise settles', async () => {
+    const tag = Symbol();
+    const [run1, resolve1] = mockAsyncFn('promise1');
+    const [run2, resolve2] = mockAsyncFn('promise2');
+
+    const ready1 = withSingleFlight(tag, run1);
+    resolve1();
+    await ready1;
+
+    const ready2 = withSingleFlight(tag, run2);
+    expect(ready2).not.toBe(ready1);
+
+    resolve2();
+    await ready2;
+    expect(log).toMatchObject([
+      'promise1 start',
+      'promise1 end',
+      'promise2 start',
+      'promise2 end',
+    ]);
+  });
+
+  it('does not share promises across different tags', async () => {
+    const [runTom, resolveTom] = mockAsyncFn('tom');
+    const [runJerry, resolveJerry] = mockAsyncFn('jerry');
+
+    const readyTom = withSingleFlight(Symbol('tom'), runTom);
+    const readyJerry = withSingleFlight(Symbol('jerry'), runJerry);
+
+    expect(readyJerry).not.toBe(readyTom);
+    expect(log).toMatchObject(['tom start', 'jerry start']);
+
+    resolveTom();
+    resolveJerry();
+    await Promise.all([readyTom, readyJerry]);
+  });
 });
 
 describe('cancelation', () => {

--- a/packages/client/src/helpers/concurrency.ts
+++ b/packages/client/src/helpers/concurrency.ts
@@ -44,30 +44,29 @@ export const withoutConcurrency = createRunner(wrapWithContinuationTracking);
 export const withCancellation = createRunner(wrapWithCancellation);
 
 const pendingPromises = new Map<TagKey, PendingPromise>();
-const singleFlightPromises = new Map<TagKey, Promise<unknown>>();
 
 /**
- * Runs an async function once while it is in flight. Concurrent calls with the
- * same tag share the in-flight promise instead of queueing another execution.
+ * Wraps an async function so concurrent calls share the in-flight promise
+ * instead of queueing another execution.
  *
- * @param tag Async functions with the same tag will share the in-flight promise.
- * @param cb Async function to run.
- * @returns Promise that resolves with the shared async function result.
+ * @param cb Async function to wrap.
+ * @returns Wrapped async function.
  */
-export function withSingleFlight<T>(
-  tag: TagKey,
-  cb: () => Promise<T>,
-): Promise<T> {
-  const pending = singleFlightPromises.get(tag) as Promise<T> | undefined;
-  if (pending) return pending;
+export function singleFlight<P extends unknown[], T>(
+  cb: (...args: P) => Promise<T>,
+): (...args: P) => Promise<T> {
+  let pending: Promise<T> | undefined;
+  return (...args: P): Promise<T> => {
+    if (pending) return pending;
 
-  const promise = cb().finally(() => {
-    if (singleFlightPromises.get(tag) === promise) {
-      singleFlightPromises.delete(tag);
-    }
-  });
-  singleFlightPromises.set(tag, promise);
-  return promise;
+    const promise = cb(...args).finally(() => {
+      if (pending === promise) {
+        pending = undefined;
+      }
+    });
+    pending = promise;
+    return promise;
+  };
 }
 
 export function hasPending(tag: TagKey) {

--- a/packages/client/src/helpers/concurrency.ts
+++ b/packages/client/src/helpers/concurrency.ts
@@ -44,6 +44,31 @@ export const withoutConcurrency = createRunner(wrapWithContinuationTracking);
 export const withCancellation = createRunner(wrapWithCancellation);
 
 const pendingPromises = new Map<TagKey, PendingPromise>();
+const singleFlightPromises = new Map<TagKey, Promise<unknown>>();
+
+/**
+ * Runs an async function once while it is in flight. Concurrent calls with the
+ * same tag share the in-flight promise instead of queueing another execution.
+ *
+ * @param tag Async functions with the same tag will share the in-flight promise.
+ * @param cb Async function to run.
+ * @returns Promise that resolves with the shared async function result.
+ */
+export function withSingleFlight<T>(
+  tag: TagKey,
+  cb: () => Promise<T>,
+): Promise<T> {
+  const pending = singleFlightPromises.get(tag) as Promise<T> | undefined;
+  if (pending) return pending;
+
+  const promise = cb().finally(() => {
+    if (singleFlightPromises.get(tag) === promise) {
+      singleFlightPromises.delete(tag);
+    }
+  });
+  singleFlightPromises.set(tag, promise);
+  return promise;
+}
 
 export function hasPending(tag: TagKey) {
   return pendingPromises.has(tag);


### PR DESCRIPTION
### 💡 Overview
Prevents duplicate concurrent call.join() executions on the same Call instance. Adds a `singleFlight` async wrapper that shares one in-flight promise across overlapping calls to the same wrapped function. Call.join() now uses this wrapper, so duplicate concurrent joins wait on the first join flow instead of starting another join attempt and potentially throwing `Illegal State: call.join() shall be called only once.`

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1098/calljoin-has-no-concurrency-guard-a-duplicate-callaccepted-can-start

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call joining so simultaneous join attempts share the same in-progress operation.
  * Prevented duplicate join workflows while preserving existing validation, retries, migration, and error handling.
  * Join operations can be initiated again normally after the previous attempt completes.

* **Tests**
  * Added coverage for concurrent call joins and shared in-flight operations.
  * Added tests confirming proper promise reuse, cleanup, and independent operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->