### PR TITLE
fix(react-dogfood): keep post-login redirects on the preview domain

### DIFF
--- a/sample-apps/react/react-dogfood/pages/api/auth/[...nextauth].ts
+++ b/sample-apps/react/react-dogfood/pages/api/auth/[...nextauth].ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import type { NextAuthOptions, Profile } from 'next-auth';
 import NextAuth from 'next-auth';
 import GoogleProvider, { GoogleProfile } from 'next-auth/providers/google';
@@ -50,10 +51,7 @@ export const authOptions: NextAuthOptions = {
             : `https://staging.getstream.io/${basePath}`;
       }
 
-      // original implementation
-      if (url.startsWith('/')) return `${baseUrl}${url}`;
-      else if (new URL(url).origin === baseUrl) return url;
-      return baseUrl;
+      return resolveRedirect(url, baseUrl);
     },
     async jwt({ token, account, profile }) {
       if (account && profile) {
@@ -76,6 +74,52 @@ export const authOptions: NextAuthOptions = {
   },
 };
 
+/**
+ * The `next-auth` default: keep same-origin callbacks, send everything else
+ * back to the deployment root.
+ */
+const resolveRedirect = (url: string, baseUrl: string) => {
+  if (url.startsWith('/')) return `${baseUrl}${url}`;
+  else if (new URL(url).origin === baseUrl) return url;
+  return baseUrl;
+};
+
+const firstHeaderValue = (header: string | string[] | undefined) => {
+  const value = Array.isArray(header) ? header[0] : header;
+  return value?.split(',')[0].trim() || undefined;
+};
+
+/**
+ * Every preview deployment gets its own hostname, but `NEXTAUTH_URL` is a
+ * static project setting pointing at the canonical domain. Deriving the base
+ * URL from the incoming request keeps post-login callbacks on the host the
+ * user is actually browsing instead of bouncing them to that canonical domain.
+ * Google sign-in still needs `NEXTAUTH_URL`, as its `redirect_uri` has to match
+ * a pre-registered one, so previews are limited to the demo account login.
+ */
+const detectPreviewBaseUrl = (req: NextApiRequest) => {
+  if (process.env.VERCEL_ENV !== 'preview') return undefined;
+  const host = firstHeaderValue(
+    req.headers['x-forwarded-host'] ?? req.headers.host,
+  );
+  if (!host) return undefined;
+  const protocol =
+    firstHeaderValue(req.headers['x-forwarded-proto']) ?? 'https';
+  return `${protocol}://${host}${basePath}`;
+};
+
+const authOptionsForRequest = (req: NextApiRequest): NextAuthOptions => {
+  const previewBaseUrl = detectPreviewBaseUrl(req);
+  if (!previewBaseUrl) return authOptions;
+  return {
+    ...authOptions,
+    callbacks: {
+      ...authOptions.callbacks,
+      redirect: async ({ url }) => resolveRedirect(url, previewBaseUrl),
+    },
+  };
+};
+
 const isVerifiedStreamEmployee = (
   provider: string,
   profile: Profile,
@@ -88,4 +132,7 @@ const isVerifiedStreamEmployee = (
   );
 };
 
-export default NextAuth(authOptions);
+const handler = async (req: NextApiRequest, res: NextApiResponse) =>
+  NextAuth(req, res, authOptionsForRequest(req));
+
+export default handler;


### PR DESCRIPTION
### 💡 Overview

Logging in on a Vercel preview of the react-dogfood app redirected back to the main instance (`pronto-staging.getstream.io`) instead of staying on the preview URL.

`NEXTAUTH_URL` is a static per-project setting, and next-auth gives it precedence over the request's forwarded host, so it became the `baseUrl` in the `redirect` callback: relative callbacks got prefixed with the canonical origin, and absolute preview callbacks failed the same-origin check and fell through to `return baseUrl`. Unsetting `NEXTAUTH_URL` on Preview is not an option, as `vercel build` in CI then leaves next-auth parsing an empty-string URL and the build crashes during page-data collection.

### 📝 Implementation notes

The route now builds its options per request, so preview deployments resolve redirects against `x-forwarded-host` / `x-forwarded-proto` (plus `NEXT_PUBLIC_BASE_PATH`) while every other environment keeps the untouched options. The old inline redirect body moved into a shared `resolveRedirect` helper, so the demo-env `baseUrl` patch and the open-redirect guard are unchanged.

Verified against the built app with `NEXTAUTH_URL=https://pronto-staging.getstream.io`, driving the real credentials callback: with `VERCEL_ENV=preview` a relative `/join/abc123`, an absolute preview URL, and a foreign-origin callback all resolve to the preview host (the last one to its root); with `VERCEL_ENV` unset the relative callback still resolves to `pronto-staging.getstream.io`. `next build`, `tsc --noEmit` and eslint are clean.

Known limits: Google sign-in still needs `NEXTAUTH_URL` for a pre-registered `redirect_uri`, so previews are limited to the demo-account login; and next-auth builds its error-page redirects from the detected origin rather than a callback, so a failed OAuth attempt can still land on the canonical domain's `/auth/signin`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication behavior for preview deployments.
  - Authentication redirects now use the request’s detected preview URL when applicable.
  - Updated request handling to provide more reliable sign-in and callback behavior across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->