### PR TITLE
test(client): isolate ringing tests with per-test user ids

### DIFF
--- a/packages/client/src/__tests__/StreamVideoClient.ringing.test.ts
+++ b/packages/client/src/__tests__/StreamVideoClient.ringing.test.ts
@@ -17,7 +17,14 @@ const secret = process.env.STREAM_SECRET!;
 
 describe('StreamVideoClient Ringing', () => {
   const serverClient = new StreamClient(apiKey, secret);
-  const testUserIds = ['oliver', 'sacha', 'marcelo'];
+
+  // user ids are generated per test: CI runs share a single Stream app, so
+  // fixed ids let a concurrently running job ring these users and satisfy the
+  // assertions in this file with an unrelated call.
+  let oliverId: string;
+  let sachaId: string;
+  let marceloId: string;
+  let testUserIds: string[];
 
   let oliverClient: StreamVideoClient;
   let sachaClient: StreamVideoClient;
@@ -54,6 +61,11 @@ describe('StreamVideoClient Ringing', () => {
   };
 
   beforeEach(async () => {
+    const suffix = crypto.randomUUID();
+    oliverId = `oliver-${suffix}`;
+    sachaId = `sacha-${suffix}`;
+    marceloId = `marcelo-${suffix}`;
+    testUserIds = [oliverId, sachaId, marceloId];
     [oliverClient, sachaClient, marceloClient] =
       await createClients(testUserIds);
   });
@@ -75,11 +87,11 @@ describe('StreamVideoClient Ringing', () => {
       await call.create({
         ring: true,
         data: {
-          created_by_id: 'oliver',
+          created_by_id: oliverId,
           members: [
-            { user_id: 'oliver' },
-            { user_id: 'sacha' },
-            { user_id: 'marcelo' },
+            { user_id: oliverId },
+            { user_id: sachaId },
+            { user_id: marceloId },
           ],
         },
       });
@@ -112,9 +124,9 @@ describe('StreamVideoClient Ringing', () => {
         ring: true,
         data: {
           members: [
-            { user_id: 'oliver' },
-            { user_id: 'sacha' },
-            { user_id: 'marcelo' },
+            { user_id: oliverId },
+            { user_id: sachaId },
+            { user_id: marceloId },
           ],
         },
       });
@@ -144,9 +156,9 @@ describe('StreamVideoClient Ringing', () => {
         ring: false, // don't ring all members by default
         data: {
           members: [
-            { user_id: 'oliver' },
-            { user_id: 'sacha' },
-            { user_id: 'marcelo' },
+            { user_id: oliverId },
+            { user_id: sachaId },
+            { user_id: marceloId },
           ],
         },
       });
@@ -162,7 +174,7 @@ describe('StreamVideoClient Ringing', () => {
       // oliver is calling sacha. only sacha should get a ring event
       const sachaIndividualRing = expectEvent(sachaClient, 'call.ring');
       const marceloIndividualRing = expectEvent(marceloClient, 'call.ring');
-      await oliverCall.ring({ members_ids: ['sacha'] });
+      await oliverCall.ring({ members_ids: [sachaId] });
       await expect(sachaIndividualRing).resolves.toHaveProperty(
         'call.cid',
         oliverCall.cid,
@@ -175,7 +187,7 @@ describe('StreamVideoClient Ringing', () => {
       // sacha is calling marcelo. only marcelo should get a ring event
       const oliverIndividualRing = expectEvent(oliverClient, 'call.ring');
       const marceloIndividualRing2 = expectEvent(marceloClient, 'call.ring');
-      await sachaCall.ring({ members_ids: ['marcelo'] });
+      await sachaCall.ring({ members_ids: [marceloId] });
       await expect(marceloIndividualRing2).resolves.toHaveProperty(
         'call.cid',
         sachaCall.cid,
@@ -241,8 +253,8 @@ describe('StreamVideoClient Ringing', () => {
       const serverCall = serverClient.video.call('default', callId);
       await serverCall.create({
         data: {
-          created_by_id: 'oliver',
-          members: [{ user_id: 'oliver' }, { user_id: 'sacha' }],
+          created_by_id: oliverId,
+          members: [{ user_id: oliverId }, { user_id: sachaId }],
         },
       });
 
@@ -266,7 +278,7 @@ describe('StreamVideoClient Ringing', () => {
       await oliverCall.create({
         ring: true,
         data: {
-          members: [{ user_id: 'oliver' }, { user_id: 'sacha' }],
+          members: [{ user_id: oliverId }, { user_id: sachaId }],
         },
       });
 
@@ -302,7 +314,7 @@ describe('StreamVideoClient Ringing', () => {
       await marceloCall.create({
         ring: true,
         data: {
-          members: [{ user_id: 'marcelo' }, { user_id: 'oliver' }],
+          members: [{ user_id: marceloId }, { user_id: oliverId }],
         },
       });
 
@@ -332,7 +344,7 @@ describe('StreamVideoClient Ringing', () => {
       await marceloCall.create({
         ring: true,
         data: {
-          members: [{ user_id: 'marcelo' }, { user_id: 'sacha' }],
+          members: [{ user_id: marceloId }, { user_id: sachaId }],
         },
       });
 
@@ -354,7 +366,7 @@ describe('StreamVideoClient Ringing', () => {
       await marceloCall.create({
         ring: true,
         data: {
-          members: [{ user_id: 'marcelo' }, { user_id: 'oliver' }],
+          members: [{ user_id: marceloId }, { user_id: oliverId }],
         },
       });
 
@@ -375,7 +387,7 @@ describe('StreamVideoClient Ringing', () => {
       await marceloCall.create({
         ring: true,
         data: {
-          members: [{ user_id: 'marcelo' }, { user_id: 'sacha' }],
+          members: [{ user_id: marceloId }, { user_id: sachaId }],
         },
       });
 


### PR DESCRIPTION
### 💡 Overview

The ringing tests hardcoded the user ids oliver/sacha/marcelo and every CI run shares one Stream app. test.yml has no concurrency group, so two runs overlapping (two PRs, a re-push while the previous run is in flight, or a version-and-release dispatch) connected the same three users to the same app at once, and a `call.ring` produced by one run satisfied the other run's assertions.

That surfaced as "should ring individual members" failing with `promise resolved "{ type: 'call.ring', ... }" instead of rejecting`, and also tripped the rejectCallWhenBusy logic and the state.calls.length assertions in the ringing interruption tests.

### 📝 Implementation notes

Generate the user ids per test instead, so concurrent runs can no longer reach each other's users.

Verified by running the file three times concurrently against a single app: all green, where two concurrent runs on the previous code failed four tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved ringing test isolation by generating unique user identifiers for each test.
  * Reduced interference between concurrently running test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->