### PR TITLE
fix(client): keep passive participants out of the spotlight

### DIFF
--- a/packages/client/src/sorting/__tests__/presets.test.ts
+++ b/packages/client/src/sorting/__tests__/presets.test.ts
@@ -1,8 +1,54 @@
 import { describe, expect, it } from 'vitest';
 import * as TestData from './participant-data';
-import { VisibilityState } from '../../types';
-import { paginatedLayoutSortPreset } from '../presets';
-import { TrackType } from '../../gen/video/sfu/models/models';
+import { StreamVideoParticipant, VisibilityState } from '../../types';
+import { Comparator } from '../comparator';
+import {
+  defaultSortPreset,
+  livestreamOrAudioRoomSortPreset,
+  paginatedLayoutSortPreset,
+  speakerLayoutSortPreset,
+} from '../presets';
+import {
+  ParticipantSource,
+  TrackType,
+} from '../../gen/video/sfu/models/models';
+
+const participant = (
+  name: string,
+  publishedTracks: TrackType[],
+  visibility: VisibilityState = VisibilityState.VISIBLE,
+  overrides: Partial<StreamVideoParticipant> = {},
+): StreamVideoParticipant =>
+  ({
+    name,
+    userId: name,
+    sessionId: name,
+    roles: ['user'],
+    publishedTracks,
+    trackLookupPrefix: name,
+    isSpeaking: false,
+    isDominantSpeaker: false,
+    audioLevel: 0,
+    image: '',
+    source: ParticipantSource.WEBRTC_UNSPECIFIED,
+    viewportVisibilityState: {
+      videoTrack: visibility,
+      screenShareTrack: visibility,
+    },
+    ...overrides,
+  }) as StreamVideoParticipant;
+
+const names = (ps: StreamVideoParticipant[]) => ps.map((p) => p.name);
+
+// every preset that prioritizes publishing participants over passive ones
+const presets: [string, Comparator<StreamVideoParticipant>][] = [
+  ['defaultSortPreset', defaultSortPreset],
+  ['speakerLayoutSortPreset', speakerLayoutSortPreset],
+  ['livestreamOrAudioRoomSortPreset', livestreamOrAudioRoomSortPreset],
+];
+
+const { UNKNOWN, VISIBLE, INVISIBLE } = VisibilityState;
+const { AUDIO, VIDEO, SCREEN_SHARE } = TrackType;
 
 describe('presets', () => {
   it('paginatedLayoutSortPreset', () => {
@@ -59,5 +105,144 @@ describe('presets', () => {
         "A",
       ]
     `);
+  });
+
+  // In SpeakerLayout the viewport is the participants bar, so the spotlight
+  // tile is never observed and stays UNKNOWN. Regression test for a passive
+  // participant holding the spotlight over a participant publishing video.
+  it.each(presets)(
+    '%s keeps passive participants out of the spotlight',
+    (_, preset) => {
+      const ps = [
+        participant('passive-viewer', [], UNKNOWN),
+        participant('host', [VIDEO]),
+        participant('local-viewer', [], VISIBLE, { isLocalParticipant: true }),
+      ];
+
+      expect(names(ps.sort(preset))).toEqual([
+        'host',
+        'passive-viewer',
+        'local-viewer',
+      ]);
+    },
+  );
+
+  it.each(presets)(
+    '%s promotes a rejoined publisher appended last',
+    (_, preset) => {
+      const ps = [
+        participant('v1', [], UNKNOWN),
+        participant('v2', []),
+        participant('v3', []),
+      ].sort(preset);
+      // a rejoining participant is appended to the end of the list
+      ps.push(participant('host', [AUDIO, VIDEO], UNKNOWN));
+
+      expect(names(ps.sort(preset))).toEqual(['host', 'v1', 'v2', 'v3']);
+    },
+  );
+
+  it.each(presets)(
+    '%s ranks passive participants below publishing ones regardless of visibility',
+    (_, preset) => {
+      const passive = [
+        participant('p1', [], UNKNOWN),
+        participant('p2', [], VISIBLE),
+        participant('p3', [], INVISIBLE),
+      ];
+      const publishing = [
+        participant('a1', [VIDEO], UNKNOWN),
+        participant('a2', [AUDIO], VISIBLE),
+        participant('a3', [AUDIO, VIDEO], INVISIBLE),
+      ];
+
+      for (const a of passive) {
+        for (const b of publishing) {
+          expect(preset(a, b)).toBe(1);
+          expect(preset(b, a)).toBe(-1);
+        }
+      }
+    },
+  );
+
+  // `publishing` ignores the track type, so a participant keeps its rank while
+  // it still publishes something. In speakerLayoutSortPreset the gated
+  // comparators cannot override this, because the gate only opens on INVISIBLE.
+  it.each<[string, TrackType[]]>([
+    ['camera and microphone on', [AUDIO, VIDEO]],
+    ['the microphone muted', [VIDEO]],
+    ['the camera turned off', [AUDIO]],
+  ])(
+    'speakerLayoutSortPreset keeps the spotlight with %s',
+    (_, spotlightTracks) => {
+      const ps = [
+        participant('spotlight', spotlightTracks, UNKNOWN),
+        participant('bar', [AUDIO, VIDEO]),
+      ];
+
+      expect(names(ps.sort(speakerLayoutSortPreset))).toEqual([
+        'spotlight',
+        'bar',
+      ]);
+    },
+  );
+
+  it('speakerLayoutSortPreset drops a spotlight that stops publishing', () => {
+    const ps = [
+      participant('spotlight', [], UNKNOWN),
+      participant('bar', [AUDIO, VIDEO]),
+    ];
+
+    expect(names(ps.sort(speakerLayoutSortPreset))).toEqual([
+      'bar',
+      'spotlight',
+    ]);
+  });
+
+  // livestreamOrAudioRoomSortPreset gates on INVISIBLE *or* UNKNOWN, so an
+  // unobserved spotlight tile stays comparable by audio and video state. This
+  // predates the `publishing` comparator, which only breaks ties between a
+  // publishing and a non-publishing participant.
+  it('livestreamOrAudioRoomSortPreset still re-ranks publishers by track state', () => {
+    const ps = [
+      participant('spotlight', [VIDEO], UNKNOWN),
+      participant('bar', [AUDIO, VIDEO]),
+    ];
+
+    expect(names(ps.sort(livestreamOrAudioRoomSortPreset))).toEqual([
+      'bar',
+      'spotlight',
+    ]);
+  });
+
+  it.each<[string, TrackType[], Partial<StreamVideoParticipant>]>([
+    ['a pinned participant', [], { pin: { isLocalPin: true, pinnedAt: 1 } }],
+    ['a presenter', [SCREEN_SHARE], {}],
+    ['the dominant speaker', [AUDIO], { isDominantSpeaker: true }],
+  ])(
+    'speakerLayoutSortPreset ranks %s above a publishing participant',
+    (_, tracks, overrides) => {
+      const ps = [
+        participant('publisher', [AUDIO, VIDEO], UNKNOWN),
+        participant('contender', tracks, VISIBLE, overrides),
+      ];
+
+      expect(names(ps.sort(speakerLayoutSortPreset))).toEqual([
+        'contender',
+        'publisher',
+      ]);
+    },
+  );
+
+  it('livestreamOrAudioRoomSortPreset still uses role as a tie breaker between publishers', () => {
+    const ps = [
+      participant('viewer', [AUDIO, VIDEO]),
+      participant('host', [AUDIO, VIDEO], UNKNOWN, { roles: ['host'] }),
+    ];
+
+    expect(names(ps.sort(livestreamOrAudioRoomSortPreset))).toEqual([
+      'host',
+      'viewer',
+    ]);
   });
 });

--- a/packages/client/src/sorting/__tests__/sorting.test.ts
+++ b/packages/client/src/sorting/__tests__/sorting.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { ParticipantSource } from '../../gen/video/sfu/models/models';
+import {
+  ParticipantSource,
+  TrackType,
+} from '../../gen/video/sfu/models/models';
+import { StreamVideoParticipant } from '../../types';
 import {
   combineComparators,
   Comparator,
   conditional,
   dominantSpeaker,
   pinned,
+  publishing,
   publishingAudio,
   publishingVideo,
   screenSharing,
@@ -35,6 +40,22 @@ describe('Sorting', () => {
     );
     const sorted = TestData.participants().sort(comparator);
     expect(sorted.map((p) => p.name)).toEqual(['F', 'D', 'B', 'A', 'E', 'C']);
+  });
+
+  it('publishing', () => {
+    const { AUDIO, VIDEO, SCREEN_SHARE } = TrackType;
+    const p = (publishedTracks: TrackType[]) =>
+      ({ publishedTracks }) as StreamVideoParticipant;
+
+    // publishing anything ranks above publishing nothing
+    expect(publishing(p([AUDIO]), p([]))).toEqual(-1);
+    expect(publishing(p([SCREEN_SHARE]), p([]))).toEqual(-1);
+    expect(publishing(p([]), p([VIDEO]))).toEqual(1);
+
+    // the track type is irrelevant, so device toggles do not change the rank
+    expect(publishing(p([AUDIO, VIDEO]), p([AUDIO]))).toEqual(0);
+    expect(publishing(p([VIDEO]), p([AUDIO]))).toEqual(0);
+    expect(publishing(p([]), p([]))).toEqual(0);
   });
 
   it('conditional comparator', () => {

--- a/packages/client/src/sorting/participants.ts
+++ b/packages/client/src/sorting/participants.ts
@@ -74,6 +74,26 @@ export const publishingAudio: Comparator<StreamVideoParticipant> = (a, b) => {
 };
 
 /**
+ * A comparator which prioritizes participants who are publishing any track
+ * over participants who are not publishing at all.
+ *
+ * Unlike `publishingVideo` and `publishingAudio`, this comparator does not
+ * distinguish between track types. Muting the microphone or turning off the
+ * camera does not change a participant's rank as long as they still publish
+ * something, which keeps the ordering stable across ordinary device toggles.
+ *
+ * @param a the first participant.
+ * @param b the second participant.
+ */
+export const publishing: Comparator<StreamVideoParticipant> = (a, b) => {
+  const hasA = a.publishedTracks.length > 0;
+  const hasB = b.publishedTracks.length > 0;
+  if (hasA && !hasB) return -1;
+  if (!hasA && hasB) return 1;
+  return 0;
+};
+
+/**
  * A comparator which prioritizes participants who are pinned.
  *
  * @param a the first participant.

--- a/packages/client/src/sorting/presets.ts
+++ b/packages/client/src/sorting/presets.ts
@@ -4,6 +4,7 @@ import { ParticipantSource } from '../gen/video/sfu/models/models';
 import {
   dominantSpeaker,
   pinned,
+  publishing,
   publishingAudio,
   publishingVideo,
   reactionType,
@@ -51,6 +52,7 @@ const withVideoIngressSource = withParticipantSource(
 export const defaultSortPreset = combineComparators(
   screenSharing,
   pinned,
+  publishing,
   ifInvisibleBy(
     combineComparators(
       dominantSpeaker,
@@ -69,6 +71,7 @@ export const speakerLayoutSortPreset = combineComparators(
   screenSharing,
   pinned,
   dominantSpeaker,
+  publishing,
   ifInvisibleBy(
     combineComparators(
       speaking,
@@ -102,6 +105,7 @@ export const paginatedLayoutSortPreset = combineComparators(
  * The sorting preset for livestreams and audio rooms.
  */
 export const livestreamOrAudioRoomSortPreset = combineComparators(
+  publishing,
   ifInvisibleOrUnknownBy(
     combineComparators(
       dominantSpeaker,

--- a/packages/client/src/store/__tests__/CallState.test.ts
+++ b/packages/client/src/store/__tests__/CallState.test.ts
@@ -266,8 +266,8 @@ describe('CallState', () => {
           "E",
           "F",
           "A",
-          "C",
           "D",
+          "C",
         ]
       `);
 
@@ -288,8 +288,8 @@ describe('CallState', () => {
           "E",
           "F",
           "A",
-          "C",
           "D",
+          "C",
         ]
       `);
     });


### PR DESCRIPTION
### 💡 Overview

A participant publishing no tracks could hold the spotlight in `SpeakerLayout` indefinitely while an actively publishing participant sat in the participants bar. It showed up most clearly on `livestream` calls after the host or transcoder feed rejoined, but the cause is not specific to rejoining: no comparator in the affected presets was able to rank a publishing participant above a passive one.

Reported state, where a viewer with no tracks held the spotlight over a participant publishing video:

| participant | publishedTracks | visibility |
| --- | --- | --- |
| `viewer` | `[]` | UNKNOWN (spotlight) |
| `webrtc-transcoder-egress-*` | `[VIDEO]` | VISIBLE (bar) |
| `viewer` (local) | `[]` | VISIBLE (bar) |

### 📝 Implementation notes

Four things compound to produce this:

1. `SpeakerLayout` calls `useSpeakerLayoutSortPreset`, replacing the call type's preset, so `livestream`'s own `livestreamOrAudioRoomSortPreset` never runs while that layout is mounted.
2. In `speakerLayoutSortPreset` the only unconditional comparators are `screenSharing`, `pinned` and `dominantSpeaker`. Everything media related sits behind `ifInvisibleBy`, which opens only on `INVISIBLE`.
3. `SpeakerLayout` sets the viewport to the participants bar, so the spotlight tile is outside the `IntersectionObserver` root, is never observed, and stays `UNKNOWN`. Rejoining participants are stamped `UNKNOWN` too.
4. `CallState.participants$` sorts in place, so ordering is a fold over the previous order. With every comparator returning `0`, arrival order wins and a rejoining participant appended last stays last.

The fix adds a `publishing` comparator: a single coarse boolean on `publishedTracks.length > 0`, applied unconditionally above the visibility gate in `defaultSortPreset`, `speakerLayoutSortPreset` and `livestreamOrAudioRoomSortPreset`.

Coarse rather than hoisting `publishingVideo` / `publishingAudio` individually, so muting the microphone or turning off the camera does not change a participant's rank while they still publish something. Only the fully passive boundary reorders anyone, which keeps ordering stable across ordinary device toggles. `pinned`, `screenSharing` and `dominantSpeaker` still take precedence.

Role based prioritisation was considered and rejected: `role('admin', 'host', 'speaker')` would make correct behaviour depend on integrators adopting those exact role names.

`paginatedLayoutSortPreset` is intentionally unchanged, as grid layouts have no spotlight slot.

One existing snapshot in `CallState.test.ts` changed, and it is the bug: it asserted `[B, E, F, A, C, D]` under `defaultSortPreset`, where `C` publishes nothing and `D` publishes audio and is the dominant speaker. It is now `[B, E, F, A, D, C]`. The test's actual purpose (order unchanged after `noopComparator()`) is preserved.

Tests cover the reported state, promotion of a rejoined publisher appended last, stability across device toggles, precedence of pin / screen share / dominant speaker, and a pairwise assertion that no passive participant ranks above a publishing one across all visibility states. A separate test documents that `livestreamOrAudioRoomSortPreset` still re-ranks publishers on microphone state, which predates this change (its gate opens on `UNKNOWN` as well as `INVISIBLE`).

Two follow ups worth tracking separately, both noted on the ticket: the SFU emits `ParticipantSource = 6` for transcoder egress participants, which is missing from the checked-in protobufs and silently disables `withVideoIngressSource` for them; and participants sliced off by `participantsBarLimit` are rendered nowhere yet labelled `UNKNOWN` rather than `INVISIBLE`.

🎫 Ticket: https://linear.app/stream/issue/REACT-1129/passive-participants-can-hold-the-spotlight-in-speakerlayout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated participant ordering to prioritize people who are actively publishing audio or video.
  * Improved speaker, livestream, and audio-room layouts so publishing participants rank consistently, while pinned, presenting, and dominant speakers retain priority.
  * Refined spotlight behavior to keep active speakers featured and remove participants who stop publishing.
  * Improved ranking consistency when participants rejoin or change visibility states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


📑 Docs: https://github.com/GetStream/docs-content/pull/1563
