### PR TITLE
ci: switch the v2 packages to the steady-state prerelease bump

### DIFF
--- a/packages/client/project.json
+++ b/packages/client/project.json
@@ -23,6 +23,8 @@
         },
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test", "docs"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-client:update-version",
           "@stream-io/video-client:github",
@@ -44,6 +46,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notes": "${notes}"
       }

--- a/packages/client/project.json
+++ b/packages/client/project.json
@@ -23,7 +23,7 @@
         },
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test", "docs"],
-        "releaseAs": "premajor",
+        "releaseAs": "prerelease",
         "preid": "beta",
         "postTargets": [
           "@stream-io/video-client:update-version",

--- a/packages/react-bindings/project.json
+++ b/packages/react-bindings/project.json
@@ -24,7 +24,7 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test", "docs"],
-        "releaseAs": "premajor",
+        "releaseAs": "prerelease",
         "preid": "beta",
         "postTargets": [
           "@stream-io/video-react-bindings:enrich-changelog",

--- a/packages/react-bindings/project.json
+++ b/packages/react-bindings/project.json
@@ -24,6 +24,8 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test", "docs"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-react-bindings:enrich-changelog",
           "@stream-io/video-react-bindings:github",
@@ -34,6 +36,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notesFile": "packages/react-bindings/.release-notes.md"
       }

--- a/packages/react-native-sdk/project.json
+++ b/packages/react-native-sdk/project.json
@@ -24,7 +24,7 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "docs"],
-        "releaseAs": "premajor",
+        "releaseAs": "prerelease",
         "preid": "beta",
         "postTargets": [
           "@stream-io/video-react-native-sdk:update-version",

--- a/packages/react-native-sdk/project.json
+++ b/packages/react-native-sdk/project.json
@@ -24,6 +24,8 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "docs"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-react-native-sdk:update-version",
           "@stream-io/video-react-native-sdk:enrich-changelog",
@@ -46,6 +48,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notesFile": "packages/react-native-sdk/.release-notes.md"
       }

--- a/packages/react-sdk/project.json
+++ b/packages/react-sdk/project.json
@@ -24,7 +24,7 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test", "docs"],
-        "releaseAs": "premajor",
+        "releaseAs": "prerelease",
         "preid": "beta",
         "postTargets": [
           "@stream-io/video-react-sdk:update-version",

--- a/packages/react-sdk/project.json
+++ b/packages/react-sdk/project.json
@@ -24,6 +24,8 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test", "docs"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-react-sdk:update-version",
           "@stream-io/video-react-sdk:enrich-changelog",
@@ -47,6 +49,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notesFile": "packages/react-sdk/.release-notes.md"
       }

--- a/packages/styling/project.json
+++ b/packages/styling/project.json
@@ -23,6 +23,8 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test"],
+        "releaseAs": "premajor",
+        "preid": "beta",
         "postTargets": [
           "@stream-io/video-styling:github",
           "@stream-io/video-styling:publish"
@@ -32,6 +34,7 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
+        "prerelease": true,
         "tag": "${tag}",
         "notes": "${notes}"
       }

--- a/packages/styling/project.json
+++ b/packages/styling/project.json
@@ -23,7 +23,7 @@
         "trackDeps": true,
         "push": true,
         "skipCommitTypes": ["ci", "refactor", "test"],
-        "releaseAs": "premajor",
+        "releaseAs": "prerelease",
         "preid": "beta",
         "postTargets": [
           "@stream-io/video-styling:github",

--- a/scripts/release/beta-line-config.test.mts
+++ b/scripts/release/beta-line-config.test.mts
@@ -1,0 +1,109 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Guards the v2 prerelease configuration.
+ *
+ * The five packages that carry the v2 major release together on the
+ * `2.0.0-beta.N` line; every other package keeps its own independent version
+ * line. Both halves of that split are easy to break silently in a project.json,
+ * so they are asserted here.
+ */
+
+const V2_PACKAGES = [
+  'client',
+  'react-sdk',
+  'react-bindings',
+  'react-native-sdk',
+  'styling',
+];
+
+// Packages that must stay on their own version line, never the v2 beta line.
+const INDEPENDENT_PACKAGES = [
+  'audio-filters-web',
+  'video-filters-web',
+  'video-filters-react-native',
+  'noise-cancellation-react-native',
+  'react-native-callingx',
+  'codemod',
+  'typescript-config',
+];
+
+interface ProjectJson {
+  targets?: {
+    version?: { options?: { releaseAs?: string; preid?: string } };
+    github?: { options?: { prerelease?: boolean } };
+  };
+}
+
+function readProject(pkg: string): ProjectJson {
+  const path = join(process.cwd(), 'packages', pkg, 'project.json');
+  return JSON.parse(readFileSync(path, 'utf8')) as ProjectJson;
+}
+
+test('every v2 package releases on the beta preid', () => {
+  for (const pkg of V2_PACKAGES) {
+    const options = readProject(pkg).targets?.version?.options;
+    assert.equal(
+      options?.preid,
+      'beta',
+      `packages/${pkg} must set preid "beta" to release on the v2 line`,
+    );
+  }
+});
+
+// `premajor` is single-use: it establishes 2.0.0-beta.0 from 1.x, but from
+// 2.0.0-beta.0 it yields 3.0.0-beta.0. `prerelease` is the steady state and
+// increments beta.N. Anything else silently leaves the v2 line.
+test('every v2 package uses a supported releaseAs', () => {
+  for (const pkg of V2_PACKAGES) {
+    const releaseAs = readProject(pkg).targets?.version?.options?.releaseAs;
+    assert.ok(
+      releaseAs === 'premajor' || releaseAs === 'prerelease',
+      `packages/${pkg} has releaseAs "${releaseAs}", expected "premajor" (bootstrap) or "prerelease" (steady state)`,
+    );
+  }
+});
+
+// Drift here would split the five across two majors, and because workspace:*
+// publishes as an exact pin, a mismatched set is a broken install.
+test('the v2 packages share one releaseAs', () => {
+  const values = new Set(
+    V2_PACKAGES.map(
+      (pkg) => readProject(pkg).targets?.version?.options?.releaseAs,
+    ),
+  );
+  assert.equal(
+    values.size,
+    1,
+    `the v2 packages must all use the same releaseAs, found: ${[...values].join(', ')}`,
+  );
+});
+
+test('v2 GitHub releases are marked as prereleases', () => {
+  for (const pkg of V2_PACKAGES) {
+    assert.equal(
+      readProject(pkg).targets?.github?.options?.prerelease,
+      true,
+      `packages/${pkg} must set prerelease on its github target, or beta releases outrank the 1.x releases on the repo page`,
+    );
+  }
+});
+
+test('independent packages stay off the v2 beta line', () => {
+  for (const pkg of INDEPENDENT_PACKAGES) {
+    const options = readProject(pkg).targets?.version?.options;
+    assert.equal(
+      options?.preid,
+      undefined,
+      `packages/${pkg} keeps its own version line and must not set a preid`,
+    );
+    assert.equal(
+      options?.releaseAs,
+      undefined,
+      `packages/${pkg} keeps its own version line and must not set releaseAs`,
+    );
+  }
+});

--- a/scripts/release/beta-line-config.test.mts
+++ b/scripts/release/beta-line-config.test.mts
@@ -54,15 +54,16 @@ test('every v2 package releases on the beta preid', () => {
   }
 });
 
-// `premajor` is single-use: it establishes 2.0.0-beta.0 from 1.x, but from
-// 2.0.0-beta.0 it yields 3.0.0-beta.0. `prerelease` is the steady state and
-// increments beta.N. Anything else silently leaves the v2 line.
-test('every v2 package uses a supported releaseAs', () => {
+// The bootstrap is done: 2.0.0-beta.0 is published, so `premajor` must no
+// longer appear. From 2.0.0-beta.0 it would yield 3.0.0-beta.0. `prerelease` is
+// the steady state and increments beta.N.
+test('every v2 package uses the steady-state releaseAs', () => {
   for (const pkg of V2_PACKAGES) {
     const releaseAs = readProject(pkg).targets?.version?.options?.releaseAs;
-    assert.ok(
-      releaseAs === 'premajor' || releaseAs === 'prerelease',
-      `packages/${pkg} has releaseAs "${releaseAs}", expected "premajor" (bootstrap) or "prerelease" (steady state)`,
+    assert.equal(
+      releaseAs,
+      'prerelease',
+      `packages/${pkg} has releaseAs "${releaseAs}"; the v2 line is bootstrapped, so it must be "prerelease"`,
     );
   }
 });


### PR DESCRIPTION
### 💡 Overview

Phase 4b of the v1/v2 branch split, and the second half of #2412.

> [!IMPORTANT]
> **Do not merge until the bootstrap release from #2412 has published `2.0.0-beta.0`.** Merging early would put the five packages on `prerelease` before they reach the 2.0 line, and the next release would compute `1.x.y-beta.N` instead.

`releaseAs: premajor` has done its single job of lifting `client`, `react-sdk`, `react-bindings`, `react-native-sdk` and `styling` from 1.x onto `2.0.0-beta.0`. Leaving it in place would compute `3.0.0-beta.0` on the next release, so this flips the five to `releaseAs: prerelease`, which increments `beta.N` and keeps the `2.0.0` core sticky.

### 📝 Implementation notes

The config test is tightened from "premajor or prerelease" to exactly `prerelease`, so a forgotten flip fails CI instead of silently shipping a new major. Negative-tested: putting `premajor` back on one package fails `every v2 package uses the steady-state releaseAs`.

Stacked on `chore/v2-beta-line`, so the diff here is only the flip plus the test change once #2412 lands.

🎫 Ticket: https://linear.app/stream/issue/REACT-1166/v1v2-branch-split-release-v1-maintenance-branch-v2-on-main

📑 Docs: n/a (internal release tooling)
