### PR TITLE
fix: do not allow empty android call display names

### DIFF
--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -223,13 +223,34 @@ class CallNotificationManager(
             notificationsState[callId]?.copy(lastSnapshot = newSnapshot)
                 ?: CallNotificationState(lastSnapshot = newSnapshot)
         val notification = createNotification(callId, call)
-        notificationManager.notify(notificationId, notification)
+        notifySafely(notificationId, notification)
         debugLog(TAG, "[notifications] updateCallNotification[$callId]: Notification posted (id=$notificationId)")
     }
 
     fun postNotification(callId: String, notification: Notification) = synchronized(lock) {
         val notificationId = getOrCreateNotificationId(callId)
-        notificationManager.notify(notificationId, notification)
+        notifySafely(notificationId, notification)
+    }
+
+    /**
+     * Posts a notification without letting a platform rejection take down the app.
+     *
+     * The system wraps any failure while sanitizing a notification attached to a foreground
+     * service into `SecurityException("Invalid FGS notification", cause)`. The underlying causes
+     * are transient or device specific (package lookups during user switches, OEM notification
+     * hooks), so the only viable defence is to log and keep the call alive; the next state change
+     * re-posts the notification.
+     */
+    private fun notifySafely(notificationId: Int, notification: Notification) {
+        try {
+            notificationManager.notify(notificationId, notification)
+        } catch (e: Exception) {
+            Log.e(
+                    TAG,
+                    "[notifications] notifySafely: Failed to post notification (id=$notificationId): ${e.message}",
+                    e
+            )
+        }
     }
 
     /**
@@ -385,8 +406,16 @@ class CallNotificationManager(
         val displayCallerName = call.displayOptions?.getString(CallService.EXTRA_DISPLAY_TITLE)
         val address = call.callAttributes.address.toString()
 
+        // CallStyle rejects a Person with a blank name (IllegalArgumentException at build time),
+        // so fall back through the display title, the call attributes and finally a static default.
+        val name =
+                sequenceOf(displayCallerName, call.callAttributes.displayName.toString())
+                        .mapNotNull { it?.trim() }
+                        .firstOrNull { it.isNotEmpty() }
+                        ?: CallService.DEFAULT_DISPLAY_NAME
+
         return Person.Builder()
-                .setName(displayCallerName ?: call.callAttributes.displayName)
+                .setName(name)
                 .setUri(address)
                 .setIcon(IconCompat.createWithResource(context, R.drawable.ic_user))
                 .setImportant(true)

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -41,6 +41,9 @@ class CallNotificationManager(
     internal companion object {
         private const val TAG = "[Callingx] CallNotificationManager"
         private const val DISABLED_COLOR = "#757575" // NOTE: hint color might be ignored by OS
+
+        /** Schemes the platform can resolve against the contacts provider. */
+        private val CONTACT_URI_SCHEMES = setOf("tel", "sip", "mailto", "content")
     }
 
     enum class OptimisticState { NONE, ACCEPTING, REJECTING }
@@ -218,13 +221,17 @@ class CallNotificationManager(
             return@synchronized
         }
 
+        // Creates the state entry when missing, which createNotification relies on below.
         val notificationId = getOrCreateNotificationId(callId)
-        notificationsState[callId] =
-            notificationsState[callId]?.copy(lastSnapshot = newSnapshot)
-                ?: CallNotificationState(lastSnapshot = newSnapshot)
         val notification = createNotification(callId, call)
-        notifySafely(notificationId, notification)
-        debugLog(TAG, "[notifications] updateCallNotification[$callId]: Notification posted (id=$notificationId)")
+        // Record the snapshot only once the post succeeds, so a rejected notification stays
+        // retryable instead of being skipped as "no state change".
+        if (notifySafely(notificationId, notification)) {
+            notificationsState[callId] =
+                notificationsState[callId]?.copy(lastSnapshot = newSnapshot)
+                    ?: CallNotificationState(lastSnapshot = newSnapshot)
+            debugLog(TAG, "[notifications] updateCallNotification[$callId]: Notification posted (id=$notificationId)")
+        }
     }
 
     fun postNotification(callId: String, notification: Notification) = synchronized(lock) {
@@ -238,18 +245,21 @@ class CallNotificationManager(
      * The system wraps any failure while sanitizing a notification attached to a foreground
      * service into `SecurityException("Invalid FGS notification", cause)`. The underlying causes
      * are transient or device specific (package lookups during user switches, OEM notification
-     * hooks), so the only viable defence is to log and keep the call alive; the next state change
-     * re-posts the notification.
+     * hooks), so the only viable defence is to log and keep the call alive.
+     *
+     * @return true when the notification was accepted by the system.
      */
-    private fun notifySafely(notificationId: Int, notification: Notification) {
-        try {
+    private fun notifySafely(notificationId: Int, notification: Notification): Boolean {
+        return try {
             notificationManager.notify(notificationId, notification)
+            true
         } catch (e: Exception) {
             Log.e(
                     TAG,
                     "[notifications] notifySafely: Failed to post notification (id=$notificationId): ${e.message}",
                     e
             )
+            false
         }
     }
 
@@ -404,7 +414,7 @@ class CallNotificationManager(
 
     private fun createPerson(call: Call.Registered): Person {
         val displayCallerName = call.displayOptions?.getString(CallService.EXTRA_DISPLAY_TITLE)
-        val address = call.callAttributes.address.toString()
+        val address = call.callAttributes.address
 
         // CallStyle rejects a Person with a blank name (IllegalArgumentException at build time),
         // so fall back through the display title, the call attributes and finally a static default.
@@ -414,12 +424,22 @@ class CallNotificationManager(
                         .firstOrNull { it.isNotEmpty() }
                         ?: CallService.DEFAULT_DISPLAY_NAME
 
-        return Person.Builder()
-                .setName(name)
-                .setUri(address)
-                .setIcon(IconCompat.createWithResource(context, R.drawable.ic_user))
-                .setImportant(true)
-                .build()
+        val builder =
+                Person.Builder()
+                        .setName(name)
+                        .setKey(address.toString())
+                        .setIcon(IconCompat.createWithResource(context, R.drawable.ic_user))
+                        .setImportant(true)
+
+        // setUri() feeds the platform's contact lookup, so it only makes sense for a handle the
+        // provider can resolve (e.g. "tel:+15551234"). Opaque ids such as Stream user ids never
+        // match a contact, and are carried by setKey() above instead.
+        val scheme = address.scheme?.lowercase()
+        if (scheme != null && scheme in CONTACT_URI_SCHEMES) {
+            builder.setUri(address.toString())
+        }
+
+        return builder.build()
     }
 
 }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -42,8 +42,16 @@ class CallNotificationManager(
         private const val TAG = "[Callingx] CallNotificationManager"
         private const val DISABLED_COLOR = "#757575" // NOTE: hint color might be ignored by OS
 
-        /** Schemes the platform can resolve against the contacts provider. */
-        private val CONTACT_URI_SCHEMES = setOf("tel", "sip", "mailto", "content")
+        /**
+         * Schemes the platform documents as resolvable for `Person.setUri()`: "tel:" is looked up
+         * through PhoneLookup and "mailto:" through the contacts email column.
+         *
+         * A contacts `CONTENT_LOOKUP_URI` is also resolvable, but any "content:" URI in a
+         * notification is run through the system's URI grant check, which throws a
+         * SecurityException from notify() when the app cannot grant it. Since no caller passes
+         * one, it is left out rather than risking that crash.
+         */
+        private val CONTACT_URI_SCHEMES = setOf("tel", "mailto")
     }
 
     enum class OptimisticState { NONE, ACCEPTING, REJECTING }
@@ -433,7 +441,7 @@ class CallNotificationManager(
 
         // setUri() feeds the platform's contact lookup, so it only makes sense for a handle the
         // provider can resolve (e.g. "tel:+15551234"). Opaque ids such as Stream user ids never
-        // match a contact, and are carried by setKey() above instead.
+        // match a contact, and are carried by setKey() above instead. See CONTACT_URI_SCHEMES.
         val scheme = address.scheme?.lowercase()
         if (scheme != null && scheme in CONTACT_URI_SCHEMES) {
             builder.setUri(address.toString())

--- a/packages/react-native-sdk/src/hooks/push/useCallingExpWithCallingStateEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useCallingExpWithCallingStateEffect.ts
@@ -30,7 +30,7 @@ export const useCallingExpWithCallingStateEffect = () => {
 
   const callDisplayName = useMemo(
     () =>
-      callCustomDisplayName ??
+      callCustomDisplayName ||
       getCallDisplayName(callMembers, participants, currentUserId),
     [callMembers, participants, currentUserId, callCustomDisplayName],
   );

--- a/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
+++ b/packages/react-native-sdk/src/utils/internal/callingx/callingx.ts
@@ -48,7 +48,7 @@ export function getCallDisplayName(
   if (names.length === 0) {
     names = [
       participants.find((participant) => participant.userId === currentUserId)
-        ?.name ?? 'Call',
+        ?.name || 'Call',
     ];
   }
 
@@ -57,7 +57,7 @@ export function getCallDisplayName(
 
 function getCallDisplayNameFromCall(call: Call): string {
   return (
-    call.state.custom?.display_name ??
+    call.state.custom?.display_name ||
     getCallDisplayName(
       call.state.members,
       call.state.participants,


### PR DESCRIPTION
### 💡 Overview

CallStyle rejects a blank-name Person, and an unguarded notify() let the system's "Invalid FGS notification". SecurityException will crash the app. 

### 📝 Implementation notes

Adds a display-name fallback, fixes empty-string fallthrough in getCallDisplayName (?? → ||), and wraps notify() in try/catch.

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved call notification reliability by keeping unsuccessful notifications eligible for retry.
  - Prevented invalid contact addresses from being used during caller information lookup.
  - Improved call display names by applying fallbacks when configured names are empty or unavailable.
  - Ensured caller details use stable identifiers for more consistent notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->