### PR TITLE
chore: adjusted firebase messaging imports

### DIFF
--- a/packages/react-native-callingx/android/build.gradle
+++ b/packages/react-native-callingx/android/build.gradle
@@ -89,7 +89,7 @@ dependencies {
   implementation "androidx.core:core-telecom:1.0.1"
   // Compile-time only dependency so StreamMessagingService can reference RemoteMessage.
   // The consuming app (via @react-native-firebase/messaging) must provide the actual runtime version.
-  compileOnly "com.google.firebase:firebase-messaging-ktx:24.1.2"
+  compileOnly "com.google.firebase:firebase-messaging:24.1.2"
   // Optional: use Firebase native code when the app has react-native-firebase installed (peer deps)
   implementation project(':react-native-firebase_app')
   implementation project(':react-native-firebase_messaging')

--- a/packages/react-native-sdk/src/utils/push/android.ts
+++ b/packages/react-native-sdk/src/utils/push/android.ts
@@ -1,7 +1,7 @@
 import { StreamVideoClient, videoLoggerSystem } from '@stream-io/video-client';
 import { Platform } from 'react-native';
 import type { StreamVideoConfig } from '../StreamVideoRN/types';
-import { type FirebaseMessagingTypes, getFirebaseMessagingLib } from './libs';
+import { getFirebaseMessagingLib } from './libs';
 import { setPushLogoutCallback } from '../internal/pushLogoutCallback';
 
 type PushConfig = NonNullable<StreamVideoConfig['push']>;
@@ -63,9 +63,7 @@ let firebaseDataHandlerDeprecationLogged = false;
  * @deprecated Ring notifications are now handled by the SDK internally. This method is a no-op;
  * you can safely remove `firebaseDataHandler(...)` wiring from your Firebase messaging handlers.
  */
-export const firebaseDataHandler = async (
-  data?: FirebaseMessagingTypes.RemoteMessage['data'],
-) => {
+export const firebaseDataHandler = async (data?: any) => {
   void data;
   if (!firebaseDataHandlerDeprecationLogged) {
     firebaseDataHandlerDeprecationLogged = true;

--- a/packages/react-native-sdk/src/utils/push/internal/android.ts
+++ b/packages/react-native-sdk/src/utils/push/internal/android.ts
@@ -6,7 +6,7 @@ import {
 } from '@stream-io/video-client';
 import { AppState, Platform } from 'react-native';
 import {
-  type FirebaseMessagingTypes,
+  type FirebaseRemoteMessage,
   getCallingxLib,
   getCallingxLibIfAvailable,
 } from '../libs';
@@ -20,7 +20,7 @@ import { canListenToWS, shouldCallBeClosed } from './utils';
  * ignored (their display is app responsibility). Android-only; a no-op on other platforms.
  */
 export const onRingNotificationReceived = async (
-  data: FirebaseMessagingTypes.RemoteMessage['data'],
+  data: FirebaseRemoteMessage['data'],
 ) => {
   /* Example data from firebase
     "message": {

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
@@ -1,12 +1,18 @@
-import { lib, type Type } from './lib';
-
-export type { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
-export type FirebaseMessagingType = Type;
+import { lib, type MessagingModule } from './lib';
 
 const INSTALLATION_INSTRUCTION =
   'Please see https://rnfirebase.io/messaging/usage#installation for installation instructions';
 
-export function getFirebaseMessagingLib(): FirebaseMessagingType {
+export type FirebaseRemoteMessage = NonNullable<
+  Awaited<ReturnType<MessagingModule['getInitialNotification']>>
+>;
+
+export type FirebaseMessagingCompat = {
+  getToken: () => Promise<string>;
+  onTokenRefresh: (listener: (token: string) => void) => () => void;
+};
+
+function getFirebaseMessagingModule() {
   if (!lib) {
     throw Error(
       '@react-native-firebase/messaging is not installed. ' +
@@ -14,4 +20,16 @@ export function getFirebaseMessagingLib(): FirebaseMessagingType {
     );
   }
   return lib;
+}
+
+export function getFirebaseMessagingLib(): () => FirebaseMessagingCompat {
+  const messagingModule = getFirebaseMessagingModule();
+  return () => {
+    const messaging = messagingModule.getMessaging();
+    return {
+      getToken: () => messagingModule.getToken(messaging),
+      onTokenRefresh: (listener) =>
+        messagingModule.onTokenRefresh(messaging, listener),
+    };
+  };
 }

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/index.ts
@@ -7,11 +7,6 @@ export type FirebaseRemoteMessage = NonNullable<
   Awaited<ReturnType<MessagingModule['getInitialNotification']>>
 >;
 
-export type FirebaseMessagingCompat = {
-  getToken: () => Promise<string>;
-  onTokenRefresh: (listener: (token: string) => void) => () => void;
-};
-
 function getFirebaseMessagingModule() {
   if (!lib) {
     throw Error(
@@ -22,14 +17,12 @@ function getFirebaseMessagingModule() {
   return lib;
 }
 
-export function getFirebaseMessagingLib(): () => FirebaseMessagingCompat {
+export function getFirebaseMessagingLib() {
   const messagingModule = getFirebaseMessagingModule();
-  return () => {
-    const messaging = messagingModule.getMessaging();
-    return {
-      getToken: () => messagingModule.getToken(messaging),
-      onTokenRefresh: (listener) =>
-        messagingModule.onTokenRefresh(messaging, listener),
-    };
-  };
+  const messaging = messagingModule.getMessaging();
+  return () => ({
+    getToken: () => messagingModule.getToken(messaging),
+    onTokenRefresh: (listener: (token: string) => void) =>
+      messagingModule.onTokenRefresh(messaging, listener),
+  });
 }

--- a/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/lib.ts
+++ b/packages/react-native-sdk/src/utils/push/libs/firebaseMessaging/lib.ts
@@ -1,9 +1,9 @@
-export type Type = typeof import('@react-native-firebase/messaging').default;
+export type MessagingModule = typeof import('@react-native-firebase/messaging');
 
-let lib: Type | undefined;
+let lib: MessagingModule | undefined;
 
 try {
-  lib = require('@react-native-firebase/messaging').default;
+  lib = require('@react-native-firebase/messaging');
 } catch {}
 
 export { lib };

--- a/packages/react-native-sdk/src/utils/push/utils.ts
+++ b/packages/react-native-sdk/src/utils/push/utils.ts
@@ -1,4 +1,4 @@
-import type { FirebaseMessagingTypes } from './libs/firebaseMessaging';
+import type { FirebaseRemoteMessage } from './libs/firebaseMessaging';
 import type { NonRingingPushEvent } from '../StreamVideoRN/types';
 
 export type StreamPushPayload =
@@ -9,8 +9,6 @@ export type StreamPushPayload =
     }
   | undefined;
 
-export function isFirebaseStreamVideoMessage(
-  message: FirebaseMessagingTypes.RemoteMessage,
-) {
+export function isFirebaseStreamVideoMessage(message: FirebaseRemoteMessage) {
   return message.data?.sender === 'stream.video';
 }


### PR DESCRIPTION
### 💡 Overview

This PR migrated our @react-native-firebase/messaging usage from the namespaced API to the modular API (to support v26). Based on reported [issue](https://github.com/GetStream/stream-video-js/issues/2381)

🎫 Ticket: https://linear.app/stream/issue/RN-424/make-sdk-compatible-with-react-native-firebase-v26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android push notification compatibility with the latest Firebase Messaging package.
  * Updated Firebase message handling for current Firebase module formats and message types.
  * Preserved Stream Video notification detection, token retrieval, and token refresh behavior.
  * Retained backward-compatible behavior for the deprecated Firebase data handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->