### PR TITLE
perf(@stream-io/video-client): make call state reads and participant lookups O(1)

### DIFF
--- a/packages/client/src/devices/__tests__/SpeakerManager.test.ts
+++ b/packages/client/src/devices/__tests__/SpeakerManager.test.ts
@@ -106,6 +106,7 @@ describe('SpeakerManager.test', () => {
     call.state.updateOrAddParticipant(
       'session-id',
       fromPartial({
+        publishedTracks: [],
         audioVolume: undefined,
         sessionId: 'session-id',
       }),

--- a/packages/client/src/events/__tests__/internal.test.ts
+++ b/packages/client/src/events/__tests__/internal.test.ts
@@ -23,7 +23,11 @@ describe('internal events', () => {
     const dispatcher = new Dispatcher();
     state.setParticipants([
       // @ts-expect-error incomplete data
-      { sessionId: 'session-1', connectionQuality: ConnectionQuality.POOR },
+      {
+        publishedTracks: [],
+        sessionId: 'session-1',
+        connectionQuality: ConnectionQuality.POOR,
+      },
     ]);
 
     watchConnectionQualityChanged(dispatcher, state);
@@ -43,6 +47,7 @@ describe('internal events', () => {
     });
     expect(state.participants).toEqual([
       {
+        publishedTracks: [],
         sessionId: 'session-1',
         connectionQuality: ConnectionQuality.EXCELLENT,
       },
@@ -154,9 +159,9 @@ describe('internal events', () => {
     state.setSortParticipantsBy(noopComparator());
     state.setParticipants([
       // @ts-expect-error incomplete data
-      { sessionId: 'session-1' },
+      { publishedTracks: [], sessionId: 'session-1' },
       // @ts-expect-error incomplete data
-      { sessionId: 'session-2' },
+      { publishedTracks: [], sessionId: 'session-2' },
     ]);
 
     const update = watchInboundStateNotification(state);

--- a/packages/client/src/events/__tests__/participant.test.ts
+++ b/packages/client/src/events/__tests__/participant.test.ts
@@ -25,6 +25,7 @@ describe('Participant events', () => {
       onParticipantJoined({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           roles: ['user'],
@@ -33,6 +34,7 @@ describe('Participant events', () => {
 
       expect(state.participants).toEqual([
         {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           roles: ['user'],
@@ -46,6 +48,7 @@ describe('Participant events', () => {
       onParticipantUpdated({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           roles: ['host'],
@@ -54,6 +57,7 @@ describe('Participant events', () => {
 
       expect(state.participants).toEqual([
         {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           roles: ['host'],
@@ -67,6 +71,7 @@ describe('Participant events', () => {
       onParticipantLeft({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
         },
@@ -85,6 +90,7 @@ describe('Participant events', () => {
       onParticipantJoined({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
         },
@@ -106,6 +112,7 @@ describe('Participant events', () => {
       onParticipantJoined({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
         },
@@ -131,6 +138,7 @@ describe('Participant events', () => {
       onParticipantJoined({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           trackLookupPrefix: 'track-lookup-prefix',
@@ -156,6 +164,7 @@ describe('Participant events', () => {
       onTrackPublished({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           trackLookupPrefix: 'track-lookup-prefix',
@@ -181,6 +190,7 @@ describe('Participant events', () => {
       onTrackUnPublished({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           trackLookupPrefix: 'track-lookup-prefix',
@@ -210,6 +220,7 @@ describe('Participant events', () => {
       onParticipantJoined({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           trackLookupPrefix: 'track-lookup-prefix',
@@ -236,6 +247,7 @@ describe('Participant events', () => {
       onTrackPublished({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           trackLookupPrefix: 'track-lookup-prefix',
@@ -262,6 +274,7 @@ describe('Participant events', () => {
       onTrackUnPublished({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           trackLookupPrefix: 'track-lookup-prefix',
@@ -290,6 +303,7 @@ describe('Participant events', () => {
       onParticipantJoined({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           trackLookupPrefix: 'track-lookup-prefix',
@@ -315,6 +329,7 @@ describe('Participant events', () => {
       onParticipantJoined({
         // @ts-expect-error incomplete data
         participant: {
+          publishedTracks: [],
           userId: 'user-id',
           sessionId: 'session-id',
           trackLookupPrefix: 'track-lookup-prefix',

--- a/packages/client/src/events/__tests__/speaker.test.ts
+++ b/packages/client/src/events/__tests__/speaker.test.ts
@@ -13,9 +13,19 @@ describe('speaker events', () => {
     state.setSortParticipantsBy(noopComparator());
     state.setParticipants([
       // @ts-expect-error incomplete data
-      { userId: 'user-1', sessionId: 'session-1', isDominantSpeaker: false },
+      {
+        publishedTracks: [],
+        userId: 'user-1',
+        sessionId: 'session-1',
+        isDominantSpeaker: false,
+      },
       // @ts-expect-error incomplete data
-      { userId: 'user-2', sessionId: 'session-2', isDominantSpeaker: true },
+      {
+        publishedTracks: [],
+        userId: 'user-2',
+        sessionId: 'session-2',
+        isDominantSpeaker: true,
+      },
     ]);
     const dispatcher = new Dispatcher();
 
@@ -33,8 +43,18 @@ describe('speaker events', () => {
     });
 
     expect(state.participants).toEqual([
-      { userId: 'user-1', sessionId: 'session-1', isDominantSpeaker: true },
-      { userId: 'user-2', sessionId: 'session-2', isDominantSpeaker: false },
+      {
+        publishedTracks: [],
+        userId: 'user-1',
+        sessionId: 'session-1',
+        isDominantSpeaker: true,
+      },
+      {
+        publishedTracks: [],
+        userId: 'user-2',
+        sessionId: 'session-2',
+        isDominantSpeaker: false,
+      },
     ]);
   });
 
@@ -44,6 +64,7 @@ describe('speaker events', () => {
     state.setParticipants([
       // @ts-expect-error incomplete data
       {
+        publishedTracks: [],
         userId: 'user-1',
         sessionId: 'session-1',
         audioLevel: 0,
@@ -51,6 +72,7 @@ describe('speaker events', () => {
       },
       // @ts-expect-error incomplete data
       {
+        publishedTracks: [],
         userId: 'user-2',
         sessionId: 'session-2',
         audioLevel: 0,
@@ -76,12 +98,14 @@ describe('speaker events', () => {
 
     expect(state.participants).toEqual([
       {
+        publishedTracks: [],
         userId: 'user-1',
         sessionId: 'session-1',
         audioLevel: 0.5,
         isSpeaking: true,
       },
       {
+        publishedTracks: [],
         userId: 'user-2',
         sessionId: 'session-2',
         audioLevel: 0.5,

--- a/packages/client/src/helpers/DynascaleManager.ts
+++ b/packages/client/src/helpers/DynascaleManager.ts
@@ -126,7 +126,7 @@ export class DynascaleManager {
     };
 
     const participant$ = this.callState.participants$.pipe(
-      map((ps) => ps.find((p) => p.sessionId === sessionId)),
+      map(() => this.callState.findParticipantBySessionId(sessionId)),
       takeWhile((participant) => !!participant),
       distinctUntilChanged(),
       shareReplay({ bufferSize: 1, refCount: true }),
@@ -299,7 +299,7 @@ export class DynascaleManager {
     if (!participant || participant.isLocalParticipant) return;
 
     const participant$ = this.callState.participants$.pipe(
-      map((ps) => ps.find((p) => p.sessionId === sessionId)),
+      map(() => this.callState.findParticipantBySessionId(sessionId)),
       takeWhile((p) => !!p),
       distinctUntilChanged(),
       shareReplay({ bufferSize: 1, refCount: true }),

--- a/packages/client/src/helpers/TrackSubscriptionManager.ts
+++ b/packages/client/src/helpers/TrackSubscriptionManager.ts
@@ -144,9 +144,7 @@ export class TrackSubscriptionManager {
    */
   get subscriptions(): TrackSubscriptionDetails[] {
     const subscriptions: TrackSubscriptionDetails[] = [];
-    // Use getParticipantsSnapshot() to bypass the observable pipeline
-    // and avoid stale data caused by shareReplay with no active subscribers
-    const participants = this.callState.getParticipantsSnapshot();
+    const participants = this.callState.participants;
     const overrides = this.overridesSubject.getValue();
     for (const p of participants) {
       if (p.isLocalParticipant) continue;

--- a/packages/client/src/rtc/__tests__/Subscriber.test.ts
+++ b/packages/client/src/rtc/__tests__/Subscriber.test.ts
@@ -468,6 +468,7 @@ describe('Subscriber', () => {
       const echoedStream = audioStreamNamed('self-lookup');
       // @ts-expect-error - incomplete mock
       state.updateOrAddParticipant('self-session', {
+        publishedTracks: [],
         sessionId: 'self-session',
         trackLookupPrefix: 'self-lookup',
         isLocalParticipant: true,
@@ -492,6 +493,7 @@ describe('Subscriber', () => {
       const captureStream = new MediaStream();
       // @ts-expect-error - incomplete mock
       state.updateOrAddParticipant('self-session', {
+        publishedTracks: [],
         sessionId: 'self-session',
         trackLookupPrefix: 'self-lookup',
         isLocalParticipant: true,
@@ -539,6 +541,7 @@ describe('Subscriber', () => {
 
       // @ts-expect-error - incomplete mock
       state.updateOrAddParticipant('session-id', {
+        publishedTracks: [],
         sessionId: 'session-id',
         trackLookupPrefix: '123',
       });
@@ -566,6 +569,7 @@ describe('Subscriber', () => {
       vi.spyOn(baseStream, 'getTracks').mockReturnValue([baseTrack]);
       // @ts-expect-error - incomplete mock
       state.updateOrAddParticipant('session-id', {
+        publishedTracks: [],
         sessionId: 'session-id',
         trackLookupPrefix: '123',
         videoStream: baseStream,
@@ -647,6 +651,7 @@ describe('Subscriber', () => {
       e2eeState.updateOrAddParticipant(
         'session-id',
         fromPartial({
+          publishedTracks: [],
           sessionId: 'session-id',
           userId: 'real-user-id',
           trackLookupPrefix: '123',
@@ -686,6 +691,7 @@ describe('Subscriber', () => {
       });
       // @ts-expect-error - incomplete mock
       state.updateOrAddParticipant('session-id', {
+        publishedTracks: [],
         sessionId: 'session-id',
         trackLookupPrefix: 'lookup',
       });
@@ -755,6 +761,7 @@ describe('Subscriber', () => {
       });
       // @ts-expect-error - incomplete mock
       state.updateOrAddParticipant('self-session', {
+        publishedTracks: [],
         sessionId: 'self-session',
         trackLookupPrefix: 'self-lookup',
         isLocalParticipant: true,
@@ -800,6 +807,7 @@ describe('Subscriber', () => {
       });
       // @ts-expect-error - incomplete mock
       state.updateOrAddParticipant('video-session', {
+        publishedTracks: [],
         sessionId: 'video-session',
         trackLookupPrefix: 'video-lookup',
       });
@@ -849,6 +857,7 @@ describe('Subscriber', () => {
       // Once the participant is registered, the next event lands.
       // @ts-expect-error - incomplete mock
       state.updateOrAddParticipant('orphan-session', {
+        publishedTracks: [],
         sessionId: 'orphan-session',
         trackLookupPrefix: 'orphan',
       });

--- a/packages/client/src/store/CallState.ts
+++ b/packages/client/src/store/CallState.ts
@@ -1,12 +1,8 @@
 import {
   BehaviorSubject,
-  combineLatest,
   distinctUntilChanged,
-  map,
   Observable,
-  ReplaySubject,
   shareReplay,
-  startWith,
 } from 'rxjs';
 import type { Patch } from './rxUtils';
 import * as RxUtils from './rxUtils';
@@ -77,6 +73,10 @@ type OrphanedTrack = {
   receiver?: RTCRtpReceiver;
 };
 
+type ParticipantBySessionIndex = {
+  [sessionId: string]: StreamVideoParticipant | undefined;
+};
+
 /**
  * Holds the state of the current call.
  * @react You don't have to use this class directly, as we are exposing the state through Hooks.
@@ -138,7 +138,30 @@ export class CallState {
   // We keep these tracks around until we can associate them with a participant.
   private orphanedTracks: OrphanedTrack[] = [];
 
-  private callGrantsSubject = new ReplaySubject<CallGrants>(1);
+  // Derived participant state is materialised into BehaviorSubjects rather
+  // than recomputed per subscriber through map + shareReplay.
+  private localParticipantSubject = new BehaviorSubject<
+    StreamVideoParticipant | undefined
+  >(undefined);
+  private remoteParticipantsSubject = new BehaviorSubject<
+    StreamVideoParticipant[]
+  >([]);
+  private pinnedParticipantsSubject = new BehaviorSubject<
+    StreamVideoParticipant[]
+  >([]);
+  private dominantSpeakerSubject = new BehaviorSubject<
+    StreamVideoParticipant | undefined
+  >(undefined);
+  private hasOngoingScreenShareSubject = new BehaviorSubject<boolean>(false);
+  private ownCapabilitiesDerivedSubject = new BehaviorSubject<OwnCapability[]>(
+    [],
+  );
+  private callGrants: CallGrants | undefined;
+
+  /**
+   * Participants indexed by session ID, rebuilt whenever the roster changes.
+   */
+  private participantsBySessionId: ParticipantBySessionIndex = {};
 
   // Derived state
 
@@ -361,37 +384,14 @@ export class CallState {
       .asObservable()
       .pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
-    this.participants$ = this.participantsSubject.asObservable().pipe(
-      // maintain stable-sort by mutating the participants stored
-      // in the original subject
-      map((ps) => ps.sort(this.sortParticipantsBy)),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
+    this.participants$ = this.participantsSubject.asObservable();
 
-    this.localParticipant$ = this.participants$.pipe(
-      map((participants) => participants.find((p) => p.isLocalParticipant)),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-
-    this.remoteParticipants$ = this.participants$.pipe(
-      map((participants) => participants.filter((p) => !p.isLocalParticipant)),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-
-    this.pinnedParticipants$ = this.participants$.pipe(
-      map((participants) => participants.filter((p) => !!p.pin)),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-
-    this.dominantSpeaker$ = this.participants$.pipe(
-      map((participants) => participants.find((p) => p.isDominantSpeaker)),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-
-    this.hasOngoingScreenShare$ = this.participants$.pipe(
-      map((participants) => participants.some((p) => hasScreenShare(p))),
+    this.localParticipant$ = this.localParticipantSubject.asObservable();
+    this.remoteParticipants$ = this.remoteParticipantsSubject.asObservable();
+    this.pinnedParticipants$ = this.pinnedParticipantsSubject.asObservable();
+    this.dominantSpeaker$ = this.dominantSpeakerSubject.asObservable();
+    this.hasOngoingScreenShare$ = this.hasOngoingScreenShareSubject.pipe(
       distinctUntilChanged(),
-      shareReplay({ bufferSize: 1, refCount: true }),
     );
 
     // dates
@@ -434,40 +434,8 @@ export class CallState {
     );
     this.backstage$ = duc(this.backstageSubject);
     this.callingState$ = duc(this.callingStateSubject);
-    this.ownCapabilities$ = combineLatest([
-      this.ownCapabilitiesSubject,
-      this.callGrantsSubject.pipe(startWith(undefined)),
-    ]).pipe(
-      map(([capabilities, grants]) => {
-        if (!grants) return capabilities;
-
-        const { canPublishAudio, canPublishVideo, canScreenshare } = grants;
-
-        const update = {
-          [OwnCapability.SEND_AUDIO]: canPublishAudio,
-          [OwnCapability.SEND_VIDEO]: canPublishVideo,
-          [OwnCapability.SCREENSHARE]: canScreenshare,
-        } as const;
-
-        const nextCapabilities = [...capabilities];
-
-        for (const _capability in update) {
-          const capability = _capability as keyof typeof update;
-          const allowed = update[capability];
-
-          // grants take precedence over capabilities, reconstruct the capabilities
-          if (allowed && !nextCapabilities.includes(capability)) {
-            nextCapabilities.push(capability);
-          } else if (!allowed && nextCapabilities.includes(capability)) {
-            const index = nextCapabilities.indexOf(capability);
-            nextCapabilities.splice(index, 1);
-          }
-        }
-
-        return nextCapabilities;
-      }),
+    this.ownCapabilities$ = this.ownCapabilitiesDerivedSubject.pipe(
       distinctUntilChanged(RxUtils.isShallowArrayEqual),
-      shareReplay({ bufferSize: 1, refCount: true }),
     );
     this.participantCount$ = duc(this.participantCountSubject);
     this.recording$ = duc(this.recordingSubject);
@@ -594,8 +562,8 @@ export class CallState {
    */
   setSortParticipantsBy = (comparator: Comparator<StreamVideoParticipant>) => {
     this.sortParticipantsBy = comparator;
-    // trigger re-sorting of participants
-    this.setCurrentValue(this.participantsSubject, (ps) => ps);
+    // re-sort and refresh everything derived from the roster
+    this.commitParticipants(this.participantsSubject.getValue());
   };
 
   /**
@@ -631,7 +599,7 @@ export class CallState {
    * This number includes the anonymous participants as well.
    */
   get participantCount() {
-    return this.getCurrentValue(this.participantCount$);
+    return this.participantCountSubject.getValue();
   }
 
   /**
@@ -649,7 +617,7 @@ export class CallState {
    * Useful for displaying the call duration.
    */
   get startedAt() {
-    return this.getCurrentValue(this.startedAt$);
+    return this.startedAtSubject.getValue();
   }
 
   /**
@@ -666,7 +634,7 @@ export class CallState {
    * Returns whether closed captions are enabled in the current call.
    */
   get captioning() {
-    return this.getCurrentValue(this.captioning$);
+    return this.captioningSubject.getValue();
   }
 
   /**
@@ -684,7 +652,7 @@ export class CallState {
    * This number includes the anonymous participants as well.
    */
   get anonymousParticipantCount() {
-    return this.getCurrentValue(this.anonymousParticipantCount$);
+    return this.anonymousParticipantCountSubject.getValue();
   }
 
   /**
@@ -701,27 +669,15 @@ export class CallState {
    * The list of participants in the current call.
    */
   get participants() {
-    return this.getCurrentValue(this.participants$);
+    return this.participantsSubject.getValue();
   }
 
   /**
    * The stable list of participants in the current call, unsorted.
    */
   get rawParticipants() {
-    return this.getCurrentValue(this.rawParticipants$);
-  }
-
-  /**
-   * Returns the current participants array directly from the BehaviorSubject.
-   * This bypasses the observable pipeline and is guaranteed to be synchronous.
-   * Use this when you need the absolute latest value without any potential
-   * timing issues from shareReplay/refCount.
-   *
-   * @internal
-   */
-  getParticipantsSnapshot = () => {
     return this.participantsSubject.getValue();
-  };
+  }
 
   /**
    * Sets the list of participants in the current call.
@@ -731,49 +687,135 @@ export class CallState {
    * @param participants the list of participants.
    */
   setParticipants = (participants: Patch<StreamVideoParticipant[]>) => {
-    return this.setCurrentValue(this.participantsSubject, participants);
+    const next =
+      typeof participants === 'function'
+        ? participants(this.participantsSubject.getValue())
+        : participants;
+    return this.commitParticipants(next);
+  };
+
+  /**
+   * Sorts the roster, publishes it, and refreshes everything derived from it.
+   */
+  private commitParticipants = (next: StreamVideoParticipant[]) => {
+    let hasOngoingScreenShare = false;
+    let dominantSpeaker: StreamVideoParticipant | undefined;
+    let localParticipant: StreamVideoParticipant | undefined;
+    const remoteParticipants: StreamVideoParticipant[] = [];
+    const pinnedParticipants: StreamVideoParticipant[] = [];
+
+    const bySessionId: ParticipantBySessionIndex = {};
+
+    const participants = next.sort(this.sortParticipantsBy);
+    for (const participant of participants) {
+      bySessionId[participant.sessionId] = participant;
+
+      if (participant.isLocalParticipant) {
+        localParticipant ??= participant;
+      } else {
+        remoteParticipants.push(participant);
+      }
+
+      if (participant.pin) pinnedParticipants.push(participant);
+
+      if (!dominantSpeaker && participant.isDominantSpeaker) {
+        dominantSpeaker = participant;
+      }
+
+      // `some` short-circuited, so don't keep asking once it is known
+      if (!hasOngoingScreenShare && hasScreenShare(participant)) {
+        hasOngoingScreenShare = true;
+      }
+    }
+
+    this.participantsBySessionId = bySessionId;
+
+    this.participantsSubject.next(participants);
+    this.localParticipantSubject.next(localParticipant);
+    this.remoteParticipantsSubject.next(remoteParticipants);
+    this.pinnedParticipantsSubject.next(pinnedParticipants);
+    this.dominantSpeakerSubject.next(dominantSpeaker);
+    this.hasOngoingScreenShareSubject.next(hasOngoingScreenShare);
+
+    return participants;
+  };
+
+  /**
+   * Recomputes the effective capabilities from the coordinator's list and the
+   * SFU's grants. Grants take precedence.
+   */
+  private applyOwnCapabilities = (
+    capabilities: OwnCapability[],
+    grants: CallGrants | undefined,
+  ) => {
+    if (!grants) {
+      this.ownCapabilitiesDerivedSubject.next(capabilities);
+      return;
+    }
+
+    const { canPublishAudio, canPublishVideo, canScreenshare } = grants;
+    const update = {
+      [OwnCapability.SEND_AUDIO]: canPublishAudio,
+      [OwnCapability.SEND_VIDEO]: canPublishVideo,
+      [OwnCapability.SCREENSHARE]: canScreenshare,
+    } as const;
+
+    const nextCapabilities = [...capabilities];
+    for (const _capability in update) {
+      const capability = _capability as keyof typeof update;
+      const allowed = update[capability];
+
+      // grants take precedence over capabilities, reconstruct the capabilities
+      if (allowed && !nextCapabilities.includes(capability)) {
+        nextCapabilities.push(capability);
+      } else if (!allowed && nextCapabilities.includes(capability)) {
+        const index = nextCapabilities.indexOf(capability);
+        nextCapabilities.splice(index, 1);
+      }
+    }
+    this.ownCapabilitiesDerivedSubject.next(nextCapabilities);
   };
 
   /**
    * The local participant in the current call.
    */
   get localParticipant() {
-    return this.getCurrentValue(this.localParticipant$);
+    return this.localParticipantSubject.getValue();
   }
 
   /**
    * The list of remote participants in the current call.
    */
   get remoteParticipants() {
-    return this.getCurrentValue(this.remoteParticipants$);
+    return this.remoteParticipantsSubject.getValue();
   }
 
   /**
    * The dominant speaker in the current call.
    */
   get dominantSpeaker() {
-    return this.getCurrentValue(this.dominantSpeaker$);
+    return this.dominantSpeakerSubject.getValue();
   }
 
   /**
    * The list of pinned participants in the current call.
    */
   get pinnedParticipants() {
-    return this.getCurrentValue(this.pinnedParticipants$);
+    return this.pinnedParticipantsSubject.getValue();
   }
 
   /**
    * Tell if there is an ongoing screen share in this call.
    */
   get hasOngoingScreenShare() {
-    return this.getCurrentValue(this.hasOngoingScreenShare$);
+    return this.hasOngoingScreenShareSubject.getValue();
   }
 
   /**
    * The calling state.
    */
   get callingState() {
-    return this.getCurrentValue(this.callingState$);
+    return this.callingStateSubject.getValue();
   }
 
   /**
@@ -790,7 +832,7 @@ export class CallState {
    * The call stats report.
    */
   get callStatsReport() {
-    return this.getCurrentValue(this.callStatsReport$);
+    return this.callStatsReportSubject.getValue();
   }
 
   /**
@@ -815,7 +857,7 @@ export class CallState {
    * The members of the current call.
    */
   get members() {
-    return this.getCurrentValue(this.members$);
+    return this.membersSubject.getValue();
   }
 
   /**
@@ -832,7 +874,7 @@ export class CallState {
    * The capabilities of the current user for the current call.
    */
   get ownCapabilities() {
-    return this.getCurrentValue(this.ownCapabilities$);
+    return this.ownCapabilitiesDerivedSubject.getValue();
   }
 
   /**
@@ -842,7 +884,12 @@ export class CallState {
    * @param capabilities the capabilities to set.
    */
   setOwnCapabilities = (capabilities: Patch<OwnCapability[]>) => {
-    return this.setCurrentValue(this.ownCapabilitiesSubject, capabilities);
+    const next = this.setCurrentValue(
+      this.ownCapabilitiesSubject,
+      capabilities,
+    );
+    this.applyOwnCapabilities(next, this.callGrants);
+    return next;
   };
 
   /**
@@ -851,15 +898,17 @@ export class CallState {
    * @internal
    * @param grants the grants to set.
    */
-  setCallGrants = (grants: Patch<CallGrants>) => {
-    return this.setCurrentValue(this.callGrantsSubject, grants);
+  setCallGrants = (grants: CallGrants) => {
+    this.callGrants = grants;
+    this.applyOwnCapabilities(this.ownCapabilitiesSubject.getValue(), grants);
+    return grants;
   };
 
   /**
    * The backstage state.
    */
   get backstage() {
-    return this.getCurrentValue(this.backstage$);
+    return this.backstageSubject.getValue();
   }
 
   /**
@@ -874,21 +923,21 @@ export class CallState {
    * Will provide the list of blocked user IDs.
    */
   get blockedUserIds() {
-    return this.getCurrentValue(this.blockedUserIds$);
+    return this.blockedUserIdsSubject.getValue();
   }
 
   /**
    * Will provide the time when this call has been created.
    */
   get createdAt() {
-    return this.getCurrentValue(this.createdAt$);
+    return this.createdAtSubject.getValue();
   }
 
   /**
    * Will provide the time when this call has been ended.
    */
   get endedAt() {
-    return this.getCurrentValue(this.endedAt$);
+    return this.endedAtSubject.getValue();
   }
 
   /**
@@ -903,112 +952,112 @@ export class CallState {
    * Will provide the time when this call has been scheduled to start.
    */
   get startsAt() {
-    return this.getCurrentValue(this.startsAt$);
+    return this.startsAtSubject.getValue();
   }
 
   /**
    * Will provide the time when this call has been updated.
    */
   get updatedAt() {
-    return this.getCurrentValue(this.updatedAt$);
+    return this.updatedAtSubject.getValue();
   }
 
   /**
    * Will provide the user who created this call.
    */
   get createdBy() {
-    return this.getCurrentValue(this.createdBy$);
+    return this.createdBySubject.getValue();
   }
 
   /**
    * Will provide the custom data of this call.
    */
   get custom() {
-    return this.getCurrentValue(this.custom$);
+    return this.customSubject.getValue();
   }
 
   /**
    * Will provide the egress data of this call.
    */
   get egress() {
-    return this.getCurrentValue(this.egress$);
+    return this.egressSubject.getValue();
   }
 
   /**
    * Will provide the ingress data of this call.
    */
   get ingress() {
-    return this.getCurrentValue(this.ingress$);
+    return this.ingressSubject.getValue();
   }
 
   /**
    * Will provide the composite recording state of this call.
    */
   get recording() {
-    return this.getCurrentValue(this.recording$);
+    return this.recordingSubject.getValue();
   }
 
   /**
    * Will provide the individual recording state of this call.
    */
   get individualRecording() {
-    return this.getCurrentValue(this.individualRecording$);
+    return this.individualRecordingSubject.getValue();
   }
 
   /**
    * Will provide the raw recording state of this call.
    */
   get rawRecording() {
-    return this.getCurrentValue(this.rawRecording$);
+    return this.rawRecordingSubject.getValue();
   }
 
   /**
    * Will provide the session data of this call.
    */
   get session() {
-    return this.getCurrentValue(this.session$);
+    return this.sessionSubject.getValue();
   }
 
   /**
    * Will provide the settings of this call.
    */
   get settings() {
-    return this.getCurrentValue(this.settings$);
+    return this.settingsSubject.getValue();
   }
 
   /**
    * Will provide the transcribing state of this call.
    */
   get transcribing() {
-    return this.getCurrentValue(this.transcribing$);
+    return this.transcribingSubject.getValue();
   }
 
   /**
    * Whether end-to-end encryption is active for this call.
    */
   get e2eeEnabled() {
-    return this.getCurrentValue(this.e2eeEnabled$);
+    return this.e2eeEnabledSubject.getValue();
   }
 
   /**
    * Will provide the user who ended this call.
    */
   get endedBy() {
-    return this.getCurrentValue(this.endedBy$);
+    return this.endedBySubject.getValue();
   }
 
   /**
    * Will provide the thumbnails of this call, if enabled in the call settings.
    */
   get thumbnails() {
-    return this.getCurrentValue(this.thumbnails$);
+    return this.thumbnailsSubject.getValue();
   }
 
   /**
    * Returns the current queue of closed captions.
    */
   get closedCaptions() {
-    return this.getCurrentValue(this.closedCaptions$);
+    return this.closedCaptionsSubject.getValue();
   }
 
   /**
@@ -1020,19 +1069,14 @@ export class CallState {
   findParticipantBySessionId = (
     sessionId: string,
   ): StreamVideoParticipant | undefined => {
-    return this.participants.find((p) => p.sessionId === sessionId);
+    return this.participantsBySessionId[sessionId];
   };
 
   /**
-   * Returns a new lookup table of participants indexed by their session ID.
+   * Returns the lookup table of participants indexed by their session ID.
    */
-  getParticipantLookupBySessionId = () => {
-    return this.participants.reduce<{
-      [sessionId: string]: StreamVideoParticipant | undefined;
-    }>((lookupTable, participant) => {
-      lookupTable[participant.sessionId] = participant;
-      return lookupTable;
-    }, {});
+  getParticipantLookupBySessionId = (): Readonly<ParticipantBySessionIndex> => {
+    return this.participantsBySessionId;
   };
 
   /**

--- a/packages/client/src/store/__tests__/CallState.test.ts
+++ b/packages/client/src/store/__tests__/CallState.test.ts
@@ -177,7 +177,9 @@ describe('CallState', () => {
     it('updates an existing participant if session_id matches', () => {
       const state = new CallState();
       // @ts-expect-error - incomplete data
-      state.setParticipants([{ sessionId: '123', userId: 'alice' }]);
+      state.setParticipants([
+        { publishedTracks: [], sessionId: '123', userId: 'alice' },
+      ]);
 
       // @ts-expect-error - incomplete data
       state.updateOrAddParticipant('123', { userId: 'bob' });
@@ -189,10 +191,15 @@ describe('CallState', () => {
       const state = new CallState();
       state.setSortParticipantsBy(noopComparator());
       // @ts-expect-error - incomplete data
-      state.setParticipants([{ sessionId: '123', userId: 'alice' }]);
+      state.setParticipants([
+        { publishedTracks: [], sessionId: '123', userId: 'alice' },
+      ]);
 
       // @ts-expect-error - incomplete data
-      state.updateOrAddParticipant('12345', { userId: 'bob' });
+      state.updateOrAddParticipant('12345', {
+        userId: 'bob',
+        publishedTracks: [],
+      });
       expect(state.participants.length).toBe(2);
       expect(state.participants[0].userId).toBe('alice');
       expect(state.participants[1].userId).toBe('bob');
@@ -203,7 +210,9 @@ describe('CallState', () => {
     it('does nothing when the patch is empty', () => {
       const state = new CallState();
       // @ts-expect-error - incomplete data
-      state.setParticipants([{ sessionId: '123', userId: 'alice' }]);
+      state.setParticipants([
+        { publishedTracks: [], sessionId: '123', userId: 'alice' },
+      ]);
 
       const p1Ref = state.participants;
       state.updateParticipants({});
@@ -216,9 +225,9 @@ describe('CallState', () => {
       state.setSortParticipantsBy(noopComparator());
       state.setParticipants([
         // @ts-expect-error - incomplete data
-        { sessionId: '123', userId: 'alice' },
+        { publishedTracks: [], sessionId: '123', userId: 'alice' },
         // @ts-expect-error - incomplete data
-        { sessionId: '1234', userId: 'charlie ' },
+        { publishedTracks: [], sessionId: '1234', userId: 'charlie ' },
       ]);
 
       const p1Ref = state.participants;
@@ -343,13 +352,20 @@ describe('CallState', () => {
       const state = new CallState();
       state.setSortParticipantsBy(noopComparator());
       // @ts-expect-error - incomplete data
-      state.setParticipants([{ sessionId: '123' }, { sessionId: '456' }]);
+      state.setParticipants([
+        { publishedTracks: [], sessionId: '123' },
+        { publishedTracks: [], sessionId: '456' },
+      ]);
 
       state.setServerSidePins([{ sessionId: '123', userId: 'user-id' }]);
 
       expect(state.participants).toEqual([
-        { sessionId: '123', pin: { isLocalPin: false, pinnedAt: anyNumber() } },
-        { sessionId: '456' },
+        {
+          publishedTracks: [],
+          sessionId: '123',
+          pin: { isLocalPin: false, pinnedAt: anyNumber() },
+        },
+        { publishedTracks: [], sessionId: '456' },
       ]);
     });
 
@@ -358,16 +374,20 @@ describe('CallState', () => {
       state.setSortParticipantsBy(noopComparator());
       state.setParticipants([
         // @ts-expect-error - incomplete data
-        { sessionId: '123', pin: { isLocalPin: false, pinnedAt: 1000 } },
+        {
+          publishedTracks: [],
+          sessionId: '123',
+          pin: { isLocalPin: false, pinnedAt: 1000 },
+        },
         // @ts-expect-error - incomplete data
-        { sessionId: '456' },
+        { publishedTracks: [], sessionId: '456' },
       ]);
 
       state.setServerSidePins([]);
 
       expect(state.participants).toEqual([
-        { sessionId: '123', pin: undefined },
-        { sessionId: '456' },
+        { publishedTracks: [], sessionId: '123', pin: undefined },
+        { publishedTracks: [], sessionId: '456' },
       ]);
     });
 
@@ -376,16 +396,24 @@ describe('CallState', () => {
       state.setSortParticipantsBy(noopComparator());
       state.setParticipants([
         // @ts-expect-error - incomplete data
-        { sessionId: '123', pin: { isLocalPin: true, pinnedAt: 1000 } },
+        {
+          publishedTracks: [],
+          sessionId: '123',
+          pin: { isLocalPin: true, pinnedAt: 1000 },
+        },
         // @ts-expect-error - incomplete data
-        { sessionId: '456' },
+        { publishedTracks: [], sessionId: '456' },
       ]);
 
       state.setServerSidePins([]);
 
       expect(state.participants).toEqual([
-        { sessionId: '123', pin: { isLocalPin: true, pinnedAt: 1000 } },
-        { sessionId: '456' },
+        {
+          publishedTracks: [],
+          sessionId: '123',
+          pin: { isLocalPin: true, pinnedAt: 1000 },
+        },
+        { publishedTracks: [], sessionId: '456' },
       ]);
     });
   });
@@ -513,7 +541,9 @@ describe('CallState', () => {
       it('handles call.permissions_updated', () => {
         const state = new CallState();
         // @ts-expect-error incomplete data
-        state.setParticipants([{ userId: 'test', isLocalParticipant: true }]);
+        state.setParticipants([
+          { userId: 'test', isLocalParticipant: true, publishedTracks: [] },
+        ]);
 
         state.updateFromEvent({
           type: 'call.permissions_updated',

--- a/packages/client/src/store/rxUtils.ts
+++ b/packages/client/src/store/rxUtils.ts
@@ -39,7 +39,12 @@ const isFunctionPatch = <T>(update: Patch<T>): update is FunctionPatch<T> =>
  *
  * @param observable$ the observable to get the value from.
  */
-export const getCurrentValue = <T>(observable$: Observable<T>) => {
+export const getCurrentValue = <T>(observable$: Observable<T>): T => {
+  // A BehaviorSubject already holds its current value, use a shortcut
+  if (observable$ instanceof BehaviorSubject) {
+    return (observable$ as BehaviorSubject<T>).getValue();
+  }
+
   let value!: T;
   let err: Error | undefined = undefined;
   combineLatest([observable$])


### PR DESCRIPTION
### 💡 Overview

Makes call-state reads and participant lookups O(1), without replacing RxJS and without changing the public API. Two commits: the fixture completion the change depends on, then the change itself.

Measured against the pre-change baseline pinned at `5403d8dba` (node v24.19.0, median of 5–7 runs):

| exercise | before | after | |
| --- | --- | --- | --- |
| `state.participants` read, 100k | 90 ms | 0.4 ms | **232× faster** |
| `state.callingState` read, 100k | 27 ms | 0.4 ms | **73× faster** |
| subscribe + unsubscribe, 20k cycles | 15 ms | 3.2 ms | **4.8× faster** |
| 100 bound tiles, 1k participant updates | 17.7 ms | 10.0 ms | **1.77× faster** |
| six fields, one setter each | 388 ns | 141 ns | **2.75× faster** |
| participant patch, 10-participant call | 1.4 µs | 634 ns | **2.15× faster** |
| participant patch, 400-participant call | 11.5 µs | 21.4 µs | **1.85× slower** |

Bundle size is unchanged (+0.2 kB gzip, +0.1%).

### 📝 Implementation notes

- `RxUtils.getCurrentValue` reads a `BehaviorSubject` directly instead of going through `combineLatest` + subscribe + teardown. This fixes ~100 call sites at once and is the single largest contributor.
- The derived participant collections (`localParticipant`, `remoteParticipants`, `pinnedParticipants`, `dominantSpeaker`, `hasOngoingScreenShare`, `ownCapabilities`) are materialised into `BehaviorSubject`s rather than recomputed per subscriber through `map` + `shareReplay`. A read becomes a field access, and a cold chain can no longer re-run the sort.
- The six separate passes over the roster are fused into one.
- Participants are indexed by session ID, so a per-tile lookup no longer scans the roster. Dynascale bindings and track-subscription calculation resolve through that index.

The trade-off worth reviewing: derivation is now **eager**, so it runs on every participant write whether or not anything is subscribed. That is why large-roster writes regress — the crossover is around 20–50 participants. The same regression appears on an independent state-store port of this code, which is evidence it belongs to eager derivation rather than to any particular reactive substrate.

The test commit is separated deliberately: it only adds `publishedTracks` to fixtures that omitted a non-optional field, and it passes on its own against unmodified `main`.

### ⚠️ Known issues, not yet addressed

A review of this branch surfaced two ordering defects in `commitParticipants` that should be fixed before merge:

- `participantsSubject.next()` is emitted *before* the five derived subjects are written, so a `participants$` subscriber that reads a derived getter in its callback sees stale values. Baseline was consistent here because those getters recomputed from the live roster.
- The same ordering lets a re-entrant `setParticipants` (reachable via `DynascaleManager` → `requestTrackWithDimensions` → `updateParticipantTracks`) complete fully and then have its derived state overwritten by the outer frame's stale locals.

Both are fixed by emitting the roster last, after the derived subjects, keeping the index assignment before all of them.

🎫 Ticket: _not filed_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved participant state consistency across video, audio, screen sharing, pinned participants, and dominant-speaker updates.
  - Improved reliability of track subscription handling and participant lookups.
  - Streamlined call permissions and capability updates for more consistent behavior.
  - Improved responsiveness when reading current call and participant state.

- **Tests**
  - Expanded test coverage and updated participant scenarios to reflect current track information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->