### PR TITLE
ci: bootstrap the v2 beta line for the five 1.x packages

### DIFF
--- a/packages/client/project.json
+++ b/packages/client/project.json
@@ -23,6 +23,8 @@
         },
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test", "docs"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-client:update-version",
           "@stream-io/video-client:github",
@@ -44,6 +46,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notes": "${notes}"
       }

--- a/packages/react-bindings/project.json
+++ b/packages/react-bindings/project.json
@@ -24,6 +24,8 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test", "docs"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-react-bindings:enrich-changelog",
           "@stream-io/video-react-bindings:github",
@@ -34,6 +36,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notesFile": "packages/react-bindings/.release-notes.md"
       }

--- a/packages/react-native-sdk/project.json
+++ b/packages/react-native-sdk/project.json
@@ -24,6 +24,8 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "docs"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-react-native-sdk:update-version",
           "@stream-io/video-react-native-sdk:enrich-changelog",
@@ -46,6 +48,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notesFile": "packages/react-native-sdk/.release-notes.md"
       }

--- a/packages/react-sdk/project.json
+++ b/packages/react-sdk/project.json
@@ -24,6 +24,8 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test", "docs"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-react-sdk:update-version",
           "@stream-io/video-react-sdk:enrich-changelog",
@@ -47,6 +49,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notesFile": "packages/react-sdk/.release-notes.md"
       }

--- a/packages/styling/project.json
+++ b/packages/styling/project.json
@@ -23,6 +23,8 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-styling:github",
           "@stream-io/video-styling:publish"
@@ -32,6 +34,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notes": "${notes}"
       }

--- a/scripts/release/beta-line-config.test.mts
+++ b/scripts/release/beta-line-config.test.mts
@@ -1,0 +1,109 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Guards the v2 prerelease configuration.
+ *
+ * The five packages that carry the v2 major release together on the
+ * `2.0.0-beta.N` line; every other package keeps its own independent version
+ * line. Both halves of that split are easy to break silently in a project.json,
+ * so they are asserted here.
+ */
+
+const V2_PACKAGES = [
+  'client',
+  'react-sdk',
+  'react-bindings',
+  'react-native-sdk',
+  'styling',
+];
+
+// Packages that must stay on their own version line, never the v2 beta line.
+const INDEPENDENT_PACKAGES = [
+  'audio-filters-web',
+  'video-filters-web',
+  'video-filters-react-native',
+  'noise-cancellation-react-native',
+  'react-native-callingx',
+  'codemod',
+  'typescript-config',
+];
+
+interface ProjectJson {
+  targets?: {
+    version?: { options?: { releaseAs?: string; preid?: string } };
+    github?: { options?: { prerelease?: boolean } };
+  };
+}
+
+function readProject(pkg: string): ProjectJson {
+  const path = join(process.cwd(), 'packages', pkg, 'project.json');
+  return JSON.parse(readFileSync(path, 'utf8')) as ProjectJson;
+}
+
+test('every v2 package releases on the beta preid', () => {
+  for (const pkg of V2_PACKAGES) {
+    const options = readProject(pkg).targets?.version?.options;
+    assert.equal(
+      options?.preid,
+      'beta',
+      `packages/${pkg} must set preid "beta" to release on the v2 line`,
+    );
+  }
+});
+
+// `premajor` is single-use: it establishes 2.0.0-beta.0 from 1.x, but from
+// 2.0.0-beta.0 it yields 3.0.0-beta.0. `prerelease` is the steady state and
+// increments beta.N. Anything else silently leaves the v2 line.
+test('every v2 package uses a supported releaseAs', () => {
+  for (const pkg of V2_PACKAGES) {
+    const releaseAs = readProject(pkg).targets?.version?.options?.releaseAs;
+    assert.ok(
+      releaseAs === 'premajor' || releaseAs === 'prerelease',
+      `packages/${pkg} has releaseAs "${releaseAs}", expected "premajor" (bootstrap) or "prerelease" (steady state)`,
+    );
+  }
+});
+
+// Drift here would split the five across two majors, and because workspace:*
+// publishes as an exact pin, a mismatched set is a broken install.
+test('the v2 packages share one releaseAs', () => {
+  const values = new Set(
+    V2_PACKAGES.map(
+      (pkg) => readProject(pkg).targets?.version?.options?.releaseAs,
+    ),
+  );
+  assert.equal(
+    values.size,
+    1,
+    `the v2 packages must all use the same releaseAs, found: ${[...values].join(', ')}`,
+  );
+});
+
+test('v2 GitHub releases are marked as prereleases', () => {
+  for (const pkg of V2_PACKAGES) {
+    assert.equal(
+      readProject(pkg).targets?.github?.options?.prerelease,
+      true,
+      `packages/${pkg} must set prerelease on its github target, or beta releases outrank the 1.x releases on the repo page`,
+    );
+  }
+});
+
+test('independent packages stay off the v2 beta line', () => {
+  for (const pkg of INDEPENDENT_PACKAGES) {
+    const options = readProject(pkg).targets?.version?.options;
+    assert.equal(
+      options?.preid,
+      undefined,
+      `packages/${pkg} keeps its own version line and must not set a preid`,
+    );
+    assert.equal(
+      options?.releaseAs,
+      undefined,
+      `packages/${pkg} keeps its own version line and must not set releaseAs`,
+    );
+  }
+});


### PR DESCRIPTION
### 💡 Overview

Phase 4a of the v1/v2 branch split. Puts the five 1.x packages (`client`, `react-sdk`, `react-bindings`, `react-native-sdk`, `styling`) on the `2.0.0-beta` line, and marks their GitHub releases as prereleases so a beta does not show as "Latest release" ahead of the real 1.x releases.

`release-v1` was cut from `main` at `dbdd1c44e` before this, so it carries no beta config and no beta tag is reachable from it.

**This is the bootstrap half of a two-step change.** `releaseAs: premajor` is temporary: it is what lifts a package from 1.x to `2.0.0-beta.0`, and it is strictly single-use because from `2.0.0-beta.0` premajor yields `3.0.0-beta.0`. A follow-up PR flips these five to `releaseAs: prerelease` once the bootstrap release has published, and tightens the config test to require it.

### 📝 Implementation notes

Two other routes to the 2.0 line were tried and rejected, both verified by dry run:

- **Steady-state `prerelease` alone lands on the wrong line.** From `1.42.0` it computes `1.43.0-beta.0`, because it only promotes the recommended bump to `premajor` when that bump is already `major`. Dry run gave `1.59.1-beta.0` / `1.43.0-beta.0` / `1.45.1-beta.0`.
- **A global `--releaseAs=premajor` on the nx invocation hits all 13 projects.** It would drag the 0.x satellites to `1.0.0-beta.0`, the dogfood app to `5.0.0-beta.0` and `typescript-config` to `1.0.0-beta.0`. Per-package config in `project.json` is what keeps the blast radius to the five.
- **Relying on a breaking commit per package** only lifts the package that commit touches. A probe `feat(client)!:` commit moved `client` to `2.0.0-beta.0` while `react-sdk` and `react-native-sdk` stayed on `1.43.0-beta.0` / `1.45.1-beta.0`.

`scripts/release/beta-line-config.test.mts` guards both halves of the version split: the five must share one supported `releaseAs` and the `beta` preid, and the seven independent packages must set neither, so a satellite cannot be pulled onto the beta line by accident. The drift detection was negative-tested rather than assumed: flipping one package's `releaseAs` fails "the v2 packages share one releaseAs", and changing a preid fails "every v2 package releases on the beta preid".

**Consequence worth knowing:** setting `releaseAs` disables dependency tracking, so on the beta line each of the five releases only when it has its own qualifying commits. `react-bindings` already shows this, dropping from a tracked `1.20.2` to "nothing changed". Since `workspace:*` publishes as an exact pin, beta runs must cover the whole dependency closure; the publish guard from #2411 blocks a mismatch before it reaches npm.

Bootstrap dry run on this branch, all 13 projects:

```
@stream-io/video-client             2.0.0-beta.0
@stream-io/video-react-bindings     2.0.0-beta.0
@stream-io/video-react-sdk          2.0.0-beta.0
@stream-io/video-react-native-sdk   2.0.0-beta.0
@stream-io/video-styling            2.0.0-beta.0
@stream-io/react-native-callingx    0.11.1        (own line)
@stream-io/video-filters-web        0.9.0         (own line)
@stream-io/video-react-native-dogfood 4.45.1      (own line)
```

`yarn test:scripts` is 66 passing, up from 61.

🎫 Ticket: https://linear.app/stream/issue/REACT-1166/v1v2-branch-split-release-v1-maintenance-branch-v2-on-main

📑 Docs: n/a (internal release tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Configured client, React, React Native, styling, and bindings packages for premajor beta releases.
  * GitHub releases for these packages will be marked as prereleases.

* **Tests**
  * Added validation to ensure consistent beta prerelease settings across packages and preserve independent package release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->