### PR TITLE
fix(react-dogfood): include all query params in the invite QR code

### DIFF
--- a/sample-apps/react/react-dogfood/components/InvitePanel/InvitePanel.tsx
+++ b/sample-apps/react/react-dogfood/components/InvitePanel/InvitePanel.tsx
@@ -3,6 +3,17 @@ import { QRCodeSVG } from 'qrcode.react';
 import { Icon, IconButton, useI18n } from '@stream-io/video-react-sdk';
 import { useIsDemoEnvironment } from '../../context/AppEnvironmentContext';
 
+/**
+ * Builds the URL encoded in the invite QR code: the current location with every
+ * query param preserved (`encryption_key`, `environment`, ...) plus `from_qr`.
+ */
+const buildQrCodeUrl = () => {
+  const { origin, pathname, search, hash } = window.location;
+  const params = new URLSearchParams(search);
+  params.set('from_qr', 'true');
+  return `${origin}${pathname}?${params.toString()}${hash}`;
+};
+
 export const InvitePopup = ({
   callId,
   close,
@@ -13,8 +24,7 @@ export const InvitePopup = ({
   const { t } = useI18n();
   const { isCopied, copyInviteLink } = useCopyInviteLink();
 
-  const qrCodeContent = new URL(window.location.toString());
-  qrCodeContent.searchParams.set('from_qr', 'true');
+  const qrCodeContent = buildQrCodeUrl();
 
   return (
     <div className="rd__invite-popup">
@@ -49,16 +59,13 @@ export const InvitePopup = ({
         </div>
         <Icon className="rd__invite-popup__id-button" icon="copy" />
       </div>
-      <div
-        className="rd__invite-popup__qr-container"
-        title={qrCodeContent.toString()}
-      >
+      <div className="rd__invite-popup__qr-container" title={qrCodeContent}>
         <p className="rd__invite-popup__qr-description">
           To test on a mobile device, scan the QR Code below:
         </p>
         <QRCodeSVG
           className="rd__invite-popup__qr-code"
-          value={qrCodeContent.toString()}
+          value={qrCodeContent}
         />
       </div>
     </div>
@@ -90,8 +97,7 @@ export const InvitePanel = () => {
   const isDemoEnvironment = useIsDemoEnvironment();
   const [expanded, setExpanded] = useState(false);
 
-  const qrCodeContent = new URL(window.location.toString());
-  qrCodeContent.searchParams.set('from_qr', 'true');
+  const qrCodeContent = buildQrCodeUrl();
   return (
     <div className="rd__invite">
       <Invite />
@@ -113,13 +119,10 @@ export const InvitePanel = () => {
                 <p className="rd__invite__qr-description">
                   {t('To test on a mobile device, scan the QR Code below:')}
                 </p>
-                <div
-                  className="rd__invite__qr-container"
-                  title={qrCodeContent.toString()}
-                >
+                <div className="rd__invite__qr-container" title={qrCodeContent}>
                   <QRCodeSVG
                     className="rd__invite__qr-code"
-                    value={qrCodeContent.toString()}
+                    value={qrCodeContent}
                   />
                 </div>
               </>
@@ -131,13 +134,10 @@ export const InvitePanel = () => {
             <p className="rd__invite__qr-description">
               {t('To test on a mobile device, scan the QR Code below:')}
             </p>
-            <div
-              className="rd__invite__qr-container"
-              title={qrCodeContent.toString()}
-            >
+            <div className="rd__invite__qr-container" title={qrCodeContent}>
               <QRCodeSVG
                 className="rd__invite__qr-code"
-                value={qrCodeContent.toString()}
+                value={qrCodeContent}
               />
             </div>
           </>


### PR DESCRIPTION
### 💡 Overview

The invite QR code in the dogfood app is rebuilt from the current location on every render, so it only ever carried the params that happened to be on the URL at that moment. That made it easy to drop call-critical ones - most notably `encryption_key`, which a phone scanning the code needs in order to join an encrypted call.

The QR value is now built through a single `buildQrCodeUrl()` helper that copies **every** param from `location.search` (`encryption_key`, `environment`, `coordinator_url`, ...), preserves the hash, and then adds `from_qr=true`. `InvitePopup` and `InvitePanel` share it instead of duplicating the URL construction.

### 📝 Implementation notes

Worth flagging for review: the previous `new URL(window.location.toString())` already included the full query string, so `encryption_key` was only missing when the URL had not been rewritten yet at render time. `useLobbyCall.replaceUrl` sets that param via `history.replaceState`, which does not trigger a React re-render. This change makes the param handling explicit and deduplicated, but if a stale key shows up again the real fix belongs at the render-trigger level - lifting the encryption key into state that both the lobby and the invite UI read.

Sample-app only; no SDK surface is touched.

🎫 Ticket: n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR code link generation when inviting others, preserving existing URL parameters while adding the QR source indicator.
  * Ensured QR codes consistently use the correct shareable link format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->