### PR TITLE
feat(client): identify the SDK and version on SFU RPCs

### DIFF
--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -40,7 +40,7 @@ import {
 import { withoutConcurrency } from './helpers/concurrency';
 import { getTimers } from './timers';
 import { getSdkInfo } from './helpers/client-details';
-import { getSdkName, getSdkVersion, Tracer, TraceSlice } from './stats';
+import { getStreamClientId, Tracer, TraceSlice } from './stats';
 import { SfuJoinError, SfuTimeoutError } from './errors';
 
 export type StreamSfuClientConstructor = {
@@ -269,13 +269,12 @@ export class StreamSfuClient {
     this.tracer = enableTracing
       ? new Tracer(`${tag}-${this.edgeName}`)
       : undefined;
-    const sdkInfo = getSdkInfo();
     this.rpc = createSignalClient({
       baseUrl: server.url,
       interceptors: [
         withHeaders({
           Authorization: `Bearer ${token}`,
-          'X-Stream-Client': `${getSdkName(sdkInfo)}@${getSdkVersion(sdkInfo)}`,
+          'X-Stream-Client': getStreamClientId(getSdkInfo()),
         }),
         this.tracer && withRequestTracer(this.tracer.trace),
         this.logger.getLogLevel() === 'trace' && withRequestLogger(this.logger),

--- a/packages/client/src/StreamSfuClient.ts
+++ b/packages/client/src/StreamSfuClient.ts
@@ -39,7 +39,8 @@ import {
 } from './helpers/promise';
 import { withoutConcurrency } from './helpers/concurrency';
 import { getTimers } from './timers';
-import { Tracer, TraceSlice } from './stats';
+import { getSdkInfo } from './helpers/client-details';
+import { getSdkName, getSdkVersion, Tracer, TraceSlice } from './stats';
 import { SfuJoinError, SfuTimeoutError } from './errors';
 
 export type StreamSfuClientConstructor = {
@@ -268,10 +269,14 @@ export class StreamSfuClient {
     this.tracer = enableTracing
       ? new Tracer(`${tag}-${this.edgeName}`)
       : undefined;
+    const sdkInfo = getSdkInfo();
     this.rpc = createSignalClient({
       baseUrl: server.url,
       interceptors: [
-        withHeaders({ Authorization: `Bearer ${token}` }),
+        withHeaders({
+          Authorization: `Bearer ${token}`,
+          'X-Stream-Client': `${getSdkName(sdkInfo)}@${getSdkVersion(sdkInfo)}`,
+        }),
         this.tracer && withRequestTracer(this.tracer.trace),
         this.logger.getLogLevel() === 'trace' && withRequestLogger(this.logger),
         withTimeout(rpcRequestTimeout, this.tracer?.trace),

--- a/packages/client/src/__tests__/StreamSfuClient.test.ts
+++ b/packages/client/src/__tests__/StreamSfuClient.test.ts
@@ -472,7 +472,7 @@ describe('StreamSfuClient RPC headers', () => {
 
       const [, init] = fetchMock.mock.calls[0];
       expect(new Headers(init.headers).get('x-stream-client')).toBe(
-        'stream-react@1.2.3',
+        'stream-video-react-v1.2.3',
       );
     } finally {
       setSdkInfo(sdkInfo!);

--- a/packages/client/src/__tests__/StreamSfuClient.test.ts
+++ b/packages/client/src/__tests__/StreamSfuClient.test.ts
@@ -3,6 +3,8 @@ import { StreamSfuClient } from '../StreamSfuClient';
 import { Dispatcher } from '../rtc';
 import { StreamClient } from '../coordinator/connection/client';
 import { getTimers } from '../timers';
+import { getSdkInfo, setSdkInfo } from '../helpers/client-details';
+import { SdkType } from '../gen/video/sfu/models/models';
 
 /**
  * Minimal `WebSocket` stub used to drive `StreamSfuClient.close()` while the
@@ -429,5 +431,51 @@ describe('StreamSfuClient.leaveAndClose()', () => {
     await leavePromise;
 
     expect(notifyLeaveSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('StreamSfuClient RPC headers', () => {
+  beforeEach(() => {
+    CapturingWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', CapturingWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('identifies the SDK and its version in every RPC request', async () => {
+    const sdkInfo = getSdkInfo();
+    setSdkInfo({
+      type: SdkType.REACT,
+      major: '1',
+      minor: '2',
+      patch: '3',
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response('{}', { headers: { 'content-type': 'application/json' } }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const sfuClient = buildSfuClient();
+      (
+        sfuClient as unknown as {
+          joinResponseTask: { resolve: (v: unknown) => void };
+        }
+      ).joinResponseTask.resolve({});
+
+      await sfuClient.startNoiseCancellation();
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(new Headers(init.headers).get('x-stream-client')).toBe(
+        'stream-react@1.2.3',
+      );
+    } finally {
+      setSdkInfo(sdkInfo!);
+    }
   });
 });

--- a/packages/client/src/stats/__tests__/utils.test.ts
+++ b/packages/client/src/stats/__tests__/utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getStreamClientId } from '../utils';
+import { SdkType } from '../../gen/video/sfu/models/models';
+
+describe('getStreamClientId', () => {
+  const sdk = (type: SdkType) => ({
+    type,
+    major: '1',
+    minor: '43',
+    patch: '1',
+  });
+
+  it('names the React SDK', () => {
+    expect(getStreamClientId(sdk(SdkType.REACT))).toBe(
+      'stream-video-react-v1.43.1',
+    );
+  });
+
+  it('names the React Native SDK', () => {
+    expect(getStreamClientId(sdk(SdkType.REACT_NATIVE))).toBe(
+      'stream-video-react-native-v1.43.1',
+    );
+  });
+
+  it('falls back to the plain JS client for every other SDK type', () => {
+    expect(getStreamClientId(sdk(SdkType.PLAIN_JAVASCRIPT))).toBe(
+      'stream-video-js-v1.43.1',
+    );
+    expect(getStreamClientId(undefined)).toBe(
+      'stream-video-js-v0.0.0-development',
+    );
+  });
+});

--- a/packages/client/src/stats/utils.ts
+++ b/packages/client/src/stats/utils.ts
@@ -51,3 +51,18 @@ export const getSdkName = (sdk: Sdk | undefined) => {
 export const getSdkVersion = (sdk: Sdk | undefined) => {
   return sdk ? `${sdk.major}.${sdk.minor}.${sdk.patch}` : '0.0.0-development';
 };
+
+/**
+ * Returns the identifier the SFU receives in the `X-Stream-Client` header,
+ * e.g. `stream-video-react-v1.43.1`. Matches the format the coordinator
+ * already gets through the client's user agent.
+ */
+export const getStreamClientId = (sdk: Sdk | undefined) => {
+  const sdkPlatforms: Partial<Record<SdkType, string>> = {
+    [SdkType.REACT]: 'react',
+    [SdkType.REACT_NATIVE]: 'react-native',
+  };
+
+  const platform = (sdk && sdkPlatforms[sdk.type]) || 'js';
+  return `stream-video-${platform}-v${getSdkVersion(sdk)}`;
+};


### PR DESCRIPTION
### 💡 Overview

The SFU's Twirp requests carry no client identity today - the SDK name and version only appear in the `JoinRequest` and `SendStats` payloads. This adds an `X-Stream-Client` header to every SFU RPC, mirroring what we already send to the coordinator.

This gap surfaced during the Android 1.31.0 incident, where `startNoiseCancellation` raced ahead of the WS join, the SFU replied `ERROR_CODE_PARTICIPANT_NOT_FOUND`, and the SDK treated it as terminal and looped. The SFU couldn't gate a server-side mitigation on the client version because the RPC didn't say who was calling. The SFU already makes decisions based on the client string (codec selection, for one), so having it on every RPC lets the backend diagnose and mitigate client-specific regressions without waiting for an SDK release.

### 📝 Implementation notes

The header carries the same client id shape the coordinator already receives through the user agent:

| SDK | `X-Stream-Client` |
| --- | --- |
| React | `stream-video-react-v1.43.1` |
| React Native | `stream-video-react-native-v1.44.2` |
| everything else | `stream-video-js-v<version>` |

`getStreamClientId` lives next to the existing `getSdkName` / `getSdkVersion` helpers so the `SdkType` mapping stays in one place, and the version comes from the same source that feeds `JoinRequest` and the stats payloads. `setSdkInfo` runs at module init in both `react-sdk/index.ts` and `react-native-sdk/src/index.ts`, well before any SFU client is constructed at join time; with SDK info unset the value degrades to `stream-video-js-v0.0.0-development`.

The WS `/ws` endpoint already carries `cid`, `user_id` and `api_key` as query params, so nothing changes there. [Format agreed with Marcelo in the thread](https://getstream.slack.com/archives/C040262MY9K/p1788870872729689).

**Backend prerequisite:** `X-Stream-Client` is a non-safelisted header on a cross-origin Twirp POST, so the SFU's CORS `Access-Control-Allow-Headers` must include it before this ships - otherwise the preflight blocks every SFU RPC from the web SDK.

**Known inconsistency:** the coordinator derives its own name from `SdkType[type].toLowerCase()`, so it sees `react_native` / `plain_javascript` where this header says `react-native` / `js`. Aligning the coordinator side is out of scope here.

The other platforms (Android, iOS, Flutter, Unity) need the same header to close the gap fleet-wide; that's tracked separately per SDK team.

🎫 Ticket: https://linear.app/stream/issue/REACT-1169/identify-the-sdk-and-version-on-sfu-twirp-requests-x-stream-client

📑 Docs: n/a - internal transport header, no public API change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SFU requests now include a standardized SDK client identifier in their headers, including the platform and version (for example, React or React Native).
  * SDK identifiers now consistently fall back to a JavaScript identifier when platform information is unavailable or unsupported.
  * Added coverage to verify SDK identifier formatting and SFU request headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->