### PR TITLE
fix(callingx): don't tear down concurrent calls on stop service

### DIFF
--- a/packages/react-native-callingx/README.md
+++ b/packages/react-native-callingx/README.md
@@ -56,6 +56,7 @@ await CallingxModule.displayIncomingCall(
 - `addEventListener(eventName, callback)`.
 - `getInitialEvents()` and `getInitialVoipEvents()`.
 - `acquireBackgroundTask(owner)` / `releaseBackgroundTask(owner)` (Android) — ref-counted keep-alive task that keeps the JS runtime/timers alive in the background; the underlying HeadlessJS task starts on the first acquire and stops once all owners release.
+- `stopService()` (Android) — asks the call service to stop. A request, not a command: the service hosts every call, so it stays alive while any call is registered or is being registered. Use `endCallWithReason(callId, reason)` to tear down an individual call.
 
 ## Event names
 

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallRegistrationStore.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallRegistrationStore.kt
@@ -137,13 +137,20 @@ object CallRegistrationStore {
         synchronized(list) { return list.toList() }
     }
 
+    /** Forgets a call entirely: it is gone, so neither its id nor its queued actions can apply. */
+    fun discardCallState(callId: String) {
+        debugLog(TAG, "[store] discardCallState: Discarding all state for callId: $callId")
+        trackedCallIds.remove(callId)
+        pendingActionsByCallId.remove(callId)
+    }
+
     /**
      * Drops the JS-coupled state only: the promises and their timeouts belong to a React context
      * that is going away, so nothing can resolve them.
      *
      * [trackedCallIds] and [pendingActionsByCallId] are deliberately kept. They describe native
-     * calls, which outlive a JS teardown — a call still resolving its Telecom endpoints has its
-     * tracked id as its only protection against the service being stopped underneath it.
+     * calls, which outlive a JS teardown: a tracked id still makes `rejectCallWhenBusy` reject
+     * later pushes, and a queued action still has to be replayed once the call registers.
      */
     fun clearPendingPromises() {
         synchronized(pendingPromises) {

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallRegistrationStore.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallRegistrationStore.kt
@@ -137,13 +137,19 @@ object CallRegistrationStore {
         synchronized(list) { return list.toList() }
     }
 
-    fun clearAll() {
+    /**
+     * Drops the JS-coupled state only: the promises and their timeouts belong to a React context
+     * that is going away, so nothing can resolve them.
+     *
+     * [trackedCallIds] and [pendingActionsByCallId] are deliberately kept. They describe native
+     * calls, which outlive a JS teardown — a call still resolving its Telecom endpoints has its
+     * tracked id as its only protection against the service being stopped underneath it.
+     */
+    fun clearPendingPromises() {
         synchronized(pendingPromises) {
             pendingTimeouts.values.forEach { mainHandler.removeCallbacks(it) }
             pendingTimeouts.clear()
             pendingPromises.clear()
         }
-        trackedCallIds.clear()
-        pendingActionsByCallId.clear()
     }
 }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -245,10 +245,7 @@ class CallService : Service(), CallRepository.Listener {
 
         unregisterReceiver(optimisticNotificationReceiver)
 
-        if (isInForeground) {
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            isInForeground = false
-        }
+        demoteForeground()
 
         notificationManager.cancelAllNotifications()
         notificationManager.stopRingtone()
@@ -295,10 +292,7 @@ class CallService : Service(), CallRepository.Listener {
                 processAction(intent)
             }
             ACTION_STOP_SERVICE -> {
-                if (isInForeground) {
-                    stopForeground(STOP_FOREGROUND_REMOVE)
-                    isInForeground = false
-                }
+                demoteForeground()
                 notificationManager.cancelAllNotifications()
                 notificationManager.stopRingtone()
                 stopSelf()
@@ -371,10 +365,7 @@ class CallService : Service(), CallRepository.Listener {
                             TAG,
                             "[service] onCallStateChanged[$callId]: No more calls, stopping service"
                     )
-                    if (isInForeground) {
-                        stopForeground(STOP_FOREGROUND_REMOVE)
-                        isInForeground = false
-                    }
+                    demoteForeground()
                     stopSelf()
                 }
             }
@@ -543,10 +534,7 @@ class CallService : Service(), CallRepository.Listener {
 
                 // Only stop foreground/service when no other calls remain
                 if (!callRepository.hasAnyCalls()) {
-                    if (isInForeground) {
-                        stopForeground(STOP_FOREGROUND_REMOVE)
-                        isInForeground = false
-                    }
+                    demoteForeground()
                     notificationManager.stopRingtone()
                     stopSelf()
                 }
@@ -579,6 +567,14 @@ class CallService : Service(), CallRepository.Listener {
         }
     }
 
+    private fun demoteForeground() {
+        if (!isInForeground) return
+        debugLog(TAG, "[service] demoteForeground: leaving foreground")
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        isInForeground = false
+        notificationManager.clearAnchor()
+    }
+
     /**
      * Promotes the service using [callId]'s notification, and records the resulting FGS anchor.
      *
@@ -601,7 +597,7 @@ class CallService : Service(), CallRepository.Listener {
                 startForeground(notificationId, notification)
             }
             isInForeground = true
-            notificationManager.commitAnchor(callId)
+            notificationManager.commitAnchor(callId, notification)
             true
         } catch (e: Exception) {
             Log.e(
@@ -668,11 +664,11 @@ class CallService : Service(), CallRepository.Listener {
         }
 
         val foregroundCallId = notificationManager.getForegroundCallId() ?: return
-        val notification = notificationManager.postedNotificationFor(foregroundCallId)
+        val notification = notificationManager.lastPostedNotification(foregroundCallId)
         if (notification == null) {
             Log.w(
                     TAG,
-                    "[service] repromoteForegroundType: no live notification for anchor $foregroundCallId"
+                    "[service] repromoteForegroundType: nothing posted for anchor $foregroundCallId"
             )
             return
         }
@@ -717,8 +713,7 @@ class CallService : Service(), CallRepository.Listener {
             // anchor we do not have — that is what surfaces later as
             // SecurityException: Invalid FGS notification.
             debugLog(TAG, "[service] repromoteForegroundIfNeeded: No anchor available, demoting")
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            isInForeground = false
+            demoteForeground()
         }
 
         notificationManager.cancelNotification(callId)

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -348,7 +348,9 @@ class CallService : Service(), CallRepository.Listener {
                             "[service] onCallStateChanged[$callId]: Starting foreground for call"
                     )
                     notificationManager.resetOptimisticState(callId)
-                    //TODO: check if this branch is not outdated
+                    // Recovery path: a registered call changed state while the service is not
+                    // foreground (e.g. an earlier promote failed, or we demoted after a failed
+                    // re-anchor). Promote here so the call keeps an FGS anchor.
                     val notification = notificationManager.createNotification(callId, call)
                     startForegroundSafely(callId, notificationId, notification)
                 }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -281,11 +281,9 @@ class CallService : Service(), CallRepository.Listener {
             }
             ACTION_START_BACKGROUND_TASK -> {
                 startBackgroundTask(intent)
-                return START_NOT_STICKY
             }
             ACTION_STOP_BACKGROUND_TASK -> {
                 stopBackgroundTask()
-                return START_NOT_STICKY
             }
             ACTION_UPDATE_CALL -> {
                 updateCall(intent)
@@ -305,11 +303,10 @@ class CallService : Service(), CallRepository.Listener {
             else -> {
                 Log.e(TAG, "[service] onStartCommand: Unknown action: ${intent.action}")
                 stopSelf()
-                return START_NOT_STICKY
             }
         }
 
-        return START_STICKY
+        return START_NOT_STICKY
     }
 
     override fun onBind(intent: Intent): IBinder? = binder

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -238,9 +238,12 @@ class CallService : Service(), CallRepository.Listener {
         debugLog(TAG, "[service] onCreate: TelecomCallService created")
 
         notificationManager = CallNotificationManager(applicationContext)
-        headlessJSManager = HeadlessTaskManager(applicationContext)
         callRepository = CallRepositoryFactory.create(applicationContext)
         callRepository.setListener(this)
+        // Constructed after callRepository: onTaskFinished reads it, and a task can only finish
+        // after onStartCommand has started one.
+        headlessJSManager =
+                HeadlessTaskManager(applicationContext) { stopServiceIfIdle(lastStartId) }
 
         val filter =
                 IntentFilter().apply {
@@ -599,7 +602,12 @@ class CallService : Service(), CallRepository.Listener {
     }
 
     /**
-     * Handles [ACTION_STOP_SERVICE] as a *request*, not a command. The service hosts every call, so
+     * Re-evaluates whether the service still has a reason to run, and stops it if not. Reached from
+     * [ACTION_STOP_SERVICE] and from [HeadlessTaskManager]'s task-finished callback — the latter
+     * because a call-less service is started by `acquireBackgroundTask` alone (via `startService`,
+     * see `CallingxModuleImpl.startBackgroundTask`) and no call-state transition would ever stop it.
+     *
+     * Both callers are making a *request*, not issuing a command: the service hosts every call, so
      * it may only go down when nothing owns it. Two independent signals are checked because they
      * cover opposite interleavings of "tear this call down" against "a new call is arriving":
      * - [CallRegistrationStore.hasRegisteredCall] covers a call already tracked when we read state.

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -76,6 +76,12 @@ class CallService : Service(), CallRepository.Listener {
         internal const val ACTION_PROCESS_ACTION = "execute_action"
         internal const val ACTION_REGISTRATION_FAILED = "registration_failed"
 
+        /**
+         * True while a [CallService] instance exists. Only meaningful in-process (the service has
+         * no `android:process`), and used to avoid creating the service just to stop it.
+         */
+        @Volatile internal var isRunning: Boolean = false
+
         fun startIncomingCallFromPush(context: Context, data: Map<String, String>) {
             debugLog(TAG, "[service] startIncomingCallFromPush: Starting incoming call from push")
 
@@ -130,7 +136,19 @@ class CallService : Service(), CallRepository.Listener {
                         putExtra(EXTRA_IS_VIDEO, isVideo)
                     }
 
-            ContextCompat.startForegroundService(context, intent)
+            try {
+                ContextCompat.startForegroundService(context, intent)
+            } catch (e: Exception) {
+                // The call was tracked above so a concurrent stop request could not race it. If
+                // the service never starts, drop the tracked id — a stale entry would block every
+                // subsequent stop and strand the foreground service.
+                Log.e(
+                        TAG,
+                        "[service] startIncomingCallFromPush: Failed to start service: ${e.message}",
+                        e
+                )
+                CallRegistrationStore.removeTrackedCall(callCid)
+            }
         }
     }
 
@@ -148,6 +166,14 @@ class CallService : Service(), CallRepository.Listener {
 
     @Volatile
     private var isInForeground = false
+
+    /**
+     * Start id of the most recently *delivered* start command. ActivityManager bumps its own last
+     * start id when `startService` is called, before delivery, so passing this to [stopSelfResult]
+     * makes any stop lose against a start that is already queued.
+     */
+    @Volatile
+    private var lastStartId = 0
 
     private val onAppForeground = Runnable { repromoteForegroundTypeIfNeeded() }
 
@@ -235,11 +261,15 @@ class CallService : Service(), CallRepository.Listener {
         }
 
         LifecycleListener.addOnForegroundListener(onAppForeground)
+
+        isRunning = true
     }
 
     override fun onDestroy() {
         super.onDestroy()
         debugLog(TAG, "[service] onDestroy: TelecomCallService destroyed")
+
+        isRunning = false
 
         LifecycleListener.removeOnForegroundListener(onAppForeground)
 
@@ -265,6 +295,8 @@ class CallService : Service(), CallRepository.Listener {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         debugLog(TAG, "[service] onStartCommand: Received intent with action: ${intent?.action}")
+
+        lastStartId = startId
 
         if (intent == null || intent.action == null) {
             Log.w(TAG, "[service] onStartCommand: Intent is null, returning START_NOT_STICKY")
@@ -294,17 +326,12 @@ class CallService : Service(), CallRepository.Listener {
                 processAction(intent)
             }
             ACTION_STOP_SERVICE -> {
-                if (isInForeground) {
-                    stopForeground(STOP_FOREGROUND_REMOVE)
-                    isInForeground = false
-                }
-                notificationManager.cancelAllNotifications()
-                notificationManager.stopRingtone()
-                stopSelf()
+                stopServiceIfIdle(startId)
+                return START_NOT_STICKY
             }
             else -> {
                 Log.e(TAG, "[service] onStartCommand: Unknown action: ${intent.action}")
-                stopSelf()
+                stopSelfResult(startId)
                 return START_NOT_STICKY
             }
         }
@@ -364,17 +391,15 @@ class CallService : Service(), CallRepository.Listener {
                 repromoteForegroundIfNeeded(callId)
                 if (!callRepository.hasRingingCall()) notificationManager.stopRingtone()
 
-                // Stop service only when no calls remain
-                if (!callRepository.hasAnyCalls()) {
+                // Stop service only when no calls remain and none is being registered
+                if (!callRepository.hasAnyCalls() &&
+                                !CallRegistrationStore.hasRegisteredCall()
+                ) {
                     debugLog(
                             TAG,
                             "[service] onCallStateChanged[$callId]: No more calls, stopping service"
                     )
-                    if (isInForeground) {
-                        stopForeground(STOP_FOREGROUND_REMOVE)
-                        isInForeground = false
-                    }
-                    stopSelf()
+                    stopSelfIfNoPendingStart(lastStartId)
                 }
             }
         }
@@ -531,6 +556,9 @@ class CallService : Service(), CallRepository.Listener {
                         TAG,
                         "[service] registerCall: Registration canceled for ${callInfo.callId} during teardown"
                 )
+                // The call never made it into the repository, so nothing else will drop its tracked
+                // id — and a stale one blocks every later stop (see stopServiceIfIdle).
+                CallRegistrationStore.removeTrackedCall(callInfo.callId)
             } catch (e: Exception) {
                 Log.e(TAG, "[service] registerCall: Error registering call: ${e.message}")
 
@@ -538,16 +566,19 @@ class CallService : Service(), CallRepository.Listener {
                     putExtra(CallingxModuleImpl.EXTRA_CALL_ID, callInfo.callId)
                 }
 
+                // CallingxModuleImpl also drops the tracked id when it receives the broadcast
+                // above, but only if a JS module instance is alive — which it need not be in a
+                // headless push flow. Removing it here too is idempotent.
+                CallRegistrationStore.removeTrackedCall(callInfo.callId)
+
                 repromoteForegroundIfNeeded(callInfo.callId)
 
                 // Only stop foreground/service when no other calls remain
-                if (!callRepository.hasAnyCalls()) {
-                    if (isInForeground) {
-                        stopForeground(STOP_FOREGROUND_REMOVE)
-                        isInForeground = false
-                    }
+                if (!callRepository.hasAnyCalls() &&
+                                !CallRegistrationStore.hasRegisteredCall()
+                ) {
                     notificationManager.stopRingtone()
-                    stopSelf()
+                    stopSelfIfNoPendingStart(lastStartId)
                 }
             }
         }
@@ -576,6 +607,55 @@ class CallService : Service(), CallRepository.Listener {
 
             return false
         }
+    }
+
+    /**
+     * Handles [ACTION_STOP_SERVICE] as a *request*, not a command. The service hosts every call, so
+     * it may only go down when nothing owns it. Two independent signals are checked because they
+     * cover opposite interleavings of "tear this call down" against "a new call is arriving":
+     * - [CallRegistrationStore.hasRegisteredCall] covers a call already tracked when we read state.
+     *   Tracking happens synchronously *before* `startForegroundService`, so it is set even while
+     *   the new call's intent is still queued and the repository is empty.
+     * - [stopSelfIfNoPendingStart] covers a call whose start reached ActivityManager *after* we
+     *   read state, which the check above cannot see.
+     */
+    private fun stopServiceIfIdle(startId: Int) {
+        if (callRepository.hasAnyCalls() || CallRegistrationStore.hasRegisteredCall()) {
+            debugLog(
+                    TAG,
+                    "[service] stopServiceIfIdle: Calls still present (tracked=${CallRegistrationStore.getTrackedCallIds()}), keeping service alive"
+            )
+            return
+        }
+
+        if (!stopSelfIfNoPendingStart(startId)) return
+
+        notificationManager.cancelAllNotifications()
+        notificationManager.stopRingtone()
+    }
+
+    /**
+     * Stops the service only if no newer start command is already pending, and demotes it from the
+     * foreground when the stop is accepted. ActivityManager bumps its own last start id when
+     * `startService` is called — before delivery — so a mismatch here means an incoming-call start
+     * is already in flight and the service must stay up for it.
+     *
+     * @return true when the stop was accepted.
+     */
+    private fun stopSelfIfNoPendingStart(startId: Int): Boolean {
+        if (!stopSelfResult(startId)) {
+            Log.w(
+                    TAG,
+                    "[service] stopSelfIfNoPendingStart: Stop refused (startId=$startId), a newer start is pending"
+            )
+            return false
+        }
+
+        if (isInForeground) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            isInForeground = false
+        }
+        return true
     }
 
     private fun startForegroundSafely(notificationId: Int, notification: Notification) {

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -245,15 +245,15 @@ class CallService : Service(), CallRepository.Listener {
 
         unregisterReceiver(optimisticNotificationReceiver)
 
-        notificationManager.cancelAllNotifications()
-        notificationManager.stopRingtone()
-        callRepository.release()
-        headlessJSManager.release()
-
         if (isInForeground) {
             stopForeground(STOP_FOREGROUND_REMOVE)
             isInForeground = false
         }
+
+        notificationManager.cancelAllNotifications()
+        notificationManager.stopRingtone()
+        callRepository.release()
+        headlessJSManager.release()
 
         scope.cancel()
     }
@@ -354,8 +354,9 @@ class CallService : Service(), CallRepository.Listener {
                             "[service] onCallStateChanged[$callId]: Starting foreground for call"
                     )
                     notificationManager.resetOptimisticState(callId)
+                    //TODO: check if this branch is not outdated
                     val notification = notificationManager.createNotification(callId, call)
-                    startForegroundSafely(notificationId, notification)
+                    startForegroundSafely(callId, notificationId, notification)
                 }
             }
             is Call.None, is Call.Unregistered -> {
@@ -578,20 +579,37 @@ class CallService : Service(), CallRepository.Listener {
         }
     }
 
-    private fun startForegroundSafely(notificationId: Int, notification: Notification) {
-        try {
+    /**
+     * Promotes the service using [callId]'s notification, and records the resulting FGS anchor.
+     *
+     * @param type an already-computed [computeForegroundServiceType] result. Callers that computed it
+     *   to decide *whether* to promote should pass it, so the mask used matches the one they checked —
+     *   recomputing can disagree if permissions or app lifecycle shift in between.
+     * @return true when the platform accepted the promotion. On failure [foregroundCallId] is left
+     *   untouched: a previously valid anchor must not be discarded because a new promote failed.
+     */
+    private fun startForegroundSafely(
+            callId: String,
+            notificationId: Int,
+            notification: Notification,
+            type: Int? = null,
+    ): Boolean {
+        return try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                startForeground(notificationId, notification, computeForegroundServiceType())
+                startForeground(notificationId, notification, type ?: computeForegroundServiceType())
             } else {
                 startForeground(notificationId, notification)
             }
             isInForeground = true
+            notificationManager.commitAnchor(callId)
+            true
         } catch (e: Exception) {
             Log.e(
                     TAG,
                     "[service] startForegroundSafely: Failed to start foreground service: ${e.message}",
                     e
             )
+            false
         }
     }
 
@@ -650,19 +668,23 @@ class CallService : Service(), CallRepository.Listener {
         }
 
         val foregroundCallId = notificationManager.getForegroundCallId() ?: return
-        val call = callRepository.getCall(foregroundCallId) ?: return
-        val notificationId = notificationManager.getOrCreateNotificationId(foregroundCallId)
-        val notification = notificationManager.createNotification(foregroundCallId, call)
-
-        try {
-            startForeground(notificationId, notification, type)
-        } catch (e: Exception) {
-            Log.e(
+        val notification = notificationManager.postedNotificationFor(foregroundCallId)
+        if (notification == null) {
+            Log.w(
                     TAG,
-                    "[service] repromoteForegroundType: failed to upgrade FGS type: ${e.message}",
-                    e
+                    "[service] repromoteForegroundType: no live notification for anchor $foregroundCallId"
             )
+            return
         }
+
+        // Deliberately ignoring the result: a failed type upgrade leaves a valid FGS on the previous,
+        // narrower type. Unlike repromoteForegroundIfNeeded, this must NOT demote.
+        startForegroundSafely(
+                foregroundCallId,
+                notificationManager.getOrCreateNotificationId(foregroundCallId),
+                notification,
+                type,
+        )
     }
 
     /**
@@ -670,16 +692,36 @@ class CallService : Service(), CallRepository.Listener {
      * and other calls remain, re-promotes the service with the next call's notification.
      */
     private fun repromoteForegroundIfNeeded(callId: String) {
-        val newForegroundNotificationId = notificationManager.cancelNotification(callId)
-        if (newForegroundNotificationId != null && isInForeground) {
-            val newForegroundCallId = notificationManager.getForegroundCallId()
-            val call = if (newForegroundCallId != null) callRepository.getCall(newForegroundCallId) else null
-            if (call != null && newForegroundCallId != null) {
-                debugLog(TAG, "[service] repromoteForegroundIfNeeded: Re-promoting with call $newForegroundCallId (notificationId=$newForegroundNotificationId)")
-                val notification = notificationManager.createNotification(newForegroundCallId, call)
-                startForegroundSafely(newForegroundNotificationId, notification)
-            }
+        val wasAnchor = notificationManager.getForegroundCallId() == callId
+        if (!isInForeground || !wasAnchor) {
+            debugLog(TAG, "[service] repromoteForegroundIfNeeded: Another call still holds the anchor, not re-anchoring")
+            notificationManager.cancelNotification(callId)
+            return
         }
+
+        val next = notificationManager.nextAnchorCandidate(excluding = callId)
+        val anchored =
+                if (next == null) {
+                    debugLog(TAG, "[service] repromoteForegroundIfNeeded: No next anchor candidate, not re-anchoring")
+                    false
+                } else {
+                    debugLog(
+                            TAG,
+                            "[service] repromoteForegroundIfNeeded: Re-anchoring to ${next.callId} (notificationId=${next.notificationId})"
+                    )
+                    startForegroundSafely(next.callId, next.notificationId, next.notification)
+                }
+
+        if (!anchored) {
+            // Nothing to anchor to, or the promote failed. Never leave isInForeground claiming an
+            // anchor we do not have — that is what surfaces later as
+            // SecurityException: Invalid FGS notification.
+            debugLog(TAG, "[service] repromoteForegroundIfNeeded: No anchor available, demoting")
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            isInForeground = false
+        }
+
+        notificationManager.cancelNotification(callId)
     }
 
     private fun startForegroundForCall(callInfo: CallInfo, incoming: Boolean) {
@@ -692,7 +734,7 @@ class CallService : Service(), CallRepository.Listener {
                     "[service] registerCall: Starting foreground for call: ${callInfo.callId}"
             )
             val notification = notificationManager.createNotification(callInfo.callId, tempCall)
-            startForegroundSafely(notificationId, notification)
+            startForegroundSafely(callInfo.callId, notificationId, notification)
         } else if (!notificationManager.isNotificationPosted(callInfo.callId)) {
             // Post only when this call has no notification yet (e.g. a second concurrent call).
             val notification = notificationManager.createNotification(callInfo.callId, tempCall)

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -585,33 +585,19 @@ class CallService : Service(), CallRepository.Listener {
     }
 
     /**
-     * The single place this service stops itself. Every caller — a call unregistering, a failed
-     * registration, [ACTION_STOP_SERVICE], an unknown action, and [HeadlessTaskManager]'s
-     * task-finished callback — is making a *request*, not issuing a command: the service hosts
-     * every call, so it may only go down once nothing owns it.
+     * The only place this service stops itself. Callers are asking, not telling: the service hosts
+     * every call, so it may only go down once nothing needs it.
      *
-     * Two of the checks cover opposite interleavings of "tear this call down" against "a new call
-     * is arriving", which is why neither alone is enough:
-     * - [CallRegistrationStore.hasRegisteredCall] covers a call already tracked when we read state.
-     *   Tracking happens synchronously *before* `startForegroundService`, so it is set even while
-     *   the new call's intent is still queued and the repository is empty.
-     * - [stopSelfResult] with the delivered start id covers an owner whose start reached
-     *   ActivityManager *after* we read state, which the checks above cannot see. ActivityManager
-     *   bumps its own last start id when `startService` is called, before delivery, so a mismatch
-     *   means a start is already in flight and the service must stay up for it.
+     * Each check catches a new call at a different stage, so none is enough alone:
+     * - `hasAnyCalls` — registered in the repository.
+     * - `hasRegisteredCall` — tracked but not registered yet. Tracking happens before the start
+     *   intent is sent, and registration completes well after it is delivered.
+     * - `hasActiveTask` — JS still holds a keep-alive owner; stopping would end its task early.
+     * - [stopSelfResult] — a newer start is already queued. ActivityManager bumps its last start id
+     *   when `startService` is called, before we see the intent.
      *
-     * A running headless task counts as an owner: JS holding entries in `_keepAliveOwners` keeps
-     * the keep-alive task's promise pending, which is what [HeadlessTaskManager.hasActiveTask]
-     * reports. `releaseBackgroundTask` debounces its stop by 2s so the ringing-push -> keep-alive
-     * hand-off can reuse the task, and destroying the service calls [HeadlessTaskManager.release],
-     * which would finish that task early. The window between JS adding an owner and the native
-     * start arriving is covered by the start-id check, since that start is what creates the
-     * service in the first place.
-     *
-     * Teardown (foreground demotion, notifications, ringtone) is left to [onDestroy]: nothing
-     * binds to this service, so destruction is not deferred, and the call-state paths have already
-     * been through [repromoteForegroundIfNeeded], which demotes when it cannot re-anchor. Demoting
-     * here would give up a valid anchor whenever the stop is refused.
+     * Teardown is [onDestroy]'s job, which always runs since nothing binds here. Demoting from the
+     * foreground here would also drop a still-valid anchor when the stop is refused.
      */
     private fun stopServiceIfIdle(startId: Int) {
         if (callRepository.hasAnyCalls() ||

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -10,7 +10,6 @@ import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.net.Uri
-import android.os.Binder
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
@@ -152,15 +151,10 @@ class CallService : Service(), CallRepository.Listener {
         }
     }
 
-    inner class CallServiceBinder : Binder() {
-        fun getService(): CallService = this@CallService
-    }
-
     private lateinit var headlessJSManager: HeadlessTaskManager
     private lateinit var notificationManager: CallNotificationManager
     private lateinit var callRepository: CallRepository
 
-    private val binder = CallServiceBinder()
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob())
     private val actionProcessingLock = Object()
 
@@ -339,12 +333,8 @@ class CallService : Service(), CallRepository.Listener {
         return START_STICKY
     }
 
-    override fun onBind(intent: Intent): IBinder? = binder
-
-    override fun onUnbind(intent: Intent): Boolean {
-        debugLog(TAG, "[service] onUnbind: Service unbound")
-        return super.onUnbind(intent)
-    }
+    /** Started-only service: nothing binds to it. */
+    override fun onBind(intent: Intent): IBinder? = null
 
     override fun onCallStateChanged(callId: String, call: Call) {
         debugLog(

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -577,7 +577,6 @@ class CallService : Service(), CallRepository.Listener {
                 if (!callRepository.hasAnyCalls() &&
                                 !CallRegistrationStore.hasRegisteredCall()
                 ) {
-                    notificationManager.stopRingtone()
                     stopSelfIfNoPendingStart(lastStartId)
                 }
             }
@@ -628,34 +627,25 @@ class CallService : Service(), CallRepository.Listener {
             return
         }
 
-        if (!stopSelfIfNoPendingStart(startId)) return
-
-        notificationManager.cancelAllNotifications()
-        notificationManager.stopRingtone()
+        stopSelfIfNoPendingStart(startId)
     }
 
     /**
-     * Stops the service only if no newer start command is already pending, and demotes it from the
-     * foreground when the stop is accepted. ActivityManager bumps its own last start id when
-     * `startService` is called — before delivery — so a mismatch here means an incoming-call start
-     * is already in flight and the service must stay up for it.
+     * Stops the service only if no newer start command is already pending. ActivityManager bumps
+     * its own last start id when `startService` is called — before delivery — so a mismatch here
+     * means an incoming-call start is already in flight and the service must stay up for it.
      *
-     * @return true when the stop was accepted.
+     * Teardown (foreground demotion, notifications, ringtone) is deliberately left to [onDestroy]:
+     * nothing binds to this service, so destruction is not deferred and that is the single place
+     * every stop path converges on.
      */
-    private fun stopSelfIfNoPendingStart(startId: Int): Boolean {
+    private fun stopSelfIfNoPendingStart(startId: Int) {
         if (!stopSelfResult(startId)) {
             Log.w(
                     TAG,
                     "[service] stopSelfIfNoPendingStart: Stop refused (startId=$startId), a newer start is pending"
             )
-            return false
         }
-
-        if (isInForeground) {
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            isInForeground = false
-        }
-        return true
     }
 
     private fun startForegroundSafely(notificationId: Int, notification: Notification) {

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -578,21 +578,17 @@ class CallService : Service(), CallRepository.Listener {
     /**
      * Promotes the service using [callId]'s notification, and records the resulting FGS anchor.
      *
-     * @param type an already-computed [computeForegroundServiceType] result. Callers that computed it
-     *   to decide *whether* to promote should pass it, so the mask used matches the one they checked —
-     *   recomputing can disagree if permissions or app lifecycle shift in between.
-     * @return true when the platform accepted the promotion. On failure [foregroundCallId] is left
+     * @return true when the platform accepted the promotion. On failure the recorded anchor is left
      *   untouched: a previously valid anchor must not be discarded because a new promote failed.
      */
     private fun startForegroundSafely(
             callId: String,
             notificationId: Int,
             notification: Notification,
-            type: Int? = null,
     ): Boolean {
         return try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                startForeground(notificationId, notification, type ?: computeForegroundServiceType())
+                startForeground(notificationId, notification, computeForegroundServiceType())
             } else {
                 startForeground(notificationId, notification)
             }
@@ -657,8 +653,7 @@ class CallService : Service(), CallRepository.Listener {
         if (!isInForeground) return // service is not foreground yet — nothing to upgrade
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
 
-        val type = computeForegroundServiceType()
-        if (type == ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL) {
+        if (computeForegroundServiceType() == ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL) {
             // Nothing extra to promote (no while-in-use permissions, or not foreground).
             return
         }
@@ -679,7 +674,6 @@ class CallService : Service(), CallRepository.Listener {
                 foregroundCallId,
                 notificationManager.getOrCreateNotificationId(foregroundCallId),
                 notification,
-                type,
         )
     }
 

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -323,7 +323,7 @@ class CallService : Service(), CallRepository.Listener {
             }
             else -> {
                 Log.e(TAG, "[service] onStartCommand: Unknown action: ${intent.action}")
-                stopSelfResult(startId)
+                stopServiceIfIdle(startId)
             }
         }
 
@@ -381,16 +381,7 @@ class CallService : Service(), CallRepository.Listener {
                 repromoteForegroundIfNeeded(callId)
                 if (!callRepository.hasRingingCall()) notificationManager.stopRingtone()
 
-                // Stop service only when no calls remain and none is being registered
-                if (!callRepository.hasAnyCalls() &&
-                                !CallRegistrationStore.hasRegisteredCall()
-                ) {
-                    debugLog(
-                            TAG,
-                            "[service] onCallStateChanged[$callId]: No more calls, stopping service"
-                    )
-                    stopSelfIfNoPendingStart(lastStartId)
-                }
+                stopServiceIfIdle(lastStartId)
             }
         }
     }
@@ -563,12 +554,7 @@ class CallService : Service(), CallRepository.Listener {
 
                 repromoteForegroundIfNeeded(callInfo.callId)
 
-                // Only stop foreground/service when no other calls remain
-                if (!callRepository.hasAnyCalls() &&
-                                !CallRegistrationStore.hasRegisteredCall()
-                ) {
-                    stopSelfIfNoPendingStart(lastStartId)
-                }
+                stopServiceIfIdle(lastStartId)
             }
         }
     }
@@ -599,23 +585,33 @@ class CallService : Service(), CallRepository.Listener {
     }
 
     /**
-     * Re-evaluates whether the service still has a reason to run, and stops it if not. Reached from
-     * [ACTION_STOP_SERVICE] and from [HeadlessTaskManager]'s task-finished callback — the latter
-     * because a call-less service is started by `acquireBackgroundTask` alone (via `startService`,
-     * see `CallingxModuleImpl.startBackgroundTask`) and no call-state transition would ever stop it.
+     * The single place this service stops itself. Every caller — a call unregistering, a failed
+     * registration, [ACTION_STOP_SERVICE], an unknown action, and [HeadlessTaskManager]'s
+     * task-finished callback — is making a *request*, not issuing a command: the service hosts
+     * every call, so it may only go down once nothing owns it.
      *
-     * Both callers are making a *request*, not issuing a command: the service hosts every call, so
-     * it may only go down when nothing owns it. Two independent signals are checked because they
-     * cover opposite interleavings of "tear this call down" against "a new call is arriving":
+     * Two of the checks cover opposite interleavings of "tear this call down" against "a new call
+     * is arriving", which is why neither alone is enough:
      * - [CallRegistrationStore.hasRegisteredCall] covers a call already tracked when we read state.
      *   Tracking happens synchronously *before* `startForegroundService`, so it is set even while
      *   the new call's intent is still queued and the repository is empty.
-     * - [stopSelfIfNoPendingStart] covers a call whose start reached ActivityManager *after* we
-     *   read state, which the check above cannot see.
+     * - [stopSelfResult] with the delivered start id covers an owner whose start reached
+     *   ActivityManager *after* we read state, which the checks above cannot see. ActivityManager
+     *   bumps its own last start id when `startService` is called, before delivery, so a mismatch
+     *   means a start is already in flight and the service must stay up for it.
      *
-     * A running headless task also counts as an owner. `releaseBackgroundTask` debounces its stop
-     * by 2s so the ringing-push -> keep-alive hand-off can reuse the task, and destroying the
-     * service calls [HeadlessTaskManager.release], which would finish that task early.
+     * A running headless task counts as an owner: JS holding entries in `_keepAliveOwners` keeps
+     * the keep-alive task's promise pending, which is what [HeadlessTaskManager.hasActiveTask]
+     * reports. `releaseBackgroundTask` debounces its stop by 2s so the ringing-push -> keep-alive
+     * hand-off can reuse the task, and destroying the service calls [HeadlessTaskManager.release],
+     * which would finish that task early. The window between JS adding an owner and the native
+     * start arriving is covered by the start-id check, since that start is what creates the
+     * service in the first place.
+     *
+     * Teardown (foreground demotion, notifications, ringtone) is left to [onDestroy]: nothing
+     * binds to this service, so destruction is not deferred, and the call-state paths have already
+     * been through [repromoteForegroundIfNeeded], which demotes when it cannot re-anchor. Demoting
+     * here would give up a valid anchor whenever the stop is refused.
      */
     private fun stopServiceIfIdle(startId: Int) {
         if (callRepository.hasAnyCalls() ||
@@ -629,24 +625,10 @@ class CallService : Service(), CallRepository.Listener {
             return
         }
 
-        stopSelfIfNoPendingStart(startId)
-    }
-
-    /**
-     * Stops the service only if no newer start command is already pending. ActivityManager bumps
-     * its own last start id when `startService` is called — before delivery — so a mismatch here
-     * means an incoming-call start is already in flight and the service must stay up for it.
-     *
-     * Deliberately does not [demoteForeground]: [onDestroy] does it, nothing binds to this service
-     * so destruction is not deferred, and the call-state stop paths have already been through
-     * [repromoteForegroundIfNeeded], which demotes when it cannot re-anchor. Demoting here would
-     * also give up a valid anchor on the paths where the stop is refused.
-     */
-    private fun stopSelfIfNoPendingStart(startId: Int) {
         if (!stopSelfResult(startId)) {
             Log.w(
                     TAG,
-                    "[service] stopSelfIfNoPendingStart: Stop refused (startId=$startId), a newer start is pending"
+                    "[service] stopServiceIfIdle: Stop refused (startId=$startId), a newer start is pending"
             )
         }
     }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -27,6 +27,7 @@ import io.getstream.rn.callingx.repo.CallRepositoryFactory
 import io.getstream.rn.callingx.utils.AudioEndpointUtils
 import io.getstream.rn.callingx.utils.LifecycleListener
 import io.getstream.rn.callingx.utils.SettingsStore
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -157,6 +158,13 @@ class CallService : Service(), CallRepository.Listener {
 
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob())
     private val actionProcessingLock = Object()
+
+    /**
+     * Calls this instance has launched a registration for that have not reached the repository yet.
+     * Scoped to the instance on purpose: it vetoes stopping the service, so a stale entry must die
+     * with the instance rather than outlive it in process-global state.
+     */
+    private val registeringCallIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     @Volatile
     private var isInForeground = false
@@ -420,6 +428,11 @@ class CallService : Service(), CallRepository.Listener {
     }
 
     override fun onCallRegistered(callId: String, incoming: Boolean) {
+        // The repository now reports this call, so hasAnyCalls() takes over the veto. This has to
+        // happen here rather than when registerCall returns: that only happens once the call has
+        // already been removed and Call.None has run the stop check.
+        registeringCallIds.remove(callId)
+
         if (incoming) {
             sendBroadcastEvent(CallingxModuleImpl.CALL_REGISTERED_INCOMING_ACTION) {
                 putExtra(CallingxModuleImpl.EXTRA_CALL_ID, callId)
@@ -521,6 +534,8 @@ class CallService : Service(), CallRepository.Listener {
             return
         }
 
+        registeringCallIds.add(callInfo.callId)
+
         scope.launch {
             try {
                 callRepository.registerCall(
@@ -538,8 +553,9 @@ class CallService : Service(), CallRepository.Listener {
                         "[service] registerCall: Registration canceled for ${callInfo.callId} during teardown"
                 )
                 // The call never made it into the repository, so nothing else will drop its tracked
-                // id — and a stale one blocks every later stop (see stopServiceIfIdle).
+                // id — and a stale one wrongly marks the user as busy for later pushes.
                 CallRegistrationStore.removeTrackedCall(callInfo.callId)
+                registeringCallIds.remove(callInfo.callId)
             } catch (e: Exception) {
                 Log.e(TAG, "[service] registerCall: Error registering call: ${e.message}")
 
@@ -551,10 +567,15 @@ class CallService : Service(), CallRepository.Listener {
                 // above, but only if a JS module instance is alive — which it need not be in a
                 // headless push flow. Removing it here too is idempotent.
                 CallRegistrationStore.removeTrackedCall(callInfo.callId)
+                registeringCallIds.remove(callInfo.callId)
 
                 repromoteForegroundIfNeeded(callInfo.callId)
 
                 stopServiceIfIdle(lastStartId)
+            } finally {
+                // Backstop for a registration that neither threw nor reached onCallRegistered.
+                // A no-op otherwise: the handover happens there, long before registerCall returns.
+                registeringCallIds.remove(callInfo.callId)
             }
         }
     }
@@ -590,8 +611,8 @@ class CallService : Service(), CallRepository.Listener {
      *
      * Each check catches a new call at a different stage, so none is enough alone:
      * - `hasAnyCalls` — registered in the repository.
-     * - `hasRegisteredCall` — tracked but not registered yet. Tracking happens before the start
-     *   intent is sent, and registration completes well after it is delivered.
+     * - `registeringCallIds` — this instance launched a registration that has not landed yet.
+     *   Registration spends up to 1.5s resolving Telecom endpoints before the repository sees it.
      * - `hasActiveTask` — JS still holds a keep-alive owner; stopping would end its task early.
      * - [stopSelfResult] — a newer start is already queued. ActivityManager bumps its last start id
      *   when `startService` is called, before we see the intent.
@@ -601,12 +622,12 @@ class CallService : Service(), CallRepository.Listener {
      */
     private fun stopServiceIfIdle(startId: Int) {
         if (callRepository.hasAnyCalls() ||
-                        CallRegistrationStore.hasRegisteredCall() ||
+                        registeringCallIds.isNotEmpty() ||
                         headlessJSManager.hasActiveTask()
         ) {
             debugLog(
                     TAG,
-                    "[service] stopServiceIfIdle: Still in use (tracked=${CallRegistrationStore.getTrackedCallIds()}, activeTask=${headlessJSManager.hasActiveTask()}), keeping service alive"
+                    "[service] stopServiceIfIdle: Still in use (registering=$registeringCallIds, activeTask=${headlessJSManager.hasActiveTask()}), keeping service alive"
             )
             return
         }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -290,8 +290,7 @@ class CallService : Service(), CallRepository.Listener {
         // tracked id makes rejectCallWhenBusy skip later pushes, and a left-behind action would
         // be replayed against a future call with the same id.
         (callRepository.calls.value.keys + registeringCallIds).forEach { callId ->
-            CallRegistrationStore.removeTrackedCall(callId)
-            CallRegistrationStore.takePendingActions(callId) // discarded: only the removal matters
+            CallRegistrationStore.discardCallState(callId)
         }
 
         callRepository.release()
@@ -631,7 +630,7 @@ class CallService : Service(), CallRepository.Listener {
      * - `hasAnyCalls` — registered in the repository.
      * - `registeringCallIds` — this instance launched a registration that has not landed yet.
      *   Registration spends up to 1.5s resolving Telecom endpoints before the repository sees it.
-     * - `hasActiveTask` — JS still holds a keep-alive owner; stopping would end its task early.
+     * - `ownsTaskSlot` — JS still holds a keep-alive owner; stopping would end its task early.
      * - [stopSelfResult] — a newer start is already queued. ActivityManager bumps its last start id
      *   when `startService` is called, before we see the intent.
      *
@@ -641,11 +640,11 @@ class CallService : Service(), CallRepository.Listener {
     private fun stopServiceIfIdle(startId: Int) {
         if (callRepository.hasAnyCalls() ||
                         registeringCallIds.isNotEmpty() ||
-                        headlessJSManager.hasActiveTask()
+                        headlessJSManager.ownsTaskSlot()
         ) {
             debugLog(
                     TAG,
-                    "[service] stopServiceIfIdle: Still in use (registering=$registeringCallIds, activeTask=${headlessJSManager.hasActiveTask()}), keeping service alive"
+                    "[service] stopServiceIfIdle: Still in use (registering=$registeringCallIds, taskSlot=${headlessJSManager.ownsTaskSlot()}), keeping service alive"
             )
             return
         }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -268,6 +268,9 @@ class CallService : Service(), CallRepository.Listener {
 
         if (intent == null || intent.action == null) {
             Log.w(TAG, "[service] onStartCommand: Intent is null, returning START_NOT_STICKY")
+            if(!callRepository.hasAnyCalls()) {
+                stopSelf()
+            }
             return START_NOT_STICKY
         }
 
@@ -491,6 +494,8 @@ class CallService : Service(), CallRepository.Listener {
 
         val callInfo = extractIntentParams(intent)
 
+        startForegroundForCall(callInfo, incoming)
+
         // If this specific call is already registered, just notify
         val existingCall = callRepository.getCall(callInfo.callId)
         if (existingCall != null) {
@@ -509,8 +514,6 @@ class CallService : Service(), CallRepository.Listener {
             }
             return
         }
-
-        startForegroundForCall(callInfo, incoming)
 
         scope.launch {
             try {
@@ -680,7 +683,8 @@ class CallService : Service(), CallRepository.Listener {
     }
 
     private fun startForegroundForCall(callInfo: CallInfo, incoming: Boolean) {
-        val tempCall = callRepository.getTempCall(callInfo, incoming)
+        val tempCall = callRepository.getCall(callInfo.callId)
+          ?: callRepository.getTempCall(callInfo, incoming)
         val notificationId = notificationManager.getOrCreateNotificationId(callInfo.callId)
         if (!isInForeground) {
             debugLog(
@@ -689,8 +693,8 @@ class CallService : Service(), CallRepository.Listener {
             )
             val notification = notificationManager.createNotification(callInfo.callId, tempCall)
             startForegroundSafely(notificationId, notification)
-        } else {
-            // Already in foreground from another call — just post the notification
+        } else if (!notificationManager.isNotificationPosted(callInfo.callId)) {
+            // Post only when this call has no notification yet (e.g. a second concurrent call).
             val notification = notificationManager.createNotification(callInfo.callId, tempCall)
             notificationManager.postNotification(callInfo.callId, notification)
         }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallService.kt
@@ -284,6 +284,16 @@ class CallService : Service(), CallRepository.Listener {
 
         notificationManager.cancelAllNotifications()
         notificationManager.stopRingtone()
+
+        // release() below disconnects every call without emitting Call.None — it cancels the
+        // observer — so nothing else would drop these process-global entries. A left-behind
+        // tracked id makes rejectCallWhenBusy skip later pushes, and a left-behind action would
+        // be replayed against a future call with the same id.
+        (callRepository.calls.value.keys + registeringCallIds).forEach { callId ->
+            CallRegistrationStore.removeTrackedCall(callId)
+            CallRegistrationStore.takePendingActions(callId) // discarded: only the removal matters
+        }
+
         callRepository.release()
         headlessJSManager.release()
 
@@ -322,6 +332,9 @@ class CallService : Service(), CallRepository.Listener {
             }
             ACTION_UPDATE_CALL -> {
                 updateCall(intent)
+                // This action never registers anything, and plain startService may have created
+                // the service just to deliver it, so re-check whether it has a reason to run.
+                stopServiceIfIdle(startId)
             }
             ACTION_PROCESS_ACTION -> {
                 processAction(intent)
@@ -513,6 +526,11 @@ class CallService : Service(), CallRepository.Listener {
 
         val callInfo = extractIntentParams(intent)
 
+        // Claimed before anything else: lastStartId is already this call's, so from here until the
+        // registration lands, this entry is the only thing stopping another call's teardown from
+        // taking the service down with a matching start id.
+        registeringCallIds.add(callInfo.callId)
+
         startForegroundForCall(callInfo, incoming)
 
         // If this specific call is already registered, just notify
@@ -531,10 +549,10 @@ class CallService : Service(), CallRepository.Listener {
                     putExtra(CallingxModuleImpl.EXTRA_CALL_ID, callInfo.callId)
                 }
             }
+            // hasAnyCalls() already covers an existing call, so hand the veto straight over.
+            registeringCallIds.remove(callInfo.callId)
             return
         }
-
-        registeringCallIds.add(callInfo.callId)
 
         scope.launch {
             try {

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
@@ -79,6 +79,20 @@ class CallingxModuleImpl(
         CallEventBus.unsubscribe(this)
 
         isModuleInitialized = false
+
+        // The JS runtime is going away, so any keep-alive owner it held is gone with it. A React
+        // context teardown does not finish in-flight headless tasks, so the service would never
+        // otherwise be told to re-check whether it still has a reason to run. Telecom-registered
+        // calls survive this and still veto the stop inside CallService.
+        if (CallService.isRunning) {
+            try {
+                Intent(reactApplicationContext, CallService::class.java)
+                        .apply { action = CallService.ACTION_STOP_SERVICE }
+                        .also { reactApplicationContext.startService(it) }
+            } catch (e: Exception) {
+                Log.e(TAG, "[module] invalidate: Failed to sweep the call service: ${e.message}", e)
+            }
+        }
     }
 
     fun setShouldRejectCallWhenBusy(shouldReject: Boolean) {

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
@@ -125,6 +125,15 @@ class CallingxModuleImpl(
 
     fun stopService(promise: Promise) {
         debugLog(TAG, "[module] stopService: Stopping CallService explicitly from JS")
+
+        if (!CallService.isRunning) {
+            // Starting the service just to stop it would construct (and immediately release) a
+            // whole CallRepository, and `startService` from the background can throw on API 26+.
+            debugLog(TAG, "[module] stopService: Service is not running, nothing to stop")
+            promise.resolve(true)
+            return
+        }
+
         try {
             Intent(reactApplicationContext, CallService::class.java)
                     .apply { action = CallService.ACTION_STOP_SERVICE }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
@@ -74,7 +74,7 @@ class CallingxModuleImpl(
         debugLog(TAG, "[module] invalidate: Invalidating module")
 
         LifecycleListener.unregister()
-        CallRegistrationStore.clearAll()
+        CallRegistrationStore.clearPendingPromises()
         AudioEndpointStore.clearAll()
         CallEventBus.unsubscribe(this)
 
@@ -82,8 +82,9 @@ class CallingxModuleImpl(
 
         // The JS runtime is going away, so any keep-alive owner it held is gone with it. A React
         // context teardown does not finish in-flight headless tasks, so the service would never
-        // otherwise be told to re-check whether it still has a reason to run. Telecom-registered
-        // calls survive this and still veto the stop inside CallService.
+        // otherwise be told to re-check whether it still has a reason to run. Native calls survive
+        // this — both registered ones and those still resolving Telecom endpoints — and veto the
+        // stop inside CallService, which is why the tracked ids above are left intact.
         if (CallService.isRunning) {
             try {
                 Intent(reactApplicationContext, CallService::class.java)

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
@@ -274,14 +274,6 @@ class CallingxModuleImpl(
             return
         }
 
-        if (!CallService.isRunning) {
-            // Plain startService, so this would create a service with no call in it — and nothing
-            // would stop it. There is no notification to update in that state anyway.
-            debugLog(TAG, "[module] updateDisplay: Service is not running, nothing to update")
-            promise.resolve(true)
-            return
-        }
-
         try {
             Intent(reactApplicationContext, CallService::class.java)
                     .apply {

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/CallingxModuleImpl.kt
@@ -250,20 +250,21 @@ class CallingxModuleImpl(
             return
         }
 
-        // for now only display options will be updated, rest of the parameters will be ignored
         try {
-            startCallService(
-                    CallService.ACTION_UPDATE_CALL,
-                    callId,
-                    callerName,
-                    phoneNumber,
-                    true,
-                    displayOptions,
-            )
+            Intent(reactApplicationContext, CallService::class.java)
+                    .apply {
+                        this.action = CallService.ACTION_UPDATE_CALL
+                        putExtra(CallService.EXTRA_CALL_ID, callId)
+                        putExtra(CallService.EXTRA_NAME, callerName)
+                        putExtra(CallService.EXTRA_URI, phoneNumber.toUri())
+                        putExtra(CallService.EXTRA_IS_VIDEO, true)
+                        putExtra(CallService.EXTRA_DISPLAY_OPTIONS, Arguments.toBundle(displayOptions))
+                    }
+                    .also { reactApplicationContext.startService(it) }
             promise.resolve(true)
         } catch (e: Exception) {
-            Log.e(TAG, "[module] updateDisplay: Failed to start foreground service: ${e.message}", e)
-            promise.reject("START_FOREGROUND_SERVICE_ERROR", e.message, e)
+            Log.e(TAG, "[module] updateDisplay: Failed to start service: ${e.message}", e)
+            promise.reject("START_SERVICE_ERROR", e.message, e)
         }
     }
 

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
@@ -27,11 +27,11 @@ class HeadlessTaskManager(
         private val onTaskFinished: () -> Unit = {},
 ) : HeadlessJsTaskEventListener {
 
+  /** A started task and the React context it belongs to, kept together so the pair cannot tear. */
+  private class ActiveTask(val id: Int, val context: WeakReference<ReactContext>)
+
   @Volatile
-  private var activeTaskId: Int? = null
-  /** The React context [activeTaskId] was started on. See [hasActiveTask]. */
-  @Volatile
-  private var startedOnContext: WeakReference<ReactContext>? = null
+  private var activeTask: ActiveTask? = null
   private var isStarting: Boolean = false
   private var pendingReactInstanceListener: ReactInstanceEventListener? = null
   @Volatile
@@ -46,14 +46,15 @@ class HeadlessTaskManager(
    *
    * React Native drops in-flight headless tasks when a React context is reloaded or destroyed —
    * there is no teardown for them — and these tasks are started with `timeout = 0`, so nothing
-   * would ever finish one and clear [activeTaskId]. Task ids also restart at 1 in a new context,
+   * would ever finish one and clear it. Task ids also restart at 1 in a new context,
    * so a stale id can name a *different* library's task. Both problems are avoided by only
    * trusting the id while the context it was started on is still the live one.
    */
   private fun liveActiveTaskId(): Int? {
-    val taskId = activeTaskId ?: return null
+    val task = activeTask ?: return null
+    val taskId = task.id
 
-    val startedOn = startedOnContext?.get()
+    val startedOn = task.context.get()
     if (startedOn != null && startedOn === currentReactContextOrNull()) return taskId
 
     debugLog(
@@ -71,8 +72,7 @@ class HeadlessTaskManager(
   fun hasActiveTask(): Boolean = liveActiveTaskId() != null
 
   private fun clearActiveTask() {
-    activeTaskId = null
-    startedOnContext = null
+    activeTask = null
   }
 
   /**
@@ -106,9 +106,9 @@ class HeadlessTaskManager(
   public fun startHeadlessTask(taskName: String, data: Bundle, timeout: Long) {
     debugLog(
             TAG,
-            "[headless] startHeadlessTask entry: activeTaskId=$activeTaskId isStarting=$isStarting"
+            "[headless] startHeadlessTask entry: activeTaskId=${activeTask?.id} isStarting=$isStarting"
     )
-    if (activeTaskId != null || isStarting) {
+    if (liveActiveTaskId() != null || isStarting) {
       Log.w(
               TAG,
               "[headless] startHeadlessTask: Task already starting or active, ignoring new task request"
@@ -164,8 +164,7 @@ class HeadlessTaskManager(
 
     UiThreadUtil.runOnUiThread {
       val taskId = headlessJsTaskContext.startTask(taskConfig)
-      activeTaskId = taskId
-      startedOnContext = WeakReference(reactContext)
+      activeTask = ActiveTask(taskId, WeakReference(reactContext))
       debugLog(TAG, "[headless] invokeStartTask: Task started: $taskId")
       isStarting = false
     }
@@ -221,10 +220,10 @@ class HeadlessTaskManager(
   }
 
   override fun onHeadlessJsTaskFinish(taskId: Int) {
-    if (taskId != activeTaskId) {
+    if (taskId != liveActiveTaskId()) {
       debugLog(
               TAG,
-              "[headless] onHeadlessJsTaskFinish: IGNORED foreign taskId=$taskId (our=$activeTaskId)"
+              "[headless] onHeadlessJsTaskFinish: IGNORED foreign taskId=$taskId (our=${activeTask?.id})"
       )
       return
     }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
@@ -15,7 +15,16 @@ import com.facebook.react.jstasks.HeadlessJsTaskConfig
 import com.facebook.react.jstasks.HeadlessJsTaskContext
 import com.facebook.react.jstasks.HeadlessJsTaskEventListener
 
-class HeadlessTaskManager(private val context: Context) : HeadlessJsTaskEventListener {
+/**
+ * @param onTaskFinished invoked after the active task finishes, unless the manager is being
+ *   released. [CallService] uses it to re-evaluate whether it still has a reason to run: a
+ *   call-less service is started by `acquireBackgroundTask` alone, and nothing else would ever
+ *   stop it.
+ */
+class HeadlessTaskManager(
+        private val context: Context,
+        private val onTaskFinished: () -> Unit = {},
+) : HeadlessJsTaskEventListener {
 
   private var activeTaskId: Int? = null
   private var isStarting: Boolean = false
@@ -166,6 +175,14 @@ class HeadlessTaskManager(private val context: Context) : HeadlessJsTaskEventLis
     debugLog(TAG, "[headless] onHeadlessJsTaskFinish Task finished: $taskId state cleared: activeTaskId=null isStarting=false")
     activeTaskId = null
     isStarting = false
+
+    if (released) {
+      // release() runs from CallService.onDestroy and finishes the task itself; the service is
+      // already going down, so re-entering its stop logic here would be noise at best.
+      debugLog(TAG, "[headless] onHeadlessJsTaskFinish: released, skipping onTaskFinished")
+      return
+    }
+    onTaskFinished()
   }
 
   /**

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
@@ -14,6 +14,7 @@ import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.jstasks.HeadlessJsTaskConfig
 import com.facebook.react.jstasks.HeadlessJsTaskContext
 import com.facebook.react.jstasks.HeadlessJsTaskEventListener
+import java.lang.ref.WeakReference
 
 /**
  * @param onTaskFinished invoked after the active task finishes, unless the manager is being
@@ -28,6 +29,9 @@ class HeadlessTaskManager(
 
   @Volatile
   private var activeTaskId: Int? = null
+  /** The React context [activeTaskId] was started on. See [hasActiveTask]. */
+  @Volatile
+  private var startedOnContext: WeakReference<ReactContext>? = null
   private var isStarting: Boolean = false
   private var pendingReactInstanceListener: ReactInstanceEventListener? = null
   @Volatile
@@ -37,8 +41,46 @@ class HeadlessTaskManager(
     private const val TAG = "[Callingx] HeadlessTaskManager"
   }
 
-  /** True while a headless task is running. The service uses it as a reason to stay alive. */
-  fun hasActiveTask(): Boolean = activeTaskId != null
+  /**
+   * True while a task we started is still running. The service treats this as a reason to stay
+   * alive, so an abandoned task must not pin it forever.
+   *
+   * React Native drops in-flight headless tasks when a React context is reloaded or destroyed —
+   * there is no teardown for them — and these tasks are started with `timeout = 0`, so nothing
+   * would ever finish one and clear [activeTaskId]. The context the task was started on is
+   * therefore checked against the live one, and a task orphaned by a reload is dropped here.
+   */
+  fun hasActiveTask(): Boolean {
+    val taskId = activeTaskId ?: return false
+
+    val startedOn = startedOnContext?.get()
+    if (startedOn != null && startedOn === currentReactContextOrNull()) return true
+
+    debugLog(
+            TAG,
+            "[headless] hasActiveTask: task $taskId was abandoned with its React context, clearing"
+    )
+    clearActiveTask()
+    return false
+  }
+
+  private fun clearActiveTask() {
+    activeTaskId = null
+    startedOnContext = null
+  }
+
+  /**
+   * [reactContext] throws when the host is not initialised, and this is read from the service's
+   * stop paths, which run off the main thread. If no context can be resolved there is no task
+   * either, so the caller treats null as "nothing running".
+   */
+  private fun currentReactContextOrNull(): ReactContext? =
+          try {
+            reactContext
+          } catch (t: Throwable) {
+            debugLog(TAG, "[headless] currentReactContextOrNull: unavailable: ${t.message}")
+            null
+          }
 
   private fun hasReactContext(): Boolean = reactContext != null
 
@@ -114,6 +156,7 @@ class HeadlessTaskManager(
     UiThreadUtil.runOnUiThread {
       val taskId = headlessJsTaskContext.startTask(taskConfig)
       activeTaskId = taskId
+      startedOnContext = WeakReference(reactContext)
       debugLog(TAG, "[headless] invokeStartTask: Task started: $taskId")
       isStarting = false
     }
@@ -144,7 +187,7 @@ class HeadlessTaskManager(
     // posted by finishTask() drains first — otherwise we'd unregister the listener before
     // it fires and lose the finish log.
     UiThreadUtil.runOnUiThread {
-      activeTaskId = null
+      clearActiveTask()
       reactContext?.let { context ->
         val headlessJsTaskContext = HeadlessJsTaskContext.getInstance(context)
         headlessJsTaskContext.removeTaskEventListener(this)
@@ -177,7 +220,7 @@ class HeadlessTaskManager(
       return
     }
     debugLog(TAG, "[headless] onHeadlessJsTaskFinish Task finished: $taskId state cleared: activeTaskId=null isStarting=false")
-    activeTaskId = null
+    clearActiveTask()
     isStarting = false
 
     if (released) {

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
@@ -74,11 +74,11 @@ class HeadlessTaskManager(
   }
 
   /**
-   * True while we own the task slot. The service treats this as a reason to stay alive, so a task
-   * abandoned by a context reload must not pin it — but a start that has been requested and not
-   * yet acknowledged must, since its id does not exist yet.
+   * True while we own the task slot, whether or not the task has an id yet. The service treats this
+   * as a reason to stay alive, so a task abandoned by a context reload must not pin it — but a start
+   * that has been requested and not yet acknowledged must, since its id does not exist yet.
    */
-  fun hasActiveTask(): Boolean = synchronized(stateLock) {
+  fun ownsTaskSlot(): Boolean = synchronized(stateLock) {
     state is TaskState.Starting || liveTaskId() != null
   }
 

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
@@ -27,12 +27,19 @@ class HeadlessTaskManager(
         private val onTaskFinished: () -> Unit = {},
 ) : HeadlessJsTaskEventListener {
 
-  /** A started task and the React context it belongs to, kept together so the pair cannot tear. */
-  private class ActiveTask(val id: Int, val context: WeakReference<ReactContext>)
+  /** Our ownership of the single HeadlessJS task slot. */
+  private sealed interface TaskState {
+    /** Nothing of ours is running or being started. */
+    object None : TaskState
+    /** A start was requested; React Native has not assigned an id yet. */
+    object Starting : TaskState
+    /** React Native is running our task, on [context]. */
+    class Active(val id: Int, val context: WeakReference<ReactContext>) : TaskState
+  }
 
-  @Volatile
-  private var activeTask: ActiveTask? = null
-  private var isStarting: Boolean = false
+  /** Guards [state] so an inspection and the replacement that follows it cannot interleave. */
+  private val stateLock = Any()
+  private var state: TaskState = TaskState.None
   private var pendingReactInstanceListener: ReactInstanceEventListener? = null
   @Volatile
   private var released: Boolean = false
@@ -42,37 +49,37 @@ class HeadlessTaskManager(
   }
 
   /**
-   * The tracked task id, or null once it is no longer ours to act on.
+   * The running task's id, or null when we have none to act on.
    *
    * React Native drops in-flight headless tasks when a React context is reloaded or destroyed —
    * there is no teardown for them — and these tasks are started with `timeout = 0`, so nothing
-   * would ever finish one and clear it. Task ids also restart at 1 in a new context,
-   * so a stale id can name a *different* library's task. Both problems are avoided by only
-   * trusting the id while the context it was started on is still the live one.
+   * would ever finish one. Ids also restart at 1 in a new context, so a stale one can name a
+   * *different* library's task. Both are avoided by trusting [TaskState.Active] only while the
+   * context it was started on is still the live one, and dropping it otherwise.
    */
-  private fun liveActiveTaskId(): Int? {
-    val task = activeTask ?: return null
-    val taskId = task.id
+  private fun liveTaskId(): Int? = synchronized(stateLock) {
+    val active = state as? TaskState.Active ?: return@synchronized null
 
-    val startedOn = task.context.get()
-    if (startedOn != null && startedOn === currentReactContextOrNull()) return taskId
+    val startedOn = active.context.get()
+    if (startedOn != null && startedOn === currentReactContextOrNull()) {
+      return@synchronized active.id
+    }
 
     debugLog(
             TAG,
-            "[headless] liveActiveTaskId: task $taskId was abandoned with its React context, dropping it"
+            "[headless] liveTaskId: task ${active.id} was abandoned with its React context, dropping it"
     )
-    clearActiveTask()
-    return null
+    state = TaskState.None
+    return@synchronized null
   }
 
   /**
-   * True while a task we started is still running. The service treats this as a reason to stay
-   * alive, so an abandoned task must not pin it forever.
+   * True while we own the task slot. The service treats this as a reason to stay alive, so a task
+   * abandoned by a context reload must not pin it — but a start that has been requested and not
+   * yet acknowledged must, since its id does not exist yet.
    */
-  fun hasActiveTask(): Boolean = liveActiveTaskId() != null
-
-  private fun clearActiveTask() {
-    activeTask = null
+  fun hasActiveTask(): Boolean = synchronized(stateLock) {
+    state is TaskState.Starting || liveTaskId() != null
   }
 
   /**
@@ -106,16 +113,18 @@ class HeadlessTaskManager(
   public fun startHeadlessTask(taskName: String, data: Bundle, timeout: Long) {
     debugLog(
             TAG,
-            "[headless] startHeadlessTask entry: activeTaskId=${activeTask?.id} isStarting=$isStarting"
+            "[headless] startHeadlessTask entry: state=${state::class.simpleName}"
     )
-    if (liveActiveTaskId() != null || isStarting) {
-      Log.w(
-              TAG,
-              "[headless] startHeadlessTask: Task already starting or active, ignoring new task request"
-      )
-      return
+    synchronized(stateLock) {
+      if (state is TaskState.Starting || liveTaskId() != null) {
+        Log.w(
+                TAG,
+                "[headless] startHeadlessTask: Task already starting or active, ignoring new task request"
+        )
+        return
+      }
+      state = TaskState.Starting
     }
-    isStarting = true
 
     if (UiThreadUtil.isOnUiThread()) {
       startTask(HeadlessJsTaskConfig(taskName, Arguments.fromBundle(data), timeout, true))
@@ -130,10 +139,10 @@ class HeadlessTaskManager(
 
   public fun stopHeadlessTask() {
     debugLog(TAG, "[headless] stopHeadlessTask: Stopping headless task")
-    // Deliberately via liveActiveTaskId: HeadlessJsTaskContext.finishTask has no notion of task
+    // Deliberately via liveTaskId: HeadlessJsTaskContext.finishTask has no notion of task
     // ownership, so finishing a stale id after a context reload would cut short whichever
     // library's task inherited that number.
-    liveActiveTaskId()?.let { taskId ->
+    liveTaskId()?.let { taskId ->
       if (UiThreadUtil.isOnUiThread()) {
         stopTask(taskId)
       } else {
@@ -164,9 +173,8 @@ class HeadlessTaskManager(
 
     UiThreadUtil.runOnUiThread {
       val taskId = headlessJsTaskContext.startTask(taskConfig)
-      activeTask = ActiveTask(taskId, WeakReference(reactContext))
+      synchronized(stateLock) { state = TaskState.Active(taskId, WeakReference(reactContext)) }
       debugLog(TAG, "[headless] invokeStartTask: Task started: $taskId")
-      isStarting = false
     }
   }
 
@@ -183,7 +191,8 @@ class HeadlessTaskManager(
   fun release() {
     released = true
     stopHeadlessTask()
-    isStarting = false
+    // Give up the slot synchronously: a Starting state would otherwise outlive the service.
+    synchronized(stateLock) { state = TaskState.None }
     // Proactively unregister the pending React-context init listener. Otherwise the callback
     // would fire after CallService is destroyed, invokeStartTask a stale task on this dead
     // manager, and register `this` as a task listener on the live ReactContext (leak).
@@ -195,7 +204,6 @@ class HeadlessTaskManager(
     // posted by finishTask() drains first — otherwise we'd unregister the listener before
     // it fires and lose the finish log.
     UiThreadUtil.runOnUiThread {
-      clearActiveTask()
       currentReactContextOrNull()?.let { context ->
         val headlessJsTaskContext = HeadlessJsTaskContext.getInstance(context)
         headlessJsTaskContext.removeTaskEventListener(this)
@@ -220,16 +228,12 @@ class HeadlessTaskManager(
   }
 
   override fun onHeadlessJsTaskFinish(taskId: Int) {
-    if (taskId != liveActiveTaskId()) {
-      debugLog(
-              TAG,
-              "[headless] onHeadlessJsTaskFinish: IGNORED foreign taskId=$taskId (our=${activeTask?.id})"
-      )
+    if (taskId != liveTaskId()) {
+      debugLog(TAG, "[headless] onHeadlessJsTaskFinish: IGNORED foreign taskId=$taskId")
       return
     }
-    debugLog(TAG, "[headless] onHeadlessJsTaskFinish Task finished: $taskId state cleared: activeTaskId=null isStarting=false")
-    clearActiveTask()
-    isStarting = false
+    debugLog(TAG, "[headless] onHeadlessJsTaskFinish: Task finished: $taskId, slot released")
+    synchronized(stateLock) { state = TaskState.None }
 
     if (released) {
       // release() runs from CallService.onDestroy and finishes the task itself; the service is

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/HeadlessTaskManager.kt
@@ -42,27 +42,33 @@ class HeadlessTaskManager(
   }
 
   /**
-   * True while a task we started is still running. The service treats this as a reason to stay
-   * alive, so an abandoned task must not pin it forever.
+   * The tracked task id, or null once it is no longer ours to act on.
    *
    * React Native drops in-flight headless tasks when a React context is reloaded or destroyed —
    * there is no teardown for them — and these tasks are started with `timeout = 0`, so nothing
-   * would ever finish one and clear [activeTaskId]. The context the task was started on is
-   * therefore checked against the live one, and a task orphaned by a reload is dropped here.
+   * would ever finish one and clear [activeTaskId]. Task ids also restart at 1 in a new context,
+   * so a stale id can name a *different* library's task. Both problems are avoided by only
+   * trusting the id while the context it was started on is still the live one.
    */
-  fun hasActiveTask(): Boolean {
-    val taskId = activeTaskId ?: return false
+  private fun liveActiveTaskId(): Int? {
+    val taskId = activeTaskId ?: return null
 
     val startedOn = startedOnContext?.get()
-    if (startedOn != null && startedOn === currentReactContextOrNull()) return true
+    if (startedOn != null && startedOn === currentReactContextOrNull()) return taskId
 
     debugLog(
             TAG,
-            "[headless] hasActiveTask: task $taskId was abandoned with its React context, clearing"
+            "[headless] liveActiveTaskId: task $taskId was abandoned with its React context, dropping it"
     )
     clearActiveTask()
-    return false
+    return null
   }
+
+  /**
+   * True while a task we started is still running. The service treats this as a reason to stay
+   * alive, so an abandoned task must not pin it forever.
+   */
+  fun hasActiveTask(): Boolean = liveActiveTaskId() != null
 
   private fun clearActiveTask() {
     activeTaskId = null
@@ -124,7 +130,10 @@ class HeadlessTaskManager(
 
   public fun stopHeadlessTask() {
     debugLog(TAG, "[headless] stopHeadlessTask: Stopping headless task")
-    activeTaskId?.let { taskId ->
+    // Deliberately via liveActiveTaskId: HeadlessJsTaskContext.finishTask has no notion of task
+    // ownership, so finishing a stale id after a context reload would cut short whichever
+    // library's task inherited that number.
+    liveActiveTaskId()?.let { taskId ->
       if (UiThreadUtil.isOnUiThread()) {
         stopTask(taskId)
       } else {
@@ -163,7 +172,7 @@ class HeadlessTaskManager(
   }
 
   private fun stopTask(taskId: Int) {
-    reactContext?.let { context ->
+    currentReactContextOrNull()?.let { context ->
       val headlessJsTaskContext = HeadlessJsTaskContext.getInstance(context)
       if (headlessJsTaskContext.isTaskRunning(taskId)) {
         headlessJsTaskContext.finishTask(taskId)
@@ -188,7 +197,7 @@ class HeadlessTaskManager(
     // it fires and lose the finish log.
     UiThreadUtil.runOnUiThread {
       clearActiveTask()
-      reactContext?.let { context ->
+      currentReactContextOrNull()?.let { context ->
         val headlessJsTaskContext = HeadlessJsTaskContext.getInstance(context)
         headlessJsTaskContext.removeTaskEventListener(this)
       }

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -1,7 +1,6 @@
 package io.getstream.rn.callingx.notifications
 
 import android.app.Notification
-import android.app.NotificationManager
 import android.content.Context
 import android.media.Ringtone
 import android.media.RingtoneManager
@@ -149,9 +148,16 @@ class CallNotificationManager(
         foregroundCallId = null
     }
 
-    private fun recordPostedLocked(callId: String, notification: Notification) {
+    private fun recordPostedLocked(
+            callId: String,
+            notification: Notification,
+            snapshot: NotificationSnapshot? = null
+    ) {
         val current = notificationsState[callId] ?: CallNotificationState()
-        notificationsState[callId] = current.copy(postedNotification = notification)
+        notificationsState[callId] = current.copy(
+                postedNotification = notification,
+                lastSnapshot = snapshot ?: current.lastSnapshot
+        )
     }
 
     /**
@@ -258,7 +264,7 @@ class CallNotificationManager(
         // Record the snapshot only once the post succeeds, so a rejected notification stays
         // retryable instead of being skipped as "no state change".
         if (notifySafely(notificationId, notification)) {
-            recordPostedLocked(callId, notification)
+            recordPostedLocked(callId, notification, newSnapshot)
             debugLog(TAG, "[notifications] updateCallNotification[$callId]: Notification posted (id=$notificationId)")
         }
     }
@@ -270,19 +276,8 @@ class CallNotificationManager(
         }
     }
 
-    private fun activePostedNotifications(): Map<Int, Notification> {
-        return try {
-            val manager =
-                    context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            manager.activeNotifications.associate { it.id to it.notification }
-        } catch (t: Throwable) {
-            Log.w(TAG, "[notifications] activePostedNotifications: query failed", t)
-            emptyMap()
-        }
-    }
-
     fun isNotificationPosted(callId: String): Boolean =
-            activePostedNotifications().containsKey(getNotificationId(callId))
+            synchronized(lock) { notificationsState[callId]?.postedNotification != null }
 
     fun lastPostedNotification(callId: String): Notification? =
             synchronized(lock) { notificationsState[callId]?.postedNotification }
@@ -329,12 +324,13 @@ class CallNotificationManager(
             return@synchronized null
         }
 
+        val postedNotification = next.value.postedNotification ?: return@synchronized null
         val nextNotificationId = getNotificationId(next.key)
         debugLog(TAG, "[notifications] nextAnchorCandidate: ${next.key} (id=$nextNotificationId)")
         return@synchronized PromotionTarget(
                 next.key,
                 nextNotificationId,
-                next.value.postedNotification!!
+                postedNotification
         )
     }
 

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -1,6 +1,7 @@
 package io.getstream.rn.callingx.notifications
 
 import android.app.Notification
+import android.app.NotificationManager
 import android.content.Context
 import android.media.Ringtone
 import android.media.RingtoneManager
@@ -165,6 +166,7 @@ class CallNotificationManager(
                         .setSmallIcon(R.drawable.ic_round_call_24)
                         .setCategory(NotificationCompat.CATEGORY_CALL)
                         .setPriority(NotificationCompat.PRIORITY_MAX)
+                        .setOnlyAlertOnce(true)
                         .setOngoing(optimisticState != OptimisticState.REJECTING)
 
         builder.setStyle(callStyle)
@@ -230,6 +232,22 @@ class CallNotificationManager(
     fun postNotification(callId: String, notification: Notification) = synchronized(lock) {
         val notificationId = getOrCreateNotificationId(callId)
         notificationManager.notify(notificationId, notification)
+    }
+
+    fun isNotificationPosted(callId: String): Boolean = synchronized(lock) {
+        val id = getNotificationId(callId)
+        return@synchronized try {
+            val manager =
+                    context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.activeNotifications.any { it.id == id }
+        } catch (e: Exception) {
+            Log.w(
+                    TAG,
+                    "[notifications] isNotificationPosted[$callId]: query failed, assuming not posted",
+                    e
+            )
+            false
+        }
     }
 
     /**

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -62,7 +62,13 @@ class CallNotificationManager(
         val hasBecameActive: Boolean = false,
     )
 
-    // Per-call state, all guarded by [lock]
+    data class PromotionTarget(
+      val callId: String,
+      val notificationId: Int,
+      val notification: Notification,
+    )
+
+  // Per-call state, all guarded by [lock]
     private val notificationsState = mutableMapOf<String, CallNotificationState>()
 
     /** The callId whose notification was used for startForeground(). */
@@ -110,10 +116,20 @@ class CallNotificationManager(
         if (!notificationsState.containsKey(callId)) {
             notificationsState[callId] = CallNotificationState()
         }
-        if (foregroundCallId == null) {
-            foregroundCallId = callId
-        }
         return@synchronized getNotificationId(callId)
+    }
+
+    /**
+     * The ONLY writer of [foregroundCallId]. Must be called from the code that actually performed a
+     * successful `startForeground()`, never speculatively — the platform, not our bookkeeping, decides
+     * what the FGS is anchored to, and a mismatch surfaces later as
+     * `SecurityException: Invalid FGS notification`.
+     */
+    fun commitAnchor(callId: String) = synchronized(lock) {
+        if (foregroundCallId != callId) {
+            debugLog(TAG, "[notifications] commitAnchor: foreground anchor is now $callId")
+        }
+        foregroundCallId = callId
     }
 
     /**
@@ -123,13 +139,7 @@ class CallNotificationManager(
      */
     fun setOptimisticState(callId: String, state: OptimisticState) = synchronized(lock) {
         // Be resilient to races where we receive optimistic actions before a notification state entry exists.
-        val current =
-            notificationsState[callId]
-                ?: CallNotificationState().also {
-                    if (foregroundCallId == null) {
-                        foregroundCallId = callId
-                    }
-                }
+        val current = notificationsState[callId] ?: CallNotificationState()
         notificationsState[callId] = if (state != OptimisticState.NONE) {
             current.copy(optimisticState = state, lastSnapshot = null)
         } else {
@@ -234,27 +244,58 @@ class CallNotificationManager(
         notificationManager.notify(notificationId, notification)
     }
 
-    fun isNotificationPosted(callId: String): Boolean = synchronized(lock) {
-        val id = getNotificationId(callId)
-        return@synchronized try {
+    private fun activePostedNotifications(): Map<Int, Notification> {
+        return try {
             val manager =
                     context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            manager.activeNotifications.any { it.id == id }
-        } catch (e: Exception) {
-            Log.w(
-                    TAG,
-                    "[notifications] isNotificationPosted[$callId]: query failed, assuming not posted",
-                    e
-            )
-            false
+            manager.activeNotifications.associate { it.id to it.notification }
+        } catch (t: Throwable) {
+            Log.w(TAG, "[notifications] activePostedNotifications: query failed", t)
+            emptyMap()
         }
     }
 
+    fun postedNotificationFor(callId: String): Notification? =
+            activePostedNotifications()[getNotificationId(callId)]
+
+    fun isNotificationPosted(callId: String): Boolean = postedNotificationFor(callId) != null
+
     /**
-     * Returns a new foreground notification ID if the caller needs to call startForeground()
-     * to re-promote the service, or null if no action is needed.
+     * Returns the first tracked call whose notification is still on screen, along with that
+     * notification so the caller can promote without rebuilding it. [excluding] is skipped because its
+     * own notification is still live at this point.
      */
-    fun cancelNotification(callId: String): Int? = synchronized(lock) {
+    fun nextAnchorCandidate(excluding: String): PromotionTarget? {
+        val candidates = synchronized(lock) { notificationsState.keys.filter { it != excluding } }
+        if (candidates.isEmpty()) return null
+
+        val posted = activePostedNotifications()
+        val nextCallId =
+                candidates.firstOrNull { posted.containsKey(getNotificationId(it)) }
+                        ?: run {
+                            debugLog(
+                                    TAG,
+                                    "[notifications] nextAnchorCandidate: no live notification to re-anchor to (excluding $excluding)"
+                            )
+                            return null
+                        }
+
+        val nextNotificationId = getNotificationId(nextCallId)
+        debugLog(
+                TAG,
+                "[notifications] nextAnchorCandidate: $nextCallId (id=$nextNotificationId)"
+        )
+        return PromotionTarget(nextCallId, nextNotificationId, posted.getValue(nextNotificationId))
+    }
+
+    /**
+     * Cancels the notification for [callId] and drops its state.
+     *
+     * Call this *after* the anchor has moved (re-promotion) or been given up (demotion). An app cannot
+     * cancel a notification carrying `FLAG_FOREGROUND_SERVICE`, so cancelling while [callId] is still
+     * the anchor silently does nothing.
+     */
+    fun cancelNotification(callId: String) = synchronized(lock) {
         debugLog(TAG, "[notifications] cancelNotification[$callId]")
         val state = notificationsState.remove(callId)
         val notificationId = getNotificationId(callId)
@@ -262,15 +303,10 @@ class CallNotificationManager(
         if (state != null) {
             debugLog(TAG, "[notifications] cancelNotification[$callId]: Cancelled (id=$notificationId)")
         }
-
         if (foregroundCallId == callId) {
-            foregroundCallId = notificationsState.keys.firstOrNull()
-            // Return the new foreground notification ID so the service can re-promote
-            if (foregroundCallId != null) {
-                return@synchronized getNotificationId(foregroundCallId!!)
-            }
+            debugLog(TAG, "[notifications] cancelNotification[$callId]: was the anchor, clearing")
+            foregroundCallId = null
         }
-        return@synchronized null
     }
 
     fun getForegroundCallId(): String? = synchronized(lock) { foregroundCallId }
@@ -322,7 +358,7 @@ class CallNotificationManager(
         notificationsState[callId] = current.copy(optimisticState = OptimisticState.NONE, lastSnapshot = null)
     }
 
-    // when skipIncomingPushInForeground is true, we use the ongoing channel 
+    // when skipIncomingPushInForeground is true, we use the ongoing channel
     // for the notification to avoid notification overlapping app ui, just for UX purposes
     private fun shouldShowAsIncoming(
             call: Call.Registered,

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -121,9 +121,7 @@ class CallNotificationManager(
     }
 
     /**
-     * Must be called from the code that actually performed a successful `startForeground()`, 
-     * never speculatively — the platform, not our bookkeeping, decides what the FGS is 
-     * anchored to, and a mismatch surfaces later as `SecurityException: Invalid FGS notification`.
+     * Must be called from the code that actually performed a successful `startForeground()`.
      */
     fun commitAnchor(callId: String, notification: Notification) = synchronized(lock) {
         if (foregroundCallId != callId) {
@@ -304,11 +302,8 @@ class CallNotificationManager(
     }
 
     /**
-     * Cancels the notification for [callId] and drops its state.
-     *
-     * Call this *after* the anchor has moved (re-promotion) or been given up (demotion). An app cannot
-     * cancel a notification carrying `FLAG_FOREGROUND_SERVICE`, so cancelling while [callId] is still
-     * the anchor silently does nothing.
+     * Cancels the notification for [callId] and drops its state. Call this *after* the anchor has
+     * moved (re-promotion) or been given up (demotion).
      */
     fun cancelNotification(callId: String) = synchronized(lock) {
         debugLog(TAG, "[notifications] cancelNotification[$callId]")

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -60,6 +60,7 @@ class CallNotificationManager(
         val lastSnapshot: NotificationSnapshot? = null,
         val activeWhen: Long? = null,
         val hasBecameActive: Boolean = false,
+        val postedNotification: Notification? = null,
     )
 
     data class PromotionTarget(
@@ -68,7 +69,7 @@ class CallNotificationManager(
       val notification: Notification,
     )
 
-  // Per-call state, all guarded by [lock]
+    // Per-call state, all guarded by [lock]
     private val notificationsState = mutableMapOf<String, CallNotificationState>()
 
     /** The callId whose notification was used for startForeground(). */
@@ -120,16 +121,28 @@ class CallNotificationManager(
     }
 
     /**
-     * The ONLY writer of [foregroundCallId]. Must be called from the code that actually performed a
-     * successful `startForeground()`, never speculatively — the platform, not our bookkeeping, decides
-     * what the FGS is anchored to, and a mismatch surfaces later as
-     * `SecurityException: Invalid FGS notification`.
+     * Must be called from the code that actually performed a successful `startForeground()`, 
+     * never speculatively — the platform, not our bookkeeping, decides what the FGS is 
+     * anchored to, and a mismatch surfaces later as `SecurityException: Invalid FGS notification`.
      */
-    fun commitAnchor(callId: String) = synchronized(lock) {
+    fun commitAnchor(callId: String, notification: Notification) = synchronized(lock) {
         if (foregroundCallId != callId) {
             debugLog(TAG, "[notifications] commitAnchor: foreground anchor is now $callId")
         }
         foregroundCallId = callId
+        recordPostedLocked(callId, notification)
+    }
+
+    fun clearAnchor() = synchronized(lock) {
+        if (foregroundCallId != null) {
+            debugLog(TAG, "[notifications] clearAnchor: foreground anchor cleared")
+        }
+        foregroundCallId = null
+    }
+
+    private fun recordPostedLocked(callId: String, notification: Notification) {
+        val current = notificationsState[callId] ?: CallNotificationState()
+        notificationsState[callId] = current.copy(postedNotification = notification)
     }
 
     /**
@@ -236,12 +249,14 @@ class CallNotificationManager(
                 ?: CallNotificationState(lastSnapshot = newSnapshot)
         val notification = createNotification(callId, call)
         notificationManager.notify(notificationId, notification)
+        recordPostedLocked(callId, notification)
         debugLog(TAG, "[notifications] updateCallNotification[$callId]: Notification posted (id=$notificationId)")
     }
 
     fun postNotification(callId: String, notification: Notification) = synchronized(lock) {
         val notificationId = getOrCreateNotificationId(callId)
         notificationManager.notify(notificationId, notification)
+        recordPostedLocked(callId, notification)
     }
 
     private fun activePostedNotifications(): Map<Int, Notification> {
@@ -255,37 +270,37 @@ class CallNotificationManager(
         }
     }
 
-    fun postedNotificationFor(callId: String): Notification? =
-            activePostedNotifications()[getNotificationId(callId)]
+    fun isNotificationPosted(callId: String): Boolean =
+            activePostedNotifications().containsKey(getNotificationId(callId))
 
-    fun isNotificationPosted(callId: String): Boolean = postedNotificationFor(callId) != null
+    fun lastPostedNotification(callId: String): Notification? =
+            synchronized(lock) { notificationsState[callId]?.postedNotification }
 
     /**
-     * Returns the first tracked call whose notification is still on screen, along with that
-     * notification so the caller can promote without rebuilding it. [excluding] is skipped because its
-     * own notification is still live at this point.
+     * Returns the first tracked call we have actually posted a notification for, along with that
+     * notification so the caller can promote without rebuilding it. [excluding] is skipped because it
+     * is the call giving up the anchor.
      */
-    fun nextAnchorCandidate(excluding: String): PromotionTarget? {
-        val candidates = synchronized(lock) { notificationsState.keys.filter { it != excluding } }
-        if (candidates.isEmpty()) return null
+    fun nextAnchorCandidate(excluding: String): PromotionTarget? = synchronized(lock) {
+        val next =
+                notificationsState.entries.firstOrNull {
+                    it.key != excluding && it.value.postedNotification != null
+                }
+        if (next == null) {
+            debugLog(
+                    TAG,
+                    "[notifications] nextAnchorCandidate: nothing posted to re-anchor to (excluding $excluding)"
+            )
+            return@synchronized null
+        }
 
-        val posted = activePostedNotifications()
-        val nextCallId =
-                candidates.firstOrNull { posted.containsKey(getNotificationId(it)) }
-                        ?: run {
-                            debugLog(
-                                    TAG,
-                                    "[notifications] nextAnchorCandidate: no live notification to re-anchor to (excluding $excluding)"
-                            )
-                            return null
-                        }
-
-        val nextNotificationId = getNotificationId(nextCallId)
-        debugLog(
-                TAG,
-                "[notifications] nextAnchorCandidate: $nextCallId (id=$nextNotificationId)"
+        val nextNotificationId = getNotificationId(next.key)
+        debugLog(TAG, "[notifications] nextAnchorCandidate: ${next.key} (id=$nextNotificationId)")
+        return@synchronized PromotionTarget(
+                next.key,
+                nextNotificationId,
+                next.value.postedNotification!!
         )
-        return PromotionTarget(nextCallId, nextNotificationId, posted.getValue(nextNotificationId))
     }
 
     /**

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -265,8 +265,9 @@ class CallNotificationManager(
 
     fun postNotification(callId: String, notification: Notification) = synchronized(lock) {
         val notificationId = getOrCreateNotificationId(callId)
-        notifySafely(notificationId, notification)
-        recordPostedLocked(callId, notification)
+        if (notifySafely(notificationId, notification)) {
+          recordPostedLocked(callId, notification)
+        }
     }
 
     private fun activePostedNotifications(): Map<Int, Notification> {

--- a/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
+++ b/packages/react-native-callingx/android/src/main/java/io/getstream/rn/callingx/notifications/CallNotificationManager.kt
@@ -307,9 +307,10 @@ class CallNotificationManager(
     }
 
     /**
-     * Returns the first tracked call we have actually posted a notification for, along with that
-     * notification so the caller can promote without rebuilding it. [excluding] is skipped because it
-     * is the call giving up the anchor.
+     * Returns the oldest tracked call with a posted notification, skipping [excluding] (the call
+     * giving up the anchor). Order is by age, not call state: Telecom allows only one ringing call
+     * and the JS SDK leaves other calls before registering a new one, so a ringing call is never
+     * picked over an active one. The notification is returned so the caller need not rebuild it.
      */
     fun nextAnchorCandidate(excluding: String): PromotionTarget? = synchronized(lock) {
         val next =

--- a/packages/react-native-callingx/src/types.ts
+++ b/packages/react-native-callingx/src/types.ts
@@ -203,6 +203,14 @@ export interface ICallingxModule {
 
   registerVoipToken(): void;
 
+  /**
+   * Asks the Android call service to stop. Android-only; resolves as a no-op on iOS.
+   *
+   * This is a *request*, not a command: the service hosts every call, so it stays alive while any
+   * call is registered or in the middle of being registered. Use {@link endCallWithReason} to tear
+   * down an individual call — this method never ends calls, and never dismisses their
+   * notifications.
+   */
   stopService(): Promise<void>;
 
   /**

--- a/packages/react-native-sdk/__tests__/push/android.test.ts
+++ b/packages/react-native-sdk/__tests__/push/android.test.ts
@@ -87,15 +87,19 @@ describe('onRingNotificationReceived — abandoning a push', () => {
     },
   );
 
-  it('still requests the stop when ending the call fails', async () => {
+  it.each<['endCallWithReason' | 'stopService', string[]]>([
+    ['endCallWithReason', ['release', 'stop']],
+    ['stopService', ['release', 'end']],
+  ])('finishes the cleanup when %s rejects', async (failing, expected) => {
     const { handler, calls, callingx, subscriptions } = setup(
       jest.fn().mockResolvedValue(undefined),
     );
-    callingx.endCallWithReason.mockRejectedValue(new Error('not tracked'));
+    callingx[failing].mockRejectedValue(new Error('boom'));
 
     await handler(RING_DATA);
 
-    expect(calls).toEqual(['release', 'stop']);
+    expect(calls).toEqual(expected);
+    // a retained entry would make every later push for this cid look like a duplicate
     expect(subscriptions.has(CALL_CID)).toBe(false);
   });
 });

--- a/packages/react-native-sdk/__tests__/push/android.test.ts
+++ b/packages/react-native-sdk/__tests__/push/android.test.ts
@@ -1,42 +1,39 @@
 /**
- * Tests for the `createStreamVideoClient` failure branches of the Android `call.ring` push handler.
- *
- * These branches abandon the push. Because `callingx.stopService()` is only a request — it no-ops
- * while any other call is registered or being registered — the abandoned call has to be ended
- * explicitly, otherwise its notification would be stranded whenever a second call is live.
+ * The two `createStreamVideoClient` failure branches of the Android `call.ring` push handler
+ * abandon the push. `callingx.stopService()` is only a request — it no-ops while another call is
+ * registered or being registered — so the abandoned call has to be ended explicitly, otherwise its
+ * notification is stranded whenever a second call is live.
  */
 
-const makeCallingx = (overrides: Partial<any> = {}) => ({
-  log: jest.fn(),
-  stopService: jest.fn().mockResolvedValue(undefined),
-  endCallWithReason: jest.fn().mockResolvedValue(undefined),
-  acquireBackgroundTask: jest.fn().mockResolvedValue(undefined),
-  releaseBackgroundTask: jest.fn().mockResolvedValue(undefined),
-  ...overrides,
-});
-
+const CALL_CID = 'default:abandoned';
 const RING_DATA = {
-  call_cid: 'default:abandoned-call',
+  call_cid: CALL_CID,
   sender: 'stream.video',
   type: 'call.ring',
-  created_by_id: 'caller-id',
 };
 
-/** Load the push handler with the client factory and platform state under test. */
-const loadHandler = ({
-  createStreamVideoClient,
-  callingx,
-  canListenToWS,
-}: {
-  createStreamVideoClient: jest.Mock;
-  callingx: ReturnType<typeof makeCallingx>;
-  canListenToWS: boolean;
-}) => {
-  let onRingNotificationReceived!: (data: any) => Promise<void>;
-  let pushUnsubscriptionCallbacks!: Map<string, (() => void)[]>;
+/** Loads the handler with a failing client factory. `calls` records the callingx sequence. */
+const setup = (createStreamVideoClient: jest.Mock) => {
+  const calls: string[] = [];
+  const callingx = {
+    log: jest.fn(),
+    acquireBackgroundTask: jest.fn().mockResolvedValue(undefined),
+    releaseBackgroundTask: jest.fn(() => {
+      calls.push('release');
+    }),
+    endCallWithReason: jest.fn(async () => {
+      calls.push('end');
+    }),
+    stopService: jest.fn(async () => {
+      calls.push('stop');
+    }),
+  };
+
+  let handler!: (data: unknown) => Promise<void>;
+  let subscriptions!: Map<string, unknown>;
   jest.isolateModules(() => {
     jest.doMock('react-native', () => ({
-      Platform: { OS: 'android', select: (o: any) => o.android },
+      Platform: { OS: 'android' },
       AppState: { currentState: 'background', addEventListener: jest.fn() },
     }));
     // mocked to keep the video-client / react-native-webrtc runtime out of the test
@@ -53,15 +50,16 @@ const loadHandler = ({
       },
     }));
     jest.doMock('../../src/utils/push/internal/utils', () => ({
-      canListenToWS: () => canListenToWS,
+      canListenToWS: () => true,
       shouldCallBeClosed: () => ({ mustEndCall: false }),
     }));
-    onRingNotificationReceived =
+    handler =
       require('../../src/utils/push/internal/android').onRingNotificationReceived;
-    pushUnsubscriptionCallbacks =
+    subscriptions =
       require('../../src/utils/push/internal/constants').pushUnsubscriptionCallbacks;
   });
-  return { onRingNotificationReceived, pushUnsubscriptionCallbacks };
+
+  return { handler, calls, callingx, subscriptions };
 };
 
 describe('onRingNotificationReceived — abandoning a push', () => {
@@ -69,63 +67,36 @@ describe('onRingNotificationReceived — abandoning a push', () => {
     jest.resetModules();
   });
 
-  it('ends the displayed call before asking the service to stop when no client is returned', async () => {
-    const callingx = makeCallingx();
-    const { onRingNotificationReceived, pushUnsubscriptionCallbacks } =
-      loadHandler({
-        createStreamVideoClient: jest.fn().mockResolvedValue(undefined),
-        callingx,
-        canListenToWS: false,
-      });
+  it.each<[string, () => jest.Mock]>([
+    ['returns no client', () => jest.fn().mockResolvedValue(undefined)],
+    ['throws', () => jest.fn().mockRejectedValue(new Error('boom'))],
+  ])(
+    'ends the call before requesting the stop when the client factory %s',
+    async (_label, clientFactory) => {
+      const { handler, calls, callingx, subscriptions } =
+        setup(clientFactory());
 
-    await onRingNotificationReceived(RING_DATA);
+      await handler(RING_DATA);
 
-    expect(callingx.endCallWithReason).toHaveBeenCalledWith(
-      RING_DATA.call_cid,
-      'error',
+      expect(calls).toEqual(['release', 'end', 'stop']);
+      expect(callingx.endCallWithReason).toHaveBeenCalledWith(
+        CALL_CID,
+        'error',
+      );
+      expect(subscriptions.has(CALL_CID)).toBe(false);
+    },
+  );
+
+  it('still requests the stop when ending the call fails', async () => {
+    const { handler, calls, callingx, subscriptions } = setup(
+      jest.fn().mockResolvedValue(undefined),
     );
-    expect(callingx.stopService).toHaveBeenCalledTimes(1);
-    expect(callingx.endCallWithReason.mock.invocationCallOrder[0]).toBeLessThan(
-      callingx.stopService.mock.invocationCallOrder[0],
-    );
-    expect(pushUnsubscriptionCallbacks.has(RING_DATA.call_cid)).toBe(false);
-  });
+    callingx.endCallWithReason.mockRejectedValue(new Error('not tracked'));
 
-  it('ends the call and releases the background task when client creation throws', async () => {
-    const callingx = makeCallingx();
-    const { onRingNotificationReceived, pushUnsubscriptionCallbacks } =
-      loadHandler({
-        createStreamVideoClient: jest.fn().mockRejectedValue(new Error('boom')),
-        callingx,
-        canListenToWS: true,
-      });
+    await handler(RING_DATA);
 
-    await onRingNotificationReceived(RING_DATA);
-
-    expect(callingx.releaseBackgroundTask).toHaveBeenCalledWith(
-      `push:${RING_DATA.call_cid}`,
-    );
-    expect(callingx.endCallWithReason).toHaveBeenCalledWith(
-      RING_DATA.call_cid,
-      'error',
-    );
-    expect(callingx.stopService).toHaveBeenCalledTimes(1);
-    expect(pushUnsubscriptionCallbacks.has(RING_DATA.call_cid)).toBe(false);
-  });
-
-  it('still stops the service when ending the call fails', async () => {
-    const callingx = makeCallingx({
-      endCallWithReason: jest.fn().mockRejectedValue(new Error('not tracked')),
-    });
-    const { onRingNotificationReceived } = loadHandler({
-      createStreamVideoClient: jest.fn().mockResolvedValue(undefined),
-      callingx,
-      canListenToWS: false,
-    });
-
-    await onRingNotificationReceived(RING_DATA);
-
-    expect(callingx.stopService).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['release', 'stop']);
+    expect(subscriptions.has(CALL_CID)).toBe(false);
   });
 });
 

--- a/packages/react-native-sdk/__tests__/push/android.test.ts
+++ b/packages/react-native-sdk/__tests__/push/android.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the `createStreamVideoClient` failure branches of the Android `call.ring` push handler.
+ *
+ * These branches abandon the push. Because `callingx.stopService()` is only a request — it no-ops
+ * while any other call is registered or being registered — the abandoned call has to be ended
+ * explicitly, otherwise its notification would be stranded whenever a second call is live.
+ */
+
+const makeCallingx = (overrides: Partial<any> = {}) => ({
+  log: jest.fn(),
+  stopService: jest.fn().mockResolvedValue(undefined),
+  endCallWithReason: jest.fn().mockResolvedValue(undefined),
+  acquireBackgroundTask: jest.fn().mockResolvedValue(undefined),
+  releaseBackgroundTask: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const RING_DATA = {
+  call_cid: 'default:abandoned-call',
+  sender: 'stream.video',
+  type: 'call.ring',
+  created_by_id: 'caller-id',
+};
+
+/** Load the push handler with the client factory and platform state under test. */
+const loadHandler = ({
+  createStreamVideoClient,
+  callingx,
+  canListenToWS,
+}: {
+  createStreamVideoClient: jest.Mock;
+  callingx: ReturnType<typeof makeCallingx>;
+  canListenToWS: boolean;
+}) => {
+  let onRingNotificationReceived!: (data: any) => Promise<void>;
+  let pushUnsubscriptionCallbacks!: Map<string, (() => void)[]>;
+  jest.isolateModules(() => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: 'android', select: (o: any) => o.android },
+      AppState: { currentState: 'background', addEventListener: jest.fn() },
+    }));
+    // mocked to keep the video-client / react-native-webrtc runtime out of the test
+    jest.doMock('@stream-io/video-client', () => ({
+      CallingState: { IDLE: 'idle', LEFT: 'left' },
+    }));
+    jest.doMock('../../src/utils/push/libs', () => ({
+      getCallingxLib: () => callingx,
+      getCallingxLibIfAvailable: () => callingx,
+    }));
+    jest.doMock('../../src/utils/StreamVideoRN', () => ({
+      StreamVideoRN: {
+        getConfig: () => ({ push: { createStreamVideoClient } }),
+      },
+    }));
+    jest.doMock('../../src/utils/push/internal/utils', () => ({
+      canListenToWS: () => canListenToWS,
+      shouldCallBeClosed: () => ({ mustEndCall: false }),
+    }));
+    onRingNotificationReceived =
+      require('../../src/utils/push/internal/android').onRingNotificationReceived;
+    pushUnsubscriptionCallbacks =
+      require('../../src/utils/push/internal/constants').pushUnsubscriptionCallbacks;
+  });
+  return { onRingNotificationReceived, pushUnsubscriptionCallbacks };
+};
+
+describe('onRingNotificationReceived — abandoning a push', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('ends the displayed call before asking the service to stop when no client is returned', async () => {
+    const callingx = makeCallingx();
+    const { onRingNotificationReceived, pushUnsubscriptionCallbacks } =
+      loadHandler({
+        createStreamVideoClient: jest.fn().mockResolvedValue(undefined),
+        callingx,
+        canListenToWS: false,
+      });
+
+    await onRingNotificationReceived(RING_DATA);
+
+    expect(callingx.endCallWithReason).toHaveBeenCalledWith(
+      RING_DATA.call_cid,
+      'error',
+    );
+    expect(callingx.stopService).toHaveBeenCalledTimes(1);
+    expect(callingx.endCallWithReason.mock.invocationCallOrder[0]).toBeLessThan(
+      callingx.stopService.mock.invocationCallOrder[0],
+    );
+    expect(pushUnsubscriptionCallbacks.has(RING_DATA.call_cid)).toBe(false);
+  });
+
+  it('ends the call and releases the background task when client creation throws', async () => {
+    const callingx = makeCallingx();
+    const { onRingNotificationReceived, pushUnsubscriptionCallbacks } =
+      loadHandler({
+        createStreamVideoClient: jest.fn().mockRejectedValue(new Error('boom')),
+        callingx,
+        canListenToWS: true,
+      });
+
+    await onRingNotificationReceived(RING_DATA);
+
+    expect(callingx.releaseBackgroundTask).toHaveBeenCalledWith(
+      `push:${RING_DATA.call_cid}`,
+    );
+    expect(callingx.endCallWithReason).toHaveBeenCalledWith(
+      RING_DATA.call_cid,
+      'error',
+    );
+    expect(callingx.stopService).toHaveBeenCalledTimes(1);
+    expect(pushUnsubscriptionCallbacks.has(RING_DATA.call_cid)).toBe(false);
+  });
+
+  it('still stops the service when ending the call fails', async () => {
+    const callingx = makeCallingx({
+      endCallWithReason: jest.fn().mockRejectedValue(new Error('not tracked')),
+    });
+    const { onRingNotificationReceived } = loadHandler({
+      createStreamVideoClient: jest.fn().mockResolvedValue(undefined),
+      callingx,
+      canListenToWS: false,
+    });
+
+    await onRingNotificationReceived(RING_DATA);
+
+    expect(callingx.stopService).toHaveBeenCalledTimes(1);
+  });
+});
+
+export {};

--- a/packages/react-native-sdk/src/hooks/push/useCallingExpWithCallingStateEffect.ts
+++ b/packages/react-native-sdk/src/hooks/push/useCallingExpWithCallingStateEffect.ts
@@ -112,12 +112,19 @@ export const useCallingExpWithCallingStateEffect = () => {
       return;
     }
 
-    callingx.updateDisplay(
-      activeCallCid,
-      createdByUserId ?? callDisplayName,
-      callDisplayName,
-      isIncoming,
-    );
+    callingx
+      .updateDisplay(
+        activeCallCid,
+        createdByUserId ?? callDisplayName,
+        callDisplayName,
+        isIncoming,
+      )
+      .catch((error: unknown) => {
+        logger.debug(
+          `useCallingExpWithCallingStateEffect: Error updating display in callingx: ${activeCallCid}`,
+          error,
+        );
+      });
   }, [activeCallCid, createdByUserId, callDisplayName, isIncoming]);
 
   // Sync microphone mute state from app → CallKit

--- a/packages/react-native-sdk/src/utils/push/internal/android.ts
+++ b/packages/react-native-sdk/src/utils/push/internal/android.ts
@@ -89,12 +89,22 @@ export const onRingNotificationReceived = async (
     if (asForegroundService) {
       finishBackgroundTask();
     }
+    // Each step is contained on its own: failing to dismiss the call must not skip the stop
+    // request, and neither may skip the unsubscription cleanup — a stale entry makes every later
+    // push for this cid look like a duplicate and get discarded.
     try {
       await callingx.endCallWithReason(call_cid, 'error');
     } catch (error) {
       nativeLog(`Failed to end call ${call_cid}: ${error}`, 'error');
     }
-    await callingx.stopService();
+    try {
+      await callingx.stopService();
+    } catch (error) {
+      nativeLog(
+        `Failed to stop the call service for ${call_cid}: ${error}`,
+        'error',
+      );
+    }
     pushUnsubscriptionCallbacks.delete(call_cid);
   };
 

--- a/packages/react-native-sdk/src/utils/push/internal/android.ts
+++ b/packages/react-native-sdk/src/utils/push/internal/android.ts
@@ -79,6 +79,25 @@ export const onRingNotificationReceived = async (
     callingx.releaseBackgroundTask(backgroundTaskOwner);
   };
 
+  /**
+   * Gives up on this push: dismisses the call the native push path already displayed, then asks
+   * the call service to stop. `stopService` is only a request — it no-ops while any other call is
+   * registered or being registered — so this call must be ended explicitly rather than relying on
+   * the service teardown to wipe it.
+   */
+  const abandonPush = async () => {
+    if (asForegroundService) {
+      finishBackgroundTask();
+    }
+    try {
+      await callingx.endCallWithReason(call_cid, 'error');
+    } catch (error) {
+      nativeLog(`Failed to end call ${call_cid}: ${error}`, 'error');
+    }
+    await callingx.stopService();
+    pushUnsubscriptionCallbacks.delete(call_cid);
+  };
+
   if (asForegroundService) {
     // initialize the callback array immediately to avoid race condition
     pushUnsubscriptionCallbacks.set(call_cid, []);
@@ -98,21 +117,13 @@ export const onRingNotificationReceived = async (
     client = await pushConfig.createStreamVideoClient();
     if (!client) {
       nativeLog(`video client not found, skipping the call.ring notification`);
-      if (asForegroundService) {
-        finishBackgroundTask();
-      }
-      await callingx.stopService();
-      pushUnsubscriptionCallbacks.delete(call_cid);
+      await abandonPush();
       return;
     }
   } catch (error) {
     //we need to release the background task and stop the service to avoid stale owner
     nativeLog(`Failed to create video client: ${error}`, 'error');
-    if (asForegroundService) {
-      finishBackgroundTask();
-    }
-    await callingx.stopService();
-    pushUnsubscriptionCallbacks.delete(call_cid);
+    await abandonPush();
     return;
   }
 


### PR DESCRIPTION
### 💡 Overview

ACTION_STOP_SERVICE unconditionally cancelled all notifications and called start-id blind stopSelf(), whose onDestroy disconnects every call. Its only caller is the createStreamVideoClient() failure path, so a ringing push landing mid-await got torn down.

also has changes from https://github.com/GetStream/stream-video-js/pull/2397 

### 📝 Implementation notes

The stop is now a request, gated on hasAnyCalls() || hasRegisteredCall() and stopSelfResult(startId) — each covers an ordering the other can't see. The push handler ends the abandoned call explicitly. Three tracked-id leak paths closed.

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android call service shutdown behavior to avoid interrupting active calls.
  - Ensured failed incoming call notifications are fully ended and cleaned up when setup fails.
  - Improved reliability after app reloads or runtime shutdowns.
  - Avoided unnecessary service startup when stopping an inactive service.
  - Improved notification tracking and foreground call handling.
  - Added error reporting for failed display updates.

- **Documentation**
  - Clarified that `stopService()` requests service shutdown and does not end individual calls.
  - Documented using `endCallWithReason()` to terminate specific calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->