### PR TITLE
fix(react-sdk): break circular import in BaseVideoPlaceholder

### DIFF
--- a/packages/react-sdk/src/core/components/Video/BaseVideoPlaceholder.tsx
+++ b/packages/react-sdk/src/core/components/Video/BaseVideoPlaceholder.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, RefAttributes, forwardRef } from 'react';
 import type { StreamVideoParticipant } from '@stream-io/video-client';
-import { Avatar } from '../../../components';
+import { Avatar } from '../../../components/Avatar';
 
 export type BaseVideoPlaceholderProps = {
   participant: StreamVideoParticipant;


### PR DESCRIPTION
### 💡 Overview

Fixes the circular dependency warning in the React SDK build. `BaseVideoPlaceholder` imported `Avatar` from the `src/components` barrel, which re-exports `./VideoPreview` → `core/components/Video/*` — looping back onto itself. 

### 📝 Implementation notes

🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated an internal component import path without changing visible behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->