### PR TITLE
fix(react-sdk): fix disabled incoming video settings button

### DIFF
--- a/sample-apps/react/react-dogfood/components/IncomingVideoSettings.tsx
+++ b/sample-apps/react/react-dogfood/components/IncomingVideoSettings.tsx
@@ -33,7 +33,7 @@ export const IncomingVideoSettingsButton = () => {
         <IncomingVideoSettingsMenu value={currentSetting} onChange={onChange} />
       }
       menuPlacement="top"
-      disabled
+      aria-disabled
     >
       <Icon icon="quality" />
       {t(`quality/short/${currentSetting}`)}


### PR DESCRIPTION
### 💡 Overview
This PR fixes an issue with the incoming video settings button being disabled.

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Updated the incoming video settings button to communicate its unavailable state through accessibility metadata while preserving its visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->