### PR TITLE
fix(pronto): honor the display name picked in the lobby

### DIFF
--- a/sample-apps/react/react-dogfood/components/MeetingUI.tsx
+++ b/sample-apps/react/react-dogfood/components/MeetingUI.tsx
@@ -33,6 +33,7 @@ import {
   RemoteFilePublisher,
   RemoteFilePublisherContext,
 } from './RemoteFilePublisher';
+import { applyDisplayName } from '../helpers/client';
 import { applyQueryConfigParams } from '../lib/queryConfigParams';
 
 const contents = {
@@ -81,6 +82,7 @@ export const MeetingUI = ({ chatClient, mode }: MeetingUIProps) => {
             const name = options.displayName || getRandomName();
             const id = chatClient?.user?.id ?? sanitizeUserId(name);
             const email = chatClient?.user?.email;
+            await applyDisplayName(name);
             await chatClient
               ?.partialUpdateUser({ id, set: { name, email } })
               .catch((err) => console.error(`Failed to update user`, err));

--- a/sample-apps/react/react-dogfood/helpers/client.ts
+++ b/sample-apps/react/react-dogfood/helpers/client.ts
@@ -95,6 +95,14 @@ export const applyDisplayName = async (name: string) => {
   // anonymous users share the `!anon` id and carry no profile to rename
   if (user.type === 'anonymous' || !name || user.name === name) return;
 
+  // The client is a singleton, and pages such as the pre-call test disconnect
+  // it when they unmount. Reconnecting a client this helper no longer owns
+  // would restore an identity the current page never asked for. Guests skip
+  // the id check: the coordinator, not the caller, assigns their id.
+  const connectedUser = client.state.connectedUser;
+  if (!connectedUser) return;
+  if (user.type !== 'guest' && connectedUser.id !== user.id) return;
+
   const nextUser: User = { ...user, name };
   await client.disconnectUser();
   await client.connectUser(nextUser, tokenOrProvider);

--- a/sample-apps/react/react-dogfood/helpers/client.ts
+++ b/sample-apps/react/react-dogfood/helpers/client.ts
@@ -1,6 +1,7 @@
 import {
   StreamClientOptions,
   StreamVideoClient,
+  TokenOrProvider,
   User,
 } from '@stream-io/video-react-sdk';
 import { isRecentDeviceSelectionEnabled } from '../hooks/useDeviceSelectionPreference';
@@ -16,6 +17,7 @@ import {
 import { customSentryLogger } from './logger';
 
 let client: StreamVideoClient | undefined;
+let connection: { user: User; tokenOrProvider: TokenOrProvider } | undefined;
 
 /**
  * Lazily initializes video client. Credentials are captured on the first
@@ -44,6 +46,7 @@ export const getClient = (
       },
     };
     if (creds.user.type === 'guest' || creds.user.type === 'anonymous') {
+      connection = { user: creds.user, tokenOrProvider: undefined };
       client = new StreamVideoClient({
         apiKey: creds.apiKey,
         user: creds.user,
@@ -57,6 +60,10 @@ export const getClient = (
         );
       }
 
+      connection = {
+        user: creds.user,
+        tokenOrProvider: tokenProvider ?? creds.userToken,
+      };
       client = new StreamVideoClient({
         apiKey: creds.apiKey,
         user: creds.user,
@@ -72,6 +79,26 @@ export const getClient = (
   }
 
   return client;
+};
+
+/**
+ * Applies a display name to the connected user.
+ *
+ * The coordinator reads the user's name from the WebSocket auth payload, which
+ * is built from the credentials captured by {@link getClient}. A name picked
+ * later (in the lobby) therefore only reaches the coordinator - and survives
+ * WebSocket reconnects - once the user reconnects with it.
+ */
+export const applyDisplayName = async (name: string) => {
+  if (!client || !connection) return;
+  const { user, tokenOrProvider } = connection;
+  // anonymous users share the `!anon` id and carry no profile to rename
+  if (user.type === 'anonymous' || !name || user.name === name) return;
+
+  const nextUser: User = { ...user, name };
+  await client.disconnectUser();
+  await client.connectUser(nextUser, tokenOrProvider);
+  connection = { user: nextUser, tokenOrProvider };
 };
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';


### PR DESCRIPTION
### 💡 Overview

The display name picked in the Pronto lobby was never honored: you joined under the name resolved server-side at page load (your session name, or a random one) no matter what you typed.

### 📝 Implementation notes

`getServerSideCredentialsProps` resolves `user.name` at page load and `getClient` captures it on the first call, so by the time the lobby renders the video client is already connected under that name. The lobby's input only ever reached the **chat** user via `partialUpdateUser`, and the video user was left untouched - so the name in the call, and `client.state.connectedUser`, stayed stale. It is also not enough to patch the user elsewhere: the coordinator reads `user_details` from the WebSocket auth payload, and that payload is rebuilt from the captured credentials on *every* open, so any rename that skips a reconnect is undone by the next one.

`applyDisplayName(name)` therefore reconnects the video user under the picked name, and `MeetingUI.onJoin` awaits it before `call.join()`. The reconnect is skipped when the name is unchanged (the common case, since the input is prefilled), and for anonymous users, who share the `!anon` id and carry no profile to rename. The chat-side update is unchanged, so both products end up with the same name.

Verified end to end against the running dogfood app: joining a lobby as the random "Sphenoid Colby" after typing `Lobby Chosen Name` gives `connectedUser.name === 'Lobby Chosen Name'`, the same name on the SFU participant, and that name on the participant tile. The lobby's call object survives the reconnect - the join right after it succeeds normally.

Known follow-up, deliberately left out of scope: the name is not persisted across page loads, so a reload falls back to the session/random name and pays for one reconnect again on the next join. Persisting it and folding it into the SSR user would make the reconnect a first-pick-only cost.

🎫 Ticket: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display names are now applied to the video connection when joining a meeting.
  * Updated names are reflected by reconnecting with the new identity before entering chat.
  * Display names remain consistent across video and chat experiences during a meeting.
  * Name changes are handled safely without affecting an unrelated active connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->