### PR TITLE
fix(rn): wrong expo plugin Android call-alive foreground service detection

### DIFF
--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/keepalive/StreamCallKeepAliveHeadlessService.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/keepalive/StreamCallKeepAliveHeadlessService.kt
@@ -97,18 +97,33 @@ class StreamCallKeepAliveHeadlessService : HeadlessJsTaskService() {
 
     @RequiresApi(Build.VERSION_CODES.Q)
     private fun computeForegroundServiceTypes(): Int {
+        // From Android 14 a claimed type must also be backed by its FOREGROUND_SERVICE_*
+        // permission, and claiming an undeclared type fails the whole startForeground() call. On
+        // older platforms those permissions do not exist, so the runtime grant is the only gate and
+        // the manifest does not need to be read at all. Read once when it is needed: this runs
+        // inside the window the system gives us to enter the foreground.
+        val declaredTypePermissions =
+            if (CallAlivePermissionsHelper.enforcesTypePermissions()) {
+                CallAlivePermissionsHelper.declaredPermissions(this)
+            } else {
+                null
+            }
+
         var types = ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
 
-        // A type is only usable when the runtime permission is granted AND, from Android 14, the
-        // matching FOREGROUND_SERVICE_* permission is declared. Claiming an undeclared type makes
-        // the whole startForeground() call fail, so drop the type instead.
-        if (canUseType(Manifest.permission.CAMERA, CallAlivePermissionsHelper.PERMISSION_CAMERA)) {
+        if (canUseType(
+                Manifest.permission.CAMERA,
+                CallAlivePermissionsHelper.PERMISSION_CAMERA,
+                declaredTypePermissions
+            )
+        ) {
             types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
         }
 
         if (canUseType(
                 Manifest.permission.RECORD_AUDIO,
-                CallAlivePermissionsHelper.PERMISSION_MICROPHONE
+                CallAlivePermissionsHelper.PERMISSION_MICROPHONE,
+                declaredTypePermissions
             )
         ) {
             types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
@@ -117,14 +132,22 @@ class StreamCallKeepAliveHeadlessService : HeadlessJsTaskService() {
         return types
     }
 
-    private fun canUseType(runtimePermission: String, fgsTypePermission: String): Boolean {
+    /**
+     * @param declaredTypePermissions the permissions declared in the app manifest, or null when the
+     * platform does not require foreground service types to be declared (Android 13 and below).
+     */
+    private fun canUseType(
+        runtimePermission: String,
+        fgsTypePermission: String,
+        declaredTypePermissions: Set<String>?
+    ): Boolean {
         val granted = ContextCompat.checkSelfPermission(this, runtimePermission) ==
             PackageManager.PERMISSION_GRANTED
         if (!granted) {
             return false
         }
-        return !CallAlivePermissionsHelper.enforcesTypePermissions() ||
-            CallAlivePermissionsHelper.isDeclared(this, fgsTypePermission)
+        return declaredTypePermissions == null ||
+            fgsTypePermission in declaredTypePermissions
     }
 
     /**

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/keepalive/StreamCallKeepAliveHeadlessService.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/keepalive/StreamCallKeepAliveHeadlessService.kt
@@ -27,7 +27,7 @@ class StreamCallKeepAliveHeadlessService : HeadlessJsTaskService() {
         // which leaves the base class with a started service and no task. Stop before going
         // foreground so we neither show an orphan notification nor hold the FGS types.
         val callCid = intent?.getStringExtra(EXTRA_CALL_CID)
-        if (callCid == null) {
+        if (intent == null || callCid.isNullOrBlank()) {
             Log.w(TAG, "onStartCommand: missing $EXTRA_CALL_CID extra, stopping service")
             stopSelf(startId)
             return START_NOT_STICKY

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/keepalive/StreamCallKeepAliveHeadlessService.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/keepalive/StreamCallKeepAliveHeadlessService.kt
@@ -1,6 +1,8 @@
 package com.streamvideo.reactnative.keepalive
 
 import android.Manifest
+import android.app.Notification
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
@@ -12,6 +14,7 @@ import androidx.core.content.ContextCompat
 import com.facebook.react.HeadlessJsTaskService
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.jstasks.HeadlessJsTaskConfig
+import com.streamvideo.reactnative.util.CallAlivePermissionsHelper
 
 /**
  * Foreground service that runs a React Native HeadlessJS task to keep a call alive.
@@ -20,12 +23,21 @@ import com.facebook.react.jstasks.HeadlessJsTaskConfig
 class StreamCallKeepAliveHeadlessService : HeadlessJsTaskService() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val safeIntent = intent ?: Intent()
-        val channelId = safeIntent.getStringExtra(EXTRA_CHANNEL_ID) ?: DEFAULT_CHANNEL_ID
-        val channelName = safeIntent.getStringExtra(EXTRA_CHANNEL_NAME) ?: DEFAULT_CHANNEL_NAME
-        val title = safeIntent.getStringExtra(EXTRA_TITLE) ?: DEFAULT_TITLE
-        val body = safeIntent.getStringExtra(EXTRA_BODY) ?: DEFAULT_BODY
-        val smallIconName = safeIntent.getStringExtra(EXTRA_SMALL_ICON_NAME)
+        // Without a call cid there is nothing to keep alive and getTaskConfig() would return null,
+        // which leaves the base class with a started service and no task. Stop before going
+        // foreground so we neither show an orphan notification nor hold the FGS types.
+        val callCid = intent?.getStringExtra(EXTRA_CALL_CID)
+        if (callCid == null) {
+            Log.w(TAG, "onStartCommand: missing $EXTRA_CALL_CID extra, stopping service")
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+
+        val channelId = intent.getStringExtra(EXTRA_CHANNEL_ID) ?: DEFAULT_CHANNEL_ID
+        val channelName = intent.getStringExtra(EXTRA_CHANNEL_NAME) ?: DEFAULT_CHANNEL_NAME
+        val title = intent.getStringExtra(EXTRA_TITLE) ?: DEFAULT_TITLE
+        val body = intent.getStringExtra(EXTRA_BODY) ?: DEFAULT_BODY
+        val smallIconName = intent.getStringExtra(EXTRA_SMALL_ICON_NAME)
 
         KeepAliveNotification.ensureChannel(this, channelId, channelName)
         val notification = KeepAliveNotification.buildOngoingNotification(
@@ -36,10 +48,32 @@ class StreamCallKeepAliveHeadlessService : HeadlessJsTaskService() {
             smallIconName = smallIconName
         )
 
-        startForegroundCompat(notification)
+        if (!startForegroundCompat(notification)) {
+            // We never entered the foreground. Stop immediately: the system arms a watchdog when
+            // startForegroundService() is used and crashes the app with
+            // ForegroundServiceDidNotStartInTimeException unless the service either goes foreground
+            // or is destroyed. Also pointless to run a JS task with no foreground service behind it.
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
 
         // Ensure HeadlessJS task is started
-        return super.onStartCommand(safeIntent, flags, startId)
+        return try {
+            super.onStartCommand(intent, flags, startId)
+            // Deliberately override the base class' START_REDELIVER_INTENT: that would have the
+            // system recreate this service (and the process) from the background after a kill,
+            // which is a background foreground-service start with while-in-use types
+            // (camera/microphone) and is rejected on Android 12+/14+. The call being kept alive
+            // does not survive the process anyway, so there is nothing to restart for.
+            START_NOT_STICKY
+        } catch (e: Exception) {
+            // startTask() can throw when the app's Application is not a ReactApplication, when the
+            // bridgeless ReactHost is missing, or when the react context was already destroyed.
+            // Don't take the app down with us.
+            Log.e(TAG, "onStartCommand: Failed to start HeadlessJS task: ${e.message}", e)
+            stopSelf(startId)
+            START_NOT_STICKY
+        }
     }
 
     override fun getTaskConfig(intent: Intent?): HeadlessJsTaskConfig? {
@@ -57,47 +91,77 @@ class StreamCallKeepAliveHeadlessService : HeadlessJsTaskService() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         stopForeground(STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
     }
 
-    @RequiresApi(Build.VERSION_CODES.R)
+    @RequiresApi(Build.VERSION_CODES.Q)
     private fun computeForegroundServiceTypes(): Int {
         var types = ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
 
-        val hasCameraPermission =
-            ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
-        if (hasCameraPermission) {
+        // A type is only usable when the runtime permission is granted AND, from Android 14, the
+        // matching FOREGROUND_SERVICE_* permission is declared. Claiming an undeclared type makes
+        // the whole startForeground() call fail, so drop the type instead.
+        if (canUseType(Manifest.permission.CAMERA, CallAlivePermissionsHelper.PERMISSION_CAMERA)) {
             types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
         }
 
-        val hasMicrophonePermission =
-            ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
-        if (hasMicrophonePermission) {
+        if (canUseType(
+                Manifest.permission.RECORD_AUDIO,
+                CallAlivePermissionsHelper.PERMISSION_MICROPHONE
+            )
+        ) {
             types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
         }
 
         return types
     }
 
-    private fun startForegroundCompat(notification: android.app.Notification) {
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                val types =
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) computeForegroundServiceTypes()
-                    else ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+    private fun canUseType(runtimePermission: String, fgsTypePermission: String): Boolean {
+        val granted = ContextCompat.checkSelfPermission(this, runtimePermission) ==
+            PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            return false
+        }
+        return !CallAlivePermissionsHelper.enforcesTypePermissions() ||
+            CallAlivePermissionsHelper.isDeclared(this, fgsTypePermission)
+    }
+
+    /**
+     * @return true when the service actually entered the foreground.
+     */
+    private fun startForegroundCompat(notification: Notification): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val types = computeForegroundServiceTypes()
+            if (tryStartForeground(notification, types)) {
+                return true
+            }
+            // The camera/microphone types are rejected on API 34+ when the app hasn't declared the
+            // matching FOREGROUND_SERVICE_* permission. mediaPlayback on its own still keeps the JS
+            // timers hot, so degrade to it rather than losing the keep-alive entirely.
+            val mediaPlaybackOnly = ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+            return types != mediaPlaybackOnly && tryStartForeground(notification, mediaPlaybackOnly)
+        }
+        return tryStartForeground(notification, null)
+    }
+
+    private fun tryStartForeground(notification: Notification, types: Int?): Boolean {
+        return try {
+            if (types != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 startForeground(NOTIFICATION_ID, notification, types)
             } else {
                 startForeground(NOTIFICATION_ID, notification)
             }
+            true
         } catch (e: Exception) {
             // Avoid crashing the app if the system rejects starting a foreground service (e.g.
             // background start restrictions, invalid notification/channel, or permission issues).
             Log.e(
                 TAG,
-                "startForegroundCompat: Failed to start foreground service: ${e.message}",
+                "tryStartForeground: Failed to start foreground service (types=$types): ${e.message}",
                 e
             )
+            false
         }
     }
 
@@ -121,7 +185,7 @@ class StreamCallKeepAliveHeadlessService : HeadlessJsTaskService() {
         private const val DEFAULT_BODY = "Tap to return to the call"
 
         fun buildStartIntent(
-            context: android.content.Context,
+            context: Context,
             callCid: String,
             channelId: String,
             channelName: String,
@@ -141,9 +205,8 @@ class StreamCallKeepAliveHeadlessService : HeadlessJsTaskService() {
             }
         }
 
-        fun buildStopIntent(context: android.content.Context): Intent {
+        fun buildStopIntent(context: Context): Intent {
             return Intent(context, StreamCallKeepAliveHeadlessService::class.java)
         }
     }
 }
-

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/CallAlivePermissionsHelper.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/CallAlivePermissionsHelper.kt
@@ -34,9 +34,6 @@ object CallAlivePermissionsHelper {
      */
     fun hasForegroundServicePermissionsDeclared(context: Context): Boolean {
         val declared = declaredPermissions(context)
-        if (declared.isEmpty()) {
-            return false
-        }
 
         val required = mutableListOf<String>()
         // FOREGROUND_SERVICE only exists from Android 9, and this SDK supports minSdk 24.

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/CallAlivePermissionsHelper.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/CallAlivePermissionsHelper.kt
@@ -1,53 +1,88 @@
 package com.streamvideo.reactnative.util
 
+import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.os.Build
 import android.util.Log
-import com.facebook.react.bridge.ReactApplicationContext
 
 
 object CallAlivePermissionsHelper {
     private const val NAME = "StreamVideoReactNative"
 
-    fun hasForegroundServicePermissionsDeclared(context: ReactApplicationContext): Boolean {
-        val packageManager = context.packageManager
-        val packageName = context.packageName
+    const val PERMISSION_FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE"
+    const val PERMISSION_MEDIA_PLAYBACK =
+        "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
+    const val PERMISSION_CAMERA = "android.permission.FOREGROUND_SERVICE_CAMERA"
+    const val PERMISSION_MICROPHONE = "android.permission.FOREGROUND_SERVICE_MICROPHONE"
 
-        try {
-            val packageInfo: PackageInfo =
-                packageManager.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS)
-            val requestedPermissions = packageInfo.requestedPermissions
+    /**
+     * From Android 14 the system verifies, at service creation time, that every foreground service
+     * type is backed by its matching FOREGROUND_SERVICE_* permission. Below that the types can be
+     * used without declaring them.
+     */
+    fun enforcesTypePermissions(): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 
-            if (requestedPermissions != null) {
-                val requiredPermissions = arrayOf(
-                    "android.permission.FOREGROUND_SERVICE",
-                    "android.permission.FOREGROUND_SERVICE_CAMERA",
-                    "android.permission.FOREGROUND_SERVICE_MICROPHONE",
-                    "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
-                )
+    fun isDeclared(context: Context, permission: String): Boolean =
+        permission in requestedPermissions(context)
 
-                val missingPermissions =
-                    requiredPermissions.filterNot { requestedPermissions.contains(it) }
+    /**
+     * The keep-alive service always runs with the `mediaPlayback` type and adds `camera` /
+     * `microphone` when those are available, so only FOREGROUND_SERVICE and (on Android 14+)
+     * FOREGROUND_SERVICE_MEDIA_PLAYBACK are hard requirements. A missing camera/microphone
+     * permission only drops that type - it must not disable the keep-alive altogether, otherwise
+     * the app silently loses audio and gets dropped from the call once it is backgrounded.
+     */
+    fun hasForegroundServicePermissionsDeclared(context: Context): Boolean {
+        val declared = requestedPermissions(context)
+        if (declared.isEmpty()) {
+            return false
+        }
 
-                if (missingPermissions.isNotEmpty()) {
-                    Log.w(
-                        NAME,
-                        "Missing ForegroundServicePermissions: ${missingPermissions.joinToString(", ")}"
-                    )
-                    return false
-                } else {
-                    return true
-                }
-            }
-        } catch (e: PackageManager.NameNotFoundException) {
-            // do nothing, this can never happen actually
-            Log.e(
+        val required = mutableListOf<String>()
+        // FOREGROUND_SERVICE only exists from Android 9, and this SDK supports minSdk 24.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            required.add(PERMISSION_FOREGROUND_SERVICE)
+        }
+        if (enforcesTypePermissions()) {
+            required.add(PERMISSION_MEDIA_PLAYBACK)
+        }
+        val missingRequired = required.filterNot { declared.contains(it) }
+        if (missingRequired.isNotEmpty()) {
+            Log.w(
                 NAME,
-                "Package not found: $packageName",
-                e
+                "Keep-call-alive is disabled: the app manifest is missing " +
+                    "${missingRequired.joinToString(", ")}. Without it the call cannot be kept " +
+                    "alive in the background and the user will be dropped from the call."
+            )
+            return false
+        }
+
+        val missingOptional =
+            listOf(PERMISSION_CAMERA, PERMISSION_MICROPHONE).filterNot { declared.contains(it) }
+        if (missingOptional.isNotEmpty() && enforcesTypePermissions()) {
+            Log.w(
+                NAME,
+                "Keep-call-alive will run without the ${missingOptional.joinToString(", ")} " +
+                    "foreground service type(s) because the app manifest does not declare them. " +
+                    "Camera/microphone may be suspended while the app is in the background."
             )
         }
-        return false
+        return true
     }
 
+    private fun requestedPermissions(context: Context): Set<String> {
+        return try {
+            val packageInfo: PackageInfo = context.packageManager.getPackageInfo(
+                context.packageName,
+                PackageManager.GET_PERMISSIONS
+            )
+            packageInfo.requestedPermissions?.toSet() ?: emptySet()
+        } catch (e: PackageManager.NameNotFoundException) {
+            // do nothing, this can never happen actually
+            Log.e(NAME, "Package not found: ${context.packageName}", e)
+            emptySet()
+        }
+    }
 }

--- a/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/CallAlivePermissionsHelper.kt
+++ b/packages/react-native-sdk/android/src/main/java/com/streamvideo/reactnative/util/CallAlivePermissionsHelper.kt
@@ -24,8 +24,6 @@ object CallAlivePermissionsHelper {
     fun enforcesTypePermissions(): Boolean =
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 
-    fun isDeclared(context: Context, permission: String): Boolean =
-        permission in requestedPermissions(context)
 
     /**
      * The keep-alive service always runs with the `mediaPlayback` type and adds `camera` /
@@ -35,7 +33,7 @@ object CallAlivePermissionsHelper {
      * the app silently loses audio and gets dropped from the call once it is backgrounded.
      */
     fun hasForegroundServicePermissionsDeclared(context: Context): Boolean {
-        val declared = requestedPermissions(context)
+        val declared = declaredPermissions(context)
         if (declared.isEmpty()) {
             return false
         }
@@ -72,7 +70,8 @@ object CallAlivePermissionsHelper {
         return true
     }
 
-    private fun requestedPermissions(context: Context): Set<String> {
+    /** The permissions declared in the app manifest. One PackageManager round trip. */
+    fun declaredPermissions(context: Context): Set<String> {
         return try {
             val packageInfo: PackageInfo = context.packageManager.getPackageInfo(
                 context.packageName,

--- a/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidPermissions.test.ts
+++ b/packages/react-native-sdk/expo-config-plugin/__tests__/withAndroidPermissions.test.ts
@@ -34,7 +34,7 @@ describe('withStreamVideoReactNativeSDKAndroidPermissions', () => {
         'android.permission.BLUETOOTH_ADMIN',
         'android.permission.FOREGROUND_SERVICE_CAMERA',
         'android.permission.FOREGROUND_SERVICE_MICROPHONE',
-        'android.permission.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK',
+        'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
       ]),
     );
   });

--- a/packages/react-native-sdk/expo-config-plugin/src/withAndroidPermissions.ts
+++ b/packages/react-native-sdk/expo-config-plugin/src/withAndroidPermissions.ts
@@ -25,7 +25,7 @@ const withStreamVideoReactNativeSDKAndroidPermissions: ConfigPlugin<
     permissions.push(
       'android.permission.FOREGROUND_SERVICE_CAMERA',
       'android.permission.FOREGROUND_SERVICE_MICROPHONE',
-      'android.permission.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK',
+      'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
     );
   }
   const config = AndroidConfig.Permissions.withPermissions(

--- a/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
+++ b/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
@@ -9,7 +9,10 @@ import {
   Platform,
 } from 'react-native';
 import { CallingState, videoLoggerSystem } from '@stream-io/video-client';
-import { keepCallAliveCallRef } from '../utils/keepCallAliveHeadlessTask';
+import {
+  endKeepCallAliveHeadlessTask,
+  keepCallAliveCallRef,
+} from '../utils/keepCallAliveHeadlessTask';
 import { getCallingxLibIfAvailable } from '../utils/push/libs';
 
 async function stopForegroundServiceNoThrow() {
@@ -21,7 +24,10 @@ async function stopForegroundServiceNoThrow() {
   }
 }
 
-async function startForegroundService(call_cid: string) {
+/**
+ * @returns true when the native foreground service was asked to start.
+ */
+async function startForegroundService(call_cid: string): Promise<boolean> {
   const logger = videoLoggerSystem.getLogger('startForegroundService');
   const isCallAliveConfigured = await (async () => {
     try {
@@ -32,10 +38,14 @@ async function startForegroundService(call_cid: string) {
     }
   })();
   if (!isCallAliveConfigured) {
-    logger.info(
-      'KeepCallAlive is not configured. Skipping foreground service setup.',
+    logger.warn(
+      'KeepCallAlive is not configured, the call will not survive the app going to the ' +
+        'background: audio publishing stops and the user is eventually dropped from the call. ' +
+        'Declare android.permission.FOREGROUND_SERVICE and ' +
+        'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK in the app manifest (see logcat, ' +
+        'tag StreamVideoReactNative, for the exact list of missing permissions).',
     );
-    return;
+    return false;
   }
   // Check for notification permission (Android 13+) before starting the service.
   const hasPostNotificationsPermission =
@@ -47,7 +57,7 @@ async function startForegroundService(call_cid: string) {
     logger.info(
       'Notification permission not granted, can not start foreground service to keep the call alive',
     );
-    return;
+    return false;
   }
   const videoConfig = StreamVideoRN.getConfig();
   const foregroundServiceConfig = videoConfig.foregroundService;
@@ -58,19 +68,34 @@ async function startForegroundService(call_cid: string) {
   // NOTE: we use requestAnimationFrame to ensure that the foreground service is started after all the current UI operations are done
   // this is a workaround for the crash - android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException: Context.startForegroundService() did not then call Service.startForeground()
   // this crash was reproducible only in some android devices
-  requestAnimationFrame(async () => {
-    try {
-      await NativeModules.StreamVideoReactNative.startKeepCallAliveService(
-        call_cid,
-        channel.id,
-        channel.name,
-        notificationTexts.title,
-        notificationTexts.body,
-        smallIconName ?? null,
-      );
-    } catch (e) {
-      logger.warn('Failed to start keep-call-alive foreground service', e);
-    }
+  return new Promise<boolean>((resolve) => {
+    requestAnimationFrame(async () => {
+      // The service declares the camera/microphone foreground service types, which are
+      // while-in-use permissions: Android requires startForegroundService() to be called while the
+      // app has a visible activity, otherwise the start is rejected. The frame we deferred to can
+      // land after the app left the foreground, so re-check before calling native.
+      if (AppState.currentState !== 'active') {
+        logger.info(
+          'App is no longer in the foreground, not starting the keep-call-alive foreground service',
+        );
+        resolve(false);
+        return;
+      }
+      try {
+        await NativeModules.StreamVideoReactNative.startKeepCallAliveService(
+          call_cid,
+          channel.id,
+          channel.name,
+          notificationTexts.title,
+          notificationTexts.body,
+          smallIconName ?? null,
+        );
+        resolve(true);
+      } catch (e) {
+        logger.warn('Failed to start keep-call-alive foreground service', e);
+        resolve(false);
+      }
+    });
   });
 }
 
@@ -147,8 +172,10 @@ export const useAndroidKeepCallAliveEffect = () => {
           return;
         }
 
-        await startForegroundService(activeCallCid);
-        foregroundServiceStartedRef.current = true;
+        // only mark as started when native actually accepted the start, so that a later render
+        // while still joined can retry.
+        foregroundServiceStartedRef.current =
+          await startForegroundService(activeCallCid);
       };
 
       // ensure that app is active before running the function
@@ -170,6 +197,8 @@ export const useAndroidKeepCallAliveEffect = () => {
     } else if (isCallEnded) {
       if (foregroundServiceStartedRef.current) {
         keepCallAliveCallRef.current = undefined;
+        // let the headless task resolve so RN unwinds it, then stop the foreground service
+        endKeepCallAliveHeadlessTask();
         // stop foreground service when the call is not active
         stopForegroundServiceNoThrow();
         foregroundServiceStartedRef.current = false;
@@ -188,6 +217,7 @@ export const useAndroidKeepCallAliveEffect = () => {
       // stop foreground service when this effect is unmounted
       if (foregroundServiceStartedRef.current) {
         keepCallAliveCallRef.current = undefined;
+        endKeepCallAliveHeadlessTask();
         stopForegroundServiceNoThrow();
         foregroundServiceStartedRef.current = false;
       }

--- a/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
+++ b/packages/react-native-sdk/src/hooks/useAndroidKeepCallAliveEffect.ts
@@ -172,10 +172,18 @@ export const useAndroidKeepCallAliveEffect = () => {
           return;
         }
 
-        // only mark as started when native actually accepted the start, so that a later render
-        // while still joined can retry.
-        foregroundServiceStartedRef.current =
-          await startForegroundService(activeCallCid);
+        try {
+          // only mark as started when native actually accepted the start, so that a later render
+          // while still joined can retry.
+          foregroundServiceStartedRef.current =
+            await startForegroundService(activeCallCid);
+        } catch (e) {
+          // run() is intentionally not awaited, so anything thrown here would surface as an
+          // unhandled rejection. Leave the ref false so a later render can retry.
+          videoLoggerSystem
+            .getLogger('useAndroidKeepCallAliveEffect')
+            .warn('Failed to start the keep-call-alive foreground service', e);
+        }
       };
 
       // ensure that app is active before running the function

--- a/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
+++ b/packages/react-native-sdk/src/utils/StreamVideoRN/types.ts
@@ -176,8 +176,7 @@ export type StreamVideoConfig = {
        */
       notificationTexts: KeepAliveAndroidNotificationTexts;
       /**
-       * The task to run in the foreground service
-       * The task must resolve a promise once complete
+       * The task to run in the foreground service.
        */
       taskToRun: (call: Call) => Promise<void>;
     };

--- a/packages/react-native-sdk/src/utils/keepCallAliveHeadlessTask.ts
+++ b/packages/react-native-sdk/src/utils/keepCallAliveHeadlessTask.ts
@@ -62,6 +62,7 @@ function registerKeepCallAliveHeadlessTaskOnce() {
       const taskEnded = new Promise<void>((resolve) => {
         resolveRunningTask = resolve;
       });
+      const ownResolver = resolveRunningTask;
 
       // React Native stops the foreground service as soon as the promise returned from here
       // settles. `taskToRun` is app-provided and may resolve early - or immediately - so its
@@ -82,7 +83,11 @@ function registerKeepCallAliveHeadlessTaskOnce() {
       try {
         await taskEnded;
       } finally {
-        resolveRunningTask = undefined;
+        // a newer task may already have installed its own resolver - clearing it here would leave
+        // that task with no way to be ended.
+        if (resolveRunningTask === ownResolver) {
+          resolveRunningTask = undefined;
+        }
       }
     },
   );

--- a/packages/react-native-sdk/src/utils/keepCallAliveHeadlessTask.ts
+++ b/packages/react-native-sdk/src/utils/keepCallAliveHeadlessTask.ts
@@ -13,6 +13,21 @@ export const keepCallAliveCallRef: { current: Call | undefined } = {
   current: undefined,
 };
 
+let resolveRunningTask: (() => void) | undefined;
+
+/**
+ * Ends the currently running keep-alive headless task.
+ *
+ * The task's promise is app-provided (`foregroundService.android.taskToRun`) and by default never
+ * resolves, so stopping the native service alone would leave the task registered in
+ * `HeadlessJsTaskContext` forever - which keeps RN's timer choreographer callback posted for the
+ * rest of the process lifetime. Resolving it here lets React Native unwind the task properly.
+ */
+export const endKeepCallAliveHeadlessTask = () => {
+  resolveRunningTask?.();
+  resolveRunningTask = undefined;
+};
+
 function registerKeepCallAliveHeadlessTaskOnce() {
   if (Platform.OS !== 'android') return;
 
@@ -42,10 +57,32 @@ function registerKeepCallAliveHeadlessTaskOnce() {
 
       const config = StreamVideoRN.getConfig();
       const taskToRun = config.foregroundService.android.taskToRun;
+      // A previous task (if any) must not keep hanging around.
+      endKeepCallAliveHeadlessTask();
+      const taskEnded = new Promise<void>((resolve) => {
+        resolveRunningTask = resolve;
+      });
+
+      // React Native stops the foreground service as soon as the promise returned from here
+      // settles. `taskToRun` is app-provided and may resolve early - or immediately - so its
+      // completion must not end the keep-alive: that would drop the call's background protection
+      // while the call is still ongoing. The task's lifetime is owned by the SDK instead, and ends
+      // via endKeepCallAliveHeadlessTask() when the call is left.
+      (async () => {
+        try {
+          await taskToRun(call);
+          logger.debug(
+            'Keep-alive taskToRun completed, keeping the call alive until the call ends',
+          );
+        } catch (e) {
+          logger.error('Keep-alive headless task failed', e);
+        }
+      })();
+
       try {
-        await taskToRun(call);
-      } catch (e) {
-        logger.error('Keep-alive headless task failed', e);
+        await taskEnded;
+      } finally {
+        resolveRunningTask = undefined;
       }
     },
   );


### PR DESCRIPTION
### 💡 Overview

The Expo plugin declared a non-existent permission, so Android's keep-alive foreground service never started.

Also other small improvements

### 📝 Implementation notes

**Root cause**

FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK doesn't exist — the real name has no _TYPE_. The native check always saw it missing and skipped the service.

**Permission check now degrades**

Requires only FOREGROUND_SERVICE and, on Android 14+, MEDIA_PLAYBACK. A missing camera/microphone permission drops that service type instead of disabling the keep-alive, and warns.

**Service hardening**

Stops itself when startForeground fails or the intent has no call cid; returns START_NOT_STICKY; validates each type against declared and granted permissions.

**SDK owns the headless task**

An app taskToRun that resolves early no longer stops the service mid-call, and the task is always finished so RN's timer callback isn't left posted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android call keep-alive reliability when call data, permissions, or foreground-service startup conditions are unavailable.
  - Prevented stale background tasks from continuing after calls end or during app cleanup.
  - Added safer handling and retry behavior for foreground-service startup failures.

- **Improvements**
  - Updated Android permission handling across supported versions.
  - Keep-alive now selects compatible foreground-service capabilities automatically.
  - Clarified background-task configuration guidance and improved task lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->