### PR TITLE
feat(video-filters-web): apply background filter changes without re-registering the filter

### DIFF
--- a/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
+++ b/packages/react-sdk/src/components/BackgroundFilters/BackgroundFilters.tsx
@@ -12,6 +12,7 @@ import { useCall, useCallStateHooks } from '@stream-io/video-react-bindings';
 import { Call, disposeOfMediaStream } from '@stream-io/video-client';
 import {
   BackgroundBlurLevel,
+  BackgroundEffectOptions,
   createRenderer,
   isMediaPipePlatformSupported,
   isPlatformSupported,
@@ -431,8 +432,10 @@ const BackgroundFilters = (props: {
   >(undefined);
   handleStatsRef.current = onStats;
 
+  const filterActive = !!backgroundFilter;
+
   useEffect(() => {
-    if (!call || !backgroundFilter) return;
+    if (!call || !filterActive) return;
 
     setIsLoading(true);
     const { unregister, registered } = call.camera.registerFilter((ms) => {
@@ -449,7 +452,7 @@ const BackgroundFilters = (props: {
     return () => {
       unregister().catch((err) => console.warn(`Can't unregister filter`, err));
     };
-  }, [call, start, backgroundFilter, setIsLoading]);
+  }, [call, start, filterActive, setIsLoading]);
 
   return children;
 };
@@ -469,6 +472,16 @@ const useRenderer = (
     segmentationOptions,
   } = api;
 
+  const optionsRef = useRef<BackgroundEffectOptions>({});
+  optionsRef.current = {
+    backgroundFilter,
+    backgroundBlurLevel,
+    backgroundImage,
+    segmentationOptions,
+  };
+
+  const processorRef = useRef<VirtualBackground | undefined>(undefined);
+
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const bgImageRef = useRef<HTMLImageElement>(null);
@@ -479,7 +492,7 @@ const useRenderer = (
     },
   );
 
-  const start = useCallback(
+  const startMediaPipe = useCallback(
     (
       ms: MediaStream,
       onError?: (error: any) => void,
@@ -487,6 +500,65 @@ const useRenderer = (
     ) => {
       let outputStream: MediaStream | undefined;
       let processor: VirtualBackground | undefined;
+
+      const output = new Promise<MediaStream>((resolve, reject) => {
+        const options = optionsRef.current;
+        if (!options.backgroundFilter) {
+          reject(new Error('No filter specified'));
+          return;
+        }
+
+        const [track] = ms.getVideoTracks();
+        if (!track) {
+          reject(new Error('No video tracks in input media stream'));
+          return;
+        }
+
+        call?.tracer.trace('backgroundFilters.enable', {
+          ...options,
+          engine: FilterEngine.MEDIA_PIPE,
+          modelFilePath,
+        });
+
+        const trackSettings = track.getSettings();
+        flushSync(() =>
+          setVideoSize({
+            width: trackSettings.width ?? 0,
+            height: trackSettings.height ?? 0,
+          }),
+        );
+
+        processor = new VirtualBackground(
+          track,
+          { ...options, basePath, modelPath: modelFilePath },
+          { onError, onStats },
+        );
+        processorRef.current = processor;
+        processor
+          .start()
+          .then((processedTrack) => {
+            outputStream = new MediaStream([processedTrack]);
+            resolve(outputStream);
+          })
+          .catch(reject);
+      });
+
+      return {
+        output,
+        stop: () => {
+          call?.tracer.trace('backgroundFilters.disable', null);
+          processorRef.current = undefined;
+          processor?.stop();
+          if (outputStream) disposeOfMediaStream(outputStream);
+        },
+      };
+    },
+    [call?.tracer, modelFilePath, basePath],
+  );
+
+  const startTf = useCallback(
+    (ms: MediaStream, onError?: (error: any) => void) => {
+      let outputStream: MediaStream | undefined;
       let renderer: Renderer | undefined;
 
       const output = new Promise<MediaStream>((resolve, reject) => {
@@ -500,117 +572,63 @@ const useRenderer = (
         const bgImageEl = bgImageRef.current;
 
         const [track] = ms.getVideoTracks();
-
         if (!track) {
           reject(new Error('No video tracks in input media stream'));
           return;
         }
 
-        if (engine === FilterEngine.MEDIA_PIPE) {
-          call?.tracer.trace('backgroundFilters.enable', {
-            backgroundFilter,
-            backgroundBlurLevel,
-            backgroundImage,
-            engine,
-            modelFilePath,
-          });
+        if (!videoEl || !canvasEl || (backgroundImage && !bgImageEl)) {
+          reject(new Error('Renderer started before elements are ready'));
+          return;
+        }
 
-          if (!videoEl) {
-            reject(new Error('Renderer started before elements are ready'));
-            return;
-          }
-
-          const trackSettings = track.getSettings();
-          flushSync(() =>
-            setVideoSize({
-              width: trackSettings.width ?? 0,
-              height: trackSettings.height ?? 0,
-            }),
-          );
-
-          processor = new VirtualBackground(
-            track,
-            {
-              basePath: basePath,
-              modelPath: modelFilePath,
+        videoEl.srcObject = ms;
+        videoEl.play().then(
+          () => {
+            const trackSettings = track.getSettings();
+            flushSync(() =>
+              setVideoSize({
+                width: trackSettings.width ?? 0,
+                height: trackSettings.height ?? 0,
+              }),
+            );
+            call?.tracer.trace('backgroundFilters.enable', {
+              backgroundFilter,
               backgroundBlurLevel,
               backgroundImage,
-              backgroundFilter,
-              segmentationOptions,
-            },
-            { onError, onStats },
-          );
-          processor
-            .start()
-            .then((processedTrack) => {
-              outputStream = new MediaStream([processedTrack]);
-              resolve(outputStream);
-            })
-            .catch((error) => {
-              reject(error);
+              engine: FilterEngine.TF,
             });
 
-          return;
-        }
+            if (!tfLite) {
+              reject(new Error('TensorFlow Lite not loaded'));
+              return;
+            }
 
-        if (engine === FilterEngine.TF) {
-          if (!videoEl || !canvasEl || (backgroundImage && !bgImageEl)) {
-            reject(new Error('Renderer started before elements are ready'));
-            return;
-          }
-
-          videoEl.srcObject = ms;
-          videoEl.play().then(
-            () => {
-              const trackSettings = track.getSettings();
-              flushSync(() =>
-                setVideoSize({
-                  width: trackSettings.width ?? 0,
-                  height: trackSettings.height ?? 0,
-                }),
-              );
-              call?.tracer.trace('backgroundFilters.enable', {
+            renderer = createRenderer(
+              tfLite,
+              videoEl,
+              canvasEl,
+              {
                 backgroundFilter,
                 backgroundBlurLevel,
-                backgroundImage,
-                engine,
-              });
+                backgroundImage: bgImageEl ?? undefined,
+              },
+              onError,
+            );
+            outputStream = canvasEl.captureStream();
 
-              if (!tfLite) {
-                reject(new Error('TensorFlow Lite not loaded'));
-                return;
-              }
-
-              renderer = createRenderer(
-                tfLite,
-                videoEl,
-                canvasEl,
-                {
-                  backgroundFilter,
-                  backgroundBlurLevel,
-                  backgroundImage: bgImageEl ?? undefined,
-                },
-                onError,
-              );
-              outputStream = canvasEl.captureStream();
-
-              resolve(outputStream);
-            },
-            () => {
-              reject(new Error('Could not play the source video stream'));
-            },
-          );
-          return;
-        }
-
-        reject(new Error('No supported engine available'));
+            resolve(outputStream);
+          },
+          () => {
+            reject(new Error('Could not play the source video stream'));
+          },
+        );
       });
 
       return {
         output,
         stop: () => {
           call?.tracer.trace('backgroundFilters.disable', null);
-          processor?.stop();
           renderer?.dispose();
           if (videoRef.current) videoRef.current.srcObject = null;
           if (outputStream) disposeOfMediaStream(outputStream);
@@ -618,17 +636,35 @@ const useRenderer = (
       };
     },
     [
-      backgroundBlurLevel,
-      backgroundFilter,
-      backgroundImage,
       call?.tracer,
       tfLite,
-      engine,
-      modelFilePath,
-      basePath,
-      segmentationOptions,
+      backgroundFilter,
+      backgroundBlurLevel,
+      backgroundImage,
     ],
   );
+
+  const start = engine === FilterEngine.TF ? startTf : startMediaPipe;
+
+  useEffect(() => {
+    if (!backgroundFilter) return;
+
+    processorRef.current
+      ?.updateOptions({
+        backgroundFilter,
+        backgroundBlurLevel,
+        backgroundImage,
+        segmentationOptions,
+      })
+      .catch((err) =>
+        console.warn(`[filters] Can't apply the background options`, err),
+      );
+  }, [
+    backgroundFilter,
+    backgroundBlurLevel,
+    backgroundImage,
+    segmentationOptions,
+  ]);
 
   const children = (
     <div className="str-video__background-filters">

--- a/packages/video-filters-web/README.md
+++ b/packages/video-filters-web/README.md
@@ -43,9 +43,46 @@ const processor = new VirtualBackground(
 // 4. Start the processor and use the processed track
 const processedTrack = await processor.start();
 
-// 5. Stop the processor
+// 5. Change the effect at any time, without restarting the track
+await processor.updateOptions({
+  backgroundFilter: 'blur',
+  backgroundBlurLevel: 'high',
+});
+
+// 6. Stop the processor
 processor.stop();
 ```
+
+### Updating the effect
+
+`updateOptions` changes the background effect of a running processor. The new
+effect is applied on the next frame - the input track, renderer and segmenter
+are preserved, so there is no interruption and the processed track doesn't
+need to be re-published.
+
+```typescript
+// switch between blur levels
+await processor.updateOptions({
+  backgroundFilter: 'blur',
+  backgroundBlurLevel: 3,
+});
+
+// switch to an image background
+await processor.updateOptions({
+  backgroundFilter: 'image',
+  backgroundImage: 'https://example.com/background.jpg',
+});
+```
+
+Notes:
+
+- `updateOptions` replaces the effect options, so always pass the complete
+  set you want applied.
+- `basePath` and `modelPath` are fixed for the lifetime of the processor;
+  changing the model requires a new instance.
+- When several updates overlap, the last one wins.
+- If the background image fails to load, the promise rejects and the current
+  background keeps rendering.
 
 ## Known limitations
 

--- a/packages/video-filters-web/src/VirtualBackground.ts
+++ b/packages/video-filters-web/src/VirtualBackground.ts
@@ -36,11 +36,24 @@ export class VirtualBackground extends BaseVideoProcessor {
 
   async updateOptions(options: BackgroundEffectOptions): Promise<void> {
     const { basePath, modelPath } = this.options;
+    const previous = this.options;
     const next = { basePath, modelPath, ...options };
     this.options = next;
-    const opts = await this.initializeSegmenterOptions();
-    if (this.options === next) {
-      this.opts = opts;
+    try {
+      const opts = await this.initializeSegmenterOptions();
+      if (this.options === next) {
+        const previousMedia = this.opts?.backgroundSource?.media;
+        this.opts = opts;
+        if (
+          previousMedia instanceof ImageBitmap &&
+          previousMedia !== opts.backgroundSource?.media
+        ) {
+          previousMedia.close();
+        }
+      }
+    } catch (error) {
+      if (this.options === next) this.options = previous;
+      throw error;
     }
   }
 

--- a/packages/video-filters-web/src/VirtualBackground.ts
+++ b/packages/video-filters-web/src/VirtualBackground.ts
@@ -1,5 +1,6 @@
 import {
   BACKGROUND_BLUR_MAP,
+  BackgroundEffectOptions,
   BackgroundOptions,
   SegmenterOptions,
   VideoTrackProcessorHooks,
@@ -27,10 +28,20 @@ export class VirtualBackground extends BaseVideoProcessor {
 
   constructor(
     track: MediaStreamVideoTrack,
-    private readonly options: BackgroundOptions = {},
+    private options: BackgroundOptions = {},
     hooks: VideoTrackProcessorHooks = {},
   ) {
     super(track, hooks);
+  }
+
+  async updateOptions(options: BackgroundEffectOptions): Promise<void> {
+    const { basePath, modelPath } = this.options;
+    const next = { basePath, modelPath, ...options };
+    this.options = next;
+    const opts = await this.initializeSegmenterOptions();
+    if (this.options === next) {
+      this.opts = opts;
+    }
   }
 
   protected async initialize(): Promise<void> {
@@ -146,6 +157,10 @@ export class VirtualBackground extends BaseVideoProcessor {
 
   private async loadBackground(url?: string) {
     if (!url) return null;
+
+    const current = this.opts?.backgroundSource;
+    if (current?.url === url) return current;
+
     const result = await fetch(url, { signal: this.abortController.signal });
     if (!result.ok) {
       throw new Error(

--- a/packages/video-filters-web/src/types.ts
+++ b/packages/video-filters-web/src/types.ts
@@ -47,17 +47,20 @@ export interface SegmenterOptions {
   isSelfieMode: boolean;
   segmentationOptions?: SegmentationOptions;
 }
-/**
- * Static configuration for the processor, defining which background
- * effect should be applied and how it should behave.
- */
-export interface BackgroundOptions {
-  basePath?: string;
-  modelPath?: string;
+export interface BackgroundEffectOptions {
   backgroundFilter?: BackgroundFilter;
   backgroundBlurLevel?: BackgroundBlurLevel;
   backgroundImage?: string | undefined;
   segmentationOptions?: SegmentationOptions;
+}
+
+/**
+ * Static configuration for the processor, defining which background
+ * effect should be applied and how it should behave.
+ */
+export interface BackgroundOptions extends BackgroundEffectOptions {
+  basePath?: string;
+  modelPath?: string;
 }
 
 /**


### PR DESCRIPTION
### 💡 Overview
This PR makes background filter switching seamless. Changing the blur level or switching background images no longer restarts the camera and the preview stays live. Previously every option change gave `start` a new identity, re-running the registration effect: `unregister()` then `registerFilter()`. Both call `applySettingsToStream()` (`muteStream()` → `unmuteStream()`), so each switch cost two camera restarts, two publish rounds, and a full MediaPipe rebuild. 

This PR adds: 
- `VirtualBackground.updateOptions()` - changes the effect of a running processor, applied on the next frame 
- `BackgroundEffectOptions` - the subset of options that can change at runtime

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/REACT-1127/introduce-updateoptions-in-video-filters-web

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update background effects while video processing continues.
  * Switch blur levels, background images, and other effect settings at runtime.
  * Configure background effects separately from model and path settings.

* **Bug Fixes**
  * Improved processor cleanup and validation during startup and shutdown.
  * Prevented outdated asynchronous updates from overriding newer settings.
  * Reused unchanged background images and preserved the current effect when image loading fails.

* **Documentation**
  * Added examples and guidance for updating effects during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->