### PR TITLE
fix(client): isolate coordinator event listener errors from the dispatch loop

### DIFF
--- a/packages/client/src/coordinator/connection/__tests__/eventListenerIsolation.test.ts
+++ b/packages/client/src/coordinator/connection/__tests__/eventListenerIsolation.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StreamClient } from '../client';
+import { StableWSConnection } from '../connection';
+import { videoLoggerSystem } from '../../../logger';
+import type { StreamVideoEvent } from '../types';
+
+const event: StreamVideoEvent = { type: 'network.changed', online: true };
+
+describe('event listener isolation', () => {
+  let client: StreamClient;
+  let sink: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sink = vi.fn();
+    videoLoggerSystem.configureLoggers({
+      coordinator: { sink, level: 'error' },
+    });
+    client = new StreamClient('key');
+  });
+
+  afterEach(() => {
+    videoLoggerSystem.restoreDefaults();
+    vi.restoreAllMocks();
+  });
+
+  const errorLogs = () =>
+    sink.mock.calls.filter(([level]) => level === 'error');
+
+  it('keeps dispatching after a listener throws', () => {
+    const failure = new Error('listener blew up');
+    const first = vi.fn(() => {
+      throw failure;
+    });
+    const second = vi.fn();
+
+    client.on('network.changed', first);
+    client.on('network.changed', second);
+
+    expect(() => client.dispatchEvent(event)).not.toThrow();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a synchronous throw through the logger', () => {
+    const failure = new Error('listener blew up');
+    client.on('network.changed', () => {
+      throw failure;
+    });
+
+    client.dispatchEvent(event);
+
+    expect(errorLogs()).toEqual([
+      [
+        'error',
+        '[coordinator]: Unhandled error in event listener',
+        failure,
+        event,
+      ],
+    ]);
+  });
+
+  it('reports a rejection from an async listener', async () => {
+    const failure = new Error('async listener blew up');
+    client.on('network.changed', async () => {
+      throw failure;
+    });
+    const next = vi.fn();
+    client.on('network.changed', next);
+
+    client.dispatchEvent(event);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(errorLogs()).toHaveLength(0);
+
+    await vi.waitFor(() => expect(errorLogs()).toHaveLength(1));
+    expect(errorLogs()[0]).toEqual([
+      'error',
+      '[coordinator]: Unhandled error in event listener',
+      failure,
+      event,
+    ]);
+  });
+
+  it('isolates a faulty `all` listener from type specific listeners', () => {
+    const all = vi.fn(() => {
+      throw new Error('all listener blew up');
+    });
+    const typed = vi.fn();
+
+    client.on('all', all);
+    client.on('network.changed', typed);
+
+    client.dispatchEvent(event);
+
+    expect(all).toHaveBeenCalledTimes(1);
+    expect(typed).toHaveBeenCalledTimes(1);
+    expect(errorLogs()).toHaveLength(1);
+  });
+
+  it('schedules the connection check even when a listener throws', () => {
+    const connection = new StableWSConnection(client);
+    const scheduleConnectionCheck = vi
+      .spyOn(connection, 'scheduleConnectionCheck')
+      .mockImplementation(() => {});
+
+    client.on('all', () => {
+      throw new Error('listener blew up');
+    });
+
+    connection.onmessage(connection.wsID, {
+      data: JSON.stringify({ type: 'custom' }),
+    } as MessageEvent);
+
+    expect(scheduleConnectionCheck).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/client/src/coordinator/connection/client.ts
+++ b/packages/client/src/coordinator/connection/client.ts
@@ -10,6 +10,7 @@ import { TokenManager } from './token_manager';
 import {
   addConnectionEventListeners,
   generateUUIDv4,
+  invokeEventListener,
   isErrorResponse,
   KnownCodes,
   removeConnectionEventListeners,
@@ -589,12 +590,12 @@ export class StreamClient {
 
     // call generic listeners
     for (const listener of this.listeners.all || []) {
-      listener(event);
+      invokeEventListener(listener, event, this.logger);
     }
 
     // call type specific listeners
     for (const listener of this.listeners[event.type] || []) {
-      listener(event);
+      invokeEventListener(listener, event, this.logger);
     }
   };
 

--- a/packages/client/src/coordinator/connection/utils.ts
+++ b/packages/client/src/coordinator/connection/utils.ts
@@ -1,6 +1,7 @@
 import type { AxiosResponse } from 'axios';
 import type { APIErrorResponse } from './types';
 import type { ConnectionErrorEvent } from '../../gen/coordinator';
+import type { ScopedLogger } from '../../logger';
 
 export const sleep = (m: number) => new Promise((r) => setTimeout(r, m));
 
@@ -118,3 +119,30 @@ export function isCloseEvent(
 ): res is CloseEvent {
   return (res as CloseEvent).code !== undefined;
 }
+
+/**
+ * Invokes a single event listener in isolation, so that a faulty listener
+ * cannot abort the dispatch loop nor the bookkeeping that follows it.
+ *
+ * @param listener the listener to invoke.
+ * @param event the event to pass to the listener.
+ * @param logger the logger to report listener failures with.
+ */
+export const invokeEventListener = <T>(
+  listener: (event: T) => unknown,
+  event: T,
+  logger: ScopedLogger,
+) => {
+  try {
+    const result = listener(event);
+    if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+      Promise.resolve(result).catch((error) => report(logger, error, event));
+    }
+  } catch (error) {
+    report(logger, error, event);
+  }
+};
+
+const report = (logger: ScopedLogger, error: unknown, event: unknown) => {
+  logger.error('Unhandled error in event listener', error, event);
+};


### PR DESCRIPTION
### 💡 Overview

A faulty coordinator event listener can no longer abort event dispatch. `StreamClient.dispatchEvent` now routes every listener through a new `invokeEventListener` helper in `src/coordinator/connection/utils.ts`.

Previously an exception from a listener propagated out of `dispatchEvent`. In `StableWSConnection.onmessage` that call is immediately followed by `this.scheduleConnectionCheck()`, so a listener bug escaped into the WebSocket `onmessage` handler and silently disabled the connection-staleness check for the rest of the session. The same applied to the `dispatchEvent` calls in `MicrophoneManager` and `DeviceManager`.

This mirrors what we did on the chat side in GetStream/stream-chat-js#1850.

### 📝 Implementation notes

`invokeEventListener` handles two failure modes: a synchronous throw, and a rejected promise from an `async` listener. The latter matters because async handlers are assignable to the void-returning listener types, so they were previously silent unhandled rejections. Both are reported through the scoped `coordinator` logger at `error` level, so listener bugs are never discarded silently.

Unlike the chat version there is no `noopLogger` / `console.error` fallback: `ScopedLogger` always has a sink, so a plain `logger.error(...)` is enough.

The two dispatch loops are otherwise untouched. The SFU-side `Dispatcher.emitOne` already catches synchronous throws (at `warn` level, without async-rejection handling) and is left alone here.

One known limitation, called out deliberately: the reporting path calls the logger directly, so a custom logger that itself throws is not contained.

Covered by `packages/client/src/coordinator/connection/__tests__/eventListenerIsolation.test.ts` (5 tests): dispatch continues past a throw, sync throws reported through the logger, async rejections captured and reported, a faulty `all` listener isolated from type-specific listeners, and `scheduleConnectionCheck` still running after a listener throws.

🎫 Ticket: https://linear.app/stream/issue/REACT-1128/coordinator-event-listener-errors-abort-ws-event-dispatch
