### PR TITLE
fix(styling): fix participant tile overlay spacing

### DIFF
--- a/packages/styling/src/ParticipantView/ParticipantView-layout.scss
+++ b/packages/styling/src/ParticipantView/ParticipantView-layout.scss
@@ -17,7 +17,7 @@ $scope-name: 'str-video__participant-view';
     outline: var(--str-video__w200) solid var(--str-video__accent-primary);
   }
 
-  & > .str-video__participant-view__menu-button {
+  .str-video__participant-view__menu-button {
     position: absolute;
     top: var(--str-video__space-8);
     left: var(--str-video__space-8);
@@ -39,7 +39,7 @@ $scope-name: 'str-video__participant-view';
     .str-video__participant-details__name {
       display: flex;
       align-items: center;
-      gap: var(--str-video__spacing-xs);
+      gap: var(--str-video__spacing-xxs);
       padding: var(--str-video__space-4) var(--str-video__space-4)
         var(--str-video__space-4) var(--str-video__space-12);
       font-size: var(--str-video__typography-font-size-xs);
@@ -52,6 +52,10 @@ $scope-name: 'str-video__participant-view';
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+
+        &:not(:last-child) {
+          margin-inline-end: var(--str-video__spacing-xxs);
+        }
       }
 
       @mixin icon {


### PR DESCRIPTION
### 💡 Overview

This PR aligns the spacing between items in the participant tile details section and fixes an issue with the participant actions menu button. 

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>
