### PR TITLE
fix:  do not end callingx service without call leave

### DIFF
--- a/packages/client/src/Call.ts
+++ b/packages/client/src/Call.ts
@@ -758,7 +758,10 @@ export class Call {
           }
         }
       }
-      globalThis.streamRNVideoSDK?.callingX?.endCall(this);
+      globalThis.streamRNVideoSDK?.callingX?.endCall(
+        this,
+        reason === 'ended' ? 'remote' : undefined,
+      );
 
       this.statsReporter?.stop();
       this.statsReporter = undefined;

--- a/packages/client/src/events/call.ts
+++ b/packages/client/src/events/call.ts
@@ -81,7 +81,6 @@ export const watchCallRejected = (call: Call) => {
  */
 export const watchCallEnded = (call: Call) => {
   return function onCallEnded() {
-    globalThis.streamRNVideoSDK?.callingX?.endCall(call, 'remote');
     const { callingState } = call.state;
     if (
       callingState !== CallingState.IDLE &&
@@ -92,9 +91,13 @@ export const watchCallEnded = (call: Call) => {
         reason: 'call.ended event received',
       });
       call
-        .leave({ message: 'call.ended event received', reject: false })
+        .leave({
+          message: 'call.ended event received',
+          reject: false,
+          reason: 'ended',
+        })
         .catch((err) => {
-          call.logger.error('Failed to leave call after call.ended ', err);
+          call.logger.error('Failed to leave call after call.ended', err);
         });
     }
   };


### PR DESCRIPTION
### 💡 Overview

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call-ending behavior by correctly distinguishing remotely ended calls from other leave scenarios.
  * Prevented duplicate call termination handling when a call-ended event is received.
  * Clarified error messaging for call-ending failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->