### PR TITLE
feat(react-native-dogfood)!: move the v2 dogfood app to the 5.x line

### DIFF
--- a/sample-apps/react-native/dogfood/README.md
+++ b/sample-apps/react-native/dogfood/README.md
@@ -1,6 +1,7 @@
 # React Native Video Example
 
 ## Setup the environment for React Native
+
 ​
 First things first, make sure you have set up the development environment for React Native. You can find the official guide [here](https://reactnative.dev/docs/environment-setup).
 
@@ -57,3 +58,10 @@ The following are the steps to run the E2E tests:
 - Install [stream-video-buddy](https://github.com/GetStream/stream-video-buddy) CLI tool.
 - Launch the simulator and install the test app by following the instructions above.
 - Start the test flow by running `yarn test-e2e:ios or yarn test-e2e:android` from the root of this project(`/sample-apps/react-native/dogfood`) to run the tests for iOS and Android, respectively. This will run the tests on a device of your choice. -->
+
+## Version lines
+
+This app tracks the SDK major it is built against. The v2 line on `main` is
+versioned `5.x.y`; the v1 line on `release-v1` stays on `4.x.y`. Keeping the
+majors disjoint stops the two branches computing the same release tag, since
+both version this app from the same tag namespace.


### PR DESCRIPTION
### 💡 Overview

Moves the v2 dogfood app to the `5.x.y` line so it stops colliding with `release-v1`, which keeps `4.x.y`.

**This is currently blocking all v1 releases.** Both branches version this app from the same tag namespace, and `release-v1` cannot see tags `main` created after the cut, so the two converge on the same version and the release fails on the tag push. `main` holds `4.45.1` and `4.45.2`; `release-v1` computes `4.45.1` next. Since the version executor pushes with `git push --atomic`, the whole push aborts and no v1 release can complete.

Same disjoint-major fix already applied to the satellite packages in #2414.

### 📝 Implementation notes

**The version stays stable, deliberately, rather than joining main's `beta` prerelease line.** It feeds the iOS marketing version and the Android `versionName`, and `CFBundleShortVersionString` must be at most three integers, so `5.0.0-beta.0` would be rejected outright. `bump_ios_version_number` runs on PR builds via `is_ci`, not only on store releases, so an invalid version string would break CI rather than just a release.

**No `releaseAs` is needed.** The dogfood preset leaves `preMajor` unset, which defaults to false, so the `BREAKING CHANGE` footer alone produces the major bump. That avoids the single-use `premajor` two-step this repo needed for the core packages and the satellites, and leaves nothing in the config to remember to remove afterwards.

Dry run on this branch confirms only the dogfood app moves:

```
@stream-io/video-react-native-dogfood   5.0.0
everything else                         nothing changed
```

The diff is a README note recording the version-line split, which is also what carries the breaking commit for the version executor to pick up. The app is private and never published to npm, so the tag is the only artifact.

### Follow-up, on release-v1

A seed tag is still needed there to clear main's existing `4.45.1`/`4.45.2` markers, the same technique used for `video-filters-web` and `callingx`. Tracked in the ticket.

🎫 Ticket: https://linear.app/stream/issue/REACT-1166/v1v2-branch-split-release-v1-maintenance-branch-v2-on-main

📑 Docs: n/a (internal sample app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on React Native SDK version lines and release numbering.
  * Clarified the version relationship between the `main` and `release-v1` branches.
  * Improved README formatting around environment setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->