### PR TITLE
fix: missing own capabilities for incoming call

### DIFF
--- a/packages/client/src/StreamVideoClient.ts
+++ b/packages/client/src/StreamVideoClient.ts
@@ -210,6 +210,7 @@ export class StreamVideoClient {
               await call.reject('busy');
             } else {
               await call.updateFromRingingEvent(e as CallRingEvent);
+              await call.get();
             }
           } else {
             call.state.updateFromCallResponse(e.call);


### PR DESCRIPTION
### 💡 Overview

This PR contains a fix for the incoming call missing own capabilities window.

The problem is when `call.created` event comes before `call.ringing` - `call.get` is not invoked in that sequence, which leads to own capabilities not being set until join flow. This may affect device manager behavior for incoming calls on pre-join stage (e.g. `canPublish` will return false in that window)

🎫 Ticket: https://linear.app/stream/issue/RN-425/incoming-call-missing-own-capabilities-issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing ringing calls now refresh their current server state after a ringing event, ensuring call details stay up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->