### PR TITLE
fix(react-dogfood): show closed captions in all environments

### DIFF
--- a/sample-apps/react/react-dogfood/components/ActiveCall.tsx
+++ b/sample-apps/react/react-dogfood/components/ActiveCall.tsx
@@ -80,8 +80,10 @@ type SidebarContent =
 
 export const ActiveCall = (props: ActiveCallProps) => {
   const { chatClient, activeCall, onLeave, onJoin } = props;
-  const { useParticipantCount } = useCallStateHooks();
+  const { useParticipantCount, useIsCallCaptioningInProgress } =
+    useCallStateHooks();
   const participantCount = useParticipantCount();
+  const isCaptioning = useIsCallCaptioningInProgress();
   const {
     current: currentTourStep,
     active: isTourActive,
@@ -195,7 +197,7 @@ export const ActiveCall = (props: ActiveCallProps) => {
                 close={() => setShowInvitePopup(false)}
               />
             )}
-            <ClosedCaptions />
+            {isCaptioning && <ClosedCaptions />}
           </div>
 
           <div

--- a/sample-apps/react/react-dogfood/components/ActiveCall.tsx
+++ b/sample-apps/react/react-dogfood/components/ActiveCall.tsx
@@ -195,7 +195,7 @@ export const ActiveCall = (props: ActiveCallProps) => {
                 close={() => setShowInvitePopup(false)}
               />
             )}
-            {isPronto && <ClosedCaptions />}
+            <ClosedCaptions />
           </div>
 
           <div

--- a/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
+++ b/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
@@ -53,11 +53,8 @@ export const ToggleClosedCaptionsButton = () => {
 };
 
 export const ClosedCaptions = () => {
-  const { useCallClosedCaptions, useIsCallCaptioningInProgress } =
-    useCallStateHooks();
+  const { useCallClosedCaptions } = useCallStateHooks();
   const closedCaptions = useCallClosedCaptions();
-  const isCaptioning = useIsCallCaptioningInProgress();
-  if (!isCaptioning) return null;
   return (
     <div className="rd__closed-captions">
       <ClosedCaptionList queue={closedCaptions} />

--- a/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
+++ b/sample-apps/react/react-dogfood/components/ClosedCaptions.tsx
@@ -53,8 +53,11 @@ export const ToggleClosedCaptionsButton = () => {
 };
 
 export const ClosedCaptions = () => {
-  const { useCallClosedCaptions } = useCallStateHooks();
+  const { useCallClosedCaptions, useIsCallCaptioningInProgress } =
+    useCallStateHooks();
   const closedCaptions = useCallClosedCaptions();
+  const isCaptioning = useIsCallCaptioningInProgress();
+  if (!isCaptioning) return null;
   return (
     <div className="rd__closed-captions">
       <ClosedCaptionList queue={closedCaptions} />


### PR DESCRIPTION
### 💡 Overview

Closed captions never appeared in the dogfood app outside the `pronto` environment: the caption overlay was gated behind `useIsProntoEnvironment()` while the toggle button that starts and stops captioning was not. On `demo`, `pronto-staging` and `pronto-sales` you could turn captioning on and never see any caption text.

### 📝 Implementation notes

- Replaced the `isPronto` gate on `<ClosedCaptions />` with a `useIsCallCaptioningInProgress()` check in `ActiveCall`, so the overlay follows the same condition as the toggle button that controls it. The caption queue subscription stays in the child, so `ActiveCall` re-renders only when captioning starts or stops.
- The closed captions **sidebar** and its toolbar button stay `pronto`-only, since that panel renders the raw `call.closed_caption` event stream and belongs with the other developer tools.
- Unchanged and still per-environment: the call type's `settings.transcription.closed_caption_mode` must not be `disabled`, and the user needs the start/stop closed captions capability.